### PR TITLE
Phase 1 / Slice 9a — Edge Function secret-management decisions

### DIFF
--- a/docs/agents/edge-functions.md
+++ b/docs/agents/edge-functions.md
@@ -1,0 +1,113 @@
+# Edge Functions: secrets, access, rotation
+
+How Edge Function secrets are stored, who holds the keys that bypass RLS, and when and how those keys rotate. Slice 9b and downstream Edge Function work follow this doc; material deviations get a new ADR.
+
+Scale baseline: solo developer, alpha cohort of 3–5 friends (P-B), pre-multi-user. Policies are sized for that scale and explicitly *not* enterprise-grade.
+
+## Decisions
+
+### 1. Secret storage — Supabase Edge Function env vars
+
+Edge Function secrets live in Supabase-managed env vars, set via the Supabase CLI (`supabase secrets set FOO=bar`) and read inside the function via `Deno.env.get("FOO")`. Encrypted at rest by Supabase, scoped to the Edge Function runtime, rotated with one CLI command, no external vendor.
+
+**Rationale.** The secrets the Edge Function needs (eventually `ANTHROPIC_API_KEY`, plus whatever else lands in the Deno runtime) are consumed by the Edge Function itself — put them where the Edge Function reads them. Supabase Vault is the right answer when the *stored procedure* needs a secret (the procedure is currently pure compute, no external calls). External managers (Doppler, 1Password CLI, AWS Secrets Manager) are overkill at this scale and add a cold-start fetch hop. Vault and external managers are not foreclosed: when a future slice needs Postgres-side secrets, that specific secret moves to Vault and the two mechanisms coexist.
+
+**Addenda.**
+
+- `SUPABASE_SERVICE_ROLE_KEY` is **platform-injected** in deployed Edge Functions — do not `supabase secrets set` it. For local `supabase functions serve` development, set it explicitly in `supabase/.env` (or whichever local env file the CLI picks up); the value matches whatever the production service-role key currently is.
+- Audit trail: the Supabase dashboard logs secret mutations with timestamp and actor. Coarse (no per-read logging) but adequate at solo scale — there *is* a trail of "when was this key last set."
+- `ANTHROPIC_API_KEY` may be set to an empty placeholder during Slice 9b, since 9b's stub does not call Anthropic. The access pattern (`Deno.env.get`) is what 9b commits to; the value lands when the function actually invokes Anthropic.
+
+### 2. Service-role access — solo developer only
+
+The Supabase service-role key is held by the solo developer only. Storage: a password manager entry titled **`ProjectApex — Supabase service-role key`** (1Password / Bitwarden / equivalent). No CI/CD secret. No shared copies. Manual `supabase functions deploy` from the developer's laptop until a future slice explicitly justifies CI deploys.
+
+**Rationale.** The service-role key bypasses RLS — it is the master key that overrides every protection Phase 5's RLS migrations install. At solo + 3–5 friends, deploys are infrequent enough that manual is not a bottleneck. Adding a GitHub Actions secret would expand the attack surface (compromised workflow, malicious dependency, leaked PAT) for a convenience that isn't paying for itself yet. Bus-factor recovery rides on the password manager's own 2FA + recovery codes.
+
+**Addenda.**
+
+- The Supabase CLI uses your separate `supabase login` token for deploys — manual deploys do not require the service-role key on disk at deploy time. The key is only on disk in `supabase/.env` for local `supabase functions serve`.
+- Adding CI deploys later is an explicit decision, not a default-on choice. When that slice lands: store the key as a GitHub Actions secret with environment-scoped protection rules, then rotate immediately so the CI copy is born in CI.
+- One-time pre-Slice-9b hygiene rotation (see §Rotation playbooks → Service-role) ensures the key in the password manager has clean provenance before the first real deploy.
+
+### 3. Rotation policy — time-based for Anthropic, event-based for service-role
+
+| Secret | Cadence | Triggers | Rollback |
+|---|---|---|---|
+| `ANTHROPIC_API_KEY` | Every 90 days | Confirmed compromise; plausible exposure; end of alpha | Provision new → `supabase secrets set` → smoke test → revoke old after 24h. Both keys live for the 24h overlap. Reversion = revert env var. |
+| Supabase service-role | On-incident only | Confirmed compromise; access-list change (CI added, partner added/removed); end of alpha; one-time pre-Slice-9b hygiene rotation | None. Dashboard rotation invalidates the old key immediately — forward-fix only. Do not rotate near deploy windows or end-of-day. |
+| Local `supabase/.env` service-role copy | Inherits upstream | Inherits upstream | Re-read from password manager. |
+
+**Rationale.** 90-day cadence on Anthropic catches the dominant API-key failure mode: silent leaks (force-pushed-but-still-in-pack-files, .env synced to cloud, etc.) where you don't realise the leak happened. Service-role has no overlap window in Supabase's model, so calendar-based rotation introduces breakage risk without compensating value — event-based only, with a high bar for what counts as an event. The paired routine: when rotating Anthropic on the 90-day cadence, also do a 5-minute access-list review (does anyone other than the developer hold service-role today?). Bundles two chores into one.
+
+**Addenda — triggers.**
+
+- **"End of alpha" is concrete**, not vibes-based: the trigger fires the moment the **first non-friend user onboards** — i.e., the first user who is not personally known to the developer. Operational test: would you invite them to dinner? If yes, they're a friend; if no, end-of-alpha has fired and every secret that was live during the friend-only alpha rotates, regardless of suspicion.
+- **Plausible exposure** = the key may have transited a clipboard manager, screenshot, screen-share, unsandboxed dev tool, or a chat / email thread you did not author. Lower bar than "confirmed compromise"; higher bar than "I had a bad feeling."
+- **Access-list change** for service-role includes both additions (CI added, bus-factor partner added) and removals (partner offboarded, CI deploys retired). New copies start fresh; offboarded copies die with the old key.
+
+**Addenda — non-triggers.** These are explicitly *not* incident-worthy:
+
+- Discovering historical evidence of a key that has **since been rotated**. The leak is dead with the key. A screenshot from 4 months ago of a key rotated 2 months ago is a non-event — do not double-rotate out of anxiety.
+- Routine deploys, schema migrations, or new Edge Function additions that consume existing secrets.
+- A friend asking "what's your stack" — describing that you use Supabase service-role is not a leak.
+
+## Rotation playbooks
+
+Executable without rederivation. If you are reading this with no prior context, the steps below are sufficient.
+
+### Anthropic API key
+
+**Prerequisite:** a recurring 90-day calendar reminder titled **"Rotate Anthropic API key"** must exist. If not already set, create it now — the cadence is worthless without a forcing function.
+
+1. console.anthropic.com → API Keys → create new key (label it with today's date, e.g., `apex-edge-2026-08-01`).
+2. `supabase secrets set ANTHROPIC_API_KEY=<new value>` (production project).
+3. Smoke test the new key directly against Anthropic before trusting it in the function path:
+
+   ```bash
+   curl https://api.anthropic.com/v1/messages \
+     -H "x-api-key: <new value>" \
+     -H "anthropic-version: 2023-06-01" \
+     -H "content-type: application/json" \
+     -d '{"model":"claude-haiku-4-5-20251001","max_tokens":4,"messages":[{"role":"user","content":"ping"}]}'
+   ```
+
+   Confirm HTTP 200 and a non-empty `content` array. Once the Edge Function actually invokes Anthropic (post-Slice-9b integration), additionally hit the function path and confirm 200 + non-empty response — but the curl check above is the minimum and runs identically pre- and post-integration.
+4. Set a 24-hour calendar reminder titled **"Revoke old Anthropic key — apex-edge-<previous date>"**.
+5. After 24 hours: console.anthropic.com → revoke old key.
+6. **If the 24-hour reminder is dismissed, snoozed, or missed**, and you are uncertain whether the old key was revoked: revoke now (in the console) and rotate the *current* key again from step 1. Never leave an unrevoked old key live past the overlap window.
+
+Reversion (if step 3 smoke-test fails): `supabase secrets set ANTHROPIC_API_KEY=<old value>` — the old key is still active during the 24-hour overlap. Investigate the failure before re-attempting rotation.
+
+### Supabase service-role key
+
+No overlap window. Run only during a daylight window where you can debug breakage. Do not run on a Friday afternoon.
+
+**Fan-out checklist** — before rotating, confirm every place the key currently lives so the post-rotation update has no gaps:
+
+- [ ] Password manager entry **`ProjectApex — Supabase service-role key`**
+- [ ] Local `supabase/.env` (for `supabase functions serve`)
+- [ ] (Future, currently N/A) GitHub Actions secret — only relevant after CI deploys are added
+- [ ] (Future, currently N/A) any bus-factor partner's password manager — only relevant if Decision #2 is revisited
+
+**Rotation steps:** verify cheap before verify expensive — local first, then production. If local breaks, production is untouched.
+
+1. Supabase Dashboard → Settings → API → rotate `service_role` key.
+2. Update the password manager entry **`ProjectApex — Supabase service-role key`** with the new value.
+3. Update local `supabase/.env` with the new value.
+4. Verify local: restart `supabase functions serve` and hit the endpoint locally; confirm 200.
+5. Verify production: `supabase functions deploy <name>` and confirm a deploy and a 200 from a smoke-test invocation. (Production Edge Functions pick up the new platform-injected value automatically — no `supabase secrets set` needed for the service-role key itself.)
+6. If anything fails: forward-fix only. There is no reversion path.
+
+### Pre-Slice-9b hygiene rotation
+
+Run once, before Slice 9b's first real deploy, to guarantee clean provenance for the service-role key in the password manager (the auto-generated key from project creation may have transited setup notes, screenshots, or clipboard managers). Use the Supabase service-role playbook above; the fan-out checklist at that point is just the password manager + local `.env`. If `supabase/.env` does not yet exist, create it as part of step 3 — Slice 9b will need it for `supabase functions serve` regardless.
+
+## Out of scope
+
+This doc covers secret storage, access list, and rotation for the Edge Function deployment context. Out of scope:
+
+- Edge Function deployment itself (Slice 9b — issue #9).
+- Anthropic API integration / digest assembly logic (downstream of 9b).
+- RLS policy design (Phase 5).
+- Multi-device or optimistic-concurrency migration paths (deferred to v3+ per ADR-0006).


### PR DESCRIPTION
## Summary
- Documents three architectural decisions for Edge Function secret management in `docs/agents/edge-functions.md` (HITL, no code).
- Decisions: (1) secrets in Supabase Edge Function env vars; (2) service-role access solo-developer only, password-manager-stored; (3) 90-day cadence on Anthropic key, event-only rotation on service-role.
- Includes executable rotation playbooks (curl smoke test against Anthropic, fan-out checklist for service-role, one-time pre-9b hygiene rotation), concrete "end of alpha" definition, and explicit non-triggers.

Closes #6. Unblocks Slice 9b (#9).

## Test plan
- [ ] Doc renders cleanly on GitHub (no broken markdown tables or code fences)
- [ ] Decisions section maps 1:1 to issue #6 acceptance criteria
- [ ] Rotation playbooks executable as written without rederivation
- [ ] No code or schema changes (documentation-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)