### PR TITLE
Phase 1 / Slice 1 — TraineeModel domain layer + MigrationDates (closes #2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,3 +17,17 @@ Default canonical vocabulary — `needs-triage`, `needs-info`, `ready-for-agent`
 ### Domain docs
 
 Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### Worktree-aware git commands (mandatory in `.claude/worktrees/*` sessions)
+
+When working inside a worktree (path matches `.claude/worktrees/<name>/`), every git-mutating command MUST be `git -C <worktree-absolute-path> <subcommand>` rather than relying on the shell's current working directory. The bash agent's `cd` does not reliably persist across tool calls, and a `git commit` that runs from the parent main repo silently lands the wrong files on the wrong branch. This was a real incident during Slice 1.
+
+Required form:
+
+```bash
+git -C /Users/arnav/Desktop/ProjectApex/.claude/worktrees/<name> add <paths>
+git -C /Users/arnav/Desktop/ProjectApex/.claude/worktrees/<name> commit -m "..."
+git -C /Users/arnav/Desktop/ProjectApex/.claude/worktrees/<name> push ...
+```
+
+Same rule for `git status`, `git log`, `git diff` when you need them to reflect the worktree's state. Read tools (`Read`, `grep` on absolute paths) are unaffected — they don't depend on cwd.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,12 +45,16 @@ _Avoid_: ambitious target, max goal
 ### Movement & sets
 
 **Movement pattern**:
-A type of motion (horizontal push, vertical pull, knee-dominant, hip-dominant, elbow flexion, etc.) — strictly motion taxonomy.
+A type of motion. Eight cases per the typed `MovementPattern` enum (Slice 1): `horizontalPush`, `verticalPush`, `horizontalPull`, `verticalPull`, `squat`, `hipHinge`, `lunge`, `isolation`. Strictly motion taxonomy — independent from muscle classification.
 _Avoid_: muscle group, exercise category
 
-**Muscle group**:
-One of six body-part groups (back, chest, biceps, shoulders, triceps, legs) — locked at six. Calves and core are not first-class muscle groups in v2.
-_Avoid_: movement pattern, body part (in code)
+**Muscle group** (trainee-model aggregation key):
+One of six body-part groups (back, chest, biceps, shoulders, triceps, legs) — locked at six. The trainee model's `muscles: [MuscleGroup: MuscleProfile]` keys on this. Calves and core are not first-class muscle groups in v2.
+_Avoid_: movement pattern, body part (in code), primary muscle (different concept — see below)
+
+**Primary muscle** (ExerciseLibrary classification, Slice 1):
+Finer-grained muscle classification carried on `ExerciseDefinition.primaryMuscle`. Nine cases: back, chest, biceps, shoulders, triceps, **quads, hamstrings, glutes, calves**. Used by AI prescription reasoning so the model can distinguish leg subgroups for muscle-balance coaching. Maps to `MuscleGroup` via `PrimaryMuscle.muscleGroup` (leg subgroups → `.legs`). Core is excluded — the 4 historical core exercises were removed from the library in Slice 1.
+_Avoid_: muscle group (different concept — primary muscle is finer-grained)
 
 **Set intent**:
 The required field on every set — `warmup`, `top`, `backoff`, `technique`, or `amrap`. No silent defaults at any layer. See ADR-0005.

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		51F067120CE1EA4A3EA813A6 /* MuscleTaxonomyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */; };
 		6ED5B7636B15C7C513C11C2E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC23D0A3EB460CF97B18574 /* Foundation.framework */; };
 		729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */; };
+		73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */; };
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -81,6 +82,7 @@
 		47E356DB2F61D07B00C69CD6 /* GymFactStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymFactStoreTests.swift; sourceTree = "<group>"; };
 		6DC23D0A3EB460CF97B18574 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		70E3BA94C76430CACFD657B5 /* EquipmentRounderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EquipmentRounderTests.swift; sourceTree = "<group>"; };
+		993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelSnapshotsTests.swift; sourceTree = "<group>"; };
 		E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MuscleTaxonomyTests.swift; sourceTree = "<group>"; };
 		EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelEnumsTests.swift; sourceTree = "<group>"; };
 		EFB324F8EA1B317B0F90575B /* ProjectApexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProjectApexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -202,6 +204,7 @@
 				E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */,
 				EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */,
 				1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */,
+				993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -333,6 +336,7 @@
 				51F067120CE1EA4A3EA813A6 /* MuscleTaxonomyTests.swift in Sources */,
 				39E16C19CFE1B1EF9BE00A32 /* TraineeModelEnumsTests.swift in Sources */,
 				729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */,
+				73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		32736E74E3F688020744DE5E /* EquipmentRounderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E3BA94C76430CACFD657B5 /* EquipmentRounderTests.swift */; };
+		39E16C19CFE1B1EF9BE00A32 /* TraineeModelEnumsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */; };
 		474B848D2F67D31C001E0879 /* MacroPlanServiceDayCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474B848C2F67D31C001E0879 /* MacroPlanServiceDayCountTests.swift */; };
 		478DD9F12F9928C6001D3636 /* SkipFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 478DD9F02F9928C5001D3636 /* SkipFeatureTests.swift */; };
 		478DD9F52F993A1E001D3636 /* PatternPhaseServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 478DD9F42F993A1E001D3636 /* PatternPhaseServiceTests.swift */; };
@@ -32,7 +33,10 @@
 		47E356CF2F61BFCF00C69CD6 /* EquipmentMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356CE2F61BFCF00C69CD6 /* EquipmentMergerTests.swift */; };
 		47E356DA2F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356D92F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift */; };
 		47E356DC2F61D07B00C69CD6 /* GymFactStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356DB2F61D07B00C69CD6 /* GymFactStoreTests.swift */; };
+		51F067120CE1EA4A3EA813A6 /* MuscleTaxonomyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */; };
 		6ED5B7636B15C7C513C11C2E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC23D0A3EB460CF97B18574 /* Foundation.framework */; };
+		729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */; };
+		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +50,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MigrationDatesTests.swift; sourceTree = "<group>"; };
 		474B848C2F67D31C001E0879 /* MacroPlanServiceDayCountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroPlanServiceDayCountTests.swift; sourceTree = "<group>"; };
 		478DD9F02F9928C5001D3636 /* SkipFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkipFeatureTests.swift; sourceTree = "<group>"; };
 		478DD9F42F993A1E001D3636 /* PatternPhaseServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternPhaseServiceTests.swift; sourceTree = "<group>"; };
@@ -76,12 +81,17 @@
 		47E356DB2F61D07B00C69CD6 /* GymFactStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymFactStoreTests.swift; sourceTree = "<group>"; };
 		6DC23D0A3EB460CF97B18574 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		70E3BA94C76430CACFD657B5 /* EquipmentRounderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EquipmentRounderTests.swift; sourceTree = "<group>"; };
+		E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MuscleTaxonomyTests.swift; sourceTree = "<group>"; };
+		EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelEnumsTests.swift; sourceTree = "<group>"; };
 		EFB324F8EA1B317B0F90575B /* ProjectApexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProjectApexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MovementPatternTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		47D91BC22F60266A007B3B34 /* ProjectApex */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = ProjectApex;
 			sourceTree = "<group>";
 		};
@@ -188,6 +198,10 @@
 				47DFED062F73D887006F4B62 /* VolumeValidationServiceTests.swift */,
 				478DD9F02F9928C5001D3636 /* SkipFeatureTests.swift */,
 				478DD9F42F993A1E001D3636 /* PatternPhaseServiceTests.swift */,
+				FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */,
+				E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */,
+				EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */,
+				1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -315,6 +329,10 @@
 				47D91CC12F61A9E7007B3B34 /* WorkoutContextAssemblyTests.swift in Sources */,
 				478DD9F52F993A1E001D3636 /* PatternPhaseServiceTests.swift in Sources */,
 				47E356DC2F61D07B00C69CD6 /* GymFactStoreTests.swift in Sources */,
+				89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */,
+				51F067120CE1EA4A3EA813A6 /* MuscleTaxonomyTests.swift in Sources */,
+				39E16C19CFE1B1EF9BE00A32 /* TraineeModelEnumsTests.swift in Sources */,
+				729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */; };
 		81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */; };
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
+		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,6 +88,7 @@
 		85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelInteractionsTests.swift; sourceTree = "<group>"; };
 		878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelProfilesTests.swift; sourceTree = "<group>"; };
 		993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelSnapshotsTests.swift; sourceTree = "<group>"; };
+		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
 		E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MuscleTaxonomyTests.swift; sourceTree = "<group>"; };
 		EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelEnumsTests.swift; sourceTree = "<group>"; };
 		EFB324F8EA1B317B0F90575B /* ProjectApexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProjectApexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -211,6 +213,7 @@
 				993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */,
 				85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */,
 				878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */,
+				DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -345,6 +348,7 @@
 				73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */,
 				81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */,
 				6ECE420C1031E80360FF1EFE /* TraineeModelProfilesTests.swift in Sources */,
+				B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		6ED5B7636B15C7C513C11C2E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC23D0A3EB460CF97B18574 /* Foundation.framework */; };
 		729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */; };
 		73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */; };
+		81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */; };
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -82,6 +83,7 @@
 		47E356DB2F61D07B00C69CD6 /* GymFactStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymFactStoreTests.swift; sourceTree = "<group>"; };
 		6DC23D0A3EB460CF97B18574 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		70E3BA94C76430CACFD657B5 /* EquipmentRounderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EquipmentRounderTests.swift; sourceTree = "<group>"; };
+		85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelInteractionsTests.swift; sourceTree = "<group>"; };
 		993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelSnapshotsTests.swift; sourceTree = "<group>"; };
 		E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MuscleTaxonomyTests.swift; sourceTree = "<group>"; };
 		EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelEnumsTests.swift; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 				EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */,
 				1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */,
 				993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */,
+				85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -337,6 +340,7 @@
 				39E16C19CFE1B1EF9BE00A32 /* TraineeModelEnumsTests.swift in Sources */,
 				729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */,
 				73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */,
+				81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		47E356DA2F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356D92F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift */; };
 		47E356DC2F61D07B00C69CD6 /* GymFactStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356DB2F61D07B00C69CD6 /* GymFactStoreTests.swift */; };
 		51F067120CE1EA4A3EA813A6 /* MuscleTaxonomyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */; };
+		5DE94F8F1D136C65C96FCAD1 /* WeekFatigueSignalsHelperAgreementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4422DE7829C0C124138BB4B0 /* WeekFatigueSignalsHelperAgreementTests.swift */; };
 		6ECE420C1031E80360FF1EFE /* TraineeModelProfilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */; };
 		6ED5B7636B15C7C513C11C2E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC23D0A3EB460CF97B18574 /* Foundation.framework */; };
 		729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */; };
@@ -55,6 +56,7 @@
 
 /* Begin PBXFileReference section */
 		1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MigrationDatesTests.swift; sourceTree = "<group>"; };
+		4422DE7829C0C124138BB4B0 /* WeekFatigueSignalsHelperAgreementTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeekFatigueSignalsHelperAgreementTests.swift; sourceTree = "<group>"; };
 		474B848C2F67D31C001E0879 /* MacroPlanServiceDayCountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroPlanServiceDayCountTests.swift; sourceTree = "<group>"; };
 		478DD9F02F9928C5001D3636 /* SkipFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkipFeatureTests.swift; sourceTree = "<group>"; };
 		478DD9F42F993A1E001D3636 /* PatternPhaseServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternPhaseServiceTests.swift; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 				85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */,
 				878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */,
 				DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */,
+				4422DE7829C0C124138BB4B0 /* WeekFatigueSignalsHelperAgreementTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -349,6 +352,7 @@
 				81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */,
 				6ECE420C1031E80360FF1EFE /* TraineeModelProfilesTests.swift in Sources */,
 				B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */,
+				5DE94F8F1D136C65C96FCAD1 /* WeekFatigueSignalsHelperAgreementTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		47E356DA2F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356D92F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift */; };
 		47E356DC2F61D07B00C69CD6 /* GymFactStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356DB2F61D07B00C69CD6 /* GymFactStoreTests.swift */; };
 		51F067120CE1EA4A3EA813A6 /* MuscleTaxonomyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */; };
+		6ECE420C1031E80360FF1EFE /* TraineeModelProfilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */; };
 		6ED5B7636B15C7C513C11C2E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC23D0A3EB460CF97B18574 /* Foundation.framework */; };
 		729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */; };
 		73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */; };
@@ -84,6 +85,7 @@
 		6DC23D0A3EB460CF97B18574 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		70E3BA94C76430CACFD657B5 /* EquipmentRounderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EquipmentRounderTests.swift; sourceTree = "<group>"; };
 		85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelInteractionsTests.swift; sourceTree = "<group>"; };
+		878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelProfilesTests.swift; sourceTree = "<group>"; };
 		993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelSnapshotsTests.swift; sourceTree = "<group>"; };
 		E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MuscleTaxonomyTests.swift; sourceTree = "<group>"; };
 		EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelEnumsTests.swift; sourceTree = "<group>"; };
@@ -208,6 +210,7 @@
 				1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */,
 				993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */,
 				85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */,
+				878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -341,6 +344,7 @@
 				729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */,
 				73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */,
 				81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */,
+				6ECE420C1031E80360FF1EFE /* TraineeModelProfilesTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/Features/Program/ProgramDayDetailView.swift
+++ b/ProjectApex/Features/Program/ProgramDayDetailView.swift
@@ -1089,7 +1089,7 @@ struct ProgramDayDetailView: View {
             weightKg: newLog.weightKg,
             rpeFelt: newLog.rpeFelt,
             rirEstimated: newLog.rpeFelt.map { max(0, 10 - $0) },
-            primaryMuscle: ExerciseLibrary.primaryMuscle(for: newLog.exerciseId) ?? exerciseForLog?.primaryMuscle
+            primaryMuscle: ExerciseLibrary.primaryMuscle(for: newLog.exerciseId)?.rawValue ?? exerciseForLog?.primaryMuscle
         )
 
         do {
@@ -1111,7 +1111,7 @@ struct ProgramDayDetailView: View {
             rirEstimated: newLog.rpeFelt.map { max(0, 10 - $0) },
             aiPrescribed: nil,
             loggedAt: newLog.loggedAt,
-            primaryMuscle: ExerciseLibrary.primaryMuscle(for: newLog.exerciseId) ?? exerciseForLog?.primaryMuscle
+            primaryMuscle: ExerciseLibrary.primaryMuscle(for: newLog.exerciseId)?.rawValue ?? exerciseForLog?.primaryMuscle
         )
         var newGroups = historicalSetLogs
         newGroups[newLog.exerciseId, default: []].append(inserted)
@@ -1433,13 +1433,25 @@ private struct ExerciseDetailCard: View {
     // MARK: Helpers
 
     private func muscleColor(for muscle: String) -> Color {
+        // Typed-first dispatch (Slice 1) with substring-match fallback for
+        // non-canonical strings. Core branch removed — core is excluded from
+        // the locked-six taxonomy per ADR-0005.
+        if let primary = PrimaryMuscle(rawValue: muscle.lowercased()) {
+            switch primary {
+            case .chest:                            return Color(red: 0.96, green: 0.42, blue: 0.30)
+            case .back:                             return Color(red: 0.30, green: 0.70, blue: 0.96)
+            case .shoulders:                        return Color(red: 0.70, green: 0.50, blue: 0.96)
+            case .quads, .hamstrings, .glutes,
+                 .calves:                           return Color(red: 0.30, green: 0.96, blue: 0.60)
+            case .biceps, .triceps:                 return Color(red: 0.96, green: 0.80, blue: 0.30)
+            }
+        }
         let lower = muscle.lowercased()
         if lower.contains("pector") || lower.contains("chest") { return Color(red: 0.96, green: 0.42, blue: 0.30) }
         if lower.contains("lat") || lower.contains("back") || lower.contains("rhom") { return Color(red: 0.30, green: 0.70, blue: 0.96) }
         if lower.contains("delt") || lower.contains("shoulder") { return Color(red: 0.70, green: 0.50, blue: 0.96) }
         if lower.contains("quad") || lower.contains("hamstr") || lower.contains("glut") || lower.contains("calf") { return Color(red: 0.30, green: 0.96, blue: 0.60) }
         if lower.contains("bicep") || lower.contains("tricep") { return Color(red: 0.96, green: 0.80, blue: 0.30) }
-        if lower.contains("core") || lower.contains("abdom") { return Color(red: 0.96, green: 0.60, blue: 0.30) }
         return Color(red: 0.78, green: 0.82, blue: 0.88) // apexChrome fallback
     }
 
@@ -1662,13 +1674,25 @@ private struct CompletedExerciseCard: View {
     }
 
     private func muscleColor(for muscle: String) -> Color {
+        // Typed-first dispatch (Slice 1) with substring-match fallback for
+        // non-canonical strings. Core branch removed — core is excluded from
+        // the locked-six taxonomy per ADR-0005.
+        if let primary = PrimaryMuscle(rawValue: muscle.lowercased()) {
+            switch primary {
+            case .chest:                            return Color(red: 0.96, green: 0.42, blue: 0.30)
+            case .back:                             return Color(red: 0.30, green: 0.70, blue: 0.96)
+            case .shoulders:                        return Color(red: 0.70, green: 0.50, blue: 0.96)
+            case .quads, .hamstrings, .glutes,
+                 .calves:                           return Color(red: 0.30, green: 0.96, blue: 0.60)
+            case .biceps, .triceps:                 return Color(red: 0.96, green: 0.80, blue: 0.30)
+            }
+        }
         let lower = muscle.lowercased()
         if lower.contains("pector") || lower.contains("chest") { return Color(red: 0.96, green: 0.42, blue: 0.30) }
         if lower.contains("lat") || lower.contains("back") || lower.contains("rhom") { return Color(red: 0.30, green: 0.70, blue: 0.96) }
         if lower.contains("delt") || lower.contains("shoulder") { return Color(red: 0.70, green: 0.50, blue: 0.96) }
         if lower.contains("quad") || lower.contains("hamstr") || lower.contains("glut") || lower.contains("calf") { return Color(red: 0.30, green: 0.96, blue: 0.60) }
         if lower.contains("bicep") || lower.contains("tricep") { return Color(red: 0.96, green: 0.80, blue: 0.30) }
-        if lower.contains("core") || lower.contains("abdom") { return Color(red: 0.96, green: 0.60, blue: 0.30) }
         return Color(red: 0.78, green: 0.82, blue: 0.88)
     }
 }

--- a/ProjectApex/Features/Program/ProgramOverviewView.swift
+++ b/ProjectApex/Features/Program/ProgramOverviewView.swift
@@ -356,7 +356,7 @@ struct ProgramOverviewView: View {
             : 1.0
         return HStack(spacing: 10) {
             // Human-readable pattern name (e.g. "Horizontal Push")
-            Text(formatPatternName(state.pattern))
+            Text(formatPatternName(state.pattern.rawValue))
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(.white.opacity(0.75))
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -858,13 +858,26 @@ private struct DayCardView: View {
     }
 
     private func muscleColor(for muscle: String) -> Color {
+        // Typed-first dispatch (Slice 1). Falls back to substring-match for
+        // non-canonical strings (e.g. "pectoralis_major" coming from a free-form
+        // muscle field). Core branch removed — core is excluded from the
+        // locked-six taxonomy per ADR-0005.
+        if let primary = PrimaryMuscle(rawValue: muscle.lowercased()) {
+            switch primary {
+            case .chest:                            return Color(red: 0.96, green: 0.42, blue: 0.30)
+            case .back:                             return Color(red: 0.30, green: 0.70, blue: 0.96)
+            case .shoulders:                        return Color(red: 0.70, green: 0.50, blue: 0.96)
+            case .quads, .hamstrings, .glutes,
+                 .calves:                           return Color(red: 0.30, green: 0.96, blue: 0.60)
+            case .biceps, .triceps:                 return Color(red: 0.96, green: 0.80, blue: 0.30)
+            }
+        }
         let lower = muscle.lowercased()
         if lower.contains("chest") || lower.contains("pect") { return Color(red: 0.96, green: 0.42, blue: 0.30) }
         if lower.contains("back") || lower.contains("lat") { return Color(red: 0.30, green: 0.70, blue: 0.96) }
         if lower.contains("shoulder") || lower.contains("delt") { return Color(red: 0.70, green: 0.50, blue: 0.96) }
-        if lower.contains("leg") || lower.contains("quad") || lower.contains("glut") || lower.contains("hamstr") { return Color(red: 0.30, green: 0.96, blue: 0.60) }
+        if lower.contains("leg") || lower.contains("quad") || lower.contains("glut") || lower.contains("hamstr") || lower.contains("calf") { return Color(red: 0.30, green: 0.96, blue: 0.60) }
         if lower.contains("arm") || lower.contains("bicep") || lower.contains("tricep") { return Color(red: 0.96, green: 0.80, blue: 0.30) }
-        if lower.contains("core") { return Color(red: 0.96, green: 0.60, blue: 0.30) }
         return Color(red: 0.78, green: 0.82, blue: 0.88)
     }
 }

--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -481,8 +481,8 @@ final class ProgramViewModel {
             // daysSinceLastTrainedByPattern — aggregate deepLiftHistory by movement pattern
             var patternMostRecent: [String: Date] = [:]
             for log in deepLiftHistory {
-                guard let pattern = ExerciseLibrary.lookup(log.exerciseId)?.movementPattern,
-                      !pattern.isEmpty else { continue }
+                guard let pattern = ExerciseLibrary.lookup(log.exerciseId)?.movementPattern.rawValue
+                else { continue }
                 if let existing = patternMostRecent[pattern] {
                     if log.loggedAt > existing { patternMostRecent[pattern] = log.loggedAt }
                 } else {
@@ -522,7 +522,7 @@ final class ProgramViewModel {
 
             let patternPhases: [String: PatternPhaseInfo]? = persistedPhaseStates.isEmpty ? nil :
                 Dictionary(uniqueKeysWithValues: persistedPhaseStates.map { state in
-                    (state.pattern, PatternPhaseInfo(
+                    (state.pattern.rawValue, PatternPhaseInfo(
                         currentPhase: state.phase.rawValue,
                         sessionsCompleted: state.sessionsCompletedInPhase,
                         sessionsRequired: state.sessionsRequiredForPhase

--- a/ProjectApex/Features/Progress/MuscleColorUtility.swift
+++ b/ProjectApex/Features/Progress/MuscleColorUtility.swift
@@ -10,20 +10,30 @@ import SwiftUI
 nonisolated enum MuscleColor {
 
     /// Returns the accent Color for a coarse muscle group string.
-    /// Matches the vocabulary used by ExerciseLibrary.primaryMuscle and set_logs.primary_muscle.
+    /// Matches the vocabulary used by ExerciseLibrary.primaryMuscle (typed
+    /// PrimaryMuscle as of Slice 1) and set_logs.primary_muscle (still a
+    /// String column at the persistence boundary). Unknown values — including
+    /// "core" (excluded from the locked-six taxonomy per ADR-0005) — return
+    /// the default grey.
     static func color(for muscle: String) -> Color {
-        switch muscle.lowercased() {
-        case "chest":       return Color(red: 0.96, green: 0.36, blue: 0.36)
-        case "back":        return Color(red: 0.30, green: 0.60, blue: 0.96)
-        case "shoulders":   return Color(red: 0.96, green: 0.60, blue: 0.20)
-        case "quads":       return Color(red: 0.30, green: 0.80, blue: 0.40)
-        case "hamstrings":  return Color(red: 0.20, green: 0.70, blue: 0.65)
-        case "glutes":      return Color(red: 0.90, green: 0.45, blue: 0.70)
-        case "biceps":      return Color(red: 0.65, green: 0.40, blue: 0.90)
-        case "triceps":     return Color(red: 0.96, green: 0.80, blue: 0.20)
-        case "calves":      return Color(red: 0.40, green: 0.45, blue: 0.90)
-        case "core":        return Color(red: 0.25, green: 0.80, blue: 0.70)
-        default:            return Color(white: 0.55)
+        guard let primary = PrimaryMuscle(rawValue: muscle.lowercased()) else {
+            return Color(white: 0.55)
+        }
+        return color(for: primary)
+    }
+
+    /// Typed-switch overload — preferred for new call sites.
+    static func color(for muscle: PrimaryMuscle) -> Color {
+        switch muscle {
+        case .chest:       return Color(red: 0.96, green: 0.36, blue: 0.36)
+        case .back:        return Color(red: 0.30, green: 0.60, blue: 0.96)
+        case .shoulders:   return Color(red: 0.96, green: 0.60, blue: 0.20)
+        case .quads:       return Color(red: 0.30, green: 0.80, blue: 0.40)
+        case .hamstrings:  return Color(red: 0.20, green: 0.70, blue: 0.65)
+        case .glutes:      return Color(red: 0.90, green: 0.45, blue: 0.70)
+        case .biceps:      return Color(red: 0.65, green: 0.40, blue: 0.90)
+        case .triceps:     return Color(red: 0.96, green: 0.80, blue: 0.20)
+        case .calves:      return Color(red: 0.40, green: 0.45, blue: 0.90)
         }
     }
 }

--- a/ProjectApex/Features/Progress/ProgressViewModel.swift
+++ b/ProjectApex/Features/Progress/ProgressViewModel.swift
@@ -260,7 +260,7 @@ final class ProgressViewModel {
         var logsByMuscle: [String: [SetLog]] = [:]
         for log in setLogs {
             let muscle = log.primaryMuscle
-                ?? ExerciseLibrary.primaryMuscle(for: log.exerciseId)
+                ?? ExerciseLibrary.primaryMuscle(for: log.exerciseId)?.rawValue
                 ?? "other"
             logsByMuscle[muscle, default: []].append(log)
         }
@@ -391,7 +391,7 @@ final class ProgressViewModel {
             var setsByMuscle: [String: Int] = [:]
             for log in weekLogs {
                 let muscle = log.primaryMuscle
-                    ?? ExerciseLibrary.primaryMuscle(for: log.exerciseId)
+                    ?? ExerciseLibrary.primaryMuscle(for: log.exerciseId)?.rawValue
                     ?? "other"
                 setsByMuscle[muscle, default: 0] += 1
             }

--- a/ProjectApex/Features/Workout/ManualSessionLogView.swift
+++ b/ProjectApex/Features/Workout/ManualSessionLogView.swift
@@ -318,7 +318,7 @@ struct ManualSessionLogView: View {
                     rirEstimated: rpe.map { max(0, 10 - $0) },
                     aiPrescribed: nil,
                     loggedAt: sessionDate,
-                    primaryMuscle: ExerciseLibrary.primaryMuscle(for: entry.exercise.exerciseId) ?? entry.exercise.primaryMuscle
+                    primaryMuscle: ExerciseLibrary.primaryMuscle(for: entry.exercise.exerciseId)?.rawValue ?? entry.exercise.primaryMuscle
                 )
                 allSetLogs.append((setLog, entry.exercise))
             }
@@ -493,13 +493,25 @@ private struct ExerciseLogCard: View {
     }
 
     private func muscleColor(for muscle: String) -> Color {
+        // Typed-first dispatch (Slice 1) with substring-match fallback for
+        // non-canonical strings. Core branch removed — core is excluded from
+        // the locked-six taxonomy per ADR-0005.
+        if let primary = PrimaryMuscle(rawValue: muscle.lowercased()) {
+            switch primary {
+            case .chest:                            return Color(red: 0.96, green: 0.42, blue: 0.30)
+            case .back:                             return Color(red: 0.30, green: 0.70, blue: 0.96)
+            case .shoulders:                        return Color(red: 0.70, green: 0.50, blue: 0.96)
+            case .quads, .hamstrings, .glutes,
+                 .calves:                           return Color(red: 0.30, green: 0.96, blue: 0.60)
+            case .biceps, .triceps:                 return Color(red: 0.96, green: 0.80, blue: 0.30)
+            }
+        }
         let lower = muscle.lowercased()
         if lower.contains("pector") || lower.contains("chest") { return Color(red: 0.96, green: 0.42, blue: 0.30) }
         if lower.contains("lat") || lower.contains("back") || lower.contains("rhom") { return Color(red: 0.30, green: 0.70, blue: 0.96) }
         if lower.contains("delt") || lower.contains("shoulder") { return Color(red: 0.70, green: 0.50, blue: 0.96) }
         if lower.contains("quad") || lower.contains("hamstr") || lower.contains("glut") || lower.contains("calf") { return Color(red: 0.30, green: 0.96, blue: 0.60) }
         if lower.contains("bicep") || lower.contains("tricep") { return Color(red: 0.96, green: 0.80, blue: 0.30) }
-        if lower.contains("core") || lower.contains("abdom") { return Color(red: 0.96, green: 0.60, blue: 0.30) }
         return Color(red: 0.78, green: 0.82, blue: 0.88)
     }
 }

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -303,7 +303,7 @@ actor WorkoutSessionManager {
             rirEstimated: rpeFelt.map { max(0, 10 - $0) },
             aiPrescribed: currentPrescription,
             loggedAt: Date(),
-            primaryMuscle: ExerciseLibrary.primaryMuscle(for: exercise.exerciseId) ?? exercise.primaryMuscle
+            primaryMuscle: ExerciseLibrary.primaryMuscle(for: exercise.exerciseId)?.rawValue ?? exercise.primaryMuscle
         )
         completedSets.append(setLog)
 

--- a/ProjectApex/Models/ExerciseLibrary.swift
+++ b/ProjectApex/Models/ExerciseLibrary.swift
@@ -25,16 +25,22 @@ import Foundation
 ///
 /// - `id`: Snake_case identifier, locked. Never changed once released. The LLM
 ///   must emit this exact string in exercise_id fields.
-/// - `primaryMuscle`: Coarse group key written to set_logs.primary_muscle.
-///   One of: chest | back | shoulders | quads | hamstrings | glutes |
-///   biceps | triceps | calves | core
+/// - `primaryMuscle`: PrimaryMuscle case (one of the 9 fine-grained values
+///   per ADR-0005's two-level muscle taxonomy). Writers to
+///   set_logs.primary_muscle pass `primaryMuscle.rawValue`.
+/// - `synergists`: Free-form muscle hint strings — broader vocabulary than
+///   PrimaryMuscle (e.g. "forearms" appears as a synergist on bicep curls
+///   but isn't a first-class trainee-model muscle group). Stays String to
+///   preserve the broader vocabulary.
+/// - `movementPattern`: MovementPattern case (one of the 8 values per
+///   ADR-0005). Writers to persisted fields pass `movementPattern.rawValue`.
 /// - `equipmentType`: Must match an EquipmentType.typeKey from GymProfile.swift.
 nonisolated struct ExerciseDefinition: Sendable, Identifiable {
     let id: String
     let name: String
-    let primaryMuscle: String
+    let primaryMuscle: PrimaryMuscle
     let synergists: [String]
-    let movementPattern: String
+    let movementPattern: MovementPattern
     let equipmentType: String
     let bodyweightOnly: Bool
 }
@@ -58,90 +64,90 @@ nonisolated enum ExerciseLibrary {
         ExerciseDefinition(
             id: "barbell_bench_press",
             name: "Barbell Bench Press",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["triceps", "shoulders"],
-            movementPattern: "horizontal_push",
+            movementPattern: .horizontalPush,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "dumbbell_bench_press",
             name: "Dumbbell Bench Press",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["triceps", "shoulders"],
-            movementPattern: "horizontal_push",
+            movementPattern: .horizontalPush,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "incline_barbell_press",
             name: "Incline Barbell Press",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["triceps", "shoulders"],
-            movementPattern: "horizontal_push",
+            movementPattern: .horizontalPush,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "incline_dumbbell_press",
             name: "Incline Dumbbell Press",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["triceps", "shoulders"],
-            movementPattern: "horizontal_push",
+            movementPattern: .horizontalPush,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "decline_bench_press",
             name: "Decline Bench Press",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["triceps", "shoulders"],
-            movementPattern: "horizontal_push",
+            movementPattern: .horizontalPush,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "machine_chest_press",
             name: "Machine Chest Press",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["triceps", "shoulders"],
-            movementPattern: "horizontal_push",
+            movementPattern: .horizontalPush,
             equipmentType: "chest_press_machine",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "cable_chest_fly",
             name: "Cable Chest Fly",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["shoulders"],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "cable_crossover",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "pec_deck_fly",
             name: "Pec Deck Fly",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["shoulders"],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "pec_deck",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "dumbbell_fly",
             name: "Dumbbell Fly",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["shoulders"],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "push_ups",
             name: "Push-Ups",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["triceps", "shoulders"],
-            movementPattern: "horizontal_push",
+            movementPattern: .horizontalPush,
             equipmentType: "flat_bench",
             bodyweightOnly: true
         ),
@@ -150,126 +156,126 @@ nonisolated enum ExerciseLibrary {
         ExerciseDefinition(
             id: "barbell_row",
             name: "Barbell Row",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["biceps", "shoulders"],
-            movementPattern: "horizontal_pull",
+            movementPattern: .horizontalPull,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "dumbbell_row",
             name: "Dumbbell Row",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["biceps", "shoulders"],
-            movementPattern: "horizontal_pull",
+            movementPattern: .horizontalPull,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "t_bar_row",
             name: "T-Bar Row",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["biceps", "shoulders"],
-            movementPattern: "horizontal_pull",
+            movementPattern: .horizontalPull,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "cable_row",
             name: "Cable Row",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["biceps", "shoulders"],
-            movementPattern: "horizontal_pull",
+            movementPattern: .horizontalPull,
             equipmentType: "cable_machine_single",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "seated_cable_row",
             name: "Seated Cable Row",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["biceps", "shoulders"],
-            movementPattern: "horizontal_pull",
+            movementPattern: .horizontalPull,
             equipmentType: "seated_row",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "lat_pulldown_wide",
             name: "Lat Pulldown (Wide Grip)",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["biceps", "shoulders"],
-            movementPattern: "vertical_pull",
+            movementPattern: .verticalPull,
             equipmentType: "lat_pulldown",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "lat_pulldown_close",
             name: "Lat Pulldown (Close Grip)",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["biceps"],
-            movementPattern: "vertical_pull",
+            movementPattern: .verticalPull,
             equipmentType: "lat_pulldown",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "pull_ups",
             name: "Pull-Ups",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["biceps"],
-            movementPattern: "vertical_pull",
+            movementPattern: .verticalPull,
             equipmentType: "pull_up_bar",
             bodyweightOnly: true
         ),
         ExerciseDefinition(
             id: "chin_ups",
             name: "Chin-Ups",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["biceps"],
-            movementPattern: "vertical_pull",
+            movementPattern: .verticalPull,
             equipmentType: "pull_up_bar",
             bodyweightOnly: true
         ),
         ExerciseDefinition(
             id: "face_pull",
             name: "Face Pull",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["shoulders"],
-            movementPattern: "horizontal_pull",
+            movementPattern: .horizontalPull,
             equipmentType: "cable_machine_single",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "cable_rear_delt_fly",
             name: "Cable Rear Delt Fly",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["shoulders"],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "cable_crossover",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "cable_straight_arm_pulldown",
             name: "Cable Straight Arm Pulldown",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["triceps"],
-            movementPattern: "vertical_pull",
+            movementPattern: .verticalPull,
             equipmentType: "cable_machine_single",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "dumbbell_single_arm_row",
             name: "Dumbbell Single Arm Row",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["biceps", "shoulders"],
-            movementPattern: "horizontal_pull",
+            movementPattern: .horizontalPull,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "assisted_pull_up",
             name: "Assisted Pull-Up",
-            primaryMuscle: "back",
+            primaryMuscle: .back,
             synergists: ["biceps"],
-            movementPattern: "vertical_pull",
+            movementPattern: .verticalPull,
             // Uses the machine's weight stack for assistance — bodyweightOnly: false
             // (contrast with pull_ups which is bodyweightOnly: true).
             // equipmentType uses pull_up_bar since there is no distinct
@@ -282,72 +288,72 @@ nonisolated enum ExerciseLibrary {
         ExerciseDefinition(
             id: "overhead_press",
             name: "Overhead Press",
-            primaryMuscle: "shoulders",
+            primaryMuscle: .shoulders,
             synergists: ["triceps"],
-            movementPattern: "vertical_push",
+            movementPattern: .verticalPush,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "dumbbell_shoulder_press",
             name: "Dumbbell Shoulder Press",
-            primaryMuscle: "shoulders",
+            primaryMuscle: .shoulders,
             synergists: ["triceps"],
-            movementPattern: "vertical_push",
+            movementPattern: .verticalPush,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "machine_shoulder_press",
             name: "Machine Shoulder Press",
-            primaryMuscle: "shoulders",
+            primaryMuscle: .shoulders,
             synergists: ["triceps"],
-            movementPattern: "vertical_push",
+            movementPattern: .verticalPush,
             equipmentType: "shoulder_press_machine",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "lateral_raise",
             name: "Lateral Raise",
-            primaryMuscle: "shoulders",
+            primaryMuscle: .shoulders,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "cable_lateral_raise",
             name: "Cable Lateral Raise",
-            primaryMuscle: "shoulders",
+            primaryMuscle: .shoulders,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "cable_machine_single",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "rear_delt_fly",
             name: "Rear Delt Fly",
-            primaryMuscle: "shoulders",
+            primaryMuscle: .shoulders,
             synergists: ["back"],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "arnold_press",
             name: "Arnold Press",
-            primaryMuscle: "shoulders",
+            primaryMuscle: .shoulders,
             synergists: ["triceps"],
-            movementPattern: "vertical_push",
+            movementPattern: .verticalPush,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "upright_row",
             name: "Upright Row",
-            primaryMuscle: "shoulders",
+            primaryMuscle: .shoulders,
             synergists: ["biceps", "back"],
-            movementPattern: "vertical_pull",
+            movementPattern: .verticalPull,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
@@ -356,81 +362,81 @@ nonisolated enum ExerciseLibrary {
         ExerciseDefinition(
             id: "barbell_back_squat",
             name: "Barbell Back Squat",
-            primaryMuscle: "quads",
+            primaryMuscle: .quads,
             synergists: ["glutes", "hamstrings"],
-            movementPattern: "squat",
+            movementPattern: .squat,
             equipmentType: "power_rack",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "front_squat",
             name: "Front Squat",
-            primaryMuscle: "quads",
+            primaryMuscle: .quads,
             synergists: ["glutes", "hamstrings"],
-            movementPattern: "squat",
+            movementPattern: .squat,
             equipmentType: "power_rack",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "leg_press",
             name: "Leg Press",
-            primaryMuscle: "quads",
+            primaryMuscle: .quads,
             synergists: ["glutes", "hamstrings"],
-            movementPattern: "squat",
+            movementPattern: .squat,
             equipmentType: "leg_press",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "hack_squat_machine",
             name: "Hack Squat Machine",
-            primaryMuscle: "quads",
+            primaryMuscle: .quads,
             synergists: ["glutes", "hamstrings"],
-            movementPattern: "squat",
+            movementPattern: .squat,
             equipmentType: "hack_squat",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "goblet_squat",
             name: "Goblet Squat",
-            primaryMuscle: "quads",
+            primaryMuscle: .quads,
             synergists: ["glutes"],
-            movementPattern: "squat",
+            movementPattern: .squat,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "leg_extension",
             name: "Leg Extension",
-            primaryMuscle: "quads",
+            primaryMuscle: .quads,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "leg_extension",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "bulgarian_split_squat",
             name: "Bulgarian Split Squat",
-            primaryMuscle: "quads",
+            primaryMuscle: .quads,
             synergists: ["glutes", "hamstrings"],
-            movementPattern: "lunge",
+            movementPattern: .lunge,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "walking_lunge",
             name: "Walking Lunge",
-            primaryMuscle: "quads",
+            primaryMuscle: .quads,
             synergists: ["glutes", "hamstrings"],
-            movementPattern: "lunge",
+            movementPattern: .lunge,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "smith_machine_squat",
             name: "Smith Machine Squat",
-            primaryMuscle: "quads",
+            primaryMuscle: .quads,
             synergists: ["glutes", "hamstrings"],
-            movementPattern: "squat",
+            movementPattern: .squat,
             equipmentType: "smith_machine",
             bodyweightOnly: false
         ),
@@ -439,54 +445,54 @@ nonisolated enum ExerciseLibrary {
         ExerciseDefinition(
             id: "conventional_deadlift",
             name: "Conventional Deadlift",
-            primaryMuscle: "hamstrings",
+            primaryMuscle: .hamstrings,
             synergists: ["glutes", "back"],
-            movementPattern: "hip_hinge",
+            movementPattern: .hipHinge,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "romanian_deadlift",
             name: "Romanian Deadlift",
-            primaryMuscle: "hamstrings",
+            primaryMuscle: .hamstrings,
             synergists: ["glutes"],
-            movementPattern: "hip_hinge",
+            movementPattern: .hipHinge,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "dumbbell_romanian_deadlift",
             name: "Dumbbell Romanian Deadlift",
-            primaryMuscle: "hamstrings",
+            primaryMuscle: .hamstrings,
             synergists: ["glutes"],
-            movementPattern: "hip_hinge",
+            movementPattern: .hipHinge,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "lying_leg_curl",
             name: "Lying Leg Curl",
-            primaryMuscle: "hamstrings",
+            primaryMuscle: .hamstrings,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "leg_curl",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "seated_leg_curl",
             name: "Seated Leg Curl",
-            primaryMuscle: "hamstrings",
+            primaryMuscle: .hamstrings,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "leg_curl",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "stiff_leg_deadlift",
             name: "Stiff Leg Deadlift",
-            primaryMuscle: "hamstrings",
+            primaryMuscle: .hamstrings,
             synergists: ["glutes", "back"],
-            movementPattern: "hip_hinge",
+            movementPattern: .hipHinge,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
@@ -495,36 +501,36 @@ nonisolated enum ExerciseLibrary {
         ExerciseDefinition(
             id: "hip_thrust",
             name: "Hip Thrust",
-            primaryMuscle: "glutes",
+            primaryMuscle: .glutes,
             synergists: ["hamstrings"],
-            movementPattern: "hip_hinge",
+            movementPattern: .hipHinge,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "cable_pull_through",
             name: "Cable Pull-Through",
-            primaryMuscle: "glutes",
+            primaryMuscle: .glutes,
             synergists: ["hamstrings"],
-            movementPattern: "hip_hinge",
+            movementPattern: .hipHinge,
             equipmentType: "cable_machine_single",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "glute_bridge",
             name: "Glute Bridge",
-            primaryMuscle: "glutes",
+            primaryMuscle: .glutes,
             synergists: ["hamstrings"],
-            movementPattern: "hip_hinge",
+            movementPattern: .hipHinge,
             equipmentType: "flat_bench",
             bodyweightOnly: true
         ),
         ExerciseDefinition(
             id: "sumo_deadlift",
             name: "Sumo Deadlift",
-            primaryMuscle: "glutes",
+            primaryMuscle: .glutes,
             synergists: ["hamstrings", "quads"],
-            movementPattern: "hip_hinge",
+            movementPattern: .hipHinge,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
@@ -533,63 +539,63 @@ nonisolated enum ExerciseLibrary {
         ExerciseDefinition(
             id: "barbell_curl",
             name: "Barbell Curl",
-            primaryMuscle: "biceps",
+            primaryMuscle: .biceps,
             synergists: ["forearms"],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "ez_bar_curl",
             name: "EZ Bar Curl",
-            primaryMuscle: "biceps",
+            primaryMuscle: .biceps,
             synergists: ["forearms"],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "ez_curl_bar",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "dumbbell_curl",
             name: "Dumbbell Curl",
-            primaryMuscle: "biceps",
+            primaryMuscle: .biceps,
             synergists: ["forearms"],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "preacher_curl",
             name: "Preacher Curl",
-            primaryMuscle: "biceps",
+            primaryMuscle: .biceps,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "preacher_curl",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "hammer_curl",
             name: "Hammer Curl",
-            primaryMuscle: "biceps",
+            primaryMuscle: .biceps,
             synergists: ["forearms"],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "cable_curl",
             name: "Cable Curl",
-            primaryMuscle: "biceps",
+            primaryMuscle: .biceps,
             synergists: ["forearms"],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "cable_machine_single",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "cable_hammer_curl",
             name: "Cable Hammer Curl",
-            primaryMuscle: "biceps",
+            primaryMuscle: .biceps,
             synergists: ["forearms"],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "cable_machine_single",
             bodyweightOnly: false
         ),
@@ -598,63 +604,63 @@ nonisolated enum ExerciseLibrary {
         ExerciseDefinition(
             id: "cable_tricep_pushdown",
             name: "Cable Tricep Pushdown",
-            primaryMuscle: "triceps",
+            primaryMuscle: .triceps,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "cable_machine_single",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "overhead_tricep_extension",
             name: "Overhead Tricep Extension",
-            primaryMuscle: "triceps",
+            primaryMuscle: .triceps,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "skull_crushers",
             name: "Skull Crushers",
-            primaryMuscle: "triceps",
+            primaryMuscle: .triceps,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "ez_curl_bar",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "dips",
             name: "Dips",
-            primaryMuscle: "triceps",
+            primaryMuscle: .triceps,
             synergists: ["chest", "shoulders"],
-            movementPattern: "vertical_push",
+            movementPattern: .verticalPush,
             equipmentType: "dip_station",
             bodyweightOnly: true
         ),
         ExerciseDefinition(
             id: "close_grip_bench_press",
             name: "Close Grip Bench Press",
-            primaryMuscle: "triceps",
+            primaryMuscle: .triceps,
             synergists: ["chest", "shoulders"],
-            movementPattern: "horizontal_push",
+            movementPattern: .horizontalPush,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "dumbbell_overhead_tricep_extension",
             name: "Dumbbell Overhead Tricep Extension",
-            primaryMuscle: "triceps",
+            primaryMuscle: .triceps,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "dumbbell_set",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "cable_overhead_tricep_extension",
             name: "Cable Overhead Tricep Extension",
-            primaryMuscle: "triceps",
+            primaryMuscle: .triceps,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "cable_machine_single",
             bodyweightOnly: false
         ),
@@ -663,27 +669,27 @@ nonisolated enum ExerciseLibrary {
         ExerciseDefinition(
             id: "smith_machine_bench_press",
             name: "Smith Machine Bench Press",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["triceps", "shoulders"],
-            movementPattern: "horizontal_push",
+            movementPattern: .horizontalPush,
             equipmentType: "smith_machine",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "smith_machine_incline_press",
             name: "Smith Machine Incline Press",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["triceps", "shoulders"],
-            movementPattern: "horizontal_push",
+            movementPattern: .horizontalPush,
             equipmentType: "smith_machine",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "cable_crossover_chest_fly",
             name: "Cable Crossover Chest Fly",
-            primaryMuscle: "chest",
+            primaryMuscle: .chest,
             synergists: ["shoulders"],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "cable_crossover",
             bodyweightOnly: false
         ),
@@ -692,68 +698,36 @@ nonisolated enum ExerciseLibrary {
         ExerciseDefinition(
             id: "standing_calf_raise",
             name: "Standing Calf Raise",
-            primaryMuscle: "calves",
+            primaryMuscle: .calves,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "barbell",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "seated_calf_raise",
             name: "Seated Calf Raise",
-            primaryMuscle: "calves",
+            primaryMuscle: .calves,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "leg_press",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
             id: "smith_machine_calf_raise",
             name: "Smith Machine Calf Raise",
-            primaryMuscle: "calves",
+            primaryMuscle: .calves,
             synergists: [],
-            movementPattern: "isolation",
+            movementPattern: .isolation,
             equipmentType: "smith_machine",
             bodyweightOnly: false
         ),
 
-        // MARK: Core
-        ExerciseDefinition(
-            id: "cable_crunch",
-            name: "Cable Crunch",
-            primaryMuscle: "core",
-            synergists: [],
-            movementPattern: "isolation",
-            equipmentType: "cable_machine_single",
-            bodyweightOnly: false
-        ),
-        ExerciseDefinition(
-            id: "hanging_leg_raise",
-            name: "Hanging Leg Raise",
-            primaryMuscle: "core",
-            synergists: [],
-            movementPattern: "isolation",
-            equipmentType: "pull_up_bar",
-            bodyweightOnly: true
-        ),
-        ExerciseDefinition(
-            id: "ab_wheel_rollout",
-            name: "Ab Wheel Rollout",
-            primaryMuscle: "core",
-            synergists: ["back", "shoulders"],
-            movementPattern: "isolation",
-            equipmentType: "resistance_bands",
-            bodyweightOnly: true
-        ),
-        ExerciseDefinition(
-            id: "plank",
-            name: "Plank",
-            primaryMuscle: "core",
-            synergists: ["shoulders", "back"],
-            movementPattern: "isolation",
-            equipmentType: "flat_bench",
-            bodyweightOnly: true
-        ),
+        // Core exercises (cable_crunch, hanging_leg_raise, ab_wheel_rollout,
+        // plank) were removed in Phase 1 / Slice 1. Per ADR-0005's two-level
+        // muscle taxonomy, core is excluded from both PrimaryMuscle and
+        // MuscleGroup — core training stimuli don't fit the EWMA-over-top-sets
+        // model and the trainee model has no axis to track core capability.
     ]
 
     // MARK: - Lookup infrastructure
@@ -775,9 +749,10 @@ nonisolated enum ExerciseLibrary {
         return nil
     }
 
-    /// Returns the coarse primary_muscle string for a given exercise_id.
-    /// Used when writing the primary_muscle column in set_logs payloads.
-    static func primaryMuscle(for exerciseId: String) -> String? {
+    /// Returns the typed PrimaryMuscle for a given exercise_id. Callers
+    /// writing the primary_muscle column in set_logs payloads pass
+    /// `.rawValue` to convert at the persistence boundary.
+    static func primaryMuscle(for exerciseId: String) -> PrimaryMuscle? {
         lookup(exerciseId)?.primaryMuscle
     }
 
@@ -912,13 +887,20 @@ nonisolated enum ExerciseLibrary {
             "exercise_id | name | primary_muscle | equipment_required",
         ]
 
-        // Group by primaryMuscle for readability in the prompt
+        // Group by primaryMuscle for readability in the prompt. Order
+        // matches the prior chest→back→shoulders→…→calves layout (core is
+        // intentionally excluded — the 4 core exercises were removed in
+        // Phase 1 / Slice 1).
         let grouped = Dictionary(grouping: all, by: \.primaryMuscle)
-        let muscleOrder = ["chest", "back", "shoulders", "quads", "hamstrings", "glutes", "biceps", "triceps", "calves", "core"]
+        let muscleOrder: [PrimaryMuscle] = [
+            .chest, .back, .shoulders,
+            .quads, .hamstrings, .glutes,
+            .biceps, .triceps, .calves,
+        ]
         for muscle in muscleOrder {
             guard let exercises = grouped[muscle] else { continue }
             for ex in exercises.sorted(by: { $0.id < $1.id }) {
-                lines.append("\(ex.id) | \(ex.name) | \(ex.primaryMuscle) | \(ex.equipmentType)")
+                lines.append("\(ex.id) | \(ex.name) | \(ex.primaryMuscle.rawValue) | \(ex.equipmentType)")
             }
         }
 

--- a/ProjectApex/Models/MigrationDates.swift
+++ b/ProjectApex/Models/MigrationDates.swift
@@ -1,0 +1,27 @@
+// MigrationDates.swift
+// ProjectApex — Models
+//
+// Canonical home for release-coupled cutover dates. Each constant pins
+// a one-time migration boundary (e.g. set-intent backfill cutoff, local-date
+// field rollout) so query-time logic can branch on "before" vs "after"
+// without scattering literal dates through services.
+//
+// Placeholder values point to the v2 release horizon and must be updated
+// to actual deploy timestamps before v2 ships.
+
+import Foundation
+
+public enum MigrationDates {
+    /// Cutoff for the set-intent backfill (per ADR-0005 — three-phase
+    /// migration with code validation shipping before DB migration).
+    /// Reads of pre-cutoff sets must tolerate missing intent; reads of
+    /// post-cutoff sets must require it.
+    public static let v2SetIntentBackfill: Date = Date(timeIntervalSince1970: 0)
+
+    /// Cutoff for the localDate-field rollout (per ADR-0005 — pre-bucketed
+    /// localDate string at write time, immune to subsequent timezone
+    /// changes). Reads of pre-cutoff sessions derive localDate from
+    /// timestamp + active timezone; reads of post-cutoff sessions trust
+    /// the stored field.
+    public static let v2LocalDateField: Date = Date(timeIntervalSince1970: 0)
+}

--- a/ProjectApex/Models/MigrationDates.swift
+++ b/ProjectApex/Models/MigrationDates.swift
@@ -11,17 +11,17 @@
 
 import Foundation
 
-public enum MigrationDates {
+enum MigrationDates {
     /// Cutoff for the set-intent backfill (per ADR-0005 — three-phase
     /// migration with code validation shipping before DB migration).
     /// Reads of pre-cutoff sets must tolerate missing intent; reads of
     /// post-cutoff sets must require it.
-    public static let v2SetIntentBackfill: Date = Date(timeIntervalSince1970: 0)
+    static let v2SetIntentBackfill: Date = Date(timeIntervalSince1970: 0)
 
     /// Cutoff for the localDate-field rollout (per ADR-0005 — pre-bucketed
     /// localDate string at write time, immune to subsequent timezone
     /// changes). Reads of pre-cutoff sessions derive localDate from
     /// timestamp + active timezone; reads of post-cutoff sessions trust
     /// the stored field.
-    public static let v2LocalDateField: Date = Date(timeIntervalSince1970: 0)
+    static let v2LocalDateField: Date = Date(timeIntervalSince1970: 0)
 }

--- a/ProjectApex/Models/MovementPattern.swift
+++ b/ProjectApex/Models/MovementPattern.swift
@@ -1,0 +1,23 @@
+// MovementPattern.swift
+// ProjectApex — Models
+//
+// Motion taxonomy used by ExerciseLibrary entries, MovementPatternPhaseState,
+// and the trainee model's PatternProfile keying. See ADR-0005 and CONTEXT.md.
+//
+// Cases mirror the eight pattern strings present in the codebase prior to
+// Slice 1's typed-enum migration. .calves and .core are deliberately absent —
+// calves contribute to the .legs MuscleGroup via PrimaryMuscle.muscleGroup,
+// and core is excluded from the trainee model entirely.
+
+import Foundation
+
+public enum MovementPattern: String, Codable, Sendable, Hashable, CaseIterable {
+    case hipHinge       = "hip_hinge"
+    case horizontalPull = "horizontal_pull"
+    case horizontalPush = "horizontal_push"
+    case isolation
+    case lunge
+    case squat
+    case verticalPull   = "vertical_pull"
+    case verticalPush   = "vertical_push"
+}

--- a/ProjectApex/Models/MovementPattern.swift
+++ b/ProjectApex/Models/MovementPattern.swift
@@ -11,7 +11,7 @@
 
 import Foundation
 
-public enum MovementPattern: String, Codable, Sendable, Hashable, CaseIterable {
+enum MovementPattern: String, Codable, Sendable, Hashable, CaseIterable {
     case hipHinge       = "hip_hinge"
     case horizontalPull = "horizontal_pull"
     case horizontalPush = "horizontal_push"

--- a/ProjectApex/Models/MuscleTaxonomy.swift
+++ b/ProjectApex/Models/MuscleTaxonomy.swift
@@ -1,0 +1,45 @@
+// MuscleTaxonomy.swift
+// ProjectApex — Models
+//
+// Two-level muscle taxonomy per ADR-0005's "Two-level muscle taxonomy"
+// amendment (added in Slice 1):
+//
+//  - PrimaryMuscle: 9 fine-grained cases used by ExerciseLibrary for
+//    AI prescription reasoning at exercise-selection time. Quads,
+//    hamstrings, glutes, and calves are first-class so the model can
+//    reason about leg-muscle balance.
+//
+//  - MuscleGroup: locked-six cases used by the trainee model as the
+//    aggregation key for capability tracking, EWMA, recovery state,
+//    and prescription accuracy. Leg subgroups collapse to .legs via
+//    PrimaryMuscle.muscleGroup.
+//
+// Core is excluded from both — core training stimuli don't fit the
+// EWMA-over-top-sets model and the trainee model has no axis to
+// track core capability.
+
+import Foundation
+
+public enum PrimaryMuscle: String, Codable, Sendable, Hashable, CaseIterable {
+    case back, chest, biceps, shoulders, triceps
+    case quads, hamstrings, glutes, calves
+}
+
+public enum MuscleGroup: String, Codable, Sendable, Hashable, CaseIterable {
+    case back, chest, biceps, shoulders, triceps, legs
+}
+
+extension PrimaryMuscle {
+    /// Collapses leg subgroups (quads/hamstrings/glutes/calves) to .legs;
+    /// upper-body muscles map 1:1.
+    public var muscleGroup: MuscleGroup {
+        switch self {
+        case .back:      return .back
+        case .chest:     return .chest
+        case .biceps:    return .biceps
+        case .shoulders: return .shoulders
+        case .triceps:   return .triceps
+        case .quads, .hamstrings, .glutes, .calves: return .legs
+        }
+    }
+}

--- a/ProjectApex/Models/MuscleTaxonomy.swift
+++ b/ProjectApex/Models/MuscleTaxonomy.swift
@@ -20,19 +20,19 @@
 
 import Foundation
 
-public enum PrimaryMuscle: String, Codable, Sendable, Hashable, CaseIterable {
+enum PrimaryMuscle: String, Codable, Sendable, Hashable, CaseIterable {
     case back, chest, biceps, shoulders, triceps
     case quads, hamstrings, glutes, calves
 }
 
-public enum MuscleGroup: String, Codable, Sendable, Hashable, CaseIterable {
+enum MuscleGroup: String, Codable, Sendable, Hashable, CaseIterable {
     case back, chest, biceps, shoulders, triceps, legs
 }
 
 extension PrimaryMuscle {
     /// Collapses leg subgroups (quads/hamstrings/glutes/calves) to .legs;
     /// upper-body muscles map 1:1.
-    public var muscleGroup: MuscleGroup {
+    var muscleGroup: MuscleGroup {
         switch self {
         case .back:      return .back
         case .chest:     return .chest

--- a/ProjectApex/Models/TraineeModel.swift
+++ b/ProjectApex/Models/TraineeModel.swift
@@ -1,0 +1,117 @@
+// TraineeModel.swift
+// ProjectApex — Models
+//
+// Top-level trainee-model value type per ADR-0005. Pure value type — no
+// actors, no I/O. The Service / LocalStore / UpdateJob slices ship
+// separately and consume this.
+//
+// Major patterns (used by isReadyForCalibrationReview and
+// shouldFireGlobalPhaseAdvance) are the six most common compound-movement
+// patterns: horizontal push, vertical push, horizontal pull, vertical
+// pull, squat, hip hinge. Lunge and isolation are excluded — they're
+// auxiliary patterns that don't carry the same calibration weight.
+
+import Foundation
+
+struct TraineeModel: Codable, Sendable, Hashable {
+    var activeProgramId: UUID?
+    var goal: GoalState
+    var projections: ProjectionState?
+    var patterns: [MovementPattern: PatternProfile]
+    var muscles: [MuscleGroup: MuscleProfile]
+    var exercises: [String: ExerciseProfile]
+    var activeLimitations: [ActiveLimitation]
+    var clearedLimitations: [ClearedLimitation]
+    var fatigueInteractions: [FatigueInteraction]
+    var prescriptionAccuracy: [MovementPattern: [SetIntent: PrescriptionAccuracy]]
+    var prescriptionIntentMismatches: [PrescriptionIntentMismatch]
+    var transfers: [ExerciseTransfer]
+    var bodyweight: BodyweightHistory
+    var lifeContextEvents: [LifeContextEvent]
+    var reassessmentRecords: [ReassessmentRecord]
+    /// Total completed sessions across the user's history. Drives the
+    /// 6-session-window check for shouldFireGlobalPhaseAdvance.
+    var totalSessionCount: Int
+
+    init(
+        activeProgramId: UUID? = nil,
+        goal: GoalState,
+        projections: ProjectionState? = nil,
+        patterns: [MovementPattern: PatternProfile] = [:],
+        muscles: [MuscleGroup: MuscleProfile] = [:],
+        exercises: [String: ExerciseProfile] = [:],
+        activeLimitations: [ActiveLimitation] = [],
+        clearedLimitations: [ClearedLimitation] = [],
+        fatigueInteractions: [FatigueInteraction] = [],
+        prescriptionAccuracy: [MovementPattern: [SetIntent: PrescriptionAccuracy]] = [:],
+        prescriptionIntentMismatches: [PrescriptionIntentMismatch] = [],
+        transfers: [ExerciseTransfer] = [],
+        bodyweight: BodyweightHistory = BodyweightHistory(),
+        lifeContextEvents: [LifeContextEvent] = [],
+        reassessmentRecords: [ReassessmentRecord] = [],
+        totalSessionCount: Int = 0
+    ) {
+        self.activeProgramId = activeProgramId
+        self.goal = goal
+        self.projections = projections
+        self.patterns = patterns
+        self.muscles = muscles
+        self.exercises = exercises
+        self.activeLimitations = activeLimitations
+        self.clearedLimitations = clearedLimitations
+        self.fatigueInteractions = fatigueInteractions
+        self.prescriptionAccuracy = prescriptionAccuracy
+        self.prescriptionIntentMismatches = prescriptionIntentMismatches
+        self.transfers = transfers
+        self.bodyweight = bodyweight
+        self.lifeContextEvents = lifeContextEvents
+        self.reassessmentRecords = reassessmentRecords
+        self.totalSessionCount = totalSessionCount
+    }
+
+    // MARK: Major patterns (calibration / phase-advance gating)
+
+    static let majorPatterns: Set<MovementPattern> = [
+        .horizontalPush, .verticalPush, .horizontalPull, .verticalPull,
+        .squat, .hipHinge,
+    ]
+
+    // MARK: Derived properties
+
+    /// True iff ≥4 of the 6 major patterns have reached `.established`
+    /// per-axis confidence AND the calibration review has not yet fired.
+    var isReadyForCalibrationReview: Bool {
+        let establishedMajors = patterns.lazy.filter { (pattern, profile) in
+            Self.majorPatterns.contains(pattern) && profile.confidence == .established
+        }.count
+        let calibrationAlreadyFired = projections?.calibrationReviewFiredAt != nil
+        return establishedMajors >= 4 && !calibrationAlreadyFired
+    }
+
+    /// Patterns whose current absence exceeds 2× their typical cadence
+    /// per ADR-0005. Patterns without enough cadence data (fewer than 2
+    /// recorded sessions) are excluded.
+    func disruptedPatterns(asOf reference: Date = Date()) -> [MovementPattern] {
+        patterns.compactMap { (pattern, profile) -> MovementPattern? in
+            guard let cadence = profile.sessionsCadenceDays,
+                  let daysSince = profile.daysSinceLastSession(asOf: reference)
+            else { return nil }
+            return Double(daysSince) > 2 * cadence ? pattern : nil
+        }
+    }
+
+    /// True when ≥4 major patterns have transitioned phase within the
+    /// last 6 sessions per ADR-0005. A pattern with
+    /// `lastPhaseTransitionAtSessionCount == 0` is treated as
+    /// never-transitioned (the initial state).
+    var shouldFireGlobalPhaseAdvance: Bool {
+        let recentlyTransitioned = patterns.lazy.filter { (pattern, profile) in
+            guard Self.majorPatterns.contains(pattern),
+                  profile.lastPhaseTransitionAtSessionCount > 0
+            else { return false }
+            let delta = totalSessionCount - profile.lastPhaseTransitionAtSessionCount
+            return delta >= 0 && delta <= 6
+        }.count
+        return recentlyTransitioned >= 4
+    }
+}

--- a/ProjectApex/Models/TraineeModelEnums.swift
+++ b/ProjectApex/Models/TraineeModelEnums.swift
@@ -1,0 +1,130 @@
+// TraineeModelEnums.swift
+// ProjectApex — Models
+//
+// Supporting enums consumed by the trainee model. See ADR-0005 for the
+// schema. Cases that ADR-0005 enumerates explicitly (SetIntent,
+// AxisConfidence, StimulusDimension) match the ADR verbatim. Cases that
+// the ADR leaves to implementation (BodyJoint, Severity, ProjectionProgress,
+// LimitationSubject) use the standard taxonomy noted above each enum.
+//
+// Note on ProgrammePhase: issue #2 listed `ProgrammePhase` as a supporting
+// enum, but the codebase already has `MesocyclePhase` (in WorkoutProgram.swift)
+// with the same semantics, and CONTEXT.md uses "Mesocycle phase" as the
+// canonical term. Slice 1 reuses MesocyclePhase rather than introducing a
+// duplicate.
+
+import Foundation
+
+// MARK: - SetIntent (ADR-0005, explicitly enumerated)
+
+/// The required field on every set; gates which sets contribute to e1RM,
+/// volume aggregation, and RPE calibration.
+public enum SetIntent: String, Codable, Sendable, Hashable, CaseIterable {
+    case warmup
+    case top
+    case backoff
+    case technique
+    case amrap
+}
+
+// MARK: - AxisConfidence (ADR-0005, explicitly enumerated)
+
+/// Per-axis confidence on PatternProfile / MuscleProfile / ExerciseProfile.
+/// Replaces the prior global confidence that lied when half the patterns
+/// had no data. Calibration review fires when ≥4 of 6 major patterns
+/// reach .established.
+public enum AxisConfidence: String, Codable, Sendable, Hashable, CaseIterable {
+    case bootstrapping
+    case calibrating
+    case established
+    case seasoned
+}
+
+// MARK: - StimulusDimension (ADR-0005 + CONTEXT.md)
+
+/// Per-set training stimulus classification; drives two-dimensional recovery.
+/// Warmup and technique sets classify as nil at the call site (Optional).
+public enum StimulusDimension: String, Codable, Sendable, Hashable, CaseIterable {
+    case neuromuscular
+    case metabolic
+    case both
+}
+
+// MARK: - Severity (standard medical taxonomy; ADR-0005 references .mild)
+
+/// Severity of an active limitation. AI-inferred limitations cap at .mild
+/// until the user confirms (per ADR-0005 — corroboration thresholds).
+public enum Severity: String, Codable, Sendable, Hashable, CaseIterable {
+    case mild
+    case moderate
+    case severe
+}
+
+// MARK: - BodyJoint (training-relevant joints)
+
+/// Anatomical joints tracked by ActiveLimitation when the limitation
+/// is joint-scoped rather than pattern- or muscle-scoped.
+public enum BodyJoint: String, Codable, Sendable, Hashable, CaseIterable {
+    case shoulder
+    case elbow
+    case wrist
+    case hip
+    case knee
+    case ankle
+    case lowerBack = "lower_back"
+    case neck
+}
+
+// MARK: - ProjectionProgress (per-pattern projection state)
+
+/// State of progression toward a PatternProjection's floor/stretch targets.
+public enum ProjectionProgress: String, Codable, Sendable, Hashable, CaseIterable {
+    case behind
+    case onTrack  = "on_track"
+    case ahead
+    case achieved
+}
+
+// MARK: - LimitationSubject (sum type — pattern | muscle | joint)
+
+/// What an ActiveLimitation / ClearedLimitation applies to. Per ADR-0005
+/// limitations are scoped per pattern, per muscle, or per joint.
+///
+/// Codable shape: `{"kind": "pattern", "value": "horizontal_push"}` etc.
+public enum LimitationSubject: Sendable, Hashable {
+    case pattern(MovementPattern)
+    case muscle(MuscleGroup)
+    case joint(BodyJoint)
+}
+
+extension LimitationSubject: Codable {
+    private enum CodingKeys: String, CodingKey { case kind, value }
+    private enum Kind: String, Codable { case pattern, muscle, joint }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .kind) {
+        case .pattern:
+            self = .pattern(try container.decode(MovementPattern.self, forKey: .value))
+        case .muscle:
+            self = .muscle(try container.decode(MuscleGroup.self, forKey: .value))
+        case .joint:
+            self = .joint(try container.decode(BodyJoint.self, forKey: .value))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .pattern(let p):
+            try container.encode(Kind.pattern, forKey: .kind)
+            try container.encode(p, forKey: .value)
+        case .muscle(let m):
+            try container.encode(Kind.muscle, forKey: .kind)
+            try container.encode(m, forKey: .value)
+        case .joint(let j):
+            try container.encode(Kind.joint, forKey: .kind)
+            try container.encode(j, forKey: .value)
+        }
+    }
+}

--- a/ProjectApex/Models/TraineeModelEnums.swift
+++ b/ProjectApex/Models/TraineeModelEnums.swift
@@ -19,7 +19,7 @@ import Foundation
 
 /// The required field on every set; gates which sets contribute to e1RM,
 /// volume aggregation, and RPE calibration.
-public enum SetIntent: String, Codable, Sendable, Hashable, CaseIterable {
+enum SetIntent: String, Codable, Sendable, Hashable, CaseIterable {
     case warmup
     case top
     case backoff
@@ -33,7 +33,7 @@ public enum SetIntent: String, Codable, Sendable, Hashable, CaseIterable {
 /// Replaces the prior global confidence that lied when half the patterns
 /// had no data. Calibration review fires when ≥4 of 6 major patterns
 /// reach .established.
-public enum AxisConfidence: String, Codable, Sendable, Hashable, CaseIterable {
+enum AxisConfidence: String, Codable, Sendable, Hashable, CaseIterable {
     case bootstrapping
     case calibrating
     case established
@@ -44,7 +44,7 @@ public enum AxisConfidence: String, Codable, Sendable, Hashable, CaseIterable {
 
 /// Per-set training stimulus classification; drives two-dimensional recovery.
 /// Warmup and technique sets classify as nil at the call site (Optional).
-public enum StimulusDimension: String, Codable, Sendable, Hashable, CaseIterable {
+enum StimulusDimension: String, Codable, Sendable, Hashable, CaseIterable {
     case neuromuscular
     case metabolic
     case both
@@ -54,7 +54,7 @@ public enum StimulusDimension: String, Codable, Sendable, Hashable, CaseIterable
 
 /// Severity of an active limitation. AI-inferred limitations cap at .mild
 /// until the user confirms (per ADR-0005 — corroboration thresholds).
-public enum Severity: String, Codable, Sendable, Hashable, CaseIterable {
+enum Severity: String, Codable, Sendable, Hashable, CaseIterable {
     case mild
     case moderate
     case severe
@@ -64,7 +64,7 @@ public enum Severity: String, Codable, Sendable, Hashable, CaseIterable {
 
 /// Anatomical joints tracked by ActiveLimitation when the limitation
 /// is joint-scoped rather than pattern- or muscle-scoped.
-public enum BodyJoint: String, Codable, Sendable, Hashable, CaseIterable {
+enum BodyJoint: String, Codable, Sendable, Hashable, CaseIterable {
     case shoulder
     case elbow
     case wrist
@@ -78,11 +78,22 @@ public enum BodyJoint: String, Codable, Sendable, Hashable, CaseIterable {
 // MARK: - ProjectionProgress (per-pattern projection state)
 
 /// State of progression toward a PatternProjection's floor/stretch targets.
-public enum ProjectionProgress: String, Codable, Sendable, Hashable, CaseIterable {
+enum ProjectionProgress: String, Codable, Sendable, Hashable, CaseIterable {
     case behind
     case onTrack  = "on_track"
     case ahead
     case achieved
+}
+
+// MARK: - ProgressionTrend (PatternProfile.trend, MuscleProfile.stagnationStatus)
+
+/// Capability trajectory used by both pattern-level trend (replacing
+/// StagnationService output) and muscle-level stagnation status per
+/// ADR-0005's service-supersession notes.
+enum ProgressionTrend: String, Codable, Sendable, Hashable, CaseIterable {
+    case progressing
+    case plateaued
+    case declining
 }
 
 // MARK: - LimitationSubject (sum type — pattern | muscle | joint)
@@ -91,7 +102,7 @@ public enum ProjectionProgress: String, Codable, Sendable, Hashable, CaseIterabl
 /// limitations are scoped per pattern, per muscle, or per joint.
 ///
 /// Codable shape: `{"kind": "pattern", "value": "horizontal_push"}` etc.
-public enum LimitationSubject: Sendable, Hashable {
+enum LimitationSubject: Sendable, Hashable {
     case pattern(MovementPattern)
     case muscle(MuscleGroup)
     case joint(BodyJoint)
@@ -101,7 +112,7 @@ extension LimitationSubject: Codable {
     private enum CodingKeys: String, CodingKey { case kind, value }
     private enum Kind: String, Codable { case pattern, muscle, joint }
 
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         switch try container.decode(Kind.self, forKey: .kind) {
         case .pattern:
@@ -113,7 +124,7 @@ extension LimitationSubject: Codable {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
         case .pattern(let p):

--- a/ProjectApex/Models/TraineeModelInteractions.swift
+++ b/ProjectApex/Models/TraineeModelInteractions.swift
@@ -1,0 +1,203 @@
+// TraineeModelInteractions.swift
+// ProjectApex — Models
+//
+// Limitation, fatigue-interaction, prescription-accuracy, transfer, and
+// bodyweight-history types per ADR-0005.
+
+import Foundation
+
+// MARK: - ActiveLimitation
+
+/// A currently flagged injury / pain state per pattern, muscle, or joint.
+/// AI-inferred limitations require ≥2 corroborating evidence and cap at
+/// .mild severity until user-confirmed (per ADR-0005).
+public struct ActiveLimitation: Codable, Sendable, Hashable {
+    public var subject: LimitationSubject
+    public var severity: Severity
+    public var onsetDate: Date
+    public var evidenceCount: Int
+    public var userConfirmed: Bool
+    public var notes: String?
+
+    public init(
+        subject: LimitationSubject,
+        severity: Severity,
+        onsetDate: Date,
+        evidenceCount: Int,
+        userConfirmed: Bool,
+        notes: String? = nil
+    ) {
+        self.subject = subject
+        self.severity = severity
+        self.onsetDate = onsetDate
+        self.evidenceCount = evidenceCount
+        self.userConfirmed = userConfirmed
+        self.notes = notes
+    }
+}
+
+// MARK: - ClearedLimitation
+
+/// An archived limitation resolved through clean training. Retention is
+/// capped at 50 entries / 12 months (enforced at write-side, not in
+/// this value type) per ADR-0005.
+public struct ClearedLimitation: Codable, Sendable, Hashable {
+    public var subject: LimitationSubject
+    public var severity: Severity
+    public var onsetDate: Date
+    public var clearedDate: Date
+    public var notes: String?
+
+    public init(
+        subject: LimitationSubject,
+        severity: Severity,
+        onsetDate: Date,
+        clearedDate: Date,
+        notes: String? = nil
+    ) {
+        self.subject = subject
+        self.severity = severity
+        self.onsetDate = onsetDate
+        self.clearedDate = clearedDate
+        self.notes = notes
+    }
+}
+
+// MARK: - FatigueInteraction
+
+/// Cross-pattern carryover — surfaces in coaching prompts only at
+/// confidence ≥ 0.7 with ≥15 paired observations.
+///
+/// Per ADR-0005:
+///  - consistencyFactor = max(0, min(1, 1 - stddev/|mean|)) over the last
+///    10 observations, with a 0.001 mean-guard for delta-percent values.
+///  - countFactor caps confidence at 0.5 below 15 observations; full
+///    weight at 15+.
+///  - confidence = consistencyFactor × countFactor.
+public struct FatigueInteraction: Codable, Sendable, Hashable {
+    public var fromPattern: MovementPattern
+    public var toPattern: MovementPattern
+    /// Delta-percent observations (e.g. -0.05 = 5% performance dip).
+    /// Newest at the end. Window of last 10 feeds consistencyFactor.
+    public var observations: [Double]
+    /// Total paired observations seen across history (for the hard-cap rule).
+    public var totalCount: Int
+
+    public init(
+        fromPattern: MovementPattern,
+        toPattern: MovementPattern,
+        observations: [Double],
+        totalCount: Int
+    ) {
+        self.fromPattern = fromPattern
+        self.toPattern = toPattern
+        self.observations = observations
+        self.totalCount = totalCount
+    }
+
+    public var consistencyFactor: Double {
+        let recent = Array(observations.suffix(10))
+        guard recent.count >= 2 else { return 0 }
+        let mean = recent.reduce(0, +) / Double(recent.count)
+        let absMean = max(abs(mean), 0.001)
+        let variance = recent.map { pow($0 - mean, 2) }.reduce(0, +) / Double(recent.count)
+        let stddev = sqrt(variance)
+        let clamped = max(0, min(1, 1 - stddev / absMean))
+        if abs(clamped - 1) < 1e-12 { return 1 }
+        if abs(clamped)     < 1e-12 { return 0 }
+        return clamped
+    }
+
+    public var countFactor: Double {
+        totalCount >= 15 ? 1.0 : 0.5
+    }
+
+    public var confidence: Double {
+        consistencyFactor * countFactor
+    }
+}
+
+// MARK: - PrescriptionAccuracy
+
+/// Per (pattern, intent) bias and RMSE — meta-coaching about the AI's
+/// own miscalibration, distinct from a single intent mismatch at log time.
+public struct PrescriptionAccuracy: Codable, Sendable, Hashable {
+    public var pattern: MovementPattern
+    public var intent: SetIntent
+    public var bias: Double
+    public var rmse: Double
+    public var sampleCount: Int
+
+    public init(pattern: MovementPattern, intent: SetIntent, bias: Double, rmse: Double, sampleCount: Int) {
+        self.pattern = pattern
+        self.intent = intent
+        self.bias = bias
+        self.rmse = rmse
+        self.sampleCount = sampleCount
+    }
+}
+
+// MARK: - PrescriptionIntentMismatch
+
+/// Diagnostic log for set-intent mismatches at log time. Inspection-only,
+/// capped at 50 entries (cap enforced at write-side); not used for rate
+/// analytics per ADR-0005.
+public struct PrescriptionIntentMismatch: Codable, Sendable, Hashable {
+    public var timestamp: Date
+    public var exerciseId: String
+    public var pattern: MovementPattern
+    public var prescribedIntent: SetIntent
+    public var loggedIntent: SetIntent
+
+    public init(
+        timestamp: Date,
+        exerciseId: String,
+        pattern: MovementPattern,
+        prescribedIntent: SetIntent,
+        loggedIntent: SetIntent
+    ) {
+        self.timestamp = timestamp
+        self.exerciseId = exerciseId
+        self.pattern = pattern
+        self.prescribedIntent = prescribedIntent
+        self.loggedIntent = loggedIntent
+    }
+}
+
+// MARK: - ExerciseTransfer
+
+/// Per-user-learned cross-exercise transfer coefficient with R². Gated
+/// on ≥5 paired observations per ADR-0005; first ~30 sessions per pair
+/// give no transfer benefit (cold-start).
+public struct ExerciseTransfer: Codable, Sendable, Hashable {
+    public var fromExerciseId: String
+    public var toExerciseId: String
+    public var coefficient: Double
+    public var rSquared: Double
+    public var pairedObservations: Int
+
+    public init(
+        fromExerciseId: String,
+        toExerciseId: String,
+        coefficient: Double,
+        rSquared: Double,
+        pairedObservations: Int
+    ) {
+        self.fromExerciseId = fromExerciseId
+        self.toExerciseId = toExerciseId
+        self.coefficient = coefficient
+        self.rSquared = rSquared
+        self.pairedObservations = pairedObservations
+    }
+}
+
+// MARK: - BodyweightHistory
+
+/// Passive-log bodyweight history per ADR-0005.
+public struct BodyweightHistory: Codable, Sendable, Hashable {
+    public var entries: [BodyweightEntry]
+
+    public init(entries: [BodyweightEntry] = []) {
+        self.entries = entries
+    }
+}

--- a/ProjectApex/Models/TraineeModelInteractions.swift
+++ b/ProjectApex/Models/TraineeModelInteractions.swift
@@ -11,15 +11,15 @@ import Foundation
 /// A currently flagged injury / pain state per pattern, muscle, or joint.
 /// AI-inferred limitations require ≥2 corroborating evidence and cap at
 /// .mild severity until user-confirmed (per ADR-0005).
-public struct ActiveLimitation: Codable, Sendable, Hashable {
-    public var subject: LimitationSubject
-    public var severity: Severity
-    public var onsetDate: Date
-    public var evidenceCount: Int
-    public var userConfirmed: Bool
-    public var notes: String?
+struct ActiveLimitation: Codable, Sendable, Hashable {
+    var subject: LimitationSubject
+    var severity: Severity
+    var onsetDate: Date
+    var evidenceCount: Int
+    var userConfirmed: Bool
+    var notes: String?
 
-    public init(
+    init(
         subject: LimitationSubject,
         severity: Severity,
         onsetDate: Date,
@@ -41,14 +41,14 @@ public struct ActiveLimitation: Codable, Sendable, Hashable {
 /// An archived limitation resolved through clean training. Retention is
 /// capped at 50 entries / 12 months (enforced at write-side, not in
 /// this value type) per ADR-0005.
-public struct ClearedLimitation: Codable, Sendable, Hashable {
-    public var subject: LimitationSubject
-    public var severity: Severity
-    public var onsetDate: Date
-    public var clearedDate: Date
-    public var notes: String?
+struct ClearedLimitation: Codable, Sendable, Hashable {
+    var subject: LimitationSubject
+    var severity: Severity
+    var onsetDate: Date
+    var clearedDate: Date
+    var notes: String?
 
-    public init(
+    init(
         subject: LimitationSubject,
         severity: Severity,
         onsetDate: Date,
@@ -74,16 +74,16 @@ public struct ClearedLimitation: Codable, Sendable, Hashable {
 ///  - countFactor caps confidence at 0.5 below 15 observations; full
 ///    weight at 15+.
 ///  - confidence = consistencyFactor × countFactor.
-public struct FatigueInteraction: Codable, Sendable, Hashable {
-    public var fromPattern: MovementPattern
-    public var toPattern: MovementPattern
+struct FatigueInteraction: Codable, Sendable, Hashable {
+    var fromPattern: MovementPattern
+    var toPattern: MovementPattern
     /// Delta-percent observations (e.g. -0.05 = 5% performance dip).
     /// Newest at the end. Window of last 10 feeds consistencyFactor.
-    public var observations: [Double]
+    var observations: [Double]
     /// Total paired observations seen across history (for the hard-cap rule).
-    public var totalCount: Int
+    var totalCount: Int
 
-    public init(
+    init(
         fromPattern: MovementPattern,
         toPattern: MovementPattern,
         observations: [Double],
@@ -95,7 +95,7 @@ public struct FatigueInteraction: Codable, Sendable, Hashable {
         self.totalCount = totalCount
     }
 
-    public var consistencyFactor: Double {
+    var consistencyFactor: Double {
         let recent = Array(observations.suffix(10))
         guard recent.count >= 2 else { return 0 }
         let mean = recent.reduce(0, +) / Double(recent.count)
@@ -108,11 +108,11 @@ public struct FatigueInteraction: Codable, Sendable, Hashable {
         return clamped
     }
 
-    public var countFactor: Double {
+    var countFactor: Double {
         totalCount >= 15 ? 1.0 : 0.5
     }
 
-    public var confidence: Double {
+    var confidence: Double {
         consistencyFactor * countFactor
     }
 }
@@ -121,14 +121,14 @@ public struct FatigueInteraction: Codable, Sendable, Hashable {
 
 /// Per (pattern, intent) bias and RMSE — meta-coaching about the AI's
 /// own miscalibration, distinct from a single intent mismatch at log time.
-public struct PrescriptionAccuracy: Codable, Sendable, Hashable {
-    public var pattern: MovementPattern
-    public var intent: SetIntent
-    public var bias: Double
-    public var rmse: Double
-    public var sampleCount: Int
+struct PrescriptionAccuracy: Codable, Sendable, Hashable {
+    var pattern: MovementPattern
+    var intent: SetIntent
+    var bias: Double
+    var rmse: Double
+    var sampleCount: Int
 
-    public init(pattern: MovementPattern, intent: SetIntent, bias: Double, rmse: Double, sampleCount: Int) {
+    init(pattern: MovementPattern, intent: SetIntent, bias: Double, rmse: Double, sampleCount: Int) {
         self.pattern = pattern
         self.intent = intent
         self.bias = bias
@@ -142,14 +142,14 @@ public struct PrescriptionAccuracy: Codable, Sendable, Hashable {
 /// Diagnostic log for set-intent mismatches at log time. Inspection-only,
 /// capped at 50 entries (cap enforced at write-side); not used for rate
 /// analytics per ADR-0005.
-public struct PrescriptionIntentMismatch: Codable, Sendable, Hashable {
-    public var timestamp: Date
-    public var exerciseId: String
-    public var pattern: MovementPattern
-    public var prescribedIntent: SetIntent
-    public var loggedIntent: SetIntent
+struct PrescriptionIntentMismatch: Codable, Sendable, Hashable {
+    var timestamp: Date
+    var exerciseId: String
+    var pattern: MovementPattern
+    var prescribedIntent: SetIntent
+    var loggedIntent: SetIntent
 
-    public init(
+    init(
         timestamp: Date,
         exerciseId: String,
         pattern: MovementPattern,
@@ -169,14 +169,14 @@ public struct PrescriptionIntentMismatch: Codable, Sendable, Hashable {
 /// Per-user-learned cross-exercise transfer coefficient with R². Gated
 /// on ≥5 paired observations per ADR-0005; first ~30 sessions per pair
 /// give no transfer benefit (cold-start).
-public struct ExerciseTransfer: Codable, Sendable, Hashable {
-    public var fromExerciseId: String
-    public var toExerciseId: String
-    public var coefficient: Double
-    public var rSquared: Double
-    public var pairedObservations: Int
+struct ExerciseTransfer: Codable, Sendable, Hashable {
+    var fromExerciseId: String
+    var toExerciseId: String
+    var coefficient: Double
+    var rSquared: Double
+    var pairedObservations: Int
 
-    public init(
+    init(
         fromExerciseId: String,
         toExerciseId: String,
         coefficient: Double,
@@ -194,10 +194,10 @@ public struct ExerciseTransfer: Codable, Sendable, Hashable {
 // MARK: - BodyweightHistory
 
 /// Passive-log bodyweight history per ADR-0005.
-public struct BodyweightHistory: Codable, Sendable, Hashable {
-    public var entries: [BodyweightEntry]
+struct BodyweightHistory: Codable, Sendable, Hashable {
+    var entries: [BodyweightEntry]
 
-    public init(entries: [BodyweightEntry] = []) {
+    init(entries: [BodyweightEntry] = []) {
         self.entries = entries
     }
 }

--- a/ProjectApex/Models/TraineeModelProfiles.swift
+++ b/ProjectApex/Models/TraineeModelProfiles.swift
@@ -1,0 +1,188 @@
+// TraineeModelProfiles.swift
+// ProjectApex — Models
+//
+// Profile types per ADR-0005 — ExerciseProfile, MuscleProfile, PatternProfile,
+// ProjectionState. PatternProfile carries the derived cadence / transition-mode
+// computed properties.
+
+import Foundation
+
+// MARK: - ExerciseProfile
+
+/// Per-exercise capability snapshot. EWMA over the last 5 valid top sets
+/// (validity 3..10 reps) per ADR-0005. `learningPhase` flips false at
+/// sessionCount >= 10. `formDegradationFlag` is RAG-fed.
+struct ExerciseProfile: Codable, Sendable, Hashable {
+    var exerciseId: String
+    var topSets: [TopSetSnapshot]
+    var sessionSnapshots: [ExerciseSessionSnapshot]
+    var e1rmCurrent: Double
+    var e1rmMedian: Double
+    var e1rmPeak: Double
+    var sessionCount: Int
+    var formDegradationFlag: Bool
+    var confidence: AxisConfidence
+
+    init(
+        exerciseId: String,
+        topSets: [TopSetSnapshot] = [],
+        sessionSnapshots: [ExerciseSessionSnapshot] = [],
+        e1rmCurrent: Double = 0,
+        e1rmMedian: Double = 0,
+        e1rmPeak: Double = 0,
+        sessionCount: Int = 0,
+        formDegradationFlag: Bool = false,
+        confidence: AxisConfidence = .bootstrapping
+    ) {
+        self.exerciseId = exerciseId
+        self.topSets = topSets
+        self.sessionSnapshots = sessionSnapshots
+        self.e1rmCurrent = e1rmCurrent
+        self.e1rmMedian = e1rmMedian
+        self.e1rmPeak = e1rmPeak
+        self.sessionCount = sessionCount
+        self.formDegradationFlag = formDegradationFlag
+        self.confidence = confidence
+    }
+
+    /// True while the exercise is in its first 10 sessions per ADR-0005.
+    var learningPhase: Bool { sessionCount < 10 }
+}
+
+// MARK: - MuscleProfile
+
+/// Per-muscle-group profile. Volume metrics are queue-event-windowed
+/// (last 7 training events per ADR-0002), not calendar-week-shaped.
+struct MuscleProfile: Codable, Sendable, Hashable {
+    var muscleGroup: MuscleGroup
+    var volumeTolerance: Double
+    var observedSweetSpot: Int?
+    var volumeDeficit: Int
+    var focusWeight: Double
+    var stagnationStatus: ProgressionTrend
+    var confidence: AxisConfidence
+
+    init(
+        muscleGroup: MuscleGroup,
+        volumeTolerance: Double = 0,
+        observedSweetSpot: Int? = nil,
+        volumeDeficit: Int = 0,
+        focusWeight: Double = 0,
+        stagnationStatus: ProgressionTrend = .progressing,
+        confidence: AxisConfidence = .bootstrapping
+    ) {
+        self.muscleGroup = muscleGroup
+        self.volumeTolerance = volumeTolerance
+        self.observedSweetSpot = observedSweetSpot
+        self.volumeDeficit = volumeDeficit
+        self.focusWeight = focusWeight
+        self.stagnationStatus = stagnationStatus
+        self.confidence = confidence
+    }
+}
+
+// MARK: - PatternProfile
+
+/// Per-movement-pattern profile. Carries phase, recovery, transition-mode
+/// state, and the recent-session date list that feeds the cadence /
+/// disruption derivations.
+struct PatternProfile: Codable, Sendable, Hashable {
+    var pattern: MovementPattern
+    var currentPhase: MesocyclePhase
+    var sessionsInPhase: Int
+    var lastPhaseTransitionAtSessionCount: Int
+    var rpeOffset: Double
+    var recovery: RecoveryProfile
+    var confidence: AxisConfidence
+    /// When non-nil and in the future, the pattern is in transition mode
+    /// (EWMA window collapsed to 3 most-recent sessions per ADR-0005).
+    var transitionModeUntil: Date?
+    var trend: ProgressionTrend
+    /// Recent session dates for this pattern, oldest first. Storage is
+    /// bounded externally (the trainee-model update job decides how many
+    /// to retain — typically the last 7..10 to support cadence and
+    /// disruption derivations without unbounded growth).
+    var recentSessionDates: [Date]
+
+    init(
+        pattern: MovementPattern,
+        currentPhase: MesocyclePhase = .accumulation,
+        sessionsInPhase: Int = 0,
+        lastPhaseTransitionAtSessionCount: Int = 0,
+        rpeOffset: Double = 0,
+        recovery: RecoveryProfile = RecoveryProfile(),
+        confidence: AxisConfidence = .bootstrapping,
+        transitionModeUntil: Date? = nil,
+        trend: ProgressionTrend = .progressing,
+        recentSessionDates: [Date] = []
+    ) {
+        self.pattern = pattern
+        self.currentPhase = currentPhase
+        self.sessionsInPhase = sessionsInPhase
+        self.lastPhaseTransitionAtSessionCount = lastPhaseTransitionAtSessionCount
+        self.rpeOffset = rpeOffset
+        self.recovery = recovery
+        self.confidence = confidence
+        self.transitionModeUntil = transitionModeUntil
+        self.trend = trend
+        self.recentSessionDates = recentSessionDates
+    }
+
+    // MARK: Derived properties
+
+    /// Pre-bucketed local-date strings (yyyy-MM-dd) for the recent
+    /// session dates, oldest first. Local-date semantics per ADR-0005.
+    var recentSessionDays: [String] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return recentSessionDates.sorted().map { formatter.string(from: $0) }
+    }
+
+    /// Mean delta in days between consecutive recent sessions.
+    /// Returns nil if fewer than 2 sessions are recorded.
+    var sessionsCadenceDays: Double? {
+        guard recentSessionDates.count >= 2 else { return nil }
+        let sorted = recentSessionDates.sorted()
+        let deltas = zip(sorted.dropFirst(), sorted).map {
+            $0.timeIntervalSince($1) / 86400.0
+        }
+        return deltas.reduce(0, +) / Double(deltas.count)
+    }
+
+    /// Whole days since the most recent session, computed against the
+    /// reference date (defaulting to now). Returns nil if no recorded
+    /// sessions. Negative deltas (recorded session in the future) clamp
+    /// to 0.
+    func daysSinceLastSession(asOf reference: Date = Date()) -> Int? {
+        guard let last = recentSessionDates.max() else { return nil }
+        let delta = reference.timeIntervalSince(last) / 86400.0
+        return max(0, Int(delta.rounded(.down)))
+    }
+
+    /// True iff transition mode is currently active (non-nil
+    /// `transitionModeUntil` in the future).
+    func inTransitionMode(asOf reference: Date = Date()) -> Bool {
+        guard let until = transitionModeUntil else { return false }
+        return reference < until
+    }
+}
+
+// MARK: - ProjectionState
+
+/// Floor + stretch projections per pattern, set at calibration review
+/// and re-derived (stretch only) on goal renegotiation per ADR-0005.
+struct ProjectionState: Codable, Sendable, Hashable {
+    var patternProjections: [PatternProjection]
+    var calibrationReviewFiredAt: Date?
+    var goalLastRenegotiatedAt: Date?
+
+    init(
+        patternProjections: [PatternProjection] = [],
+        calibrationReviewFiredAt: Date? = nil,
+        goalLastRenegotiatedAt: Date? = nil
+    ) {
+        self.patternProjections = patternProjections
+        self.calibrationReviewFiredAt = calibrationReviewFiredAt
+        self.goalLastRenegotiatedAt = goalLastRenegotiatedAt
+    }
+}

--- a/ProjectApex/Models/TraineeModelSnapshots.swift
+++ b/ProjectApex/Models/TraineeModelSnapshots.swift
@@ -1,0 +1,154 @@
+// TraineeModelSnapshots.swift
+// ProjectApex — Models
+//
+// Pure-value snapshot / record types referenced by the trainee model.
+// All Codable, Sendable, Hashable.
+//
+// Each `localDate` field is the pre-bucketed local-date string per
+// ADR-0005 ("immune to subsequent timezone changes"); typically of the
+// form "YYYY-MM-DD" written at session-completion time.
+
+import Foundation
+
+// MARK: - TopSetSnapshot
+
+/// One top-set observation (intent == .top, reps in 3..10) feeding the
+/// EWMA window per ADR-0005.
+public struct TopSetSnapshot: Codable, Sendable, Hashable {
+    public var sessionId: UUID
+    public var localDate: String
+    public var weightKg: Double
+    public var reps: Int
+    public var e1rm: Double
+
+    public init(sessionId: UUID, localDate: String, weightKg: Double, reps: Int, e1rm: Double) {
+        self.sessionId = sessionId
+        self.localDate = localDate
+        self.weightKg = weightKg
+        self.reps = reps
+        self.e1rm = e1rm
+    }
+}
+
+// MARK: - ExerciseSessionSnapshot
+
+/// Per-session-per-exercise snapshot — captures the heaviest top set
+/// of that session (used by transition-mode plain-mean over recent
+/// sessions per ADR-0005) plus aggregate counts.
+public struct ExerciseSessionSnapshot: Codable, Sendable, Hashable {
+    public var sessionId: UUID
+    public var localDate: String
+    public var heaviestTopSet: TopSetSnapshot?
+    public var topSetCount: Int
+
+    public init(sessionId: UUID, localDate: String, heaviestTopSet: TopSetSnapshot?, topSetCount: Int) {
+        self.sessionId = sessionId
+        self.localDate = localDate
+        self.heaviestTopSet = heaviestTopSet
+        self.topSetCount = topSetCount
+    }
+}
+
+// MARK: - BodyweightEntry
+
+/// One passive-log bodyweight observation.
+public struct BodyweightEntry: Codable, Sendable, Hashable {
+    public var localDate: String
+    public var weightKg: Double
+
+    public init(localDate: String, weightKg: Double) {
+        self.localDate = localDate
+        self.weightKg = weightKg
+    }
+}
+
+// MARK: - LifeContextEvent
+
+/// Disruption / context event — persist-only in v2 per ADR-0005.
+public struct LifeContextEvent: Codable, Sendable, Hashable {
+    public var localDate: String
+    public var kind: String
+    public var notes: String?
+
+    public init(localDate: String, kind: String, notes: String? = nil) {
+        self.localDate = localDate
+        self.kind = kind
+        self.notes = notes
+    }
+}
+
+// MARK: - ReassessmentRecord
+
+/// Records a heavy reassessment firing — per ADR-0005, fires when ≥4 of
+/// 6 major patterns transition phase within a 6-session window.
+public struct ReassessmentRecord: Codable, Sendable, Hashable {
+    public var triggeredAt: Date
+    public var triggeringSessionCount: Int
+    public var advancedPatterns: [MovementPattern]
+
+    public init(triggeredAt: Date, triggeringSessionCount: Int, advancedPatterns: [MovementPattern]) {
+        self.triggeredAt = triggeredAt
+        self.triggeringSessionCount = triggeringSessionCount
+        self.advancedPatterns = advancedPatterns
+    }
+}
+
+// MARK: - PatternProjection
+
+/// Per-pattern projection set at calibration review (or re-derived on
+/// goal renegotiation for the stretch leg). Floor is immovable; stretch
+/// is user-adjustable upward only per ADR-0005.
+public struct PatternProjection: Codable, Sendable, Hashable {
+    public var pattern: MovementPattern
+    public var floor: Double
+    public var stretch: Double
+    public var progress: ProjectionProgress
+
+    public init(pattern: MovementPattern, floor: Double, stretch: Double, progress: ProjectionProgress) {
+        self.pattern = pattern
+        self.floor = floor
+        self.stretch = stretch
+        self.progress = progress
+    }
+}
+
+// MARK: - RecoveryProfile
+
+/// Two-dimensional recovery state per ADR-0005 — separate NM and
+/// metabolic axes because heavy 1–3RM and high-rep moderate work tax
+/// different systems with different decay curves.
+public struct RecoveryProfile: Codable, Sendable, Hashable {
+    public var lastNeuromuscularStimulusAt: Date?
+    public var lastMetabolicStimulusAt: Date?
+    public var neuromuscularReadiness: Double
+    public var metabolicReadiness: Double
+
+    public init(
+        lastNeuromuscularStimulusAt: Date? = nil,
+        lastMetabolicStimulusAt: Date? = nil,
+        neuromuscularReadiness: Double = 1.0,
+        metabolicReadiness: Double = 1.0
+    ) {
+        self.lastNeuromuscularStimulusAt = lastNeuromuscularStimulusAt
+        self.lastMetabolicStimulusAt = lastMetabolicStimulusAt
+        self.neuromuscularReadiness = neuromuscularReadiness
+        self.metabolicReadiness = metabolicReadiness
+    }
+}
+
+// MARK: - GoalState
+
+/// Plain-language goal at onboarding plus optional focus areas. No
+/// numerical targets at onboarding — projections are set at calibration
+/// review per ADR-0005.
+public struct GoalState: Codable, Sendable, Hashable {
+    public var statement: String
+    public var focusAreas: [MuscleGroup]
+    public var updatedAt: Date
+
+    public init(statement: String, focusAreas: [MuscleGroup] = [], updatedAt: Date) {
+        self.statement = statement
+        self.focusAreas = focusAreas
+        self.updatedAt = updatedAt
+    }
+}

--- a/ProjectApex/Models/TraineeModelSnapshots.swift
+++ b/ProjectApex/Models/TraineeModelSnapshots.swift
@@ -14,14 +14,14 @@ import Foundation
 
 /// One top-set observation (intent == .top, reps in 3..10) feeding the
 /// EWMA window per ADR-0005.
-public struct TopSetSnapshot: Codable, Sendable, Hashable {
-    public var sessionId: UUID
-    public var localDate: String
-    public var weightKg: Double
-    public var reps: Int
-    public var e1rm: Double
+struct TopSetSnapshot: Codable, Sendable, Hashable {
+    var sessionId: UUID
+    var localDate: String
+    var weightKg: Double
+    var reps: Int
+    var e1rm: Double
 
-    public init(sessionId: UUID, localDate: String, weightKg: Double, reps: Int, e1rm: Double) {
+    init(sessionId: UUID, localDate: String, weightKg: Double, reps: Int, e1rm: Double) {
         self.sessionId = sessionId
         self.localDate = localDate
         self.weightKg = weightKg
@@ -35,13 +35,13 @@ public struct TopSetSnapshot: Codable, Sendable, Hashable {
 /// Per-session-per-exercise snapshot — captures the heaviest top set
 /// of that session (used by transition-mode plain-mean over recent
 /// sessions per ADR-0005) plus aggregate counts.
-public struct ExerciseSessionSnapshot: Codable, Sendable, Hashable {
-    public var sessionId: UUID
-    public var localDate: String
-    public var heaviestTopSet: TopSetSnapshot?
-    public var topSetCount: Int
+struct ExerciseSessionSnapshot: Codable, Sendable, Hashable {
+    var sessionId: UUID
+    var localDate: String
+    var heaviestTopSet: TopSetSnapshot?
+    var topSetCount: Int
 
-    public init(sessionId: UUID, localDate: String, heaviestTopSet: TopSetSnapshot?, topSetCount: Int) {
+    init(sessionId: UUID, localDate: String, heaviestTopSet: TopSetSnapshot?, topSetCount: Int) {
         self.sessionId = sessionId
         self.localDate = localDate
         self.heaviestTopSet = heaviestTopSet
@@ -52,11 +52,11 @@ public struct ExerciseSessionSnapshot: Codable, Sendable, Hashable {
 // MARK: - BodyweightEntry
 
 /// One passive-log bodyweight observation.
-public struct BodyweightEntry: Codable, Sendable, Hashable {
-    public var localDate: String
-    public var weightKg: Double
+struct BodyweightEntry: Codable, Sendable, Hashable {
+    var localDate: String
+    var weightKg: Double
 
-    public init(localDate: String, weightKg: Double) {
+    init(localDate: String, weightKg: Double) {
         self.localDate = localDate
         self.weightKg = weightKg
     }
@@ -65,12 +65,12 @@ public struct BodyweightEntry: Codable, Sendable, Hashable {
 // MARK: - LifeContextEvent
 
 /// Disruption / context event — persist-only in v2 per ADR-0005.
-public struct LifeContextEvent: Codable, Sendable, Hashable {
-    public var localDate: String
-    public var kind: String
-    public var notes: String?
+struct LifeContextEvent: Codable, Sendable, Hashable {
+    var localDate: String
+    var kind: String
+    var notes: String?
 
-    public init(localDate: String, kind: String, notes: String? = nil) {
+    init(localDate: String, kind: String, notes: String? = nil) {
         self.localDate = localDate
         self.kind = kind
         self.notes = notes
@@ -81,12 +81,12 @@ public struct LifeContextEvent: Codable, Sendable, Hashable {
 
 /// Records a heavy reassessment firing — per ADR-0005, fires when ≥4 of
 /// 6 major patterns transition phase within a 6-session window.
-public struct ReassessmentRecord: Codable, Sendable, Hashable {
-    public var triggeredAt: Date
-    public var triggeringSessionCount: Int
-    public var advancedPatterns: [MovementPattern]
+struct ReassessmentRecord: Codable, Sendable, Hashable {
+    var triggeredAt: Date
+    var triggeringSessionCount: Int
+    var advancedPatterns: [MovementPattern]
 
-    public init(triggeredAt: Date, triggeringSessionCount: Int, advancedPatterns: [MovementPattern]) {
+    init(triggeredAt: Date, triggeringSessionCount: Int, advancedPatterns: [MovementPattern]) {
         self.triggeredAt = triggeredAt
         self.triggeringSessionCount = triggeringSessionCount
         self.advancedPatterns = advancedPatterns
@@ -98,13 +98,13 @@ public struct ReassessmentRecord: Codable, Sendable, Hashable {
 /// Per-pattern projection set at calibration review (or re-derived on
 /// goal renegotiation for the stretch leg). Floor is immovable; stretch
 /// is user-adjustable upward only per ADR-0005.
-public struct PatternProjection: Codable, Sendable, Hashable {
-    public var pattern: MovementPattern
-    public var floor: Double
-    public var stretch: Double
-    public var progress: ProjectionProgress
+struct PatternProjection: Codable, Sendable, Hashable {
+    var pattern: MovementPattern
+    var floor: Double
+    var stretch: Double
+    var progress: ProjectionProgress
 
-    public init(pattern: MovementPattern, floor: Double, stretch: Double, progress: ProjectionProgress) {
+    init(pattern: MovementPattern, floor: Double, stretch: Double, progress: ProjectionProgress) {
         self.pattern = pattern
         self.floor = floor
         self.stretch = stretch
@@ -117,13 +117,13 @@ public struct PatternProjection: Codable, Sendable, Hashable {
 /// Two-dimensional recovery state per ADR-0005 — separate NM and
 /// metabolic axes because heavy 1–3RM and high-rep moderate work tax
 /// different systems with different decay curves.
-public struct RecoveryProfile: Codable, Sendable, Hashable {
-    public var lastNeuromuscularStimulusAt: Date?
-    public var lastMetabolicStimulusAt: Date?
-    public var neuromuscularReadiness: Double
-    public var metabolicReadiness: Double
+struct RecoveryProfile: Codable, Sendable, Hashable {
+    var lastNeuromuscularStimulusAt: Date?
+    var lastMetabolicStimulusAt: Date?
+    var neuromuscularReadiness: Double
+    var metabolicReadiness: Double
 
-    public init(
+    init(
         lastNeuromuscularStimulusAt: Date? = nil,
         lastMetabolicStimulusAt: Date? = nil,
         neuromuscularReadiness: Double = 1.0,
@@ -141,12 +141,12 @@ public struct RecoveryProfile: Codable, Sendable, Hashable {
 /// Plain-language goal at onboarding plus optional focus areas. No
 /// numerical targets at onboarding — projections are set at calibration
 /// review per ADR-0005.
-public struct GoalState: Codable, Sendable, Hashable {
-    public var statement: String
-    public var focusAreas: [MuscleGroup]
-    public var updatedAt: Date
+struct GoalState: Codable, Sendable, Hashable {
+    var statement: String
+    var focusAreas: [MuscleGroup]
+    var updatedAt: Date
 
-    public init(statement: String, focusAreas: [MuscleGroup] = [], updatedAt: Date) {
+    init(statement: String, focusAreas: [MuscleGroup] = [], updatedAt: Date) {
         self.statement = statement
         self.focusAreas = focusAreas
         self.updatedAt = updatedAt

--- a/ProjectApex/Services/PatternPhaseService.swift
+++ b/ProjectApex/Services/PatternPhaseService.swift
@@ -21,9 +21,12 @@ import Foundation
 // MARK: - MovementPatternPhaseState
 
 /// Per-movement-pattern periodization state. Persisted to UserDefaults.
+/// Slice 1 migrated `pattern` from String to MovementPattern; Codable
+/// round-trip is wire-compatible (MovementPattern's String raw values
+/// match the prior storage strings).
 nonisolated struct MovementPatternPhaseState: Codable, Sendable, Identifiable {
-    /// Movement pattern key, e.g. "horizontal_push", "squat", "isolation".
-    let pattern: String
+    /// Movement pattern, e.g. .horizontalPush, .squat, .isolation.
+    let pattern: MovementPattern
     /// Current periodization phase for this specific movement pattern.
     var phase: MesocyclePhase
     /// Completed (non-skipped) sessions for this pattern in the current phase.
@@ -32,7 +35,7 @@ nonisolated struct MovementPatternPhaseState: Codable, Sendable, Identifiable {
     let sessionsRequiredForPhase: Int
 
     /// Identifiable conformance — pattern is stable within a programme.
-    var id: String { pattern }
+    var id: MovementPattern { pattern }
 }
 
 // MARK: - PatternPhaseInfo
@@ -93,12 +96,12 @@ nonisolated enum PatternPhaseService {
     ///
     /// - Parameters:
     ///   - current: The currently persisted pattern phase states.
-    ///   - trainedPatterns: Movement pattern strings trained in the just-completed session.
+    ///   - trainedPatterns: Movement patterns trained in the just-completed session.
     ///   - daysPerWeek: The programme's training days per week (from UserDefaults or skeleton).
     /// - Returns: Updated array with counters incremented and phase transitions applied.
     static func advancePhases(
         current: [MovementPatternPhaseState],
-        trainedPatterns: Set<String>,
+        trainedPatterns: Set<MovementPattern>,
         daysPerWeek: Int
     ) -> [MovementPatternPhaseState] {
         guard !trainedPatterns.isEmpty else { return current }
@@ -126,7 +129,8 @@ nonisolated enum PatternPhaseService {
 
         // Create new entries for patterns encountered for the first time
         let existingPatterns = Set(updated.map(\.pattern))
-        for pattern in trainedPatterns.sorted() where !existingPatterns.contains(pattern) {
+        let newPatterns = trainedPatterns.subtracting(existingPatterns).sorted { $0.rawValue < $1.rawValue }
+        for pattern in newPatterns {
             let req = sessionsRequired(for: .accumulation, daysPerWeek: daysPerWeek)
             updated.append(MovementPatternPhaseState(
                 pattern: pattern,
@@ -158,10 +162,9 @@ nonisolated enum PatternPhaseService {
         guard !setLogs.isEmpty else { return [] }
 
         // Group distinct session IDs per movement pattern
-        var sessionsByPattern: [String: Set<UUID>] = [:]
+        var sessionsByPattern: [MovementPattern: Set<UUID>] = [:]
         for log in setLogs {
-            guard let def = ExerciseLibrary.lookup(log.exerciseId),
-                  !def.movementPattern.isEmpty else { continue }
+            guard let def = ExerciseLibrary.lookup(log.exerciseId) else { continue }
             sessionsByPattern[def.movementPattern, default: []].insert(log.sessionId)
         }
 
@@ -199,7 +202,7 @@ nonisolated enum PatternPhaseService {
             ))
         }
 
-        return states.sorted { $0.pattern < $1.pattern }
+        return states.sorted { $0.pattern.rawValue < $1.pattern.rawValue }
     }
 
     // MARK: - Persistence

--- a/ProjectApex/Services/SessionPlanService.swift
+++ b/ProjectApex/Services/SessionPlanService.swift
@@ -56,8 +56,13 @@ nonisolated struct WeekFatigueSignals: Codable, Sendable {
     let repCompletionRate: Double?
     /// Number of significant compound lift misses this week (< 60% rep completion).
     let significantMissCount: Int
-    /// Total sets per muscle group this week, e.g. ["chest": 12, "back": 14].
-    let setsPerMuscleGroup: [String: Int]
+    /// Total sets per muscle group this week, e.g. [.chest: 12, .back: 14].
+    /// Slice 1 migrated from [String: Int] to [MuscleGroup: Int] (locked-six
+    /// per ADR-0005). Wire-compatible JSON shape: leg subgroups
+    /// (quads/hamstrings/glutes/calves) collapse to "legs"; core entries
+    /// drop entirely. Behavioral note: this slightly coarsens what the LLM
+    /// sees compared to the previous string-keyed shape.
+    let setsPerMuscleGroup: [MuscleGroup: Int]
     /// True when cumulative weekly RPE > 8.2 across 3+ sessions.
     let fatigueManagementFlagged: Bool
     /// True when deload triggers fire: ≥2 of [avg_rpe > 8.0, rep_rate < 75%, 3+ misses].
@@ -94,7 +99,7 @@ nonisolated struct WeekFatigueSignals: Codable, Sendable {
         // Where we have aiPrescribed data, compare. Otherwise skip.
         var repCompPairs: [(target: Int, actual: Int)] = []
         var sigMisses = 0
-        var muscleSetCounts: [String: Int] = [:]
+        var muscleSetCounts: [MuscleGroup: Int] = [:]
 
         for log in setLogs {
             if let prescribed = log.aiPrescribed {
@@ -104,9 +109,11 @@ nonisolated struct WeekFatigueSignals: Codable, Sendable {
                 let rate = Double(actual) / Double(max(target, 1))
                 if rate < 0.60 { sigMisses += 1 }
             }
-            // Muscle group from exerciseId — use as-is (snake_case muscle group).
-            let key = muscleGroupKey(for: log.exerciseId)
-            muscleSetCounts[key, default: 0] += 1
+            // Muscle group from exerciseId — drops core / other (no
+            // representation in the locked-six MuscleGroup taxonomy).
+            if let group = muscleGroup(for: log.exerciseId) {
+                muscleSetCounts[group, default: 0] += 1
+            }
         }
 
         let repRate: Double?
@@ -139,21 +146,28 @@ nonisolated struct WeekFatigueSignals: Codable, Sendable {
         )
     }
 
-    /// Maps an exerciseId (e.g. "barbell_bench_press") to a coarse muscle group key.
-    private static func muscleGroupKey(for exerciseId: String) -> String {
+    /// Maps an exerciseId to a MuscleGroup. Prefers the canonical
+    /// ExerciseLibrary lookup; falls back to string heuristics for
+    /// non-canonical IDs. Returns nil for core / unmapped IDs (the
+    /// locked-six MuscleGroup taxonomy excludes both per ADR-0005).
+    private static func muscleGroup(for exerciseId: String) -> MuscleGroup? {
+        if let primary = ExerciseLibrary.primaryMuscle(for: exerciseId) {
+            return primary.muscleGroup
+        }
         let lower = exerciseId.lowercased()
-        if lower.contains("bench") || lower.contains("chest") || lower.contains("pec") { return "chest" }
-        if lower.contains("row") || lower.contains("pulldown") || lower.contains("pull_up") || lower.contains("lat") { return "back" }
-        if lower.contains("squat") || lower.contains("leg_press") || lower.contains("quad") || lower.contains("lunge") { return "quads" }
-        if lower.contains("deadlift") || lower.contains("hamstring") || lower.contains("rdl") { return "hamstrings" }
-        if lower.contains("glute") || lower.contains("hip_thrust") { return "glutes" }
-        if lower.contains("press") && lower.contains("shoulder") { return "shoulders" }
-        if lower.contains("overhead") || lower.contains("ohp") { return "shoulders" }
-        if lower.contains("curl") && !lower.contains("leg") { return "biceps" }
-        if lower.contains("tricep") || lower.contains("pushdown") { return "triceps" }
-        if lower.contains("calf") || lower.contains("raise") { return "calves" }
-        if lower.contains("ab") || lower.contains("core") { return "core" }
-        return "other"
+        if lower.contains("bench") || lower.contains("chest") || lower.contains("pec") { return .chest }
+        if lower.contains("row") || lower.contains("pulldown") || lower.contains("pull_up") || lower.contains("lat") { return .back }
+        if lower.contains("squat") || lower.contains("leg_press") || lower.contains("quad") || lower.contains("lunge") { return .legs }
+        if lower.contains("deadlift") || lower.contains("hamstring") || lower.contains("rdl") { return .legs }
+        if lower.contains("glute") || lower.contains("hip_thrust") { return .legs }
+        if lower.contains("press") && lower.contains("shoulder") { return .shoulders }
+        if lower.contains("overhead") || lower.contains("ohp") { return .shoulders }
+        if lower.contains("curl") && !lower.contains("leg") { return .biceps }
+        if lower.contains("tricep") || lower.contains("pushdown") { return .triceps }
+        if lower.contains("calf") || lower.contains("raise") { return .legs }
+        // "ab"/"core" mappings dropped — core is excluded from the locked-six
+        // MuscleGroup taxonomy per ADR-0005.
+        return nil
     }
 }
 

--- a/ProjectApex/Services/SessionPlanService.swift
+++ b/ProjectApex/Services/SessionPlanService.swift
@@ -56,13 +56,14 @@ nonisolated struct WeekFatigueSignals: Codable, Sendable {
     let repCompletionRate: Double?
     /// Number of significant compound lift misses this week (< 60% rep completion).
     let significantMissCount: Int
-    /// Total sets per muscle group this week, e.g. [.chest: 12, .back: 14].
-    /// Slice 1 migrated from [String: Int] to [MuscleGroup: Int] (locked-six
-    /// per ADR-0005). Wire-compatible JSON shape: leg subgroups
-    /// (quads/hamstrings/glutes/calves) collapse to "legs"; core entries
-    /// drop entirely. Behavioral note: this slightly coarsens what the LLM
-    /// sees compared to the previous string-keyed shape.
-    let setsPerMuscleGroup: [MuscleGroup: Int]
+    /// Total sets per primary muscle this week, e.g.
+    /// [.chest: 12, .quads: 6, .hamstrings: 4]. Keyed on PrimaryMuscle so
+    /// the LLM sees fine-grained leg-subgroup balance ("user has been
+    /// quad-light for 3 sessions" reasoning); collapsing to MuscleGroup
+    /// at this stage would erase the very distinction PrimaryMuscle was
+    /// introduced to preserve. Core is excluded — the 4 core exercises
+    /// were removed from ExerciseLibrary in Slice 1.
+    let setsPerPrimaryMuscle: [PrimaryMuscle: Int]
     /// True when cumulative weekly RPE > 8.2 across 3+ sessions.
     let fatigueManagementFlagged: Bool
     /// True when deload triggers fire: ≥2 of [avg_rpe > 8.0, rep_rate < 75%, 3+ misses].
@@ -73,7 +74,7 @@ nonisolated struct WeekFatigueSignals: Codable, Sendable {
         case weeklyAvgRPE              = "weekly_avg_rpe"
         case repCompletionRate         = "rep_completion_rate"
         case significantMissCount      = "significant_miss_count"
-        case setsPerMuscleGroup        = "sets_per_muscle_group"
+        case setsPerPrimaryMuscle      = "sets_per_primary_muscle"
         case fatigueManagementFlagged  = "fatigue_management_flagged"
         case deloadTriggered           = "deload_triggered"
     }
@@ -86,7 +87,7 @@ nonisolated struct WeekFatigueSignals: Codable, Sendable {
                 weeklyAvgRPE: nil,
                 repCompletionRate: nil,
                 significantMissCount: 0,
-                setsPerMuscleGroup: [:],
+                setsPerPrimaryMuscle: [:],
                 fatigueManagementFlagged: false,
                 deloadTriggered: false
             )
@@ -99,7 +100,7 @@ nonisolated struct WeekFatigueSignals: Codable, Sendable {
         // Where we have aiPrescribed data, compare. Otherwise skip.
         var repCompPairs: [(target: Int, actual: Int)] = []
         var sigMisses = 0
-        var muscleSetCounts: [MuscleGroup: Int] = [:]
+        var muscleSetCounts: [PrimaryMuscle: Int] = [:]
 
         for log in setLogs {
             if let prescribed = log.aiPrescribed {
@@ -109,10 +110,10 @@ nonisolated struct WeekFatigueSignals: Codable, Sendable {
                 let rate = Double(actual) / Double(max(target, 1))
                 if rate < 0.60 { sigMisses += 1 }
             }
-            // Muscle group from exerciseId — drops core / other (no
-            // representation in the locked-six MuscleGroup taxonomy).
-            if let group = muscleGroup(for: log.exerciseId) {
-                muscleSetCounts[group, default: 0] += 1
+            // Primary muscle from exerciseId — drops core / unknown (no
+            // representation in the 9-case PrimaryMuscle taxonomy).
+            if let muscle = primaryMuscle(for: log.exerciseId) {
+                muscleSetCounts[muscle, default: 0] += 1
             }
         }
 
@@ -140,33 +141,34 @@ nonisolated struct WeekFatigueSignals: Codable, Sendable {
             weeklyAvgRPE: avgRPE,
             repCompletionRate: repRate,
             significantMissCount: sigMisses,
-            setsPerMuscleGroup: muscleSetCounts,
+            setsPerPrimaryMuscle: muscleSetCounts,
             fatigueManagementFlagged: fatigueManagementFlagged,
             deloadTriggered: deloadTriggered
         )
     }
 
-    /// Maps an exerciseId to a MuscleGroup. Prefers the canonical
+    /// Maps an exerciseId to a PrimaryMuscle. Prefers the canonical
     /// ExerciseLibrary lookup; falls back to string heuristics for
-    /// non-canonical IDs. Returns nil for core / unmapped IDs (the
-    /// locked-six MuscleGroup taxonomy excludes both per ADR-0005).
-    private static func muscleGroup(for exerciseId: String) -> MuscleGroup? {
+    /// non-canonical IDs. Returns nil for core / unmapped IDs (the 9-case
+    /// PrimaryMuscle taxonomy excludes core per ADR-0005).
+    private static func primaryMuscle(for exerciseId: String) -> PrimaryMuscle? {
         if let primary = ExerciseLibrary.primaryMuscle(for: exerciseId) {
-            return primary.muscleGroup
+            return primary
         }
         let lower = exerciseId.lowercased()
         if lower.contains("bench") || lower.contains("chest") || lower.contains("pec") { return .chest }
         if lower.contains("row") || lower.contains("pulldown") || lower.contains("pull_up") || lower.contains("lat") { return .back }
-        if lower.contains("squat") || lower.contains("leg_press") || lower.contains("quad") || lower.contains("lunge") { return .legs }
-        if lower.contains("deadlift") || lower.contains("hamstring") || lower.contains("rdl") { return .legs }
-        if lower.contains("glute") || lower.contains("hip_thrust") { return .legs }
+        if lower.contains("squat") || lower.contains("leg_press") || lower.contains("quad") || lower.contains("lunge") { return .quads }
+        if lower.contains("deadlift") || lower.contains("rdl") { return .hamstrings }
+        if lower.contains("hamstring") { return .hamstrings }
+        if lower.contains("glute") || lower.contains("hip_thrust") { return .glutes }
         if lower.contains("press") && lower.contains("shoulder") { return .shoulders }
         if lower.contains("overhead") || lower.contains("ohp") { return .shoulders }
         if lower.contains("curl") && !lower.contains("leg") { return .biceps }
         if lower.contains("tricep") || lower.contains("pushdown") { return .triceps }
-        if lower.contains("calf") || lower.contains("raise") { return .legs }
-        // "ab"/"core" mappings dropped — core is excluded from the locked-six
-        // MuscleGroup taxonomy per ADR-0005.
+        if lower.contains("calf") || lower.contains("raise") { return .calves }
+        // "ab"/"core" mappings dropped — core is excluded from the 9-case
+        // PrimaryMuscle taxonomy per ADR-0005.
         return nil
     }
 }

--- a/ProjectApex/Services/VolumeValidationService.swift
+++ b/ProjectApex/Services/VolumeValidationService.swift
@@ -52,7 +52,7 @@ nonisolated enum VolumeValidationService {
             for exercise in day.exercises {
                 // Use ExerciseLibrary for the canonical muscle; fall back to the
                 // exercise's own primaryMuscle field if the ID is non-canonical.
-                let muscle = ExerciseLibrary.primaryMuscle(for: exercise.exerciseId)
+                let muscle = ExerciseLibrary.primaryMuscle(for: exercise.exerciseId)?.rawValue
                     ?? exercise.primaryMuscle
                 targetMap[muscle, default: 0] += exercise.sets
             }
@@ -66,7 +66,7 @@ nonisolated enum VolumeValidationService {
             // Prefer the primary_muscle column (populated at write time);
             // fall back to ExerciseLibrary lookup for older rows.
             let muscle = log.primaryMuscle
-                ?? ExerciseLibrary.primaryMuscle(for: log.exerciseId)
+                ?? ExerciseLibrary.primaryMuscle(for: log.exerciseId)?.rawValue
                 ?? "other"
             actualMap[muscle, default: 0] += 1
         }

--- a/ProjectApexTests/ExerciseLibraryTests.swift
+++ b/ProjectApexTests/ExerciseLibraryTests.swift
@@ -7,11 +7,15 @@
 //   3. lookup() resolves canonical IDs directly
 //   4. lookup() resolves known normalization map variants
 //   5. lookup() returns nil for unknown exercise IDs
-//   6. primaryMuscle(for:) convenience returns correct strings
+//   6. primaryMuscle(for:) convenience returns correct PrimaryMuscle cases
 //   7. All exercises reference valid EquipmentType typeKey strings
-//   8. promptReferenceBlock() contains every exercise ID
-//   9. All normalization map values point to valid canonical IDs
-//  10. No exercise maps to "other" via its primaryMuscle
+//   8. Synergist values use the broader-than-PrimaryMuscle vocabulary correctly
+//   9. promptReferenceBlock() contains every exercise ID
+//  10. All normalization map values point to valid canonical IDs
+//  11. Slice 1 — no exercise is core-classified (the 4 core entries were removed)
+//  12. Slice 1 — every entry's primaryMuscle is a valid PrimaryMuscle case
+//      (vacuous via the type system, kept for documentation) and every entry's
+//      movementPattern is a valid MovementPattern case (also type-enforced)
 
 import Testing
 import Foundation
@@ -34,11 +38,12 @@ private let validEquipmentTypeKeys: Set<String> = [
     "pec_deck", "preacher_curl", "cable_crossover",
 ]
 
-/// Coarse muscle group keys that are valid for primary_muscle in set_logs.
-private let validMuscleGroups: Set<String> = [
-    "chest", "back", "shoulders", "quads", "hamstrings",
-    "glutes", "biceps", "triceps", "calves", "core",
-]
+/// Synergists use a broader vocabulary than PrimaryMuscle — "forearms" is
+/// a valid synergist hint on bicep curls but isn't a first-class trainee-model
+/// muscle group. This set is the union of PrimaryMuscle's raw values and the
+/// known broader hints.
+private let validSynergistMuscles: Set<String> = Set(PrimaryMuscle.allCases.map(\.rawValue))
+    .union(["forearms"])
 
 // MARK: - ExerciseLibraryTests
 
@@ -74,9 +79,9 @@ struct ExerciseLibraryTests {
     func lookupKnownExercise() {
         let def = ExerciseLibrary.lookup("barbell_bench_press")
         #expect(def != nil)
-        #expect(def?.primaryMuscle == "chest")
+        #expect(def?.primaryMuscle == .chest)
         #expect(def?.equipmentType == "barbell")
-        #expect(def?.movementPattern == "horizontal_push")
+        #expect(def?.movementPattern == .horizontalPush)
     }
 
     @Test("lookup resolves all canonical IDs in all[]")
@@ -150,30 +155,29 @@ struct ExerciseLibraryTests {
     }
 
     @Test("bare 'lat_pulldown' is intentionally NOT normalized (ambiguous width)")
-    func lookupBareLatiPulldownIsUnresolved() {
+    func lookupBareLatPulldownIsUnresolved() {
         // 'lat_pulldown' without _wide/_close suffix is ambiguous.
         // It is intentionally excluded from the normalization map.
         // The backfill script will surface it as unresolved for human review.
         #expect(ExerciseLibrary.lookup("lat_pulldown") == nil)
     }
 
-    // MARK: primaryMuscle(for:) convenience
+    // MARK: primaryMuscle(for:) convenience — typed result per Slice 1
 
-    @Test("primaryMuscle returns correct string for canonical ID")
+    @Test("primaryMuscle returns correct PrimaryMuscle for canonical ID")
     func primaryMuscleConvenienceCanonical() {
-        #expect(ExerciseLibrary.primaryMuscle(for: "barbell_back_squat") == "quads")
-        #expect(ExerciseLibrary.primaryMuscle(for: "conventional_deadlift") == "hamstrings")
-        #expect(ExerciseLibrary.primaryMuscle(for: "overhead_press") == "shoulders")
-        #expect(ExerciseLibrary.primaryMuscle(for: "cable_tricep_pushdown") == "triceps")
-        #expect(ExerciseLibrary.primaryMuscle(for: "hip_thrust") == "glutes")
-        #expect(ExerciseLibrary.primaryMuscle(for: "cable_crunch") == "core")
-        #expect(ExerciseLibrary.primaryMuscle(for: "standing_calf_raise") == "calves")
+        #expect(ExerciseLibrary.primaryMuscle(for: "barbell_back_squat") == .quads)
+        #expect(ExerciseLibrary.primaryMuscle(for: "conventional_deadlift") == .hamstrings)
+        #expect(ExerciseLibrary.primaryMuscle(for: "overhead_press") == .shoulders)
+        #expect(ExerciseLibrary.primaryMuscle(for: "cable_tricep_pushdown") == .triceps)
+        #expect(ExerciseLibrary.primaryMuscle(for: "hip_thrust") == .glutes)
+        #expect(ExerciseLibrary.primaryMuscle(for: "standing_calf_raise") == .calves)
     }
 
-    @Test("primaryMuscle returns correct string via normalization map")
+    @Test("primaryMuscle returns correct PrimaryMuscle via normalization map")
     func primaryMuscleConvenienceNormalized() {
-        #expect(ExerciseLibrary.primaryMuscle(for: "bench_press") == "chest")
-        #expect(ExerciseLibrary.primaryMuscle(for: "rdl") == "hamstrings")
+        #expect(ExerciseLibrary.primaryMuscle(for: "bench_press") == .chest)
+        #expect(ExerciseLibrary.primaryMuscle(for: "rdl") == .hamstrings)
     }
 
     @Test("primaryMuscle returns nil for unknown exercise")
@@ -194,29 +198,55 @@ struct ExerciseLibraryTests {
         #expect(invalid.isEmpty, "Exercises with invalid equipment types:\n\(invalid.joined(separator: "\n"))")
     }
 
-    // MARK: Muscle group validity
+    // MARK: Synergist validity (synergists remain [String] for broader vocabulary)
 
-    @Test("All exercises have valid primaryMuscle values")
-    func validPrimaryMuscles() {
-        var invalid: [String] = []
-        for ex in ExerciseLibrary.all {
-            if !validMuscleGroups.contains(ex.primaryMuscle) {
-                invalid.append("\(ex.id): '\(ex.primaryMuscle)'")
-            }
-        }
-        #expect(invalid.isEmpty, "Exercises with invalid primaryMuscle:\n\(invalid.joined(separator: "\n"))")
-    }
-
-    @Test("All synergist values are valid muscle group strings")
+    @Test("All synergist values are valid muscle hint strings")
     func validSynergists() {
-        let extendedValid = validMuscleGroups.union(["forearms"])
         var invalid: [String] = []
         for ex in ExerciseLibrary.all {
-            for s in ex.synergists where !extendedValid.contains(s) {
+            for s in ex.synergists where !validSynergistMuscles.contains(s) {
                 invalid.append("\(ex.id): synergist '\(s)'")
             }
         }
         #expect(invalid.isEmpty, "Exercises with invalid synergists:\n\(invalid.joined(separator: "\n"))")
+    }
+
+    // MARK: Slice 1 — classification-consistency + content-removal guards
+
+    @Test("No exercise has primaryMuscle outside the 9-case PrimaryMuscle set")
+    func primaryMuscleAlwaysInTaxonomy() {
+        // Type-system enforced. This test documents the contract and would
+        // catch any compile-level regression where ExerciseDefinition.primaryMuscle
+        // was widened back to String.
+        let valid = Set(PrimaryMuscle.allCases.map(\.rawValue))
+        for ex in ExerciseLibrary.all {
+            #expect(valid.contains(ex.primaryMuscle.rawValue))
+        }
+    }
+
+    @Test("No exercise has movementPattern outside the 8-case MovementPattern set")
+    func movementPatternAlwaysInTaxonomy() {
+        let valid = Set(MovementPattern.allCases.map(\.rawValue))
+        for ex in ExerciseLibrary.all {
+            #expect(valid.contains(ex.movementPattern.rawValue))
+        }
+    }
+
+    @Test("No core exercises remain — the 4 core entries were removed in Slice 1")
+    func coreExercisesRemoved() {
+        let coreIds = ["cable_crunch", "hanging_leg_raise", "ab_wheel_rollout", "plank"]
+        for id in coreIds {
+            #expect(ExerciseLibrary.byId[id] == nil,
+                    "Expected core exercise '\(id)' to be absent from ExerciseLibrary")
+        }
+    }
+
+    @Test("No synergist string equals 'core'")
+    func noCoreInSynergists() {
+        for ex in ExerciseLibrary.all {
+            #expect(!ex.synergists.contains("core"),
+                    "\(ex.id) lists 'core' as a synergist — core is excluded from the trainee-model taxonomy")
+        }
     }
 
     // MARK: Normalization map integrity

--- a/ProjectApexTests/MigrationDatesTests.swift
+++ b/ProjectApexTests/MigrationDatesTests.swift
@@ -1,0 +1,22 @@
+// MigrationDatesTests.swift
+// ProjectApexTests
+//
+// Pins MigrationDates as a namespaced enum with the two release-coupled
+// cutover constants per ADR-0005.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("MigrationDates")
+struct MigrationDatesTests {
+    @Test("v2SetIntentBackfill exists as a Date constant")
+    func setIntentBackfillExists() {
+        let _: Date = MigrationDates.v2SetIntentBackfill
+    }
+
+    @Test("v2LocalDateField exists as a Date constant")
+    func localDateFieldExists() {
+        let _: Date = MigrationDates.v2LocalDateField
+    }
+}

--- a/ProjectApexTests/MovementPatternTests.swift
+++ b/ProjectApexTests/MovementPatternTests.swift
@@ -1,0 +1,34 @@
+// MovementPatternTests.swift
+// ProjectApexTests
+//
+// Verifies MovementPattern enum (introduced by Phase 1 / Slice 1).
+// Schema source: ADR-0005, taxonomy mirrors the 8 existing codebase strings.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("MovementPattern")
+struct MovementPatternTests {
+    @Test("horizontalPush round-trips via Codable as \"horizontal_push\"")
+    func codableRoundTripHorizontalPush() throws {
+        let original = MovementPattern.horizontalPush
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MovementPattern.self, from: encoded)
+        #expect(decoded == original)
+        #expect(String(data: encoded, encoding: .utf8) == "\"horizontal_push\"")
+    }
+
+    @Test("allCases mirrors the 8 codebase-existing patterns; .calves and .core absent")
+    func allCasesMatchCodebaseTaxonomy() {
+        let expectedRawValues: Set<String> = [
+            "hip_hinge", "horizontal_pull", "horizontal_push", "isolation",
+            "lunge", "squat", "vertical_pull", "vertical_push",
+        ]
+        let actualRawValues = Set(MovementPattern.allCases.map(\.rawValue))
+        #expect(actualRawValues == expectedRawValues)
+        #expect(MovementPattern.allCases.count == 8)
+        #expect(!actualRawValues.contains("calves"))
+        #expect(!actualRawValues.contains("core"))
+    }
+}

--- a/ProjectApexTests/MuscleTaxonomyTests.swift
+++ b/ProjectApexTests/MuscleTaxonomyTests.swift
@@ -1,0 +1,73 @@
+// MuscleTaxonomyTests.swift
+// ProjectApexTests
+//
+// Verifies PrimaryMuscle (9 fine-grained cases) and MuscleGroup
+// (locked-six per ADR-0005) plus the PrimaryMuscle.muscleGroup mapping.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("PrimaryMuscle")
+struct PrimaryMuscleTests {
+    @Test("allCases has 9 cases; .core absent")
+    func nineCasesNoCore() {
+        let expected: Set<String> = [
+            "back", "chest", "biceps", "shoulders", "triceps",
+            "quads", "hamstrings", "glutes", "calves",
+        ]
+        let actual = Set(PrimaryMuscle.allCases.map(\.rawValue))
+        #expect(actual == expected)
+        #expect(PrimaryMuscle.allCases.count == 9)
+        #expect(!actual.contains("core"))
+    }
+
+    @Test("Codable round-trip uses raw string values")
+    func codableRoundTrip() throws {
+        for muscle in PrimaryMuscle.allCases {
+            let encoded = try JSONEncoder().encode(muscle)
+            let decoded = try JSONDecoder().decode(PrimaryMuscle.self, from: encoded)
+            #expect(decoded == muscle)
+        }
+    }
+}
+
+@Suite("MuscleGroup")
+struct MuscleGroupTests {
+    @Test("allCases is the locked-six per ADR-0005")
+    func sixCasesLocked() {
+        let expected: Set<String> = ["back", "chest", "biceps", "shoulders", "triceps", "legs"]
+        let actual = Set(MuscleGroup.allCases.map(\.rawValue))
+        #expect(actual == expected)
+        #expect(MuscleGroup.allCases.count == 6)
+    }
+
+    @Test("Codable round-trip uses raw string values")
+    func codableRoundTrip() throws {
+        for group in MuscleGroup.allCases {
+            let encoded = try JSONEncoder().encode(group)
+            let decoded = try JSONDecoder().decode(MuscleGroup.self, from: encoded)
+            #expect(decoded == group)
+        }
+    }
+}
+
+@Suite("PrimaryMuscle.muscleGroup")
+struct PrimaryMuscleMappingTests {
+    @Test("Leg subgroups collapse to .legs")
+    func legSubgroupsCollapse() {
+        #expect(PrimaryMuscle.quads.muscleGroup == .legs)
+        #expect(PrimaryMuscle.hamstrings.muscleGroup == .legs)
+        #expect(PrimaryMuscle.glutes.muscleGroup == .legs)
+        #expect(PrimaryMuscle.calves.muscleGroup == .legs)
+    }
+
+    @Test("Upper-body muscles map 1:1")
+    func upperBodyOneToOne() {
+        #expect(PrimaryMuscle.back.muscleGroup == .back)
+        #expect(PrimaryMuscle.chest.muscleGroup == .chest)
+        #expect(PrimaryMuscle.biceps.muscleGroup == .biceps)
+        #expect(PrimaryMuscle.shoulders.muscleGroup == .shoulders)
+        #expect(PrimaryMuscle.triceps.muscleGroup == .triceps)
+    }
+}

--- a/ProjectApexTests/PatternPhaseServiceTests.swift
+++ b/ProjectApexTests/PatternPhaseServiceTests.swift
@@ -56,7 +56,7 @@ private func makeLogs(exerciseId: String, sessionCount: Int) -> [SetLog] {
 /// Convenience to make a state already at `sessionsCompletedInPhase` sessions
 /// with the correct threshold for 4 days/week.
 private func makeState(
-    pattern: String,
+    pattern: MovementPattern,
     phase: MesocyclePhase,
     completed: Int,
     required: Int
@@ -99,13 +99,13 @@ struct PatternPhaseServiceTests {
     @Test("Reaching accumulation threshold advances pattern to intensification")
     func accumulationAdvancesToIntensification() {
         // At threshold: 7 completed, 8 required. One more session pushes it over.
-        let current = [makeState(pattern: "horizontal_push", phase: .accumulation, completed: 7, required: 8)]
+        let current = [makeState(pattern: .horizontalPush, phase: .accumulation, completed: 7, required: 8)]
         let updated = PatternPhaseService.advancePhases(
             current: current,
-            trainedPatterns: ["horizontal_push"],
+            trainedPatterns: [.horizontalPush],
             daysPerWeek: 4
         )
-        let state = updated.first { $0.pattern == "horizontal_push" }
+        let state = updated.first { $0.pattern == .horizontalPush }
         #expect(state?.phase == .intensification)
         #expect(state?.sessionsCompletedInPhase == 0)
         #expect(state?.sessionsRequiredForPhase == 8)
@@ -115,13 +115,13 @@ struct PatternPhaseServiceTests {
 
     @Test("Reaching intensification threshold advances pattern to peaking")
     func intensificationAdvancesToPeaking() {
-        let current = [makeState(pattern: "horizontal_push", phase: .intensification, completed: 7, required: 8)]
+        let current = [makeState(pattern: .horizontalPush, phase: .intensification, completed: 7, required: 8)]
         let updated = PatternPhaseService.advancePhases(
             current: current,
-            trainedPatterns: ["horizontal_push"],
+            trainedPatterns: [.horizontalPush],
             daysPerWeek: 4
         )
-        let state = updated.first { $0.pattern == "horizontal_push" }
+        let state = updated.first { $0.pattern == .horizontalPush }
         #expect(state?.phase == .peaking)
         #expect(state?.sessionsCompletedInPhase == 0)
         #expect(state?.sessionsRequiredForPhase == 6)
@@ -131,13 +131,13 @@ struct PatternPhaseServiceTests {
 
     @Test("Reaching peaking threshold advances pattern to deload")
     func peakingAdvancesToDeload() {
-        let current = [makeState(pattern: "horizontal_push", phase: .peaking, completed: 5, required: 6)]
+        let current = [makeState(pattern: .horizontalPush, phase: .peaking, completed: 5, required: 6)]
         let updated = PatternPhaseService.advancePhases(
             current: current,
-            trainedPatterns: ["horizontal_push"],
+            trainedPatterns: [.horizontalPush],
             daysPerWeek: 4
         )
-        let state = updated.first { $0.pattern == "horizontal_push" }
+        let state = updated.first { $0.pattern == .horizontalPush }
         #expect(state?.phase == .deload)
         #expect(state?.sessionsCompletedInPhase == 0)
     }
@@ -147,13 +147,13 @@ struct PatternPhaseServiceTests {
     @Test("Deload phase is terminal — pattern does not advance further")
     func deloadIsTerminal() {
         // Put pattern at the deload threshold (2 of 3 sessions done, then one more).
-        let current = [makeState(pattern: "horizontal_push", phase: .deload, completed: 2, required: 3)]
+        let current = [makeState(pattern: .horizontalPush, phase: .deload, completed: 2, required: 3)]
         let updated = PatternPhaseService.advancePhases(
             current: current,
-            trainedPatterns: ["horizontal_push"],
+            trainedPatterns: [.horizontalPush],
             daysPerWeek: 4
         )
-        let state = updated.first { $0.pattern == "horizontal_push" }
+        let state = updated.first { $0.pattern == .horizontalPush }
         // Should remain in deload — no phase beyond it.
         #expect(state?.phase == .deload)
     }
@@ -163,17 +163,17 @@ struct PatternPhaseServiceTests {
     @Test("Untrained patterns are not advanced when session is recorded for other patterns")
     func untrainedPatternNotAdvanced() {
         let current = [
-            makeState(pattern: "horizontal_push", phase: .accumulation, completed: 3, required: 8),
-            makeState(pattern: "squat",           phase: .accumulation, completed: 3, required: 8)
+            makeState(pattern: .horizontalPush, phase: .accumulation, completed: 3, required: 8),
+            makeState(pattern: .squat,           phase: .accumulation, completed: 3, required: 8)
         ]
         // Only train horizontal_push today.
         let updated = PatternPhaseService.advancePhases(
             current: current,
-            trainedPatterns: ["horizontal_push"],
+            trainedPatterns: [.horizontalPush],
             daysPerWeek: 4
         )
-        let push = updated.first { $0.pattern == "horizontal_push" }
-        let squat = updated.first { $0.pattern == "squat" }
+        let push = updated.first { $0.pattern == .horizontalPush }
+        let squat = updated.first { $0.pattern == .squat }
 
         #expect(push?.sessionsCompletedInPhase == 4)  // incremented
         #expect(squat?.sessionsCompletedInPhase == 3) // unchanged
@@ -189,7 +189,7 @@ struct PatternPhaseServiceTests {
         let logs = makeLogs(exerciseId: "barbell_bench_press", sessionCount: 9)
         let states = PatternPhaseService.computeInitialPhases(from: logs, daysPerWeek: 4)
 
-        let push = states.first { $0.pattern == "horizontal_push" }
+        let push = states.first { $0.pattern == .horizontalPush }
         #expect(push != nil, "horizontal_push should be present in migration output")
         #expect(push?.phase == .intensification)
         #expect(push?.sessionsCompletedInPhase == 1)
@@ -209,10 +209,10 @@ struct PatternPhaseServiceTests {
     func firstTimePatternCreated() {
         let updated = PatternPhaseService.advancePhases(
             current: [],
-            trainedPatterns: ["horizontal_push"],
+            trainedPatterns: [.horizontalPush],
             daysPerWeek: 4
         )
-        let state = updated.first { $0.pattern == "horizontal_push" }
+        let state = updated.first { $0.pattern == .horizontalPush }
         #expect(state != nil, "New pattern should be inserted")
         #expect(state?.phase == .accumulation)
         #expect(state?.sessionsCompletedInPhase == 1)
@@ -228,17 +228,17 @@ struct PatternPhaseServiceTests {
         defer { UserDefaults.standard.removeObject(forKey: key) }
 
         let states = [
-            makeState(pattern: "horizontal_push", phase: .accumulation,    completed: 3, required: 8),
-            makeState(pattern: "squat",           phase: .intensification, completed: 5, required: 8)
+            makeState(pattern: .horizontalPush, phase: .accumulation,    completed: 3, required: 8),
+            makeState(pattern: .squat,           phase: .intensification, completed: 5, required: 8)
         ]
         PatternPhaseService.persist(states)
         let loaded = PatternPhaseService.load()
 
         #expect(loaded.count == states.count)
-        let push = loaded.first { $0.pattern == "horizontal_push" }
+        let push = loaded.first { $0.pattern == .horizontalPush }
         #expect(push?.phase == .accumulation)
         #expect(push?.sessionsCompletedInPhase == 3)
-        let squat = loaded.first { $0.pattern == "squat" }
+        let squat = loaded.first { $0.pattern == .squat }
         #expect(squat?.phase == .intensification)
         #expect(squat?.sessionsCompletedInPhase == 5)
     }
@@ -251,7 +251,7 @@ struct PatternPhaseServiceTests {
         UserDefaults.standard.removeObject(forKey: key)
         defer { UserDefaults.standard.removeObject(forKey: key) }
 
-        let states = [makeState(pattern: "horizontal_push", phase: .accumulation, completed: 2, required: 8)]
+        let states = [makeState(pattern: .horizontalPush, phase: .accumulation, completed: 2, required: 8)]
         PatternPhaseService.persist(states)
         // Verify data was actually written
         #expect(!PatternPhaseService.load().isEmpty)
@@ -272,8 +272,8 @@ struct PatternPhaseServiceTests {
         let second = PatternPhaseService.computeInitialPhases(from: logs, daysPerWeek: 4)
 
         #expect(first.count == second.count)
-        let push1 = first.first  { $0.pattern == "horizontal_push" }
-        let push2 = second.first { $0.pattern == "horizontal_push" }
+        let push1 = first.first  { $0.pattern == .horizontalPush }
+        let push2 = second.first { $0.pattern == .horizontalPush }
         #expect(push1?.phase == push2?.phase)
         #expect(push1?.sessionsCompletedInPhase == push2?.sessionsCompletedInPhase)
     }
@@ -283,13 +283,13 @@ struct PatternPhaseServiceTests {
         // After migration, the gate prevents re-running computeInitialPhases.
         // This test confirms that calling advancePhases on already-populated states
         // increments sessionsCompletedInPhase rather than resetting it.
-        let initial = [makeState(pattern: "horizontal_push", phase: .accumulation, completed: 5, required: 8)]
+        let initial = [makeState(pattern: .horizontalPush, phase: .accumulation, completed: 5, required: 8)]
         let after = PatternPhaseService.advancePhases(
             current: initial,
-            trainedPatterns: ["horizontal_push"],
+            trainedPatterns: [.horizontalPush],
             daysPerWeek: 4
         )
-        let state = after.first { $0.pattern == "horizontal_push" }
+        let state = after.first { $0.pattern == .horizontalPush }
         // Should be 6, not 1 (which would indicate a re-initialisation)
         #expect(state?.sessionsCompletedInPhase == 6)
         #expect(state?.phase == .accumulation)

--- a/ProjectApexTests/TraineeModelEnumsTests.swift
+++ b/ProjectApexTests/TraineeModelEnumsTests.swift
@@ -1,0 +1,117 @@
+// TraineeModelEnumsTests.swift
+// ProjectApexTests
+//
+// Verifies the supporting enums (SetIntent, AxisConfidence, StimulusDimension,
+// Severity, BodyJoint, ProjectionProgress) and the LimitationSubject sum
+// type. Per-enum case-coverage + Codable round-trip.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("SetIntent")
+struct SetIntentTests {
+    @Test("Cases match ADR-0005 verbatim")
+    func adrCases() {
+        #expect(Set(SetIntent.allCases.map(\.rawValue)) ==
+                ["warmup", "top", "backoff", "technique", "amrap"])
+    }
+
+    @Test("Codable round-trip")
+    func codable() throws {
+        for value in SetIntent.allCases {
+            let data = try JSONEncoder().encode(value)
+            #expect(try JSONDecoder().decode(SetIntent.self, from: data) == value)
+        }
+    }
+}
+
+@Suite("AxisConfidence")
+struct AxisConfidenceTests {
+    @Test("Cases match ADR-0005 verbatim")
+    func adrCases() {
+        #expect(Set(AxisConfidence.allCases.map(\.rawValue)) ==
+                ["bootstrapping", "calibrating", "established", "seasoned"])
+    }
+
+    @Test("Codable round-trip")
+    func codable() throws {
+        for value in AxisConfidence.allCases {
+            let data = try JSONEncoder().encode(value)
+            #expect(try JSONDecoder().decode(AxisConfidence.self, from: data) == value)
+        }
+    }
+}
+
+@Suite("StimulusDimension")
+struct StimulusDimensionTests {
+    @Test("Cases match ADR-0005 / CONTEXT.md")
+    func cases() {
+        #expect(Set(StimulusDimension.allCases.map(\.rawValue)) ==
+                ["neuromuscular", "metabolic", "both"])
+    }
+}
+
+@Suite("Severity")
+struct SeverityTests {
+    @Test("Standard severity ordering")
+    func cases() {
+        #expect(Set(Severity.allCases.map(\.rawValue)) ==
+                ["mild", "moderate", "severe"])
+    }
+}
+
+@Suite("BodyJoint")
+struct BodyJointTests {
+    @Test("Includes lowerBack with snake_case raw value")
+    func lowerBackEncoding() throws {
+        let data = try JSONEncoder().encode(BodyJoint.lowerBack)
+        #expect(String(data: data, encoding: .utf8) == "\"lower_back\"")
+    }
+
+    @Test("All cases round-trip")
+    func roundTrip() throws {
+        for joint in BodyJoint.allCases {
+            let data = try JSONEncoder().encode(joint)
+            #expect(try JSONDecoder().decode(BodyJoint.self, from: data) == joint)
+        }
+    }
+}
+
+@Suite("ProjectionProgress")
+struct ProjectionProgressTests {
+    @Test("onTrack uses snake_case raw value")
+    func onTrackEncoding() throws {
+        let data = try JSONEncoder().encode(ProjectionProgress.onTrack)
+        #expect(String(data: data, encoding: .utf8) == "\"on_track\"")
+    }
+}
+
+@Suite("LimitationSubject")
+struct LimitationSubjectTests {
+    @Test("Pattern subject round-trips with kind+value discriminator")
+    func patternRoundTrip() throws {
+        let original = LimitationSubject.pattern(.horizontalPush)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(LimitationSubject.self, from: data)
+        #expect(decoded == original)
+
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: String]
+        #expect(json?["kind"] == "pattern")
+        #expect(json?["value"] == "horizontal_push")
+    }
+
+    @Test("Muscle subject round-trips")
+    func muscleRoundTrip() throws {
+        let original = LimitationSubject.muscle(.legs)
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(LimitationSubject.self, from: data) == original)
+    }
+
+    @Test("Joint subject round-trips")
+    func jointRoundTrip() throws {
+        let original = LimitationSubject.joint(.lowerBack)
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(LimitationSubject.self, from: data) == original)
+    }
+}

--- a/ProjectApexTests/TraineeModelInteractionsTests.swift
+++ b/ProjectApexTests/TraineeModelInteractionsTests.swift
@@ -1,0 +1,187 @@
+// TraineeModelInteractionsTests.swift
+// ProjectApexTests
+//
+// Round-trip tests for limitation/interaction types plus FatigueInteraction's
+// derived properties (consistencyFactor, countFactor, confidence).
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("ActiveLimitation")
+struct ActiveLimitationTests {
+    @Test("Round-trip preserves all fields including LimitationSubject")
+    func roundTrip() throws {
+        let original = ActiveLimitation(
+            subject: .joint(.shoulder),
+            severity: .mild,
+            onsetDate: Date(timeIntervalSince1970: 1_750_000_000),
+            evidenceCount: 3,
+            userConfirmed: false,
+            notes: "Anterior delt tightness on bench"
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ActiveLimitation.self, from: data)
+        #expect(decoded == original)
+    }
+}
+
+@Suite("ClearedLimitation")
+struct ClearedLimitationTests {
+    @Test("Round-trip with cleared date")
+    func roundTrip() throws {
+        let original = ClearedLimitation(
+            subject: .pattern(.horizontalPush),
+            severity: .moderate,
+            onsetDate: Date(timeIntervalSince1970: 1_700_000_000),
+            clearedDate: Date(timeIntervalSince1970: 1_750_000_000),
+            notes: nil
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(ClearedLimitation.self, from: data) == original)
+    }
+}
+
+@Suite("FatigueInteraction")
+struct FatigueInteractionTests {
+    @Test("countFactor caps at 0.5 below 15 observations")
+    func countFactorBelow15() {
+        let interaction = FatigueInteraction(
+            fromPattern: .squat, toPattern: .hipHinge,
+            observations: [-0.05, -0.04, -0.06], totalCount: 14
+        )
+        #expect(interaction.countFactor == 0.5)
+    }
+
+    @Test("countFactor reaches 1.0 at 15 observations")
+    func countFactorAt15() {
+        let interaction = FatigueInteraction(
+            fromPattern: .squat, toPattern: .hipHinge,
+            observations: Array(repeating: -0.05, count: 10), totalCount: 15
+        )
+        #expect(interaction.countFactor == 1.0)
+    }
+
+    @Test("Perfectly consistent observations yield consistencyFactor 1.0")
+    func consistencyFactorPerfect() {
+        let interaction = FatigueInteraction(
+            fromPattern: .squat, toPattern: .hipHinge,
+            observations: Array(repeating: -0.05, count: 10),
+            totalCount: 20
+        )
+        #expect(interaction.consistencyFactor == 1.0)
+    }
+
+    @Test("consistencyFactor is 0 with fewer than 2 observations")
+    func consistencyFactorTooFew() {
+        let zero = FatigueInteraction(
+            fromPattern: .squat, toPattern: .hipHinge,
+            observations: [], totalCount: 0
+        )
+        #expect(zero.consistencyFactor == 0)
+        let one = FatigueInteraction(
+            fromPattern: .squat, toPattern: .hipHinge,
+            observations: [-0.05], totalCount: 1
+        )
+        #expect(one.consistencyFactor == 0)
+    }
+
+    @Test("Mean-guard prevents divide-by-zero when observations average ~0")
+    func consistencyFactorMeanGuard() {
+        // Observations sum to 0; without mean-guard we'd divide stddev/0.
+        let interaction = FatigueInteraction(
+            fromPattern: .squat, toPattern: .hipHinge,
+            observations: [0.05, -0.05, 0.05, -0.05],
+            totalCount: 20
+        )
+        // With mean-guard 0.001, stddev/absMean is huge → clamped to 0.
+        #expect(interaction.consistencyFactor == 0)
+    }
+
+    @Test("confidence = consistencyFactor × countFactor")
+    func confidenceProduct() {
+        let interaction = FatigueInteraction(
+            fromPattern: .squat, toPattern: .hipHinge,
+            observations: Array(repeating: -0.05, count: 10),
+            totalCount: 10  // below 15 → countFactor 0.5
+        )
+        #expect(interaction.confidence == interaction.consistencyFactor * 0.5)
+        #expect(interaction.confidence == 0.5)  // 1.0 × 0.5
+    }
+
+    @Test("Codable round-trip preserves observations and totalCount")
+    func roundTrip() throws {
+        let original = FatigueInteraction(
+            fromPattern: .squat, toPattern: .hipHinge,
+            observations: [-0.04, -0.05, -0.06, -0.05],
+            totalCount: 25
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(FatigueInteraction.self, from: data) == original)
+    }
+}
+
+@Suite("PrescriptionAccuracy")
+struct PrescriptionAccuracyTests {
+    @Test("Round-trip")
+    func roundTrip() throws {
+        let original = PrescriptionAccuracy(
+            pattern: .horizontalPush, intent: .top,
+            bias: -0.025, rmse: 0.04, sampleCount: 18
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(PrescriptionAccuracy.self, from: data) == original)
+    }
+}
+
+@Suite("PrescriptionIntentMismatch")
+struct PrescriptionIntentMismatchTests {
+    @Test("Round-trip")
+    func roundTrip() throws {
+        let original = PrescriptionIntentMismatch(
+            timestamp: Date(timeIntervalSince1970: 1_750_000_000),
+            exerciseId: "barbell_bench_press",
+            pattern: .horizontalPush,
+            prescribedIntent: .top,
+            loggedIntent: .backoff
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(PrescriptionIntentMismatch.self, from: data) == original)
+    }
+}
+
+@Suite("ExerciseTransfer")
+struct ExerciseTransferTests {
+    @Test("Round-trip with R² and observation count")
+    func roundTrip() throws {
+        let original = ExerciseTransfer(
+            fromExerciseId: "barbell_bench_press",
+            toExerciseId: "overhead_press",
+            coefficient: 0.62,
+            rSquared: 0.71,
+            pairedObservations: 12
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(ExerciseTransfer.self, from: data) == original)
+    }
+}
+
+@Suite("BodyweightHistory")
+struct BodyweightHistoryTests {
+    @Test("Default init yields empty entries")
+    func defaultEmpty() {
+        #expect(BodyweightHistory().entries.isEmpty)
+    }
+
+    @Test("Round-trip preserves entry order")
+    func roundTrip() throws {
+        let original = BodyweightHistory(entries: [
+            BodyweightEntry(localDate: "2026-05-01", weightKg: 82.4),
+            BodyweightEntry(localDate: "2026-05-04", weightKg: 82.6),
+        ])
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(BodyweightHistory.self, from: data)
+        #expect(decoded == original)
+        #expect(decoded.entries.map(\.localDate) == ["2026-05-01", "2026-05-04"])
+    }
+}

--- a/ProjectApexTests/TraineeModelProfilesTests.swift
+++ b/ProjectApexTests/TraineeModelProfilesTests.swift
@@ -1,0 +1,228 @@
+// TraineeModelProfilesTests.swift
+// ProjectApexTests
+//
+// Tests for ExerciseProfile, MuscleProfile, PatternProfile (+ derived
+// properties), ProjectionState. Round-trip + derived-property correctness
+// across empty, single-session, and multi-session fixtures.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("ExerciseProfile")
+struct ExerciseProfileTests {
+    @Test("learningPhase flips to false at sessionCount 10")
+    func learningPhaseBoundary() {
+        var profile = ExerciseProfile(exerciseId: "barbell_bench_press")
+        profile.sessionCount = 0
+        #expect(profile.learningPhase == true)
+        profile.sessionCount = 9
+        #expect(profile.learningPhase == true)
+        profile.sessionCount = 10
+        #expect(profile.learningPhase == false)
+        profile.sessionCount = 50
+        #expect(profile.learningPhase == false)
+    }
+
+    @Test("Round-trip with top sets")
+    func roundTrip() throws {
+        let original = ExerciseProfile(
+            exerciseId: "barbell_bench_press",
+            topSets: [TopSetSnapshot(sessionId: UUID(), localDate: "2026-05-01",
+                                     weightKg: 100, reps: 5, e1rm: 116.67)],
+            e1rmCurrent: 116.67,
+            e1rmMedian: 115,
+            e1rmPeak: 120,
+            sessionCount: 12,
+            formDegradationFlag: false,
+            confidence: .established
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(ExerciseProfile.self, from: data) == original)
+    }
+}
+
+@Suite("MuscleProfile")
+struct MuscleProfileTests {
+    @Test("Default init bootstraps confidence + progressing trend")
+    func defaultInit() {
+        let profile = MuscleProfile(muscleGroup: .chest)
+        #expect(profile.confidence == .bootstrapping)
+        #expect(profile.stagnationStatus == .progressing)
+        #expect(profile.observedSweetSpot == nil)
+    }
+
+    @Test("Round-trip with sweet spot set")
+    func roundTrip() throws {
+        let original = MuscleProfile(
+            muscleGroup: .legs,
+            volumeTolerance: 22,
+            observedSweetSpot: 14,
+            volumeDeficit: 0,
+            focusWeight: 1.2,
+            stagnationStatus: .plateaued,
+            confidence: .established
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(MuscleProfile.self, from: data) == original)
+    }
+}
+
+@Suite("PatternProfile.recentSessionDays")
+struct PatternProfileRecentSessionDaysTests {
+    @Test("Empty fixture yields empty list")
+    func empty() {
+        let profile = PatternProfile(pattern: .squat)
+        #expect(profile.recentSessionDays == [])
+    }
+
+    @Test("Returns yyyy-MM-dd local-date strings sorted ascending")
+    func formattedAndSorted() {
+        let dates: [Date] = [
+            isoDate("2026-05-04"),
+            isoDate("2026-05-01"),
+            isoDate("2026-04-28"),
+        ]
+        let profile = PatternProfile(pattern: .squat, recentSessionDates: dates)
+        #expect(profile.recentSessionDays == ["2026-04-28", "2026-05-01", "2026-05-04"])
+    }
+}
+
+@Suite("PatternProfile.sessionsCadenceDays")
+struct PatternProfileCadenceTests {
+    @Test("Empty / single-session fixture returns nil")
+    func tooFew() {
+        let empty = PatternProfile(pattern: .squat)
+        #expect(empty.sessionsCadenceDays == nil)
+        let one = PatternProfile(pattern: .squat, recentSessionDates: [isoDate("2026-05-01")])
+        #expect(one.sessionsCadenceDays == nil)
+    }
+
+    @Test("Two sessions 3 days apart yields cadence 3.0")
+    func twoSessions() {
+        let profile = PatternProfile(pattern: .squat, recentSessionDates: [
+            isoDate("2026-05-01"), isoDate("2026-05-04"),
+        ])
+        #expect(profile.sessionsCadenceDays == 3.0)
+    }
+
+    @Test("Multiple sessions yield mean delta")
+    func multipleSessions() {
+        // Deltas: 3, 2, 5 → mean 10/3 ≈ 3.333…
+        let profile = PatternProfile(pattern: .squat, recentSessionDates: [
+            isoDate("2026-05-01"), isoDate("2026-05-04"),
+            isoDate("2026-05-06"), isoDate("2026-05-11"),
+        ])
+        let cadence = profile.sessionsCadenceDays ?? -1
+        #expect(abs(cadence - (10.0 / 3.0)) < 1e-9)
+    }
+}
+
+@Suite("PatternProfile.daysSinceLastSession")
+struct PatternProfileDaysSinceLastTests {
+    @Test("Empty fixture yields nil")
+    func empty() {
+        let profile = PatternProfile(pattern: .squat)
+        #expect(profile.daysSinceLastSession(asOf: isoDate("2026-05-04")) == nil)
+    }
+
+    @Test("Same-day reference yields 0")
+    func sameDay() {
+        let profile = PatternProfile(pattern: .squat, recentSessionDates: [isoDate("2026-05-04")])
+        #expect(profile.daysSinceLastSession(asOf: isoDate("2026-05-04")) == 0)
+    }
+
+    @Test("Reference 5 days after last session yields 5")
+    func fiveDaysOut() {
+        let profile = PatternProfile(pattern: .squat, recentSessionDates: [isoDate("2026-04-29")])
+        #expect(profile.daysSinceLastSession(asOf: isoDate("2026-05-04")) == 5)
+    }
+
+    @Test("Future reference (negative delta) clamps to 0")
+    func futureReference() {
+        let profile = PatternProfile(pattern: .squat, recentSessionDates: [isoDate("2026-05-10")])
+        #expect(profile.daysSinceLastSession(asOf: isoDate("2026-05-04")) == 0)
+    }
+}
+
+@Suite("PatternProfile.inTransitionMode")
+struct PatternProfileInTransitionModeTests {
+    @Test("Nil transitionModeUntil yields false")
+    func nilUntil() {
+        let profile = PatternProfile(pattern: .squat)
+        #expect(profile.inTransitionMode(asOf: Date()) == false)
+    }
+
+    @Test("Future transitionModeUntil yields true")
+    func future() {
+        let profile = PatternProfile(
+            pattern: .squat,
+            transitionModeUntil: isoDate("2026-05-10")
+        )
+        #expect(profile.inTransitionMode(asOf: isoDate("2026-05-04")) == true)
+    }
+
+    @Test("Past transitionModeUntil yields false")
+    func past() {
+        let profile = PatternProfile(
+            pattern: .squat,
+            transitionModeUntil: isoDate("2026-05-01")
+        )
+        #expect(profile.inTransitionMode(asOf: isoDate("2026-05-04")) == false)
+    }
+}
+
+@Suite("PatternProfile Codable")
+struct PatternProfileCodableTests {
+    @Test("Round-trip preserves all fields")
+    func roundTrip() throws {
+        let original = PatternProfile(
+            pattern: .horizontalPush,
+            currentPhase: .intensification,
+            sessionsInPhase: 3,
+            lastPhaseTransitionAtSessionCount: 22,
+            rpeOffset: -0.25,
+            recovery: RecoveryProfile(neuromuscularReadiness: 0.7, metabolicReadiness: 0.9),
+            confidence: .established,
+            transitionModeUntil: isoDate("2026-05-10"),
+            trend: .progressing,
+            recentSessionDates: [isoDate("2026-04-28"), isoDate("2026-05-01")]
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(PatternProfile.self, from: data) == original)
+    }
+}
+
+@Suite("ProjectionState")
+struct ProjectionStateTests {
+    @Test("Default init: empty + nil timestamps")
+    func defaultInit() {
+        let state = ProjectionState()
+        #expect(state.patternProjections.isEmpty)
+        #expect(state.calibrationReviewFiredAt == nil)
+        #expect(state.goalLastRenegotiatedAt == nil)
+    }
+
+    @Test("Round-trip with multiple pattern projections")
+    func roundTrip() throws {
+        let original = ProjectionState(
+            patternProjections: [
+                PatternProjection(pattern: .horizontalPush, floor: 100, stretch: 120, progress: .onTrack),
+                PatternProjection(pattern: .squat, floor: 140, stretch: 165, progress: .ahead),
+            ],
+            calibrationReviewFiredAt: isoDate("2026-04-15"),
+            goalLastRenegotiatedAt: nil
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(ProjectionState.self, from: data) == original)
+    }
+}
+
+// MARK: - Helpers
+
+private func isoDate(_ ymd: String) -> Date {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd"
+    formatter.timeZone = TimeZone(identifier: "UTC")
+    return formatter.date(from: ymd)!
+}

--- a/ProjectApexTests/TraineeModelSnapshotsTests.swift
+++ b/ProjectApexTests/TraineeModelSnapshotsTests.swift
@@ -1,0 +1,161 @@
+// TraineeModelSnapshotsTests.swift
+// ProjectApexTests
+//
+// Codable round-trip tests for snapshot value types.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("TopSetSnapshot")
+struct TopSetSnapshotTests {
+    @Test("Codable round-trip preserves all fields")
+    func roundTrip() throws {
+        let original = TopSetSnapshot(
+            sessionId: UUID(),
+            localDate: "2026-05-04",
+            weightKg: 100.0,
+            reps: 5,
+            e1rm: 116.67
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(TopSetSnapshot.self, from: data)
+        #expect(decoded == original)
+    }
+}
+
+@Suite("ExerciseSessionSnapshot")
+struct ExerciseSessionSnapshotTests {
+    @Test("Round-trip with heaviest top set")
+    func withTopSet() throws {
+        let top = TopSetSnapshot(
+            sessionId: UUID(),
+            localDate: "2026-05-04",
+            weightKg: 120, reps: 4, e1rm: 136
+        )
+        let original = ExerciseSessionSnapshot(
+            sessionId: top.sessionId,
+            localDate: top.localDate,
+            heaviestTopSet: top,
+            topSetCount: 3
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ExerciseSessionSnapshot.self, from: data)
+        #expect(decoded == original)
+        #expect(decoded.heaviestTopSet?.weightKg == 120)
+    }
+
+    @Test("Round-trip with no top sets")
+    func withoutTopSet() throws {
+        let original = ExerciseSessionSnapshot(
+            sessionId: UUID(), localDate: "2026-05-04",
+            heaviestTopSet: nil, topSetCount: 0
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(ExerciseSessionSnapshot.self, from: data) == original)
+    }
+}
+
+@Suite("BodyweightEntry")
+struct BodyweightEntryTests {
+    @Test("Codable round-trip")
+    func roundTrip() throws {
+        let original = BodyweightEntry(localDate: "2026-05-04", weightKg: 82.4)
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(BodyweightEntry.self, from: data) == original)
+    }
+}
+
+@Suite("LifeContextEvent")
+struct LifeContextEventTests {
+    @Test("Round-trip with notes")
+    func withNotes() throws {
+        let original = LifeContextEvent(localDate: "2026-05-04", kind: "travel", notes: "10 days abroad")
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(LifeContextEvent.self, from: data) == original)
+    }
+
+    @Test("Round-trip without notes")
+    func withoutNotes() throws {
+        let original = LifeContextEvent(localDate: "2026-05-04", kind: "illness")
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(LifeContextEvent.self, from: data) == original)
+    }
+}
+
+@Suite("ReassessmentRecord")
+struct ReassessmentRecordTests {
+    @Test("Round-trip preserves advanced-patterns list order")
+    func roundTrip() throws {
+        let original = ReassessmentRecord(
+            triggeredAt: Date(timeIntervalSince1970: 1_750_000_000),
+            triggeringSessionCount: 24,
+            advancedPatterns: [.horizontalPush, .squat, .verticalPull, .hipHinge]
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ReassessmentRecord.self, from: data)
+        #expect(decoded == original)
+        #expect(decoded.advancedPatterns == [.horizontalPush, .squat, .verticalPull, .hipHinge])
+    }
+}
+
+@Suite("PatternProjection")
+struct PatternProjectionTests {
+    @Test("Round-trip preserves floor/stretch/progress")
+    func roundTrip() throws {
+        let original = PatternProjection(
+            pattern: .squat, floor: 140.0, stretch: 165.0, progress: .onTrack
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(PatternProjection.self, from: data) == original)
+    }
+}
+
+@Suite("RecoveryProfile")
+struct RecoveryProfileTests {
+    @Test("Default init yields full readiness on both axes, no stimulus history")
+    func defaultInit() {
+        let profile = RecoveryProfile()
+        #expect(profile.neuromuscularReadiness == 1.0)
+        #expect(profile.metabolicReadiness == 1.0)
+        #expect(profile.lastNeuromuscularStimulusAt == nil)
+        #expect(profile.lastMetabolicStimulusAt == nil)
+    }
+
+    @Test("Round-trip preserves both axes independently")
+    func roundTrip() throws {
+        let original = RecoveryProfile(
+            lastNeuromuscularStimulusAt: Date(timeIntervalSince1970: 1_700_000_000),
+            lastMetabolicStimulusAt: Date(timeIntervalSince1970: 1_710_000_000),
+            neuromuscularReadiness: 0.4,
+            metabolicReadiness: 0.7
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(RecoveryProfile.self, from: data) == original)
+    }
+}
+
+@Suite("GoalState")
+struct GoalStateTests {
+    @Test("Round-trip with focus areas")
+    func roundTripWithFocus() throws {
+        let original = GoalState(
+            statement: "Get visibly stronger in the upper body",
+            focusAreas: [.chest, .back, .shoulders],
+            updatedAt: Date(timeIntervalSince1970: 1_750_000_000)
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(GoalState.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test("Round-trip with empty focus areas")
+    func roundTripEmpty() throws {
+        let original = GoalState(
+            statement: "Maintain general fitness",
+            updatedAt: Date(timeIntervalSince1970: 1_750_000_000)
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(GoalState.self, from: data) == original)
+    }
+}

--- a/ProjectApexTests/TraineeModelTests.swift
+++ b/ProjectApexTests/TraineeModelTests.swift
@@ -1,0 +1,252 @@
+// TraineeModelTests.swift
+// ProjectApexTests
+//
+// Tests for TraineeModel root + derived properties (isReadyForCalibrationReview,
+// disruptedPatterns, shouldFireGlobalPhaseAdvance) across empty, single-pattern,
+// and fully-populated fixtures + Codable round-trip.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("TraineeModel.isReadyForCalibrationReview")
+struct TraineeModelCalibrationReadyTests {
+    @Test("Empty model: false")
+    func empty() {
+        let model = TraineeModel(goal: defaultGoal())
+        #expect(model.isReadyForCalibrationReview == false)
+    }
+
+    @Test("3 major patterns established: false")
+    func threeEstablished() {
+        var model = TraineeModel(goal: defaultGoal())
+        model.patterns = [
+            .horizontalPush: PatternProfile(pattern: .horizontalPush, confidence: .established),
+            .verticalPush:   PatternProfile(pattern: .verticalPush,   confidence: .established),
+            .squat:          PatternProfile(pattern: .squat,          confidence: .established),
+        ]
+        #expect(model.isReadyForCalibrationReview == false)
+    }
+
+    @Test("4 major patterns established + calibration not fired: true")
+    func fourEstablishedNotFired() {
+        var model = TraineeModel(goal: defaultGoal())
+        model.patterns = [
+            .horizontalPush:  PatternProfile(pattern: .horizontalPush,  confidence: .established),
+            .verticalPush:    PatternProfile(pattern: .verticalPush,    confidence: .established),
+            .squat:           PatternProfile(pattern: .squat,           confidence: .established),
+            .hipHinge:        PatternProfile(pattern: .hipHinge,        confidence: .established),
+        ]
+        #expect(model.isReadyForCalibrationReview == true)
+    }
+
+    @Test("4 major patterns established but calibration already fired: false")
+    func fourEstablishedAlreadyFired() {
+        var model = TraineeModel(goal: defaultGoal())
+        model.patterns = [
+            .horizontalPush:  PatternProfile(pattern: .horizontalPush,  confidence: .established),
+            .verticalPush:    PatternProfile(pattern: .verticalPush,    confidence: .established),
+            .squat:           PatternProfile(pattern: .squat,           confidence: .established),
+            .hipHinge:        PatternProfile(pattern: .hipHinge,        confidence: .established),
+        ]
+        model.projections = ProjectionState(calibrationReviewFiredAt: Date(timeIntervalSince1970: 1_700_000_000))
+        #expect(model.isReadyForCalibrationReview == false)
+    }
+
+    @Test("Established but on auxiliary patterns (lunge, isolation): false")
+    func auxiliaryDoesntCount() {
+        var model = TraineeModel(goal: defaultGoal())
+        model.patterns = [
+            .lunge:     PatternProfile(pattern: .lunge,     confidence: .established),
+            .isolation: PatternProfile(pattern: .isolation, confidence: .established),
+            .squat:     PatternProfile(pattern: .squat,     confidence: .established),
+            .hipHinge:  PatternProfile(pattern: .hipHinge,  confidence: .established),
+        ]
+        // Only 2 of the 6 majors established → false
+        #expect(model.isReadyForCalibrationReview == false)
+    }
+}
+
+@Suite("TraineeModel.disruptedPatterns")
+struct TraineeModelDisruptedPatternsTests {
+    @Test("Empty model: empty list")
+    func empty() {
+        let model = TraineeModel(goal: defaultGoal())
+        #expect(model.disruptedPatterns(asOf: isoDate("2026-05-04")) == [])
+    }
+
+    @Test("Pattern within 2x cadence: not disrupted")
+    func withinCadence() {
+        var model = TraineeModel(goal: defaultGoal())
+        // Cadence ~3 days, last session 4 days ago → 4 < 6 → not disrupted
+        model.patterns[.squat] = PatternProfile(pattern: .squat, recentSessionDates: [
+            isoDate("2026-04-25"), isoDate("2026-04-28"), isoDate("2026-04-30"),
+        ])
+        #expect(model.disruptedPatterns(asOf: isoDate("2026-05-04")) == [])
+    }
+
+    @Test("Pattern beyond 2x cadence: disrupted")
+    func beyondCadence() {
+        var model = TraineeModel(goal: defaultGoal())
+        // Cadence ~3 days, last session 10 days ago → 10 > 6 → disrupted
+        model.patterns[.squat] = PatternProfile(pattern: .squat, recentSessionDates: [
+            isoDate("2026-04-18"), isoDate("2026-04-21"), isoDate("2026-04-24"),
+        ])
+        #expect(model.disruptedPatterns(asOf: isoDate("2026-05-04")) == [.squat])
+    }
+
+    @Test("Pattern with insufficient cadence data: not in disrupted list")
+    func insufficientData() {
+        var model = TraineeModel(goal: defaultGoal())
+        // Only one recorded session → no cadence → can't classify as disrupted
+        model.patterns[.squat] = PatternProfile(pattern: .squat, recentSessionDates: [
+            isoDate("2026-04-01"),
+        ])
+        #expect(model.disruptedPatterns(asOf: isoDate("2026-05-04")) == [])
+    }
+}
+
+@Suite("TraineeModel.shouldFireGlobalPhaseAdvance")
+struct TraineeModelShouldFireGlobalPhaseAdvanceTests {
+    @Test("Empty model: false")
+    func empty() {
+        let model = TraineeModel(goal: defaultGoal())
+        #expect(model.shouldFireGlobalPhaseAdvance == false)
+    }
+
+    @Test("3 major patterns transitioned within 6 sessions: false")
+    func threeRecent() {
+        var model = TraineeModel(goal: defaultGoal())
+        model.totalSessionCount = 30
+        model.patterns = [
+            .horizontalPush: PatternProfile(pattern: .horizontalPush, lastPhaseTransitionAtSessionCount: 28),
+            .verticalPush:   PatternProfile(pattern: .verticalPush,   lastPhaseTransitionAtSessionCount: 26),
+            .squat:          PatternProfile(pattern: .squat,          lastPhaseTransitionAtSessionCount: 25),
+        ]
+        #expect(model.shouldFireGlobalPhaseAdvance == false)
+    }
+
+    @Test("4 major patterns transitioned within 6 sessions: true")
+    func fourRecent() {
+        var model = TraineeModel(goal: defaultGoal())
+        model.totalSessionCount = 30
+        model.patterns = [
+            .horizontalPush: PatternProfile(pattern: .horizontalPush, lastPhaseTransitionAtSessionCount: 28),
+            .verticalPush:   PatternProfile(pattern: .verticalPush,   lastPhaseTransitionAtSessionCount: 26),
+            .squat:          PatternProfile(pattern: .squat,          lastPhaseTransitionAtSessionCount: 25),
+            .hipHinge:       PatternProfile(pattern: .hipHinge,       lastPhaseTransitionAtSessionCount: 27),
+        ]
+        #expect(model.shouldFireGlobalPhaseAdvance == true)
+    }
+
+    @Test("4 major patterns transitioned but >6 sessions ago: false")
+    func fourTooOld() {
+        var model = TraineeModel(goal: defaultGoal())
+        model.totalSessionCount = 30
+        model.patterns = [
+            .horizontalPush: PatternProfile(pattern: .horizontalPush, lastPhaseTransitionAtSessionCount: 20),
+            .verticalPush:   PatternProfile(pattern: .verticalPush,   lastPhaseTransitionAtSessionCount: 18),
+            .squat:          PatternProfile(pattern: .squat,          lastPhaseTransitionAtSessionCount: 22),
+            .hipHinge:       PatternProfile(pattern: .hipHinge,       lastPhaseTransitionAtSessionCount: 21),
+        ]
+        // All deltas > 6 → none counted
+        #expect(model.shouldFireGlobalPhaseAdvance == false)
+    }
+
+    @Test("4 major + auxiliary patterns transitioned: only majors count")
+    func auxiliaryDoesntCount() {
+        var model = TraineeModel(goal: defaultGoal())
+        model.totalSessionCount = 30
+        model.patterns = [
+            .horizontalPush: PatternProfile(pattern: .horizontalPush, lastPhaseTransitionAtSessionCount: 28),
+            .verticalPush:   PatternProfile(pattern: .verticalPush,   lastPhaseTransitionAtSessionCount: 26),
+            .lunge:          PatternProfile(pattern: .lunge,          lastPhaseTransitionAtSessionCount: 27),
+            .isolation:      PatternProfile(pattern: .isolation,      lastPhaseTransitionAtSessionCount: 28),
+        ]
+        // Only 2 majors recently transitioned → false
+        #expect(model.shouldFireGlobalPhaseAdvance == false)
+    }
+}
+
+@Suite("TraineeModel Codable")
+struct TraineeModelCodableTests {
+    @Test("Round-trip on a populated fixture preserves all fields")
+    func roundTrip() throws {
+        var model = TraineeModel(
+            goal: GoalState(
+                statement: "Get visibly stronger",
+                focusAreas: [.chest, .back],
+                updatedAt: isoDate("2026-04-01")
+            ),
+            totalSessionCount: 24
+        )
+        model.activeProgramId = UUID()
+        model.patterns[.squat] = PatternProfile(
+            pattern: .squat, currentPhase: .intensification, sessionsInPhase: 4,
+            confidence: .established,
+            recentSessionDates: [isoDate("2026-04-28"), isoDate("2026-05-01")]
+        )
+        model.muscles[.legs] = MuscleProfile(muscleGroup: .legs, volumeTolerance: 22)
+        model.exercises["barbell_bench_press"] = ExerciseProfile(
+            exerciseId: "barbell_bench_press", sessionCount: 12,
+            confidence: .established
+        )
+        model.activeLimitations.append(ActiveLimitation(
+            subject: .joint(.shoulder), severity: .mild,
+            onsetDate: isoDate("2026-04-15"), evidenceCount: 2, userConfirmed: false
+        ))
+        model.fatigueInteractions.append(FatigueInteraction(
+            fromPattern: .squat, toPattern: .hipHinge,
+            observations: [-0.05, -0.06, -0.04], totalCount: 18
+        ))
+        model.prescriptionAccuracy[.horizontalPush] = [
+            .top: PrescriptionAccuracy(
+                pattern: .horizontalPush, intent: .top,
+                bias: -0.02, rmse: 0.03, sampleCount: 16
+            )
+        ]
+        model.transfers.append(ExerciseTransfer(
+            fromExerciseId: "barbell_bench_press", toExerciseId: "overhead_press",
+            coefficient: 0.6, rSquared: 0.7, pairedObservations: 8
+        ))
+        model.bodyweight.entries.append(BodyweightEntry(localDate: "2026-05-04", weightKg: 82))
+        model.lifeContextEvents.append(LifeContextEvent(
+            localDate: "2026-04-15", kind: "travel", notes: "10 days abroad"
+        ))
+        model.reassessmentRecords.append(ReassessmentRecord(
+            triggeredAt: isoDate("2026-04-20"),
+            triggeringSessionCount: 18,
+            advancedPatterns: [.horizontalPush, .squat, .verticalPull, .hipHinge]
+        ))
+        model.projections = ProjectionState(
+            patternProjections: [
+                PatternProjection(pattern: .squat, floor: 140, stretch: 165, progress: .onTrack),
+            ],
+            calibrationReviewFiredAt: isoDate("2026-04-15")
+        )
+
+        let data = try JSONEncoder().encode(model)
+        let decoded = try JSONDecoder().decode(TraineeModel.self, from: data)
+        #expect(decoded == model)
+    }
+
+    @Test("Round-trip on an empty-baseline fixture")
+    func emptyRoundTrip() throws {
+        let model = TraineeModel(goal: defaultGoal())
+        let data = try JSONEncoder().encode(model)
+        #expect(try JSONDecoder().decode(TraineeModel.self, from: data) == model)
+    }
+}
+
+// MARK: - Helpers
+
+private func defaultGoal() -> GoalState {
+    GoalState(statement: "test goal", updatedAt: isoDate("2026-04-01"))
+}
+
+private func isoDate(_ ymd: String) -> Date {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd"
+    formatter.timeZone = TimeZone(identifier: "UTC")
+    return formatter.date(from: ymd)!
+}

--- a/ProjectApexTests/WeekFatigueSignalsHelperAgreementTests.swift
+++ b/ProjectApexTests/WeekFatigueSignalsHelperAgreementTests.swift
@@ -1,0 +1,56 @@
+// WeekFatigueSignalsHelperAgreementTests.swift
+// ProjectApexTests
+//
+// Slice 1.8 regression guard: WeekFatigueSignals.compute aggregates each
+// canonical exercise into the same PrimaryMuscle bucket that ExerciseLibrary
+// reports for that exercise's primaryMuscle field. The internal helper
+// (`primaryMuscle(for:)`) is private; testing through the public surface
+// (compute → setsPerPrimaryMuscle dictionary keys) ensures any future drift
+// where the helper bypasses the library lookup is caught.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("WeekFatigueSignals helper / ExerciseLibrary agreement")
+struct WeekFatigueSignalsHelperAgreementTests {
+
+    @Test("Every canonical exercise aggregates to its ExerciseDefinition.primaryMuscle bucket")
+    func everyCanonicalExerciseAgrees() {
+        var disagreements: [String] = []
+
+        for exercise in ExerciseLibrary.all {
+            let log = makeSetLog(exerciseId: exercise.id)
+            let signals = WeekFatigueSignals.compute(from: [log], sessionCount: 1)
+            let bucketed = signals.setsPerPrimaryMuscle.first?.key
+
+            if bucketed != exercise.primaryMuscle {
+                disagreements.append(
+                    "\(exercise.id): library says .\(exercise.primaryMuscle.rawValue), " +
+                    "helper bucketed as \(bucketed.map { ".\($0.rawValue)" } ?? "nil")"
+                )
+            }
+        }
+
+        #expect(disagreements.isEmpty,
+                "Helper / ExerciseLibrary disagreement on canonical lifts:\n\(disagreements.joined(separator: "\n"))")
+    }
+}
+
+// MARK: - Helpers
+
+private func makeSetLog(exerciseId: String) -> SetLog {
+    SetLog(
+        id: UUID(),
+        sessionId: UUID(),
+        exerciseId: exerciseId,
+        setNumber: 1,
+        weightKg: 60,
+        repsCompleted: 5,
+        rpeFelt: 7,
+        rirEstimated: nil,
+        aiPrescribed: nil,
+        loggedAt: Date(),
+        primaryMuscle: nil
+    )
+}

--- a/docs/adr/0005-persistent-structured-trainee-model.md
+++ b/docs/adr/0005-persistent-structured-trainee-model.md
@@ -84,3 +84,18 @@ Sub-variants within the structured model (this is where the real grilling happen
 - The `MovementPattern` enum is cleaned to motion patterns only — calves and core are removed (calves contribute to `legs` muscle-group volume aggregation; core is not modelled as a first-class trainee axis in v2).
 - `MuscleGroup` is locked at six (back / chest / biceps / shoulders / triceps / legs) — drives both the trainee model's per-muscle storage and the Progress tab's narrative cards.
 - The trainee model is the AI's *behavioural memory*; the `MesocycleSkeleton` (ADR-0002) is the AI's *plan*. Session generation reads both: skeleton for what's queued next, trainee model for who the user is. Keeping them separate means each can evolve independently — the skeleton can be regenerated without losing trainee-model state, and the trainee model accumulates across multiple regenerated programmes.
+
+### Two-level muscle taxonomy (Slice 1 amendment, 2026-05-04)
+
+The original wording above conflated two distinct concerns: the trainee model's aggregation key and the ExerciseLibrary's exercise-classification field. Slice 1 implementation surfaced the conflict (the codebase's existing exercise data splits the legs into quads / hamstrings / glutes / calves — finer than the locked-six). Resolution: a two-level taxonomy.
+
+- **`MuscleGroup`** (locked-six: back, chest, biceps, shoulders, triceps, legs) is the **trainee model's aggregation key**. `muscles: [MuscleGroup: MuscleProfile]` uses these as keys for capability tracking, EWMA computation, recovery state, and prescription accuracy. This level is locked.
+- **`PrimaryMuscle`** (9 cases: back, chest, biceps, shoulders, triceps, quads, hamstrings, glutes, calves) is the **ExerciseLibrary's classification field**. Finer-grained, used by AI prescription reasoning at exercise-selection time so the model can reason about leg-muscle balance ("this user has been quad-light for 3 sessions") that the locked-six aggregation would erase.
+- **`PrimaryMuscle.muscleGroup`** is the canonical mapping function: leg subgroups (`quads`, `hamstrings`, `glutes`, `calves`) collapse to `MuscleGroup.legs`; upper-body muscles map 1:1.
+- **Core is excluded from both taxonomies.** Core training stimuli (planks, hanging leg raises, ab wheel rollouts, cable crunches) don't fit the EWMA-over-top-sets model that the trainee model uses to track capability — they're isometric or dynamic-but-not-load-progressing in shape. Rather than carrying a first-class core axis that the model can't update, the v2 ExerciseLibrary drops core exercises entirely; users wanting accessory core work can do it outside the AI-coached programme structure.
+
+This is one canonical representation (`PrimaryMuscle`) with a derived view (`MuscleGroup`), not two parallel string/enum systems.
+
+### MovementPattern taxonomy (Slice 1 clarification)
+
+This document originally described movement patterns as "knee-dominant, hip-dominant, elbow flexion, etc." — a generic biomechanics framing. The actual codebase taxonomy that ExerciseLibrary uses (and that the typed `MovementPattern` enum mirrors) is finer-grained and equipment-aware: `hipHinge`, `horizontalPull`, `horizontalPush`, `isolation`, `lunge`, `squat`, `verticalPull`, `verticalPush`. CONTEXT.md is the canonical place for this enumeration; the ADR defers to it.

--- a/scripts/add_test_file.rb
+++ b/scripts/add_test_file.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# Adds a Swift file under ProjectApexTests/ to the ProjectApexTests target.
+# Usage: ruby scripts/add_test_file.rb <RelativePathFromRepoRoot>
+# Example: ruby scripts/add_test_file.rb ProjectApexTests/MovementPatternTests.swift
+# Idempotent — skips silently if the file is already registered.
+
+require 'xcodeproj'
+
+rel_path = ARGV[0] or abort "Usage: ruby scripts/add_test_file.rb ProjectApexTests/<File>.swift"
+abort "Path must start with ProjectApexTests/" unless rel_path.start_with?('ProjectApexTests/')
+
+basename = File.basename(rel_path)
+project = Xcodeproj::Project.open('ProjectApex.xcodeproj')
+test_target = project.targets.find { |t| t.name == 'ProjectApexTests' } or abort "ProjectApexTests target not found"
+tests_group = project.main_group['ProjectApexTests'] || project.main_group.new_group('ProjectApexTests', 'ProjectApexTests')
+
+if tests_group.files.any? { |f| f.path == basename }
+  puts "#{basename} already registered — skipping."
+  exit 0
+end
+
+file_ref = tests_group.new_file(basename)
+test_target.source_build_phase.add_file_reference(file_ref)
+project.save
+puts "Added #{basename} to ProjectApexTests target."


### PR DESCRIPTION
## Summary

Phase 1 / Slice 1 — the foundation deep module for the persistent structured trainee model per ADR-0005. Ships ~28 trainee-model sub-types, all foundation enums (including `MovementPattern`, `PrimaryMuscle`, `MuscleGroup`), `MigrationDates`, the typed-enum migration of all stringly-typed muscle / pattern call sites, deletion of the 4 core exercises from `ExerciseLibrary`, and the ADR-0005 / CONTEXT.md amendments that resolve the as-built taxonomy ambiguity surfaced during planning.

Pure value types — no actors, no I/O. The downstream slices (TraineeModelService, TraineeModelLocalStore, TraineeModelUpdateJob, set-intent migration) all consume this.

Closes #2.

## Resolved planning ambiguity

Issue #2 originally presumed `MovementPattern` and `MuscleGroup` already existed as Swift enums with `.calves` / `.core` cases that needed removal. As-built reality: neither enum existed; both concepts were stringly-typed throughout the codebase. The slice was rescoped:

- **Two-level muscle taxonomy.** `MuscleGroup` (locked-six per ADR-0005) is the trainee-model aggregation key. `PrimaryMuscle` (9 cases — adds quads / hamstrings / glutes / calves) is the ExerciseLibrary classification field. `PrimaryMuscle.muscleGroup` collapses leg subgroups to `.legs`. Documented in ADR-0005 amendment + CONTEXT.md.
- **MovementPattern taxonomy.** Mirrors the 8 codebase-existing patterns (`hipHinge`, `horizontalPull`, `horizontalPush`, `isolation`, `lunge`, `squat`, `verticalPull`, `verticalPush`). CONTEXT.md updated to replace the prior "knee-dominant / hip-dominant / elbow flexion" sketch with the actual enumeration.
- **Core exercises** (`cable_crunch`, `hanging_leg_raise`, `ab_wheel_rollout`, `plank`) deleted from ExerciseLibrary — core training stimuli don't fit the EWMA-over-top-sets model.

## What's in this slice (commit-by-commit)

1. **Slice 1.1** — Foundation enums + `MigrationDates`: `MovementPattern`, `PrimaryMuscle` (+ `muscleGroup` mapping), `MuscleGroup`, `SetIntent`, `AxisConfidence`, `StimulusDimension`, `Severity`, `BodyJoint`, `ProjectionProgress`, `LimitationSubject` (sum type), `MigrationDates` namespace.
2. **Slice 1.2** — Snapshot value types: `TopSetSnapshot`, `ExerciseSessionSnapshot`, `BodyweightEntry`, `LifeContextEvent`, `ReassessmentRecord`, `PatternProjection`, `RecoveryProfile` (two-dimensional), `GoalState`.
3. **Slice 1.3** — Limitation + interaction types: `ActiveLimitation`, `ClearedLimitation`, `FatigueInteraction` (+ `consistencyFactor` with floating-point boundary snap, `countFactor`, `confidence`), `PrescriptionAccuracy`, `PrescriptionIntentMismatch`, `ExerciseTransfer`, `BodyweightHistory`.
4. **Slice 1.4** — Profile types with derived properties: `ExerciseProfile` (+ `learningPhase`), `MuscleProfile`, `PatternProfile` (+ `recentSessionDays`, `sessionsCadenceDays`, `daysSinceLastSession`, `inTransitionMode`), `ProjectionState`, `ProgressionTrend` enum.
5. **Slice 1.5** — `TraineeModel` root + derived properties: `isReadyForCalibrationReview`, `disruptedPatterns(asOf:)`, `shouldFireGlobalPhaseAdvance`. `majorPatterns` set covers the 6 compound patterns.
6. **Slice 1.6** — String→typed-enum migration across `ExerciseDefinition`, `ExerciseLibrary` (75 entries), `MovementPatternPhaseState`, `PatternPhaseService`, `SessionPlanService.WeekFatigueSignals.setsPerMuscleGroup`, 4 UI muscle-color helpers; deletes 4 core exercises; updates `ExerciseLibraryTests` + `PatternPhaseServiceTests` for the typed shape; adds classification-consistency tests.
7. **Slice 1.7** — ADR-0005 amendment ("Two-level muscle taxonomy" + "MovementPattern taxonomy" sections) and CONTEXT.md updates.

## Behavioural notes

- `WeekFatigueSignals.setsPerMuscleGroup` migration coarsens the LLM's view of leg-muscle distribution: quads / hamstrings / glutes / calves all collapse to `legs` (the locked-six aggregation), and core entries drop. Slightly less granular than the prior string-keyed shape but consistent with the rest of the trainee-model aggregation.
- `MovementPatternPhaseState.pattern` migration is wire-compatible with existing UserDefaults storage (raw values match prior strings).
- `synergists` on `ExerciseDefinition` stays `[String]` — synergists carry broader vocabulary (e.g. "forearms") not in the locked PrimaryMuscle taxonomy. Documented in `ExerciseDefinition`'s doc-comment.
- UI helpers use typed-first dispatch with substring-match fallback for non-canonical strings (e.g. "pectoralis_major" coming from a free-form muscle field).

## Test plan

- [ ] All 83 Slice 1 tests pass: foundation enums (22), snapshots (12), interactions (14), profiles (19), TraineeModel root (16), updated ExerciseLibrary + PatternPhaseService.
- [ ] `xcodebuild build` succeeds (no related warnings).
- [ ] Pre-existing test failures in `WriteAheadQueueTests`, `SetPrescriptionValidationTests`, `GymStreakServiceTests`, `MemoryServiceTests` are unrelated to this slice (none reference `MovementPattern` / `PrimaryMuscle` / `MuscleGroup` / `SetIntent`).
- [ ] No core exercises remain in `ExerciseLibrary` (`coreExercisesRemoved` test verifies).
- [ ] No exercise has `primaryMuscle` outside the 9-case PrimaryMuscle (`primaryMuscleAlwaysInTaxonomy` test — type-system enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)