### PR TITLE
Land Phase 1 design artifacts (6 ADRs, CONTEXT.md, agent-skills)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,17 @@
 2. **Context-Aware Coding:** When I assign you a task, use your file-reading tools to check `ARCHITECTURE.md` for the relevant database schemas, actor models, and UI/UX design tokens before writing code.
 3. **Backlog Tracking:** When I explicitly tell you a task is complete and working, use your file-editing tool to open `BACKLOG.md` and change that specific task from `[ ]` to `[x]`.
 4. **Wait for Commands:** After completing a coding task or updating the backlog, simply tell me it is done and wait for my next instruction. Do not proceed on your own.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues on `thearnavmenon/ProjectApex` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default canonical vocabulary — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,147 @@
+# Project Apex — Domain Glossary
+
+The ubiquitous language for Project Apex. When writing code, issues, PRDs, tests, or commit messages, use these terms exactly. Don't drift to synonyms listed under `_Avoid_`.
+
+If a concept needs more than two sentences to define, it isn't a term — it's a concept. The ADR is the source of truth; this file links to it.
+
+## Language
+
+### Programme structure
+
+**Queue**:
+The programme as an ordered list of session slots, advanced by training events not by calendar time. See ADR-0002.
+_Avoid_: schedule, calendar, plan
+
+**Mesocycle skeleton**:
+The gym-agnostic ordered sequence of session slots grouped into phases; lives in `programs.mesocycle_json`. See ADR-0002, ADR-0005.
+_Avoid_: programme plan, mesocycle (without "skeleton")
+
+**Mesocycle phase**:
+One of Accumulation, Intensification, Peaking, or Deload — phase position is per-pattern, not global.
+_Avoid_: programme phase, training block
+
+**Pattern phase**:
+The current phase position for a single movement pattern within the mesocycle phase progression. Stored on `PatternProfile.currentPhase`.
+_Avoid_: phase (when ambiguous)
+
+### Trainee model
+
+**Trainee model**:
+The persistent structured behavioural model per user — capability, recovery, goal, projections — updated server-side after each session. See ADR-0005, ADR-0006.
+_Avoid_: user profile, user state, user data
+
+**Calibration review**:
+The one-time UI screen fired when ≥4 of 6 major patterns reach `.established` per-axis confidence; sets floor + stretch projections. See ADR-0005.
+_Avoid_: assessment, test block, week 1 test
+
+**Floor projection**:
+The capability-based realistic target — immovable on goal renegotiation. See ADR-0005.
+_Avoid_: target, conservative goal
+
+**Stretch projection**:
+The user-adjustable-upward target — re-derived silently on goal renegotiation. See ADR-0005.
+_Avoid_: ambitious target, max goal
+
+### Movement & sets
+
+**Movement pattern**:
+A type of motion (horizontal push, vertical pull, knee-dominant, hip-dominant, elbow flexion, etc.) — strictly motion taxonomy.
+_Avoid_: muscle group, exercise category
+
+**Muscle group**:
+One of six body-part groups (back, chest, biceps, shoulders, triceps, legs) — locked at six. Calves and core are not first-class muscle groups in v2.
+_Avoid_: movement pattern, body part (in code)
+
+**Set intent**:
+The required field on every set — `warmup`, `top`, `backoff`, `technique`, or `amrap`. No silent defaults at any layer. See ADR-0005.
+_Avoid_: set type, set kind
+
+**Top set**:
+A set with `intent == .top` AND reps in 3..10 — the sole contributor to e1RM estimation.
+_Avoid_: heavy set, max set, working set
+
+### Capability metrics
+
+**e1RM**:
+Epley estimated 1-rep max — `weight × (1 + reps / 30)`, computed only on top sets within the 3..10-rep validity range.
+_Avoid_: 1RM, one-rep-max
+
+**EWMA**:
+Exponentially weighted moving average over the last 5 valid top sets, α = 0.333 — the standard mode for e1RM estimation. See ADR-0005.
+_Avoid_: rolling average, moving average (without qualifier)
+
+**Transition mode**:
+A per-pattern flag that collapses the e1RM update window from N=5 EWMA to N=3 plain-mean over recent sessions. Triggered by calibration recency, deload-end, phase transition, or long-absence return. **Unrelated to mesocycle phase transition.** See ADR-0005.
+_Avoid_: phase transition
+
+### Coaching signals
+
+**Stimulus dimension**:
+A set's training stimulus classification — `neuromuscular`, `metabolic`, or `both`. Warmup and technique sets classify as `nil`. Drives two-dimensional recovery. See ADR-0005.
+_Avoid_: training stimulus, fatigue type
+
+**Active limitation**:
+A currently flagged injury / pain state per pattern, muscle, or joint — AI-inferred caps at `.mild` until user-confirmed.
+_Avoid_: injury, pain (too general)
+
+**Cleared limitation**:
+An archived limitation resolved through clean training — retention capped at 50 entries / 12 months.
+_Avoid_: resolved injury, healed limitation
+
+**Form degradation flag**:
+An SE-widening signal on an exercise when notes mention form decay. Independent from active limitation; a single note can contribute to both.
+_Avoid_: technique flag, form note
+
+**Fatigue interaction**:
+A cross-pattern carryover signal — surfaces in prompts only at confidence ≥ 0.7 with ≥15 paired observations.
+_Avoid_: crossover fatigue, pattern interaction
+
+**Prescription accuracy**:
+The AI's own bias and RMSE per pattern × intent — meta-coaching about the AI's miscalibration. Distinct from a single intent mismatch at log time.
+_Avoid_: AI accuracy, calibration
+
+### Multi-gym
+
+**Cross-gym transfer**:
+Capability follows the user across gyms; per-session generation is gym-aware. See ADR-0002, ADR-0005.
+_Avoid_: gym switch, multi-gym sync, cross-exercise transfer (different concept)
+
+### Build process (Mattpocock skills vocabulary)
+
+**HITL**:
+Human-in-the-loop — issue tag for items requiring human input (visual feedback, design judgment, product decisions).
+_Avoid_: human-required, manual
+
+**AFK**:
+Away-from-keyboard — issue tag for items an agent can run autonomously without human context.
+_Avoid_: automated, agent-only
+
+**Tracer-bullet vertical slice**:
+The unit of work for `to-issues` — a thin end-to-end cut through all integration layers (data → logic → UI), independently mergeable and testable.
+_Avoid_: feature, ticket, story, horizontal slice
+
+## Relationships
+
+- A **Trainee model** belongs to one user; a **Mesocycle skeleton** belongs to one programme; one user has one trainee model and one or more (paused) mesocycle skeletons.
+- The **Queue** is a view over the active **Mesocycle skeleton**.
+- **Top set**s feed **EWMA**; **EWMA** computes **e1RM**; **transition mode** changes the EWMA window shape.
+- A **Set intent** value gates whether a set contributes to **EWMA** (only `top`), volume aggregation, and RPE calibration.
+- **Stimulus dimension** classifies sets and feeds two-dimensional recovery on **PatternProfile**.
+- A **Form degradation flag** widens **e1RM** SE; an **active limitation** gates exercises and prescription.
+- **Calibration review** sets **floor projection** and **stretch projection** using current **EWMA** capability.
+- **Movement pattern** and **muscle group** are independent taxonomies — a set is associated with both via its exercise.
+
+## Example dialogue
+
+> **Engineer**: "What does it mean for the trainee model to be 'in transition mode' for bench?"
+> **Domain**: "**Transition mode** is a flag on the bench's `PatternProfile` that collapses the **EWMA** window from 5 top sets to the 3 most recent sessions, switching from exponential weighting to plain mean. Triggered by calibration recency, deload-end, **pattern phase** transition, or long-absence return — and importantly, it's *not* the same thing as a mesocycle phase transition. See ADR-0005."
+
+> **Engineer**: "Should this be a `ready-for-agent` issue or `ready-for-human`?"
+> **Domain**: "If the work is a **tracer-bullet vertical slice** with no visual or design-judgment component — schema, server-side rules, deterministic logic — it's **AFK** and gets `ready-for-agent`. If it needs visual feedback or product judgment, it's **HITL** and gets `ready-for-human`."
+
+## Flagged ambiguities
+
+- **"Phase"** is overloaded. Always qualify: **mesocycle phase** (Accumulation / Intensification / Peaking / Deload) is unrelated to **transition mode** (an EWMA window-mode flag).
+- **"Transfer"** is overloaded. **Cross-gym transfer** = capability follows user across gyms. **Cross-exercise transfer** = capability extrapolation between related exercises (e.g., bench → OHP). Different mechanisms; surface both terms when both apply.
+- **"Top set"** is not "the heaviest set in a session" — it requires `intent == .top` AND reps in 3..10. A heaviest set with reps > 10 is not a top set and does not contribute to e1RM.
+- **"Limitation"** vs **"form degradation flag"**: independent signals about different things (joint health vs technique quality). A single note can contribute to both.

--- a/docs/adr/0001-out-of-order-session-semantics.md
+++ b/docs/adr/0001-out-of-order-session-semantics.md
@@ -1,0 +1,39 @@
+# Out-of-order session semantics: untouched queue + dedupe by session ID
+
+**Status**: accepted, 2026-05-01
+
+## Context
+
+The programme is a queue of sessions in fixed order (Push A → Pull A → Legs A → Push B → …) under ADR-0002. FB-009 already lets the user start any generated session out of queue order; the question was what happens to the queue when they do.
+
+## Decision
+
+When a user picks an out-of-order session and completes it (call this **Model E**):
+
+1. The queue pointer **does not advance**. Tomorrow's "Up next" is whatever it would have been.
+2. The **next instance of the picked session in the queue** is auto-marked complete (de-dupe), with explicit user confirmation in the post-workout summary screen — not silent.
+3. De-dupe matches by **exact session ID/name**, not by movement-pattern family. Legs A done out-of-order consumes the next Legs A in the queue, not the next Legs B.
+
+If the picked session has no future instance in the queue, the session is logged as a free-floating training event and no de-dupe occurs.
+
+## Considered Options
+
+- **Model A — untouched queue, no de-dupe.** Simplest. Out-of-order sessions are free-floating logs. Rejected: feels like the app ignored what the user actually did.
+- **Model B — strict skip-ahead.** Picking session at queue position K marks all earlier sessions skipped. Rejected: punishingly loses planned sessions.
+- **Model C — slot consumption + de-dupe.** Today's slot consumed by the picked session; original head marked skipped. Rejected: violates "the plan is sacred" — substituting one session for today's slot shouldn't void the planned session entirely.
+- **Model D — replace-and-shift.** Picked session replaces queue head; original head goes to back of queue. Rejected: doesn't match user expectation that the queue continues from where it was.
+- **Model E (chosen).** Untouched queue, de-dupe future instance, explicit user confirmation. Preserves "the plan is sacred" while honouring substitution intent.
+
+Within Model E, three sub-variants were also weighed (one chosen, two rejected):
+
+- **E1 — silent de-dupe.** The next Legs A in the queue is silently marked complete after today's out-of-order Legs A finishes. Rejected: silent magic is hostile when the user disagrees with the system's inference, and there's no recovery affordance.
+- **E2 — explicit confirmation in the post-workout summary (chosen).** Post-workout summary asks: *"This counts as your next Legs A (Week 6) too — mark complete?"* with a default of yes and a "no, keep both" override. Single-screen friction (a screen the user already sees), full agency, undoable.
+- **Family-level matching** (e.g., Legs A done out-of-order consumes the next *any-Legs* session). Rejected: Legs A and Legs B are programmed with different exercise selections and volume targets — treating them as fungible defeats the point of the AI's plan structure.
+
+Locked combination: **Model E + E2 (explicit confirmation in post-workout summary) + exact session-ID match** for the de-dupe target.
+
+## Consequences
+
+- The queue can outlast its planned session count if the user repeatedly does sessions out-of-order without de-dupe matches (e.g., freestyle sessions). Acceptable.
+- The post-workout summary gains an E2 confirmation card ("This counts as your next Legs A — mark complete?"). Default is yes, undo affordance available.
+- Queue-pointer advancement remains tied to in-order completions and explicit skips, never to out-of-order substitutions.

--- a/docs/adr/0002-queue-shape-programme-model.md
+++ b/docs/adr/0002-queue-shape-programme-model.md
@@ -1,0 +1,37 @@
+# Queue-shape programme model: drop calendar dates
+
+**Status**: accepted, 2026-05-01
+
+## Context
+
+The original v1.0 PRD framed the programme as a calendar-anchored 12-week mesocycle with sessions assigned to specific dates. By the time v2 design started, the shipped behaviour had already drifted: FB-011 made progression training-time-anchored (no calendar advancement), FB-009 allowed free day selection (any generated session can start regardless of date), and `GymStreakService` counted training events with a 1-day-gap absorber rather than calendar streaks. Three independent features were quietly converging on the same model — the calendar metaphor was decorative, not load-bearing.
+
+## Decision
+
+The programme is a **queue of sessions in a fixed phase-aware order**, advanced by training events (completion or skip), not by calendar time. Specifically:
+
+1. The `MesocycleSkeleton` is a sequence of typed slots (Push A, Pull A, Legs A, …) grouped into phases (Accumulation, Intensification, Peaking, Deload). No dates.
+2. Length is measured in **sessions, not weeks**. A trainee on holiday for two weeks doesn't "lose" two weeks of programme — they pick up the queue where they left off.
+3. **Rest days are not modelled.** "Rest day" is a calendar concept with no place in a queue model. Time between sessions is unstructured and rendered as the absence of a session, not as a planned event.
+4. Programme length is flexible — the macro skeleton can extend or compress at reassessment based on observed progress, rather than terminating at a fixed 12-week boundary.
+5. **The programme is calendar-free; the Today UI uses local-clock day-boundaries for state transitions only.** This demarcation matters: the *programme* (skeleton, queue, advancement) never references calendar dates. The *Today UI surface* uses local-clock 4am day-flips for the post-session → pre-session state transition (per ADR-0003), because "today" is a local-clock concept for the user. The two layers are decoupled — calendar lives only in the user-facing state transition, not in any programme data.
+
+## Considered Options
+
+- **(A) Calendar-shaped programme, original v1.0 spec.** Sessions assigned to dates; calendar grid as primary surface. Rejected: doesn't match the user's actual training pattern (variable cadence, travel, life context), and FB-011 had already reverted the advancement logic away from this model.
+- **(B) Hybrid: calendar grid for display + training-time advancement for state.** Visually calendar-shaped, semantically queue-shaped. Rejected: lying about what the data represents leads to UX inconsistency (e.g., what does "Tuesday" show on a queue-progressing programme where Tuesday hasn't been trained?).
+- **(C) Pure queue (chosen).** Calendar metaphor dropped from both data model and UI. Programme tab becomes a phase-segmented vertical list of sessions in queue order; Today shows "Up next" rather than "Today's session."
+
+Within the chosen (C) pure-queue model, three sub-variants were also weighed:
+
+- **(C-i) Length: fixed 12 weeks vs flexible.** Chose flexible — the macro skeleton can extend if progress is slow, compress if fast. Reassessed every 6 sessions (light) and at phase transitions (heavy).
+- **(C-ii) Length unit: weeks vs sessions.** Chose sessions. "12 weeks" implies calendar progression; "48 sessions" describes the actual programme content.
+- **(C-iii) Rest days: explicit entity vs derived from absence vs not modelled at all.** Chose not modelled. Derivation worked but produced empty calendar cells with no semantic content; the queue model has no place for "non-training days" because the unit of work is the session, not the day.
+
+## Consequences
+
+- The `Week` model in code keeps `dayOfWeek: Int` only as a programmed-week ordinal (1 through `daysPerWeek`), not a Mon–Sun mapping. Future readers should not treat it as a calendar mapping.
+- `VolumeValidationService` (and its successor in the trainee model) windows over **last 7 training events**, not last 7 calendar days.
+- Reminders / nudges (N1 staleness, N2 day-of) use queue-aware language ("Push A is up next — when you're ready"), never schedule-shaming ("you missed Tuesday").
+- `disruptedPatterns` detection (long-absence flag) uses days-since-last-session, but the *programme* never advances on calendar tick — only the user's *re-entry* coaching does.
+- Multi-gym programme architecture (per ADR-0005, persistent trainee model) inherits this shape — the queue is user-scoped, gym-aware Stage 2 generation produces gym-specific prescriptions per session.

--- a/docs/adr/0003-three-tab-navigation-today-state-machine.md
+++ b/docs/adr/0003-three-tab-navigation-today-state-machine.md
@@ -1,0 +1,61 @@
+# Three-tab navigation: Today / Program / Progress, with Today as a state machine
+
+**Status**: accepted, 2026-05-01
+
+## Context
+
+The shipped MVP used four tabs (Program / Workout / Progress / Settings). The Workout tab was a state-machine router with no content when idle — it was a "place" the user only visited to start a session, not a real surface. Settings had become a kitchen sink (API keys + scanner launcher + regenerate + training profile + dev tools). The daily flow on a cold launch took four taps before the user saw a prescription.
+
+This ADR depends on ADR-0002 (queue-shape programme): Today's state-machine semantics assume queue progression rather than calendar-anchored sessions.
+
+## Decision
+
+Collapse to **three tabs — Today / Program / Progress** — with Settings reachable via a gear icon in Today's nav bar. Today is a state machine with three explicit states:
+
+1. **Pre-session** — landing surface when no session is live. Hero is "Up next" (queue head from ADR-0002), with greeting+streak chip, last-session card (collapsible log), AI signals strip, recent+up-next strip, and a footer link to the Program tab.
+2. **Live-session** — `WorkoutView` is the **root** of Today's NavigationStack. Pop-back is impossible because there's nothing behind it. Tab bar stays visible (mid-session escape to Program / Progress is allowed and preserves session state). Mid-session backward review of the current session lives in a swipe-down `Session Log` sheet on `ActiveSetView`.
+3. **Post-session** — full-screen celebration summary fires on completion → dismisses to a distinct post-session surface with the populated session log (exercises, weights, reps, RPE) front-and-centre, "Up next" deferred to a small footer line, and the E2 de-dupe confirmation card from ADR-0001 placed near the bottom (post-session bookkeeping, not the celebration).
+
+Post-session state reverts to pre-session at **4am calendar-day flip** (anchored to user's local clock, immune to app foregrounding mid-night).
+
+## Considered Options
+
+Four navigation-shape alternatives:
+
+- **(A) Add Today as a 5th tab** alongside the existing four. Rejected: HIG-borderline, doesn't address the Workout-tab-is-empty-when-idle problem, and Settings remains the kitchen sink.
+- **(B) Replace Program with Today**. Rejected: loses the calendar (queue list, post-ADR-0002) as a first-class surface; users still want to browse the full programme.
+- **(C) Collapse Workout into Today, Settings → gear icon (chosen).** Workout disappears as a tab; Today's state machine owns pre-/in-/post-session. Three tabs total.
+- **(D) Hub-and-spoke (no tabs).** Single feed, every surface a card. Rejected: bigger rewrite than v2 warrants and loses the mental separation between "what's now" / "the plan" / "how I'm trending."
+
+Within the chosen (C) shape, three sub-variants for the **live-session state** were weighed:
+
+- **L1 — Workout is Today's root (chosen).** No pop-back. Tab bar visible. Already aligned with the shipped P4-E3 architecture (Workout was promoted to the Program-tab nav stack rather than full-screen-cover); this just makes Workout the root of Today's stack instead.
+- **L2 — Workout pushed on top of Today; Today root becomes a Live Control Panel** with pause/end-early/Session-Log content. Rejected: redundant with affordances already in `ActiveSetView`; doubles the surface for the same data.
+- **L3 — Workout pushed on top; Today root shows pre-session UI** ("Up next: …"). Rejected: confusing — showing "Up next: Push A" while the user is mid-set in Push A.
+
+Three sub-variants for the **post-session state**:
+
+- **P1 — Summary as full-screen takeover, then snap directly to pre-session ("Up next").** Rejected: transitionally jarring — the user just finished, they don't want the app immediately pushing the next session.
+- **P2 — Today's post-session state IS the summary, persists until manual dismiss.** Rejected: no celebration moment.
+- **P3 — Hybrid: full-screen summary fires on completion, dismisses to a distinct post-session surface that persists until the next calendar-day flip (chosen).** Celebration moment + persistent reference surface.
+
+Sub-variants for the **revert trigger** from post-session → pre-session:
+
+- **R1 — Calendar-day flip with 4am cutoff (chosen).** Predictable, automatic, late-night-session-friendly.
+- **R2 — Next session started.** Rejected: post-session sticks for arbitrarily long if user doesn't train.
+- **R3 — Manual dismiss only.** Rejected: friction for no benefit.
+- **R4 — Either-or hybrid.** Rejected: complexity without clear win.
+
+Sub-variants for **Up Next visibility on the post-session screen**:
+
+- **U1 — Fully hidden.** Rejected: hides useful info.
+- **U2 — Small footer card** ("Up next: Pull A — when you're ready," no Start CTA) (chosen). Acknowledges queue continues without competing with celebration framing.
+- **U3 — Secondary card below the log.** Rejected: too prominent; starts to look like pre-session shape.
+
+## Consequences
+
+- The Workout tab disappears entirely; live-session badge state moves to Today's tab badge.
+- Settings becomes a gear icon in Today's nav bar — content is reduced (per follow-up Settings reorganisation work).
+- Crash recovery and migration alerts collapse into Today's hero card rather than firing as launch-time alert dialogs (eliminates pain point #3 from the v2 design).
+- Live Activities and Dynamic Island deep-links land in `ActiveSetView` (Today's root in live-session state), no intermediate router needed.
+- The post-session state-transition trigger (4am local) intentionally uses the local calendar even though the *programme* (per ADR-0002) is calendar-free — "today" is a local-clock concept for the user, even when the programme isn't.

--- a/docs/adr/0004-drop-gym-scanner-adopt-global-equipment-catalog.md
+++ b/docs/adr/0004-drop-gym-scanner-adopt-global-equipment-catalog.md
@@ -1,0 +1,52 @@
+# Drop the gym scanner; adopt a global AI-grown equipment catalog
+
+**Status**: accepted, 2026-05-01
+
+## Context
+
+The shipped MVP includes a Vision-API gym scanner (`GymScanner/` directory: `CameraManager`, `ScannerView`, `ScannerViewModel`, `EquipmentMerger`, `VisionAPIService`, `SystemPrompt_GymScan.txt`). It captures equipment via camera and infers presence via Anthropic Vision. P1-T02 already retreated from "Vision returns weight ranges" to presence-only because Vision was unreliable on weight inference; P1-T12 already changed from continuous-pan to single-shot per-equipment. In real-world use at large commercial gyms, the scanner is socially awkward (photographing an unfamiliar gym), incomplete (50+ machines can't be panned in one session), and post-scan cleanup is needed regardless. The structured `EquipmentType` enum has ~26 cases plus a `case unknown(String)` escape hatch, but specialty gear common at large gyms (hip thrust, GHD, T-bar row, trap bar, belt squat, plate-loaded variants, calf raise, abductor/adductor, sissy squat, sled) has no first-class representation.
+
+This ADR is referenced by ADR-0005 (trainee model): equipment data feeds the trainee model's session-generation context via the gym profile, and the multi-gym semantics in ADR-0005 inherit the catalog architecture decided here.
+
+## Decision
+
+Two coupled changes:
+
+1. **Retire the gym scanner entirely.** Delete `GymScanner/` directory and the gym-scan system prompt. Drop AVFoundation usage from onboarding. Drop the camera permission request from the onboarding flow.
+2. **Adopt a global, AI-grown equipment catalog (C5).** New `equipment_catalog` Postgres table, scoped *globally* (no `user_id` foreign key), seeded with the existing ~26 structured types plus ~10 specialty additions. The catalog grows organically: when a user types a machine name not present in the catalog, an Anthropic inference call infers structured metadata (category, weight type, default max, default increment, primary muscle groups), the user reviews/edits, and the new entry is written to the global catalog plus referenced by the user's `gym_profiles.equipment` row. Per-gym overrides (this gym's max is 35kg not the default 50kg) live on the user's gym profile, not the catalog. The `case unknown(String)` enum case becomes obsolete and is removed.
+
+Equipment-onboarding flow without scanner: a single scrollable list of equipment items with **most common at top, specialty below**, tap-to-select. A search input at the top handles tail items — types not in the list trigger AI inference → user confirms → catalog grows.
+
+**List sort order**: items are sorted by **frequency of selection across the global catalog** (descending). On cold start (empty global usage data), an initial developer-curated ordering seeds the list — barbell / dumbbell / cable / power rack / adjustable bench / etc. at the top; specialty plate-loaded and machine variants below. Once usage data accrues (≥50 selections per item across all users), frequency replaces the curated ordering. Alphabetical sort is offered as a search-time secondary order; not the default. Documented in code as a single source of truth so the ordering doesn't drift from this commitment.
+
+## Considered Options
+
+Five catalog-growth alternatives:
+
+- **(C1) Static expanded catalog.** Manually expand the structured `EquipmentType` enum with ~30 specialty cases, owned by the developer. Rejected: maintenance treadmill — the long tail is infinite, and someone has to keep adding gear forever.
+- **(C2) Keep current catalog, lean on `unknown(String)` heavily.** Surface "Add custom" prominently; AI receives free-text names and reasons about them. Rejected: underuses the structured catalog. Most equipment is well-known and *should* be structured (with proper increments, exercise mapping); custom-as-default loses signal.
+- **(C3) Hybrid: moderate static expansion + first-class custom equipment** (~10 specialty additions plus a structured custom-equipment flow). Was the assistant's initial recommendation; rejected in favour of (C5) on user pushback.
+- **(C4) Per-user AI inference, no global persistence.** Each user pays the inference cost separately for the same equipment. Rejected: wasteful at multi-user scale (P-B alpha test); each new user re-pays AI for known machines.
+- **(C5) Global AI-grown catalog (chosen).** First user to encounter a machine pays the inference cost; the catalog persists globally; subsequent users hit the cache. Self-improving. Aligned with multi-user trajectory (alpha test under (P-B) becomes the seeding cohort).
+
+Two scanner-retirement sub-variants:
+
+- **Keep scanner code dormant** in case we want to revive it later. Rejected: dead code rots; the deferred decision becomes a future cleanup task. If revived later, re-implement against the catalog architecture rather than restoring stale code.
+- **Retire entirely (chosen).** `GymScanner/` deleted, dependencies (AVFoundation usage in onboarding, Vision API key path, camera permission prompt) removed.
+
+Two onboarding-flow sub-variants for batch equipment entry:
+
+- **Starter packs ("Commercial Gym Starter Pack" / "Home Gym" / "Hotel Gym" presets, each adds ~30 items in one tap).** Rejected: presets are an extra layer of indirection — the user already has to know which preset matches their gym, at which point they might as well just tap items.
+- **Single scrollable list, common at top, search for tail (chosen).** Tap-to-select for known items; search + AI inference for specialty. Simplest direct flow.
+
+One catalog-moderation sub-variant for multi-user scale:
+
+- **Global catalog with no moderation** (any user-created catalog entry becomes immediately authoritative for all future users). Rejected for v3+ scale where adversarial or low-quality entries become a real risk. **Acceptable for v2 alpha-test under (P-B)** because the user cohort is the developer plus ~5 trusted friends — pre-moderation acceptance is fine at this scale. Multi-user post-launch (v3) will need a moderation/report mechanism (community flag, admin review, reputation-weighted edits, or pre-acceptance review for new entries). Documented here so future v3 readers see the alpha-test assumption was deliberate and not an oversight.
+
+## Consequences
+
+- The `case unknown(String)` enum case is removed via a phased migration: **Phase 0** — the v2 release ships with backfill code that reads existing `gym_profiles.equipment` rows referencing `unknown(String)`, runs an Anthropic inference call per unique unknown name, writes catalog entries, and rewrites the gym-profile rows to reference catalog IDs. Phase 0 runs once per user on first launch of the v2 build; failures are logged and the user is prompted to manually add unmatched items at next gym-profile edit. **Phase 1** — once Phase 0 has rolled out and backfill is verified complete, the `unknown(String)` enum case is deleted from the codebase and the migration code is removed in a follow-up release. Rollback: if Phase 0 backfill fails for any user, the `unknown(String)` rows persist in their gym profile and the enum case survives until manual reconciliation; the system never silently loses data.
+- API key configuration loses the camera-vision dependency; the only remaining Vision API surface is set-by-set inference and macro/session generation (per ADR-0005's prompt architecture).
+- Multi-gym onboarding (under ADR-0005's gym-aware Stage 2 generation) becomes faster: the same catalog seeds every new gym profile, only per-gym overrides differ.
+- Cold-start cost for the very first user (empty global catalog) is bounded for a typical commercial gym — most items match the developer-seeded ~36-entry catalog, requiring only a handful of inference calls for genuinely specialty items. **Specialty-heavy gyms (powerlifting, CrossFit, strongman) may require 20+ inference calls during cold-start** because more equipment falls outside the seed; this is mitigated by the catalog growing rapidly across early users (the first powerlifting-gym alpha tester pays the inference cost once, the second hits cache for the same items). Each call produces a permanent catalog entry that benefits all future users.
+- The catalog grows monotonically; no per-user pollution of the global record (per-gym corrections live on the user's gym profile). Bad inference results can be edited at the user's gym profile without affecting the global catalog; a moderation/report mechanism for the global catalog is deferred to multi-user post-launch.

--- a/docs/adr/0005-persistent-structured-trainee-model.md
+++ b/docs/adr/0005-persistent-structured-trainee-model.md
@@ -1,0 +1,86 @@
+# Persistent structured trainee model
+
+**Status**: accepted, 2026-05-01
+
+## Context
+
+Pre-v2, the AI inferred user state from raw `set_logs` on every session: e1RM trends came from `StagnationService` (Epley over a 3-session window), volume gaps from `VolumeValidationService` (sets-per-week vs target, calendar-week-shaped), per-pattern phases from `PatternPhaseService`. Episodic notes lived in pgvector via `MemoryService` and were retrieved by semantic similarity at inference time. Coaching cues felt generic because the AI was rebuilding its understanding of the user from raw logs every session — there was no aggregated, structured behavioural memory across sessions. RAG handled episodic recall but couldn't aggregate ("the user has had 5 left-shoulder mentions in 10 sessions" is not a query RAG answers natively).
+
+This ADR is tightly coupled to ADR-0006 (server-side update logic): the trainee model's update rules run server-side via Edge Function. It also references ADR-0002 (queue-shape progression for window definitions) and is referenced by ADR-0004 (gym profile feeds session-generation context).
+
+## Decision
+
+Build a **persistent, structured trainee model** — a typed object per user, persisted in Supabase, updated after every completed session, consulted before every prescription. It supersedes scattered services and centralises behavioural state.
+
+**Relationship to `MesocycleSkeleton`**: the queue itself (the ordered list of session slots from ADR-0002) is **not** a field on `TraineeModel`. The skeleton lives on the existing `programs` table (`programs.mesocycle_json` JSONB), is per-programme-per-user, and represents the structural plan. `TraineeModel` represents the *behavioural model of the user* — capability, recovery, goal, projections — and is consulted alongside the skeleton during session generation. The two are kept separate because they have different update cadences (skeleton mutates on regenerate / phase boundary; trainee model mutates after every session) and different ownership (skeleton is the AI's plan; trainee model is the user's learned profile). `TraineeModel` may carry an `activeProgramId: UUID` reference for join purposes, but the skeleton is read from `programs` at consumption time, not duplicated.
+
+Top-level shape of `TraineeModel` (stored fields):
+
+- `goal: GoalState` — plain-language goal + focus areas; no numerical targets at onboarding.
+- `projections: ProjectionState?` — floor (capability-based, immovable) + stretch (user-adjustable upward only); set at calibration review (fires when ≥4 of 6 major patterns reach `.established` per-axis confidence — typically ~6–8 sessions of normal training, but the threshold is the rule, not the heuristic), re-derived silently on goal renegotiation.
+- `patterns: [MovementPattern: PatternProfile]` — phase, RPE-offset, recovery (two-dimensional NM + metabolic), per-axis confidence, transition-mode flag.
+- `muscles: [MuscleGroup: MuscleProfile]` — volume tolerance, observed sweet spot (current-context estimate, varies with phase), volume deficit (queue-event-windowed per ADR-0002), focus weight from goal.
+- `exercises: [String: ExerciseProfile]` — per-exercise capability (EWMA over last 5 valid top sets, validity 3–10 reps), median capability alongside peak, learning-phase flag (`sessionCount < 10`), form-degradation flag (RAG-fed).
+- `activeLimitations: [ActiveLimitation]` + `clearedLimitations` — injury / pain state per pattern / muscle / joint; AI-inferred limitations require ≥2 corroborating evidence and cap at `.mild` until user-confirmed.
+- `fatigueInteractions: [FatigueInteraction]` — cross-pattern carryover patterns; surface in prompts only at confidence ≥ 0.7 with ≥15 paired observations.
+- `prescriptionAccuracy: [MovementPattern: [SetIntent: PrescriptionAccuracy]]` — meta-coaching: the AI's own bias and RMSE per pattern × intent.
+- `prescriptionIntentMismatches: [PrescriptionIntentMismatch]` — diagnostic log (inspection-only, capped at 50; not used for rate analytics).
+- `transfers: [TransferKey: ExerciseTransfer]` — per-user-learned cross-exercise transfer coefficients with R²; gated on ≥5 paired observations.
+- `bodyweight: BodyweightHistory` — passive logging.
+- `lifeContextEvents: [LifeContextEvent]` — disruption history, persist-only in v2 (consumption deferred).
+
+Computed properties (derived at read time, not stored):
+
+- `isReadyForCalibrationReview: Bool` — true iff ≥4 of 6 major patterns are at `.established` AND calibration review has not yet fired.
+- `disruptedPatterns: [MovementPattern]` — derived from per-pattern `sessionsCadenceDays` and `daysSinceLastSession`; a pattern is disrupted when current absence exceeds 2× typical cadence. Consumed by B5 (programme-reacts-to-life-context) coaching prompts.
+- `shouldFireGlobalPhaseAdvance: Bool` — derived from per-pattern `lastPhaseTransitionAtSessionCount`; fires when ≥4 major patterns transitioned within a 6-session window.
+
+RAG (`MemoryService`) is reframed as a **sensor that feeds structured fields** — not demoted, not parallel. A periodic cadence (after every session that adds a new note) runs a single multi-classification LLM call producing both per-exercise form-degradation counts and per-joint limitation evidence; both feed the trainee model as structured updates.
+
+`SetIntent` (`.warmup | .top | .backoff | .technique | .amrap`) is a required field on every set with no silent defaults at any layer. AI prescriptions without intent fail validation and re-prompt. Freestyle user-logged sets present an explicit picker. Intent gates which sets contribute to e1RM (only `.top`, validity 3–10 reps), volume aggregation (warmup/technique zero-weighted), and RPE calibration (top + amrap full, backoff half, others excluded).
+
+## Considered Options
+
+Three top-level alternatives:
+
+- **Continue with raw-logs-each-session.** Rejected: this is the current behaviour and produces generic coaching cues — every session re-derives user state from scratch, never building persistent behavioural memory.
+- **Pure RAG, no structured model.** Rejected: RAG retrieves semantically similar episodic notes but can't aggregate ("how has shoulder felt over the last 6 sessions" isn't a similarity-search query). Aggregation is what makes structured.
+- **Structured trainee model alongside RAG, with RAG-feeds-structured (chosen).** Best of both — episodic recall via RAG, aggregated behavioural memory via structured fields, with explicit pipeline where periodic RAG summarisation populates structured updates.
+
+Sub-variants within the structured model (this is where the real grilling happened):
+
+- **Confidence: global enum vs per-axis.** Chose per-axis. Global confidence (`.bootstrapping | .calibrating | .established | .seasoned`) was a lie when half the patterns had no data; each `PatternProfile` / `MuscleProfile` / `ExerciseProfile` carries its own.
+- **e1RM update: Bayesian vs rolling-window vs EWMA.** Chose EWMA (α = 0.333, N = 5, validity 3–10 reps). Bayesian was hand-waved; plain rolling-window weights all observations equally regardless of recency; EWMA is the honest middle. With a transition-mode collapse (when `inTransitionMode` from calibration-recency / phase-transition / long-absence triggers, window collapses to 3 most recent **sessions** — heaviest top set per session, plain mean, sample variance with Bessel correction — to avoid measuring intra-session consistency rather than recent capability across sessions).
+- **e1RM window: top sets vs sessions.** Chose top-set-counted (last 5 valid top sets, possibly multiple per session in 5×5 programmes). Cadence derives from unique session days within the window.
+- **Capability: peak only vs median + peak.** Chose both. Default prescription targets median (typical-day capability); peak is stretch reference for unusually-good days only. Real coaches prescribe to typical, not peak.
+- **Recovery: single-dimensional vs two-dimensional.** Chose two-dimensional (NM + metabolic). Single dimension was wrong for hybrid hypertrophy/strength trainees where heavy 1–3RM and high-rep moderate work tax different systems with different decay curves. Stimulus dimension is classified per set via joint intensity-and-reps consideration with low-stimulus sets (warmup, technique) explicitly excluded via `Optional` return.
+- **Capability granularity: pattern-level only vs exercise-level.** Chose exercise as source of truth, pattern as aggregator. Cross-exercise transfer (C3) needs exercise-level granularity to reason "bench got stronger, OHP/dips should bump."
+- **Transfer matrix: static literature defaults vs learned per-user.** Chose learned per-user, gated on ≥5 paired observations. Static defaults dressed up guesses as values; refusing to propagate until paired observations exist is honest. Cold-start cost: first ~30 sessions per pair give no transfer benefit.
+- **Linearity assumption for transfers.** Chose log residuals + Spearman-correlation flag at ≥10 observations + additional SE widening proportional to residual stddev when flagged. Doesn't fit a non-linear model (overkill for v2); detects when linearity is wrong and widens uncertainty accordingly.
+- **`StimulusResponseProfile` (.volumeBiased / .balanced / .intensityBiased): include vs drop.** Dropped. Single global label was a fortune-cookie; per-muscle would require multi-phase data with meaningful variation that v2 single-user won't generate quickly enough to be useful.
+- **Fatigue interaction confidence: count-only vs count × consistency.** Chose count × consistency. `consistencyFactor = max(0, min(1, 1 - stddev/|mean|))` over last 10 observations, with a 0.001 mean-guard for delta-percent values. Hard cap of 0.5 below 15 observations; surfacing threshold 0.7. Practical effect: fatigue interactions don't surface in prompts for the first ~30 sessions per pair.
+- **Goal: numerical targets at onboarding vs plain-language → calibration-review projections.** Chose plain-language at onboarding, projections at calibration review. Day-1 numerical targets were pseudo-precision — the AI doesn't have data to project honestly on session 1.
+- **Calibration: named "test block" vs continuous.** Chose continuous. No "Assessment Block" / "Week 1 Test" surface; first ~6–8 sessions are normal training, calibration review fires once when per-axis confidences mature.
+- **Reassessment cadence: fixed (every 6 / every 12) vs phase-tied.** Chose phase-tied. Light reassessment per-pattern at phase midpoints/transitions (silent, model-internal); heavy reassessment when ≥4 of 6 major patterns transition phase within a 6-session window (UI screen + goal renegotiation).
+- **Set intent silent defaults vs explicit-everywhere.** Chose explicit-everywhere. AI prescriptions without intent fail validation; freestyle sets prompt at log time; migration happens in three phases with code validation shipping before DB migration so no write-window gap exists.
+- **AI-inferred limitations: corroboration thresholds.** Chose ≥2 corroborating evidence required, cap at `.mild` severity until user-confirmed via UI.
+- **Form-degradation classifier: separate vs integrated with limitation classifier.** Chose integrated single LLM call with structured multi-part output. Form-degradation and limitations are independent signals — a note can contribute to both.
+- **Day boundaries for cadence: device-local vs UTC vs pre-bucketed local.** Chose pre-bucketed `localDate` string at write time. Immune to subsequent timezone changes (user travels Sydney → Tokyo without breaking cadence calculations).
+- **Disruption history (`lifeContextEvents`): act now vs persist-only vs defer.** Chose persist-only — cheap detection seeds v2.5 work for free without committing to a consumption design now.
+
+## Consequences
+
+### Service supersession
+
+- `StagnationService` is superseded — its Epley-based logic moves into the trainee-model update routine, output lives on `MuscleProfile.stagnationStatus` and `PatternProfile.trend`.
+- `VolumeValidationService` is superseded with semantics fix — output lives on `MuscleProfile.volumeDeficit`, windowed over last 7 training events (not calendar weeks per ADR-0002).
+- `PatternPhaseService` is partially folded in — phase storage moves to `PatternProfile.currentPhase` + `sessionsInPhase`, advance logic gains plateau-awareness (clearly plateaued patterns no longer auto-advance).
+- `MemoryService` (RAG) is reframed as a sensor — kept and extended with `summariseRecentNotes()` cadence that classifies form-degradation + limitations into structured trainee-model fields. Not demoted; the RAG embedding pipeline still runs for episodic semantic search at set-by-set inference time.
+
+### Implementation consequences
+
+- `WorkoutContext` payload becomes a `TraineeModelDigest` — a request-time projection of relevant trainee-model fields, narrower than the full model (token economics).
+- Update rules run server-side via Supabase Edge Function (per ADR-0006); idempotency at DB layer; client posts session-completion events via the existing `WriteAheadQueue` rails.
+- The `MovementPattern` enum is cleaned to motion patterns only — calves and core are removed (calves contribute to `legs` muscle-group volume aggregation; core is not modelled as a first-class trainee axis in v2).
+- `MuscleGroup` is locked at six (back / chest / biceps / shoulders / triceps / legs) — drives both the trainee model's per-muscle storage and the Progress tab's narrative cards.
+- The trainee model is the AI's *behavioural memory*; the `MesocycleSkeleton` (ADR-0002) is the AI's *plan*. Session generation reads both: skeleton for what's queued next, trainee model for who the user is. Keeping them separate means each can evolve independently — the skeleton can be regenerated without losing trainee-model state, and the trainee model accumulates across multiple regenerated programmes.

--- a/docs/adr/0006-server-side-trainee-model-update-logic.md
+++ b/docs/adr/0006-server-side-trainee-model-update-logic.md
@@ -1,0 +1,69 @@
+# Server-side trainee-model update logic via Supabase Edge Function
+
+**Status**: accepted, 2026-05-01
+
+## Context
+
+The trainee model defined in ADR-0005 needs an update routine that runs after every completed session: fits the EWMA, recomputes trends, updates RPE-offsets, recovery rates, fatigue interactions, prescription accuracy, transfer coefficients, and so on. The routine touches every section of the model and contains the most behaviourally significant business logic in v2. Where it runs determines how consistent the logic is across users, how easy it is to fix bugs, and how multi-user-ready the system is when (P-B) lands at end of v2.
+
+Solo v2 doesn't strictly require server-side. But the multi-user pivot is on the immediate roadmap, and the trainee model logic is exactly the kind of per-user computation that must produce identical results for every user regardless of which client version they're running. The user explicitly pushed for "server-side from day 1" rather than retrofitting later.
+
+This ADR is tightly coupled to ADR-0005 (the trainee model itself) — neither makes sense without the other. The decision here determines where the model's update rules live and how they're invoked.
+
+## Decision
+
+Trainee-model update logic runs **server-side, from day 1**, via a Supabase Edge Function calling a Postgres stored procedure within a transaction. Implementation:
+
+1. **Schema:**
+   ```sql
+   CREATE TABLE trainee_models (
+       user_id UUID PRIMARY KEY REFERENCES users(id),
+       created_at TIMESTAMPTZ DEFAULT NOW(),
+       updated_at TIMESTAMPTZ DEFAULT NOW(),
+       session_count INTEGER DEFAULT 0,
+       model_json JSONB NOT NULL
+       -- No global confidence_level column. Per-axis confidence (per ADR-0005)
+       -- lives inside model_json on each PatternProfile / MuscleProfile /
+       -- ExerciseProfile. Calibration-review readiness is computed at read time
+       -- from those per-axis values, not stored at top level.
+   );
+   
+   CREATE TABLE trainee_model_applied_sessions (
+       user_id UUID NOT NULL,
+       session_id UUID NOT NULL,
+       applied_at TIMESTAMPTZ DEFAULT NOW(),
+       PRIMARY KEY (user_id, session_id)
+   );
+   ```
+
+2. **Idempotency at the DB layer.** The `(user_id, session_id) PRIMARY KEY` on `trainee_model_applied_sessions` is the idempotency mechanism. The stored procedure inserts into this table inside the same transaction as the model update; `ON CONFLICT DO NOTHING` short-circuits duplicate session submissions. Retries from `WriteAheadQueue` replay, network retry, or crash recovery converge to a single applied update.
+
+3. **Client integration via existing rails.** Session completion writes a "trainee_model_update" item to the existing `WriteAheadQueue` (per shipped P3-T06 architecture). On flush, the WAQ posts to the Edge Function. The Edge Function runs the stored procedure and returns the updated model snapshot. The client's local SwiftData cache (per F2) updates from the response. No new failure-mode design needed — reuses crash-sentinel + WAQ rails already shipped.
+
+4. **Single-device-per-user for v2** with a documented optimistic-concurrency migration path for v3+. Multi-device updates for the same user are not in scope; documented in code (`TraineeModel` block comment) and ARCHITECTURE.md.
+
+## Considered Options
+
+Three placement alternatives:
+
+- **Client-side update logic, eventual server move when needed.** All update rules in Swift; Supabase is just persistence. Rejected: when (P-B) lands at end of v2, every alpha-test friend on a slightly different app build runs slightly different update logic — coaching state diverges by client version. Retrofitting later means duplicating logic across Swift and Edge Function for the migration window, which is more work than starting server-side.
+- **Hybrid: some logic each side** (e.g., e1RM math client-side because it's hot-path, fatigue interactions server-side because they accumulate). Rejected: split-brain risk. Whichever side computes a field becomes authoritative; mixing means clients can disagree with the server about state and the resolution rule is non-obvious.
+- **Server-side from day 1 (chosen).** All update rules in the Edge Function / stored procedure. Client computes nothing authoritative; reads cached snapshot for prompt-digest assembly only.
+
+Sub-variants:
+
+- **Idempotency: in-app dedup vs DB-PK constraint.** Chose DB-PK. In-app dedup would require the Edge Function to query an "already applied" log before mutating, which is racy under concurrent retries. The PK constraint is atomic — `INSERT … ON CONFLICT DO NOTHING` succeeds iff this is the first apply, so the model update only runs once.
+- **Edge Function vs separate Node service.** Chose Edge Function. Supabase is already in the stack; deploying a separate Node service adds infrastructure (deployment pipeline, monitoring, secrets management, rollback story) without benefit for v2's scale.
+- **Client-side fallback when Edge Function is down.** Rejected. A client-side fallback path would mean two implementations of every update rule — the bug-divergence risk that motivated server-side in the first place. **What does happen when the Edge Function is unreachable**: the WAQ retains the session-completion event and retries on connectivity restoration; the local SwiftData cache continues to show the *last-known* trainee-model snapshot (from the most recent successful update); session-generation prompts and set-by-set inference run against that stale snapshot until connectivity is restored. The trainee model becomes briefly stale (last-completed session not yet reflected in capability estimates, recovery rates, etc.) but never inconsistent. User-visible effect: prescriptions for the next session may not yet reflect the most recent session's gains/fatigue; once connectivity returns and WAQ flushes, the model catches up and subsequent prescriptions adjust. No UI error is shown for routine outages — the WAQ retry is silent.
+- **Rule-versioning: forward-only vs auto-recompute.** Chose forward-only. When an update rule changes (e.g., re-tuning EWMA α from 0.333 to 0.30, or adding a new fatigue-interaction trigger), existing trainee-model rows continue from their current state with the new logic applied to subsequent updates. The alternative — auto-recompute from session-1 across the entire `set_logs` history under the new logic — would be the rigorous answer but requires a recompute pipeline (re-run all rules across N sessions of historical data per affected user, atomically, without losing user-visible state) which is non-trivial to build correctly. Auto-recompute is deferred to v2.5 as a backfill mode triggered explicitly per rule change. For v2: rule changes apply forward-only; documented per change in commit messages and ADRs (or supersession ADRs) so trainee-model evolution is auditable.
+- **Sync semantics: optimistic concurrency vs single-device-locked.** Chose single-device-locked for v2. Optimistic concurrency requires a `version: Int` column + retry-on-conflict logic; under (P-B) every alpha-test user has a single device, so the scenario doesn't arise. Migration path documented for v3+ (add version column, retry-on-conflict in stored procedure).
+- **Update fires from client async vs sync.** Chose async via WAQ. Synchronous "complete session → wait for trainee-model update → unblock UI" would add 200–500ms to the post-set-complete flow; async via WAQ keeps the UI responsive and the model is eventually consistent on the order of seconds.
+
+## Consequences
+
+- The trainee-model update logic — including all the math from ADR-0005 (EWMA, transition mode, two-dimensional recovery classification, fatigue interaction confidence, transfer regression, form-degradation cascade, etc.) — lives in Postgres-flavoured PL/pgSQL or in TypeScript inside the Edge Function. The math is non-trivial; testing strategy must include both Swift-side cache-population tests and server-side update-rule tests, with shared fixtures.
+- A deployment pipeline for Edge Functions is required (Supabase CLI, CI integration). The first deployment is the most expensive; subsequent updates ship via the same pipeline.
+- A versioning story for the update logic itself: when an update rule changes (e.g., we re-tune the EWMA α from 0.333 to 0.30), existing trainee-model rows don't auto-recompute — they continue from their current state with the new logic applied to subsequent updates. A backfill mode (recompute all sessions from scratch under new logic) is deferred to v2.5; documented as a known limitation.
+- Observability: the Edge Function should log structured events on every update (user_id, session_id, applied_at, durations) into a Supabase table or external log sink. Failure cases (validation errors, math edge cases, stored-procedure errors) need explicit logging because they're invisible to the client beyond "the WAQ retries."
+- The trainee-model JSONB column is a contract between Edge Function (writer) and client (reader for digest assembly). Schema migrations to the JSONB shape need to be coordinated — adding a new field is safe; renaming or removing requires a migration pass.
+- Multi-device support remains explicitly out of scope. If a v3 user wants the app on iPhone + iPad simultaneously, the documented optimistic-concurrency migration is the path: add `version: Int` column to `trainee_models`, change the stored procedure to read+version → mutate → write WHERE version = X with retry on conflict.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,39 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — ubiquitous-language glossary; terse term definitions with rejected synonyms.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (this is the layout for ProjectApex):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-out-of-order-session-semantics.md
+│   ├── 0002-queue-shape-programme-model.md
+│   ├── 0003-three-tab-navigation-today-state-machine.md
+│   ├── 0004-drop-gym-scanner-adopt-global-equipment-catalog.md
+│   ├── 0005-persistent-structured-trainee-model.md
+│   └── 0006-server-side-trainee-model-update-logic.md
+└── ProjectApex/      ← Swift sources
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0005 (persistent trainee model) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on `thearnavmenon/ProjectApex`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone (including from worktrees).
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

Materialises the design-session output (previously stuck on a worktree branch) onto `main` so that ADR / CONTEXT.md references in upcoming Phase 1 build slices resolve to real files. Pure docs — no code changes.

Lands:
- `docs/adr/0001..0006` — locked architectural decisions
- `CONTEXT.md` — domain glossary (ubiquitous language)
- `docs/agents/{domain,issue-tracker,triage-labels}.md` — agent skill specs
- `CLAUDE.md` — appends \`## Agent skills\` pointer block

Prerequisite for Issue #2 (Phase 1 / Slice 1 — TraineeModel domain layer). Without this, every comment citing ADR-0005 in upcoming code dangles.

Note: \`docs/agents/edge-functions.md\` was listed as a possible inclusion (from Slice 9a) but does not yet exist in the worktree, so it's not part of this PR.

## Test plan

- [ ] `main` contains all 11 files post-merge
- [ ] No code references break (none expected — pure additions, plus appended-only edit to `CLAUDE.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)