### PR TITLE
chore: diagnostic CI step — list runner Xcode and simulator runtimes (for #28, do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,20 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
+      - name: Diagnostic — list runner Xcode and simulator runtimes (for #28)
+        # One-shot diagnostic to surface what the macos-15 runner image actually
+        # has installed. Will be reverted in PR-2 once the destination pin is
+        # known. Do not merge this PR.
+        run: |
+          echo "===== xcrun simctl list runtimes ====="
+          xcrun simctl list runtimes
+          echo
+          echo "===== ls /Applications | grep -i Xcode ====="
+          ls /Applications | grep -i Xcode
+          echo
+          echo "===== xcodebuild -showsdks ====="
+          xcodebuild -showsdks
+
       - name: Resolve Swift packages
         run: |
           xcodebuild -resolvePackageDependencies \


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

This is a **diagnostic-only PR** for issue #28. It is not intended for merge — it exists to capture one CI run's output of three runner-inventory commands so we can pin the workflow's destination spec against verified values in PR-2.

Once PR-1's CI run completes, the diagnostic output will be commented into issue #28 for review. PR-1 will then be closed without merge once PR-2 (the actual fix) is ready.

## What changed

Adds a single `Diagnostic — list runner Xcode and simulator runtimes` step to `.github/workflows/ci.yml`, sitting between `Show Xcode version` and `Resolve Swift packages`. The step runs:

```bash
xcrun simctl list runtimes
ls /Applications | grep -i Xcode
xcodebuild -showsdks
```

…and prints the output to the CI log. No other workflow steps are modified — the existing `iPhone 16 Pro, OS=latest` build step remains as-is and is expected to fail on this PR exactly as it has on every PR since #19. We're observing, not fixing.

## Why a separate PR

Per the path-A approach agreed in #28's reconciliation pass:

1. PR-1 (this one) — observe what the runner image actually has installed.
2. PR-2 — pin Xcode select target + destination iOS version against the observed inventory. Single diagnostic step is reverted as part of that PR.

The two-PR sequence avoids guessing at the runner inventory and committing pinned values that may not match reality.

## Acceptance for PR-1

- [ ] CI run on this PR completes (build & test step still fails, as expected).
- [ ] Diagnostic step's output is visible in the CI log.
- [ ] Findings (Xcode versions present, iOS simulator runtimes available, SDK list) commented into issue #28.

## Out of scope

Anything that addresses the underlying CI failure. PR-2 owns the actual fix. The header comment in `ci.yml` (`TDD Section 14.6 compliance: macOS 15 / Xcode 16 / iPhone 16 Pro`) will be aligned with whatever destination pin lands in PR-2 — or §14.6 will be amended in lockstep — also out of scope here.

## Auto-close scrub

This PR's title and body deliberately avoid GitHub auto-close keyword patterns (`close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`) preceding `#28`. Issue #28 stays open until PR-2's merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
