### PR TITLE
ProgramDayDetailView workout-sheet callbacks

### DIFF
--- a/ProjectApex/Features/Program/ProgramDayDetailView.swift
+++ b/ProjectApex/Features/Program/ProgramDayDetailView.swift
@@ -324,13 +324,21 @@ struct ProgramDayDetailView: View {
                     viewModel?.markDayPaused(dayId: currentDay.id, weekId: week.id)
                 },
                 onSessionDismissed: {
-                    // Pop back to this view after the session is done; also trigger the
-                    // programme calendar to scroll to the current week.
                     navigateToWorkout = false
                     viewModel?.scrollToCurrentWeekTrigger += 1
+                    if currentDay.status == .completed {
+                        Task { await loadHistoricalSetLogs() }
+                    }
                 },
                 resumeState: resumeState,
-                startingExerciseIndex: workoutStartingExerciseIndex
+                startingExerciseIndex: workoutStartingExerciseIndex,
+                onSkipSession: {
+                    currentDay.status = .skipped
+                    viewModel?.markDaySkipped(dayId: currentDay.id, weekId: week.id)
+                },
+                onBack: {
+                    navigateToWorkout = false
+                }
             )
             .environment(deps)
         }


### PR DESCRIPTION
## Summary
- `onSessionDismissed` re-fires `loadHistoricalSetLogs()` when the dismissed day is `.completed`, so the day-detail view reflects newly logged sets without a manual refresh.
- New `onSkipSession` callback marks the day `.skipped` via `markDaySkipped`, providing an in-session skip path alongside the existing "Skip this session" tertiary button.
- New `onBack` callback dismisses the workout sheet (`navigateToWorkout = false`).

Originally an in-progress local edit; reconciled and split out from the force-sync developer-tool bundle (separate PR).

## Test plan
- [ ] Build succeeds; navigating into a workout from `ProgramDayDetailView` retains all existing flows (start / pause / resume / skip)
- [ ] Completing a session and dismissing the sheet reloads historical set logs in the day-detail view (no manual refresh required)
- [ ] In-session skip path marks the day `.skipped` correctly and persists across relaunch
- [ ] Back from the workout sheet dismisses to the day-detail view (no navigation glitches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)