### PR TITLE
fix: weightKg=0 valid for bodyweight exercises (partial fix for #24)

### DIFF
--- a/ProjectApexTests/EquipmentRounderTests.swift
+++ b/ProjectApexTests/EquipmentRounderTests.swift
@@ -40,14 +40,18 @@ final class SetPrescriptionValidationTests: XCTestCase {
 
     // MARK: - weightKg
 
-    func test_weightKgZero_throwsInvalidWeight() {
+    // weightKg represents external/added load on the bar or machine, NOT total
+    // system load — the user's bodyweight is a separate field on UserProfile /
+    // InferenceContext (`bodyweightKg`). Zero is therefore a legitimate
+    // prescription for bodyweight exercises (push-ups, dips, pull-ups), and
+    // SystemPrompt_Inference.txt records the migration: "weight_kg response
+    // format changed from '> 0' to '>= 0' to allow bodyweight prescriptions."
+    // The negative case is covered by test_weightKgNegative_throwsInvalidWeight
+    // below; the original test asserting that zero throws was a stale leftover
+    // from the pre-migration ">0" rule. Resolves #24.1.
+    func test_weightKgZero_doesNotThrow_forBodyweightExercises() {
         var p = validPrescription(); p.weightKg = 0.0
-        XCTAssertThrowsError(try p.validate()) { error in
-            guard case .invalidWeight(let v) = error as? PrescriptionValidationError else {
-                return XCTFail("Expected .invalidWeight, got \(error)")
-            }
-            XCTAssertEqual(v, 0.0, accuracy: 0.001)
-        }
+        XCTAssertNoThrow(try p.validate())
     }
 
     func test_weightKgNegative_throwsInvalidWeight() {


### PR DESCRIPTION
## Summary

Resolves the `#24.1` half of issue #24 — `test_weightKgZero_throwsInvalidWeight` was a stale leftover from the pre-migration `> 0` rule on `SetPrescription.weight_kg`. The system prompt was migrated to `>= 0` to allow bodyweight prescriptions (push-ups, dips, pull-ups), but the test was never updated and started failing once #23 surfaced it.

No production code changed — the validation implementation already accepts `>= 0`.

## What changed

- **Renamed**: `test_weightKgZero_throwsInvalidWeight` → `test_weightKgZero_doesNotThrow_forBodyweightExercises`
- **Flipped assertion**: `XCTAssertThrowsError` → `XCTAssertNoThrow`
- **Added doc comment** explaining that `weightKg` is external/added load (bar or machine), not total system load. The user's body mass lives in a separate `bodyweightKg` field on `UserProfile` / `InferenceContext`. Comment also points at the `SystemPrompt_Inference.txt` migration note that records the `> 0` → `>= 0` change.

## Why

Codebase-wide grep on `weightKg` / `weight_kg` confirms unambiguous external-load semantics across all 8+ call sites:

- `SetPrescription.validate()` — the test target
- `EquipmentRounder` — rounds to achievable barbell loads (irrelevant for bodyweight)
- `TopSetSnapshot.make` Epley e1RM calc — `weight × (1 + reps/30)` with weight=0 yields e1RM=0, which is correct for bodyweight tracking (the body-mass-corrected e1RM lives elsewhere)
- Volume aggregation — `weightKg × reps` with weight=0 yields zero load volume, which is the right answer for bar load (different metric than total-system volume)

All consumers treat `weight_kg` as bar/machine load only. The `> 0` rule predates the migration and was a false positive once `#23` cleaned up the test harness and let the failure surface.

`SystemPrompt_Inference.txt` explicitly records the migration: *"weight_kg response format changed from '> 0' to '>= 0' to allow bodyweight prescriptions."*

## Verification

- 36/36 `SetPrescriptionValidationTests` pass on iPhone 17 Pro / iOS 26.4.1.
- Renamed test passes.
- `test_weightKgNegative_throwsInvalidWeight` still present and still passes — coverage of negative weights preserved (the implementation rule is `>= 0`, so negatives still throw).

## Issue closure

This PR partially addresses #24 — the `#24.1` half. Issue #24 will be fully closed by PR (e) which lands `#24.2` (LLM retry policy + ADR-0007). Title and body deliberately avoid GitHub auto-close keyword patterns (`closes`, `fixes`, `resolves`) preceding `#24` so this merge does not trigger auto-closure.

## Reconstruction context

4th of 5 PRs reconstructing the working-tree-on-main incident. PRs #25 (process), #26 (Slice 5), #27 (#23 test-harness) merged. Remaining: PR (e) — #24.2 retry policy + ADR-0007 + `WorkoutSessionManagerTests` companion fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)