### PR TITLE
Force Sync from Supabase developer tool

### DIFF
--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -539,7 +539,8 @@ struct ContentView: View {
                 confirmedProfile = nil
                 programViewModel = nil
                 showOnboarding = true
-            }
+            },
+            programViewModel: programViewModel
         )
     }
 

--- a/ProjectApex/Settings/DeveloperSettingsView.swift
+++ b/ProjectApex/Settings/DeveloperSettingsView.swift
@@ -36,6 +36,9 @@ struct DeveloperSettingsView: View {
     /// Called after "Reset All App Data" completes so ContentView can return to onboarding.
     var onResetAll: (() -> Void)?
 
+    /// Shared ProgramViewModel — used by "Force Sync from Supabase" to bypass the UserDefaults cache.
+    var programViewModel: ProgramViewModel? = nil
+
     // MARK: - Environment
 
     @Environment(AppDependencies.self) private var deps
@@ -71,6 +74,8 @@ struct DeveloperSettingsView: View {
     @State private var showResetOnboardingConfirmation: Bool = false
     /// Controls the "Clear RAG Memory" confirmation alert.
     @State private var showClearMemoryConfirmation: Bool = false
+    /// Controls the "Force Sync from Supabase" confirmation alert.
+    @State private var showForceSyncConfirmation: Bool = false
 
     /// Gym weight correction facts loaded from GymFactStore for display and deletion.
     @State private var gymFacts: [GymFactStore.WeightFact] = []
@@ -143,6 +148,15 @@ struct DeveloperSettingsView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Deletes all AI memory embeddings for this user from Supabase. Useful for testing cold-start AI behaviour.")
+        }
+        // Force Sync from Supabase confirmation
+        .alert("Force Sync from Supabase?", isPresented: $showForceSyncConfirmation) {
+            Button("Sync Now") {
+                Task { await performForceSync() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Clears the local programme cache and reloads from Supabase. Use this to reflect direct database edits.")
         }
     }
 
@@ -373,6 +387,15 @@ struct DeveloperSettingsView: View {
             } label: {
                 Label("Clear RAG Memory", systemImage: "brain.filled.head.profile")
             }
+
+            // Bypasses the UserDefaults cache and reloads the programme from Supabase.
+            // Useful when direct DB edits need to surface in the app.
+            Button {
+                showForceSyncConfirmation = true
+            } label: {
+                Label("Force Sync from Supabase", systemImage: "arrow.triangle.2.circlepath")
+            }
+            .disabled(programViewModel == nil)
         } header: {
             Text("Developer Tools")
         } footer: {
@@ -620,6 +643,16 @@ struct DeveloperSettingsView: View {
         } catch {
             showBanner("Failed: \(error.localizedDescription)", isError: true)
         }
+    }
+
+    /// Clears the UserDefaults programme cache and reloads from Supabase.
+    /// Use this to surface direct database edits without a full app reset.
+    @MainActor
+    private func performForceSync() async {
+        guard let vm = programViewModel else { return }
+        Mesocycle.clearUserDefaults()
+        await vm.loadProgram()
+        showBanner("Programme reloaded from Supabase.", isError: false)
     }
 }
 

--- a/ProjectApex/Settings/SettingsView.swift
+++ b/ProjectApex/Settings/SettingsView.swift
@@ -42,6 +42,9 @@ struct SettingsView: View {
     /// Called after a developer reset so ContentView can return to onboarding.
     var onResetAll: (() -> Void)? = nil
 
+    /// Shared ProgramViewModel — forwarded to DeveloperSettingsView for force-sync.
+    var programViewModel: ProgramViewModel? = nil
+
     // MARK: - Local mutable equipment list
 
     /// Working copy of the equipment list. Seeded from confirmedProfile on appear.
@@ -461,7 +464,7 @@ struct SettingsView: View {
     private var developerSection: some View {
         Section("Developer") {
             #if DEBUG
-            NavigationLink(destination: DeveloperSettingsView(onResetAll: onResetAll)) {
+            NavigationLink(destination: DeveloperSettingsView(onResetAll: onResetAll, programViewModel: programViewModel)) {
                 Label("Developer Settings", systemImage: "key.fill")
             }
             #endif


### PR DESCRIPTION
## Summary
- Adds a DEBUG-only "Force Sync from Supabase" button to `DeveloperSettingsView` that clears the local `Mesocycle` UserDefaults cache and reloads the programme from Supabase.
- Wires `ContentView` → `SettingsView` → `DeveloperSettingsView` to forward the shared `ProgramViewModel`; button is disabled when `programViewModel == nil`.
- Confirmation alert before the cache clear.

Useful when direct DB edits need to surface in the app without a full reset. Originally an in-progress local edit; reconciled and split out from a separate workout-sheet-callbacks bundle (separate PR).

## Test plan
- [ ] Build succeeds in DEBUG; button visible in Developer Settings → Developer Tools section
- [ ] Tapping the button shows the confirmation alert; "Sync Now" clears UserDefaults and re-fetches the programme
- [ ] Banner shows "Programme reloaded from Supabase." on success
- [ ] Button disabled when `programViewModel` is nil (defensive — ContentView always forwards it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)