### PR TITLE
fix: test-harness H1 stream-drain + H2 .serialized + StreakResult timing flake

### DIFF
--- a/ProjectApexTests/GymStreakServiceTests.swift
+++ b/ProjectApexTests/GymStreakServiceTests.swift
@@ -118,7 +118,15 @@ struct StreakResultTests {
 
     @Test("result computed exactly 6 hours ago is not stale")
     func isStale_exactlyTreshold() {
-        let sixHoursAgo = Date().addingTimeInterval(-6 * 3600)
+        // Anchor `now` to a fixed reference and derive `sixHoursAgo` from it,
+        // then pass `now` explicitly into `isStale(relativeTo:)`. Earlier the
+        // test computed `sixHoursAgo` via `Date().addingTimeInterval(-6h)` and
+        // then relied on the default `relativeTo: Date()` arg being evaluated
+        // later — the elapsed microseconds between the two `Date()` calls
+        // pushed `now.timeIntervalSince(computedAt)` strictly greater than 6h,
+        // making the strict `>` boundary fire and the test flaky.
+        let now = Date()
+        let sixHoursAgo = now.addingTimeInterval(-6 * 3600)
         let result = StreakResult(
             currentStreakDays: 5,
             longestStreak: 5,
@@ -127,7 +135,7 @@ struct StreakResultTests {
             computedAt: sixHoursAgo
         )
         // Exactly at threshold is NOT stale (> not >=)
-        #expect(!result.isStale())
+        #expect(!result.isStale(relativeTo: now))
     }
 
     @Test("neutral result is always stale (computedAt = .distantPast)")

--- a/ProjectApexTests/MemoryServiceTests.swift
+++ b/ProjectApexTests/MemoryServiceTests.swift
@@ -40,14 +40,52 @@ final class MockURLProtocol: URLProtocol, @unchecked Sendable {
             client?.urlProtocol(self, didFailWithError: URLError(.unknown))
             return
         }
+        // URLSession reifies httpBody → httpBodyStream for transport, so the
+        // request reaching this layer always has httpBody=nil even when the
+        // caller set one. Drain the stream into Data and rebuild the request
+        // so handlers can read body contents through request.httpBody as if
+        // it were a fresh URLRequest. See issue #23.
+        let canonical = Self.canonicalize(request)
         do {
-            let (response, data) = try handler(request)
+            let (response, data) = try handler(canonical)
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             client?.urlProtocol(self, didLoad: data)
             client?.urlProtocolDidFinishLoading(self)
         } catch {
             client?.urlProtocol(self, didFailWithError: error)
         }
+    }
+
+    /// Drains `request.httpBodyStream` (if present) and re-attaches the bytes
+    /// as `httpBody` so test handlers can inspect POST/PATCH payloads through
+    /// the standard property. Returns the request unchanged when no stream
+    /// is present. Per issue #23.
+    private static func canonicalize(_ request: URLRequest) -> URLRequest {
+        guard request.httpBody == nil, let stream = request.httpBodyStream else {
+            return request
+        }
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read > 0 {
+                data.append(buffer, count: read)
+            } else if read < 0 {
+                break  // stream error — return whatever we accumulated
+            } else {
+                break  // 0 = EOF
+            }
+        }
+
+        var copy = request
+        copy.httpBody = data
+        return copy
     }
 
     override func stopLoading() {}
@@ -84,7 +122,13 @@ private func http500(url: URL) -> HTTPURLResponse {
 
 // MARK: - MemoryServiceTests
 
-@Suite("MemoryService")
+// .serialized: MockURLProtocol.requestHandler is a class-level
+// `nonisolated(unsafe) static var`. swift-testing runs @Tests within a @Suite
+// in parallel by default; concurrent tests would trample each other's handler
+// (issue #23, H2). Per-suite serialization is the cheap fix — the suite runs
+// in ~80ms even serialized — and should not be removed without first making
+// the handler per-instance.
+@Suite("MemoryService", .serialized)
 struct MemoryServiceTests {
 
     // MARK: Pain keyword detection

--- a/ProjectApexTests/WriteAheadQueueTests.swift
+++ b/ProjectApexTests/WriteAheadQueueTests.swift
@@ -63,8 +63,13 @@ private final class WAQMockURLProtocol: URLProtocol, @unchecked Sendable {
             client?.urlProtocolDidFinishLoading(self)
             return
         }
+        // URLSession reifies httpBody → httpBodyStream for transport, so
+        // request.httpBody at this layer is always nil. Drain the stream
+        // back into Data so handlers reading request.httpBody see the
+        // payload. See issue #23.
+        let canonical = Self.canonicalize(request)
         do {
-            let (response, data) = try handler(request)
+            let (response, data) = try handler(canonical)
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             client?.urlProtocol(self, didLoad: data)
             client?.urlProtocolDidFinishLoading(self)
@@ -74,6 +79,35 @@ private final class WAQMockURLProtocol: URLProtocol, @unchecked Sendable {
     }
 
     override func stopLoading() {}
+
+    /// Drains `request.httpBodyStream` (when present) and re-attaches the
+    /// bytes as `httpBody` so handlers can inspect POST/PATCH payloads
+    /// through the standard property. Per issue #23.
+    private static func canonicalize(_ request: URLRequest) -> URLRequest {
+        guard request.httpBody == nil, let stream = request.httpBodyStream else {
+            return request
+        }
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read > 0 {
+                data.append(buffer, count: read)
+            } else {
+                break  // 0 = EOF, <0 = error
+            }
+        }
+
+        var copy = request
+        copy.httpBody = data
+        return copy
+    }
 }
 
 // MARK: - Helper: build SupabaseClient with mock session


### PR DESCRIPTION
## Summary

Resolves the test-harness state-bleed and stream-reification bugs that caused intermittent failures in `MemoryServiceTests` and `WriteAheadQueueTests`, plus one timing flake in `GymStreakServiceTests`. See #23 for the investigation.

## What changed

### H1 — URLProtocol stream reification

`URLSession` transports POST/PATCH bodies via `httpBodyStream` rather than `httpBody`, so `request.httpBody` at the `URLProtocol` layer is always `nil`. `MockURLProtocol`'s handlers were reading `request.httpBody` and seeing empty payloads → false-pass / false-fail depending on assertion shape.

**Fix**: `canonicalize(_:)` helper that drains `httpBodyStream` into `Data` and re-attaches as `httpBody` before invoking the handler. Applied in `MemoryServiceTests` (the suite that triggered the investigation).

### H1 cross-cutting catch — `WAQMockURLProtocol`

Per the new CLAUDE.md "Cross-cutting fixes — grep before declaring done" discipline, grepped for the same pattern (`request.httpBody` reads in URLProtocol mocks) across the codebase and found `WAQMockURLProtocol` had identical code with the same bug. Applied the fix there too. Without the grep this would have shipped as a half-fix — exactly the failure mode that motivated the new discipline (the H1 stream-drain fix landed in `MockURLProtocol`, but `WAQMockURLProtocol` had identical code with the same bug; only a full-suite run caught it).

### H2 — parallel state-bleed in MemoryService suite

swift-testing runs `@Suite` tests in parallel by default. Suite-shared static handler state (`MockURLProtocol.handler`) was being clobbered across concurrent tests within the suite, producing nondeterministic failures.

**Fix**: `@Suite("MemoryService", .serialized)` forces sequential execution within the suite.

### StreakResult timing flake

`isStale_exactlyTreshold` computed `sixHoursAgo` via `Date().addingTimeInterval(-6h)` then relied on the default `relativeTo: Date()` arg being evaluated *later*; the elapsed microseconds between the two `Date()` calls pushed `now.timeIntervalSince(computedAt)` strictly greater than 6h, making the strict `>` boundary fire and the test flaky.

**Fix**: anchor `now` once at the top of the test, derive `sixHoursAgo` from it, pass `now` explicitly to `isStale(relativeTo:)`. Threshold is now exactly 6h with no microsecond drift.

## Verification

- Previously: 7 `MemoryService` failures + 1 `StreakResult` failure + 1 `WriteAheadQueue` failure (the bonus catch) → **0 failures**.
- 5 consecutive deterministic runs of all affected suites (`MemoryService`, `WriteAheadQueueTests`, `StreakResult — score formula and tier classification`, `GymStreakComputationTests`).
- One pre-existing failure remains on this branch: `SetPrescriptionValidationTests.test_weightKgZero_throwsInvalidWeight` at `EquipmentRounderTests.swift:45`. That is the **#24.1** test, lands in PR (d). Already failing on main before this branch (contributed to the red CI on #25 / #26).

## Issue closure

Issue #23 is currently in CLOSED state (premature closure from the 6h-19m incident — see #25 for the codified discipline). **I will reopen #23 just before merging this PR** so the `Closes #23` keyword on the merge commit fires correctly.

## Reconstruction context

3rd of 5 PRs reconstructing the working-tree-on-main incident. PRs #25 (process amendments) and #26 (Slice 5) merged. Remaining: PR (d) #24.1 weightKg, (e) #24.2 retry policy + ADR-0007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)