### PR TITLE
chore: codify slice-completion + process-commitment + cross-cutting-grep discipline in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,22 @@
 # AI Co-Developer Instructions
 1. **Strictly Non-Autonomous:** You are an assistant, not an autonomous agent. ONLY work on the specific task I explicitly assign to you. Do NOT automatically start the next task on the backlog.
 2. **Context-Aware Coding:** When I assign you a task, use your file-reading tools to check `ARCHITECTURE.md` for the relevant database schemas, actor models, and UI/UX design tokens before writing code.
-3. **Backlog Tracking:** When I explicitly tell you a task is complete and working, use your file-editing tool to open `BACKLOG.md` and change that specific task from `[ ]` to `[x]`.
-4. **Wait for Commands:** After completing a coding task or updating the backlog, simply tell me it is done and wait for my next instruction. Do not proceed on your own.
+3. **Slice completion tracking:** When I confirm a tracer-bullet slice is complete and working, close the corresponding GitHub issue with a completion comment summarising what shipped, any pre-deploy reminders, and links to spinoff issues. Do NOT modify `BACKLOG.md` — that file tracks product features (P0-T01, FB-XXX, etc.), not the per-slice issues that live in the GitHub tracker. (The Slice 1 closure pattern in #2 is the precedent — issue closure happens via a merged PR's Closes #N keyword per Process commitment rule 1, not before.)
+4. **Wait for Commands:** After completing a coding task or closing the slice issue, simply tell me it is done and wait for my next instruction. Do not proceed on your own.
+
+## Process commitment
+
+1. **Branch + commit per logical unit, PR-before-close.** Slice/issue work happens on a feature branch off `main`, never on `main` directly. Each logical unit gets its own commit and its own PR. GitHub issues close via the PR's Closes #N keyword on merge — never via standalone close-comment before the work is committed and merged. *Motivating failure (6h-19m incident):* four logical units (Slice 5, #23, #24.1, #24.2) conflated into a single uncommitted working-tree state on `main`, with issue #4 closed prematurely via a celebratory comment that pointed at no commit, no PR, and nothing on `origin/main`.
+
+2. **Cross-cutting grep is grep-and-report, not grep-and-rewrite.** When the "Cross-cutting fixes — grep before declaring done" section below surfaces additional sites, list them with a recommendation and wait for explicit authorization before editing. The grep section finds the sites; this rule constrains what to do with them. *Motivating failure (four-cosmetic-test-files incident):* agent grepped for `URLError` mocks during #24.2, found four, edited all four without authorization. Three of the four had not been authorized — they were unilateral "consistency" rewrites of tests that were already passing.
+
+3. **Surface ambiguity, don't fill it silently.** When an instruction has a hole or an "or" with an unspecified default, surface the ambiguity and ask before acting on a unilateral interpretation. Absence of explicit prohibition is not authorization. *Motivating failure (ADR-0007 form decision):* the directive "amend ADR-0001 or whichever ADR codifies no-silent-fallbacks" had a hole when grep showed no ADR explicitly codified the principle, and the agent unilaterally chose new-ADR rather than asking.
+
+## Cross-cutting fixes — grep before declaring done
+
+When the fix is to a *pattern* rather than a single call site (test-harness bugs, Codable shape changes, retry-policy adjustments, lifecycle hooks, etc.), grep the codebase for every occurrence of that pattern before declaring the fix complete — not just the file that triggered the investigation. A near-miss happened in #23: the H1 stream-drain fix landed in `MockURLProtocol`, but `WAQMockURLProtocol` had identical code with the same bug; only a full-suite run caught it. The lesson: when the change is structural, the search radius is the whole codebase.
+
+Practical form: after writing the fix, grep for the pattern that motivated it (e.g. `request.httpBody` for URLProtocol mocks, `static var.*Handler` for shared mock state, `weightKg >=` for validation predicates) and confirm every hit either uses the fix or has a documented reason to differ. Report the grep result alongside the fix, not after the user notices the second site.
 
 ## Agent skills
 


### PR DESCRIPTION
## What changed

Rule 3 rewritten: BACKLOG.md flip replaced with GitHub issue closure via merged PR (`Closes #N` keyword), and BACKLOG.md is explicitly out of scope for slice tracking — it remains for product features (`P0-T01`, `FB-XXX`). New `## Process commitment` section with three numbered rules: branch + commit per logical unit with PR-before-close; cross-cutting grep is grep-and-report not grep-and-rewrite; surface ambiguity rather than fill it silently. New `## Cross-cutting fixes — grep before declaring done` section codifying the pattern-radius discipline. Rule 4 reworded ("closing the slice issue" instead of "updating the backlog") for consistency with the new rule 3.

## Why

Three motivating incidents from the prior session, all preserved in the rules as italicised citations rather than recapitulated here. The 6h-19m incident: four logical units (Slice 5, #23, #24.1, #24.2) conflated into one uncommitted working-tree state on `main`, with issue #4 closed prematurely via standalone comment pointing at nothing on `origin/main`. The four-cosmetic-test-files incident: a `URLError` mock grep during #24.2 turned into four unauthorized "consistency" edits, three of which were rewrites of tests that were already passing. The ADR-0007 form decision: an "amend ADR-0001 or whichever" directive with a hole that should have prompted a clarifying question and instead became a unilateral new-ADR call.

## Context

This is the first of five reconstruction PRs from the working-tree-on-main incident. Reconstruction approach is stash-everything-then-cherry-pick-per-unit: `stash@{0}` ("reconstruction-source-2026-05-04") holds the full 19-file working state, with each PR pulling out only its unit's files via `git checkout stash@{0} -- <files>`. Sequence after this merge: Slice 5 next (`Closes #4` — the issue closed prematurely; this PR re-opens the proper closure path), then #23 (test-harness fixes), then #24.1 (weightKg test fix) and #24.2 (LLM retry classification + ADR-0007) as a paired batch. Three cosmetic test files reverted, not in any PR.