### PR TITLE
Phase 1 / Slice 5 — TopSetSnapshot factory + local_date column

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		6ED5B7636B15C7C513C11C2E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC23D0A3EB460CF97B18574 /* Foundation.framework */; };
 		729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */; };
 		73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */; };
 		81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */; };
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
@@ -90,6 +91,7 @@
 		85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelInteractionsTests.swift; sourceTree = "<group>"; };
 		878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelProfilesTests.swift; sourceTree = "<group>"; };
 		993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelSnapshotsTests.swift; sourceTree = "<group>"; };
+		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
 		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
 		E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MuscleTaxonomyTests.swift; sourceTree = "<group>"; };
 		EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelEnumsTests.swift; sourceTree = "<group>"; };
@@ -213,6 +215,7 @@
 				EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */,
 				1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */,
 				993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */,
+				B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */,
 				85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */,
 				878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */,
 				DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */,
@@ -349,6 +352,7 @@
 				39E16C19CFE1B1EF9BE00A32 /* TraineeModelEnumsTests.swift in Sources */,
 				729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */,
 				73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */,
+				A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */,
 				81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */,
 				6ECE420C1031E80360FF1EFE /* TraineeModelProfilesTests.swift in Sources */,
 				B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */,

--- a/ProjectApex/Models/TraineeModelSnapshots.swift
+++ b/ProjectApex/Models/TraineeModelSnapshots.swift
@@ -14,19 +14,65 @@ import Foundation
 
 /// One top-set observation (intent == .top, reps in 3..10) feeding the
 /// EWMA window per ADR-0005.
+///
+/// Carries both `date` (UTC instant — preserved for ordering and display)
+/// and `localDate` (pre-bucketed yyyy-MM-dd string in the user's then-local
+/// timezone). The UTC instant orders the EWMA window since localDate is
+/// day-granular only; the local string is what cadence and disruption
+/// derivations operate on.
 struct TopSetSnapshot: Codable, Sendable, Hashable {
     var sessionId: UUID
+    var date: Date
     var localDate: String
     var weightKg: Double
     var reps: Int
     var e1rm: Double
 
-    init(sessionId: UUID, localDate: String, weightKg: Double, reps: Int, e1rm: Double) {
+    /// Private to ensure `make(setLog:loggedInTimezone:)` is the structural
+    /// single construction path for new snapshots — no caller can bypass
+    /// the timezone pinning by stuffing arbitrary values in directly.
+    /// Codable's synthesised `init(from:)` does not depend on this init,
+    /// so JSON / SwiftData round-trips remain unaffected.
+    private init(sessionId: UUID, date: Date, localDate: String, weightKg: Double, reps: Int, e1rm: Double) {
         self.sessionId = sessionId
+        self.date = date
         self.localDate = localDate
         self.weightKg = weightKg
         self.reps = reps
         self.e1rm = e1rm
+    }
+
+    /// Phase 1 / Slice 5 — single construction path for new snapshots.
+    /// Pre-buckets `localDate` in the supplied timezone at write time so
+    /// subsequent timezone changes (Sydney → Tokyo) can't shift the
+    /// already-recorded date. See ADR-0005 — "Day boundaries for cadence:
+    /// chose pre-bucketed `localDate` string at write time."
+    static func make(setLog: SetLog, loggedInTimezone: TimeZone = .current) -> TopSetSnapshot {
+        let weight = setLog.weightKg
+        let reps   = setLog.repsCompleted
+        // Epley: weight × (1 + reps/30). Validity is gated by callers
+        // (top sets in 3..10 reps per ADR-0005); the formula itself is
+        // pure and applies the same shape to any (weight, reps).
+        let e1rm = weight * (1.0 + Double(reps) / 30.0)
+
+        // Locale pinned to en_US_POSIX so the format string yyyy-MM-dd is
+        // interpreted as ISO-8601 calendar fields regardless of host locale.
+        // Timezone is the explicit parameter — no implicit fallback to
+        // TimeZone.current at format time.
+        let formatter = DateFormatter()
+        formatter.locale     = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone   = loggedInTimezone
+        let localDate = formatter.string(from: setLog.loggedAt)
+
+        return TopSetSnapshot(
+            sessionId: setLog.sessionId,
+            date: setLog.loggedAt,
+            localDate: localDate,
+            weightKg: weight,
+            reps: reps,
+            e1rm: e1rm
+        )
     }
 }
 

--- a/ProjectApexTests/TopSetSnapshotFactoryTests.swift
+++ b/ProjectApexTests/TopSetSnapshotFactoryTests.swift
@@ -1,0 +1,205 @@
+// TopSetSnapshotFactoryTests.swift
+// ProjectApexTests
+//
+// Tests for TopSetSnapshot.make(setLog:loggedInTimezone:) — Phase 1 / Slice 5.
+// See ADR-0005 ("pre-bucketed localDate string at write time"), issue #4.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("TopSetSnapshot.make factory")
+struct TopSetSnapshotFactoryTests {
+
+    // MARK: Fixtures
+
+    private static let sydney = TimeZone(identifier: "Australia/Sydney")!
+    private static let tokyo  = TimeZone(identifier: "Asia/Tokyo")!
+    private static let utc    = TimeZone(identifier: "UTC")!
+
+    /// 2026-05-03 14:30:00 UTC.
+    /// In Australia/Sydney (UTC+10, no DST in May): 2026-05-04 00:30 — date 2026-05-04.
+    /// In Asia/Tokyo     (UTC+9):                    2026-05-03 23:30 — date 2026-05-03.
+    /// In UTC:                                       2026-05-03 14:30 — date 2026-05-03.
+    private static let acrossSydneyMidnight = Date(timeIntervalSince1970: 1_777_818_600)
+
+    private func setLog(
+        loggedAt: Date = TopSetSnapshotFactoryTests.acrossSydneyMidnight,
+        weightKg: Double = 100.0,
+        reps: Int = 5
+    ) -> SetLog {
+        SetLog(
+            id: UUID(),
+            sessionId: UUID(),
+            exerciseId: "barbell_back_squat",
+            setNumber: 1,
+            weightKg: weightKg,
+            repsCompleted: reps,
+            rpeFelt: 8,
+            rirEstimated: 2,
+            aiPrescribed: nil,
+            loggedAt: loggedAt,
+            primaryMuscle: "quads"
+        )
+    }
+
+    // MARK: - Cycle 1: factory exists, copies scalar fields
+
+    @Test("Factory copies sessionId, weightKg, reps from the set log")
+    func copiesScalarFields() {
+        let log = setLog(weightKg: 102.5, reps: 7)
+        let snap = TopSetSnapshot.make(setLog: log, loggedInTimezone: Self.sydney)
+
+        #expect(snap.sessionId == log.sessionId)
+        #expect(snap.weightKg  == 102.5)
+        #expect(snap.reps      == 7)
+    }
+
+    // MARK: - Cycle 2: Epley e1RM (CONTEXT.md — weight × (1 + reps/30))
+
+    @Test("Factory computes Epley e1rm = weight × (1 + reps/30)")
+    func computesEpleyE1rm() {
+        let log = setLog(weightKg: 100.0, reps: 5)
+        let snap = TopSetSnapshot.make(setLog: log, loggedInTimezone: Self.sydney)
+
+        // 100 × (1 + 5/30) = 100 × 1.16666… = 116.666…
+        let expected = 100.0 * (1.0 + 5.0 / 30.0)
+        #expect(abs(snap.e1rm - expected) < 1e-9)
+    }
+
+    // MARK: - Cycle 3: localDate formatted yyyy-MM-dd in supplied timezone
+
+    @Test("localDate formatted as yyyy-MM-dd in the supplied timezone")
+    func localDateFormattedInSuppliedTimezone() {
+        // 2026-05-03 14:30 UTC → 2026-05-04 00:30 Sydney → date 2026-05-04.
+        let log = setLog(loggedAt: Self.acrossSydneyMidnight)
+        let snap = TopSetSnapshot.make(setLog: log, loggedInTimezone: Self.sydney)
+
+        #expect(snap.localDate == "2026-05-04")
+    }
+
+    // MARK: - Cycle 4: Sydney→Tokyo timezone immunity (the watchpoint scenario)
+
+    /// User logs a top set at 2026-05-04 00:30 Sydney time. The pre-bucketed
+    /// `localDate` must record "2026-05-04" — the user's then-local date —
+    /// and remain that string regardless of any subsequent timezone in
+    /// which the snapshot is read or re-rendered. Re-formatting the same
+    /// `loggedAt` instant in Tokyo (UTC+9) would yield "2026-05-03"; the
+    /// snapshot's pre-bucketed string is immune to that drift.
+    @Test("Sydney→Tokyo timezone immunity: pre-bucketed localDate doesn't drift")
+    func sydneyToTokyoTimezoneImmunity() {
+        let log = setLog(loggedAt: Self.acrossSydneyMidnight)
+        let snap = TopSetSnapshot.make(setLog: log, loggedInTimezone: Self.sydney)
+
+        // 1. Captured at the user's then-local Sydney date.
+        #expect(snap.localDate == "2026-05-04")
+
+        // 2. The same instant rendered in Tokyo would yield a different
+        //    date — but the snapshot stores a string, not a Date+TZ pair,
+        //    so reading later in any timezone observes the captured value.
+        let tokyoFormatter = DateFormatter()
+        tokyoFormatter.locale     = Locale(identifier: "en_US_POSIX")
+        tokyoFormatter.dateFormat = "yyyy-MM-dd"
+        tokyoFormatter.timeZone   = Self.tokyo
+        let tokyoRenderedFromInstant = tokyoFormatter.string(from: log.loggedAt)
+        #expect(tokyoRenderedFromInstant == "2026-05-03")
+
+        // 3. Demonstrate the immunity: the snapshot's stored string is
+        //    unchanged after Codable round-trip in any reader timezone.
+        let data = try! JSONEncoder().encode(snap)
+        let decoded = try! JSONDecoder().decode(TopSetSnapshot.self, from: data)
+        #expect(decoded.localDate == "2026-05-04")
+    }
+
+    // MARK: - Cycle 5: edge-of-midnight crossings
+
+    /// 23:59 Sydney on day X stays date X (does not bleed forward into
+    /// X+1); 00:01 next-local-day is day X+1. UTC-rendered date diverges
+    /// from local date in Sydney's window 14:00–24:00 UTC.
+    @Test("Edge-of-midnight: 23:59 stays date X; 00:01 next-local-day is X+1")
+    func edgeOfMidnightCrossings() {
+        // 2026-05-03 23:59:00 Sydney = 2026-05-03 13:59:00 UTC.
+        // (Sydney is UTC+10 in May, no DST. Sydney's 23:59 May 3 is
+        // UTC's 13:59 May 3 — same calendar date in UTC.)
+        let sydneyMay3_2359 = Date(timeIntervalSince1970: 1_777_816_740)
+
+        // +120s: 23:59:00 + 2min = 00:01 May 4 Sydney = 14:01 May 3 UTC.
+        let sydneyMay4_0001 = sydneyMay3_2359.addingTimeInterval(120)
+
+        let snap2359 = TopSetSnapshot.make(
+            setLog: setLog(loggedAt: sydneyMay3_2359),
+            loggedInTimezone: Self.sydney
+        )
+        let snap0001 = TopSetSnapshot.make(
+            setLog: setLog(loggedAt: sydneyMay4_0001),
+            loggedInTimezone: Self.sydney
+        )
+
+        #expect(snap2359.localDate == "2026-05-03")
+        #expect(snap0001.localDate == "2026-05-04")
+
+        // Same instants rendered in UTC produce a different date —
+        // confirming we are not silently using UTC.
+        let utcFormatter = DateFormatter()
+        utcFormatter.locale     = Locale(identifier: "en_US_POSIX")
+        utcFormatter.dateFormat = "yyyy-MM-dd"
+        utcFormatter.timeZone   = Self.utc
+        #expect(utcFormatter.string(from: sydneyMay3_2359) == "2026-05-03")
+        #expect(utcFormatter.string(from: sydneyMay4_0001) == "2026-05-03")
+        // ↑ both render as 2026-05-03 in UTC because Sydney's 23:59 May 3
+        //   and 00:01 May 4 are both within UTC's 13:59–14:01 May 3 window.
+        //   Sydney-bucketed snapshot disagrees with UTC for the second one
+        //   ("2026-05-04" Sydney vs "2026-05-03" UTC) — confirming the
+        //   factory honours its loggedInTimezone parameter rather than
+        //   silently bucketing in UTC.
+        #expect(snap0001.localDate != utcFormatter.string(from: sydneyMay4_0001))
+    }
+
+    // MARK: - Cycle 6: explicit timezone honoured (no silent system fallback)
+
+    /// The factory must not silently fall back to TimeZone.current — passing
+    /// two different explicit timezones for the same instant must produce two
+    /// different localDates whenever the instant straddles their date boundary.
+    @Test("Explicit timezone is honoured; passing different timezones yields different localDates")
+    func explicitTimezoneHonoured() {
+        // 2026-05-03 14:30 UTC straddles Sydney's date boundary:
+        //   Sydney (UTC+10) → 2026-05-04
+        //   Tokyo  (UTC+9)  → 2026-05-03
+        //   UTC             → 2026-05-03
+        let log = setLog(loggedAt: Self.acrossSydneyMidnight)
+
+        let sydneySnap = TopSetSnapshot.make(setLog: log, loggedInTimezone: Self.sydney)
+        let tokyoSnap  = TopSetSnapshot.make(setLog: log, loggedInTimezone: Self.tokyo)
+        let utcSnap    = TopSetSnapshot.make(setLog: log, loggedInTimezone: Self.utc)
+
+        #expect(sydneySnap.localDate == "2026-05-04")
+        #expect(tokyoSnap.localDate  == "2026-05-03")
+        #expect(utcSnap.localDate    == "2026-05-03")
+
+        // Sanity: the three snapshots disagree on date for the same instant
+        // — proving each respected its parameter rather than collapsing
+        // to a single shared system timezone.
+        #expect(sydneySnap.localDate != tokyoSnap.localDate)
+        #expect(sydneySnap.localDate != utcSnap.localDate)
+    }
+
+    // MARK: - Cycle 7: UTC date field captured for ordering / display
+
+    /// Per the issue body, the factory captures both `date` (UTC timestamp,
+    /// preserved for ordering and display) and `localDate` (pre-bucketed
+    /// string) atomically at construction. The UTC instant is needed to
+    /// order the EWMA window since localDate is day-granular only.
+    @Test("Factory captures setLog.loggedAt as the snapshot's date, and Codable round-trips it")
+    func capturesUTCDateAndRoundTrips() throws {
+        let log = setLog(loggedAt: Self.acrossSydneyMidnight)
+        let snap = TopSetSnapshot.make(setLog: log, loggedInTimezone: Self.sydney)
+
+        #expect(snap.date == log.loggedAt)
+
+        let data = try JSONEncoder().encode(snap)
+        let decoded = try JSONDecoder().decode(TopSetSnapshot.self, from: data)
+        #expect(decoded.date      == snap.date)
+        #expect(decoded.localDate == snap.localDate)
+        #expect(decoded == snap)
+    }
+}

--- a/ProjectApexTests/TraineeModelProfilesTests.swift
+++ b/ProjectApexTests/TraineeModelProfilesTests.swift
@@ -26,11 +26,20 @@ struct ExerciseProfileTests {
 
     @Test("Round-trip with top sets")
     func roundTrip() throws {
+        // TopSetSnapshot's memberwise init is private — route through the
+        // canonical factory so timezone pinning is structurally enforced.
+        let log = SetLog(
+            id: UUID(), sessionId: UUID(), exerciseId: "barbell_bench_press",
+            setNumber: 1, weightKg: 100, repsCompleted: 5,
+            rpeFelt: nil, rirEstimated: nil, aiPrescribed: nil,
+            loggedAt: Date(timeIntervalSince1970: 1_777_708_800), // 2026-05-02 08:00 UTC
+            primaryMuscle: nil
+        )
+        let topSet = TopSetSnapshot.make(setLog: log, loggedInTimezone: TimeZone(identifier: "UTC")!)
         let original = ExerciseProfile(
             exerciseId: "barbell_bench_press",
-            topSets: [TopSetSnapshot(sessionId: UUID(), localDate: "2026-05-01",
-                                     weightKg: 100, reps: 5, e1rm: 116.67)],
-            e1rmCurrent: 116.67,
+            topSets: [topSet],
+            e1rmCurrent: topSet.e1rm,
             e1rmMedian: 115,
             e1rmPeak: 120,
             sessionCount: 12,

--- a/ProjectApexTests/TraineeModelSnapshotsTests.swift
+++ b/ProjectApexTests/TraineeModelSnapshotsTests.swift
@@ -7,20 +7,43 @@ import Testing
 import Foundation
 @testable import ProjectApex
 
+/// Builds a TopSetSnapshot via the canonical factory — the memberwise init
+/// is private so that timezone pinning is structurally enforced. Tests use
+/// this helper instead of constructing TopSetSnapshot directly.
+private func makeTopSetFixture(
+    sessionId: UUID = UUID(),
+    loggedAt: Date = Date(timeIntervalSince1970: 1_777_818_600),
+    weightKg: Double = 100,
+    reps: Int = 5,
+    timezone: TimeZone = TimeZone(identifier: "Australia/Sydney")!
+) -> TopSetSnapshot {
+    let log = SetLog(
+        id: UUID(),
+        sessionId: sessionId,
+        exerciseId: "test_exercise",
+        setNumber: 1,
+        weightKg: weightKg,
+        repsCompleted: reps,
+        rpeFelt: nil,
+        rirEstimated: nil,
+        aiPrescribed: nil,
+        loggedAt: loggedAt,
+        primaryMuscle: nil
+    )
+    return TopSetSnapshot.make(setLog: log, loggedInTimezone: timezone)
+}
+
 @Suite("TopSetSnapshot")
 struct TopSetSnapshotTests {
     @Test("Codable round-trip preserves all fields")
     func roundTrip() throws {
-        let original = TopSetSnapshot(
-            sessionId: UUID(),
-            localDate: "2026-05-04",
-            weightKg: 100.0,
-            reps: 5,
-            e1rm: 116.67
-        )
+        // Factory pins timezone (Sydney) → localDate "2026-05-04" since
+        // 2026-05-03 14:30 UTC = 2026-05-04 00:30 Sydney.
+        let original = makeTopSetFixture()
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(TopSetSnapshot.self, from: data)
         #expect(decoded == original)
+        #expect(decoded.localDate == "2026-05-04")
     }
 }
 
@@ -28,11 +51,9 @@ struct TopSetSnapshotTests {
 struct ExerciseSessionSnapshotTests {
     @Test("Round-trip with heaviest top set")
     func withTopSet() throws {
-        let top = TopSetSnapshot(
-            sessionId: UUID(),
-            localDate: "2026-05-04",
-            weightKg: 120, reps: 4, e1rm: 136
-        )
+        // 120 × (1 + 4/30) = 136.0 exactly, so the asserted weightKg below
+        // doesn't drift relative to the factory-computed e1rm.
+        let top = makeTopSetFixture(weightKg: 120, reps: 4)
         let original = ExerciseSessionSnapshot(
             sessionId: top.sessionId,
             localDate: top.localDate,

--- a/migrations/0002_add_local_date_to_set_logs.sql
+++ b/migrations/0002_add_local_date_to_set_logs.sql
@@ -1,0 +1,37 @@
+-- Migration: 0002_add_local_date_to_set_logs.sql
+-- Phase 1 / Slice 5 — pre-bucketed local-date on set_logs (issue #4, ADR-0005)
+--
+-- Adds the local_date TEXT column to set_logs.  Pre-bucketed at write time
+-- (yyyy-MM-dd, formatted in the user's then-local timezone by the Swift
+-- TopSetSnapshot.make(setLog:loggedInTimezone:) factory), so cadence and
+-- disruption derivations remain stable across subsequent timezone changes
+-- (e.g. user travels Sydney → Tokyo without breaking cadence calculations).
+-- See ADR-0005 — "Day boundaries for cadence: device-local vs UTC vs
+-- pre-bucketed local. Chose pre-bucketed `localDate` string at write time."
+--
+-- Backfill default '1970-01-01' exists ONLY to satisfy NOT NULL during the
+-- column add against existing rows.  New writes always populate explicitly
+-- via the Swift factory; no production code path relies on the default for
+-- a newly-created row.
+--
+-- Sentinel rows ('1970-01-01') are NOT consumed raw at read time.  The
+-- read-time derivation pattern lives in Swift at MigrationDates.v2LocalDateField
+-- (see ProjectApex/Models/MigrationDates.swift): consumers branch on
+-- "set logged before vs after the cutoff" and derive localDate on-the-fly
+-- from `logged_at` + active timezone for pre-cutoff rows.  When this
+-- migration is applied to a production database, update v2LocalDateField
+-- in MigrationDates.swift to the actual deploy timestamp so future readers
+-- can distinguish pre-cutoff (sentinel-tagged) from post-cutoff (factory-
+-- written) rows.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS makes re-running safe.
+
+ALTER TABLE public.set_logs
+  ADD COLUMN IF NOT EXISTS local_date TEXT NOT NULL DEFAULT '1970-01-01';
+
+COMMENT ON COLUMN public.set_logs.local_date IS
+  'Pre-bucketed local-date string (yyyy-MM-dd) per ADR-0005. Captured at '
+  'write time in the logging user''s then-local timezone via the Swift '
+  'TopSetSnapshot factory; immune to subsequent timezone changes. Default '
+  '''1970-01-01'' is a backfill-only sentinel — new writes populate '
+  'explicitly.';


### PR DESCRIPTION
## Summary

Introduces the canonical construction path for `TopSetSnapshot` per ADR-0005 ("pre-bucketed `localDate` string at write time"). Memberwise init is now private; the factory `TopSetSnapshot.make(setLog:loggedInTimezone:)` is the single entry point so timezone pinning is structurally enforced.

The Sydney→Tokyo watchpoint scenario from issue #4 is the motivating case: a top set logged at 2026-05-04 00:30 Sydney must record `localDate = "2026-05-04"` and remain that string regardless of any subsequent timezone in which the snapshot is read or re-rendered. Re-formatting the same instant in Tokyo yields "2026-05-03"; the snapshot's pre-bucketed string is immune to that drift.

## What changed

- **`TopSetSnapshot`** gains a `date: Date` field (UTC instant — preserved for ordering the EWMA window since `localDate` is day-granular only) alongside `localDate: String`. Memberwise init made `private` so callers cannot bypass the timezone pinning.
- **Factory `make(setLog:loggedInTimezone:)`** computes Epley e1rm (`weight × (1 + reps/30)`) and formats `localDate` via a `DateFormatter` pinned to `en_US_POSIX` locale plus an *explicit* timezone parameter — no silent fallback to `TimeZone.current` at format time.
- **Migration `0002_add_local_date_to_set_logs.sql`** adds `public.set_logs.local_date TEXT NOT NULL DEFAULT '1970-01-01'`. The default is a backfill-only sentinel for the `NOT NULL ADD COLUMN`; new writes always populate explicitly via the Swift factory.
- **7 TDD tests** in `TopSetSnapshotFactoryTests`:
  1. Scalar field copy (sessionId, weightKg, reps)
  2. Epley e1rm formula
  3. `yyyy-MM-dd` formatting in supplied timezone
  4. Sydney→Tokyo timezone immunity (Codable round-trip preserves the captured string)
  5. Edge-of-midnight crossings (23:59 vs 00:01-next-local-day; UTC-rendered date diverges from local in Sydney's 14:00–24:00 UTC window)
  6. Explicit timezone honoured (passing different timezones yields different `localDate`s for the same instant)
  7. UTC `date` field captured for ordering, Codable round-trips both `date` and `localDate`
- **Existing tests refactored**: `TraineeModelSnapshotsTests` / `TraineeModelProfilesTests` route fixtures through the factory now that the memberwise init is private. Helper `makeTopSetFixture(...)` added to `TraineeModelSnapshotsTests` to keep call sites concise.

## Pre-deploy reminder

When migration `0002` is applied to the production database, update `MigrationDates.v2LocalDateField` in `ProjectApex/Models/MigrationDates.swift` to the actual deploy timestamp. Read-time derivation in Swift branches on "set logged before vs after the cutoff" and derives `localDate` on-the-fly from `logged_at` + active timezone for pre-cutoff rows; the cutoff timestamp is the seam between sentinel-tagged and factory-written rows.

## Verification

- TDD red-green for each of the 7 cycles above.
- All 12 tests across the 4 affected suites pass on iPhone 17 Pro / iOS 26.4.1:
  - `TopSetSnapshot.make factory` (7)
  - `TopSetSnapshot` (1)
  - `ExerciseSessionSnapshot` (1)
  - `ExerciseProfile` (3)

Pre-existing test failures in `MemoryServiceTests` / `WriteAheadQueueTests` / `GymStreakServiceTests` from the `#23` test-harness bugs are still present in this branch — those fixes are still in the reconstruction stash and land in PR (c). Not introduced by this PR; expected to clear when (c) merges.

## Issue closure

Issue #4 was closed prematurely earlier (the 6h-19m incident — see #25 for the codified discipline). It is currently in CLOSED state. **I will reopen #4 just before merging this PR** so the `Closes #4` keyword on the merge commit fires correctly. If the issue is already reopened by the time you review, this note can be ignored.

## Reconstruction context

This is the 2nd of 5 PRs reconstructing the working-tree-on-main incident. PR #25 (process amendments) was the precedent and is now merged. Remaining PRs (c) #23 test-harness, (d) #24.1 weightKg, (e) #24.2 retry policy + ADR-0007 each branch from a clean `main` and land sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)