### PR TITLE
feat: AnthropicProvider prompt-caching (Slice 7 / #5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,12 @@ Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/ag
 
 Authoritative for Edge Function secret storage, service-role access list, and key rotation policy. Read before any Slice 9b+ Edge Function work — do not redo the analysis from scratch. See `docs/agents/edge-functions.md`.
 
+### Integration test flag
+
+`APEX_INTEGRATION_TESTS=1` — environment variable that gates live-API tests requiring real credentials and network access. Set in the Xcode scheme's environment variables for local or CI runs. Tests gated by this flag:
+- `AIInferenceServiceTests.test_liveAPI_*` — real Anthropic API round-trip
+- `AnthropicProviderCachingTests.test_smokeTest_cacheEffectiveness_*` — two identical Anthropic calls asserting `cache_read_input_tokens > 0` on the second call (verifies prompt-caching mechanism end-to-end; uses a padded system prompt to clear the 1,024-token cache minimum)
+
 ### Worktree-aware git commands (mandatory in `.claude/worktrees/*` sessions)
 
 When working inside a worktree (path matches `.claude/worktrees/<name>/`), every git-mutating command MUST be `git -C <worktree-absolute-path> <subcommand>` rather than relying on the shell's current working directory. The bash agent's `cd` does not reliably persist across tool calls, and a `git commit` that runs from the parent main repo silently lands the wrong files on the wrong branch. This was a real incident during Slice 1.

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		47D91CB32F61A8CB007B3B34 /* GymProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D91CB22F61A8CB007B3B34 /* GymProfileTests.swift */; };
 		47D91CC12F61A9E7007B3B34 /* WorkoutContextAssemblyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D91CC02F61A9E7007B3B34 /* WorkoutContextAssemblyTests.swift */; };
 		47D91CC32F61AADC007B3B34 /* AIInferenceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D91CC22F61AADC007B3B34 /* AIInferenceServiceTests.swift */; };
+		47DFED092F99B001006F4B62 /* AnthropicProviderCachingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DFED082F99B001006F4B62 /* AnthropicProviderCachingTests.swift */; };
 		47DFECFD2F72C1FC006F4B62 /* ExerciseLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DFECFC2F72C1FC006F4B62 /* ExerciseLibraryTests.swift */; };
 		47DFED052F73D858006F4B62 /* StagnationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DFED042F73D858006F4B62 /* StagnationServiceTests.swift */; };
 		47DFED072F73D887006F4B62 /* VolumeValidationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DFED062F73D887006F4B62 /* VolumeValidationServiceTests.swift */; };
@@ -76,6 +77,7 @@
 		47D91CB22F61A8CB007B3B34 /* GymProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymProfileTests.swift; sourceTree = "<group>"; };
 		47D91CC02F61A9E7007B3B34 /* WorkoutContextAssemblyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutContextAssemblyTests.swift; sourceTree = "<group>"; };
 		47D91CC22F61AADC007B3B34 /* AIInferenceServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIInferenceServiceTests.swift; sourceTree = "<group>"; };
+		47DFED082F99B001006F4B62 /* AnthropicProviderCachingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicProviderCachingTests.swift; sourceTree = "<group>"; };
 		47DFECED2F723975006F4B62 /* InferenceRetrySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceRetrySheet.swift; sourceTree = "<group>"; };
 		47DFECF42F7261C1006F4B62 /* ExerciseSwapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSwapViewModel.swift; sourceTree = "<group>"; };
 		47DFECF52F7261EE006F4B62 /* ExerciseSwapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSwapView.swift; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 				47D91CB22F61A8CB007B3B34 /* GymProfileTests.swift */,
 				47D91CC02F61A9E7007B3B34 /* WorkoutContextAssemblyTests.swift */,
 				47D91CC22F61AADC007B3B34 /* AIInferenceServiceTests.swift */,
+				47DFED082F99B001006F4B62 /* AnthropicProviderCachingTests.swift */,
 				47E356CA2F61BA7300C69CD6 /* SupabaseClientTests.swift */,
 				47E356CE2F61BFCF00C69CD6 /* EquipmentMergerTests.swift */,
 				47E356D92F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift */,
@@ -325,6 +328,7 @@
 				47BB8E622F6273750082C53F /* EquipmentConstraintValidationTests.swift in Sources */,
 				47D91CB12F619817007B3B34 /* AIInferenceSpikeTests.swift in Sources */,
 				47D91CC32F61AADC007B3B34 /* AIInferenceServiceTests.swift in Sources */,
+				47DFED092F99B001006F4B62 /* AnthropicProviderCachingTests.swift in Sources */,
 				47DFED052F73D858006F4B62 /* StagnationServiceTests.swift in Sources */,
 				47BB8E752F6294B00082C53F /* WorkoutSessionManagerTests.swift in Sources */,
 				47C5C1BC2F62C08E0005F99E /* MemoryServiceTests.swift in Sources */,

--- a/ProjectApex/AICoach/LLMProvider.swift
+++ b/ProjectApex/AICoach/LLMProvider.swift
@@ -102,10 +102,27 @@ protocol LLMProvider: Sendable {
     func complete(systemPrompt: String, userPayload: String) async throws -> String
 }
 
+// MARK: - AnthropicCacheUsage
+
+/// Cache token counts from an Anthropic response's `usage` block.
+/// Both fields are zero when caching did not apply (e.g. prompt below the
+/// minimum token threshold, or `enableCaching` was false).
+nonisolated struct AnthropicCacheUsage: Sendable, Equatable {
+    let cacheCreationInputTokens: Int
+    let cacheReadInputTokens: Int
+}
+
 // MARK: - AnthropicProvider
 
 /// Calls the Anthropic Messages API (claude-3-5-sonnet-* and later models).
 /// Reference: https://docs.anthropic.com/en/api/messages
+///
+/// When `enableCaching` is true (the default), the system prompt is sent as a
+/// structured text block with `cache_control: { type: "ephemeral" }`, making it
+/// eligible for Anthropic's prompt-caching. Anthropic silently ignores the marker
+/// when the cached prefix is below the per-model minimum (1,024 tokens for
+/// claude-sonnet-4-5). Pass `enableCaching: false` for one-shot callers that never
+/// repeat the same prompt — they avoid the 25% cache-write overhead.
 nonisolated struct AnthropicProvider: LLMProvider {
 
     let apiKey: String
@@ -116,27 +133,69 @@ nonisolated struct AnthropicProvider: LLMProvider {
     /// URLSession request timeout in seconds.
     /// Set inference uses 30s; program generation uses 600s (Opus + 32k tokens can take 2+ min).
     let requestTimeout: TimeInterval
+    let enableCaching: Bool
 
     private let session: URLSession
+
+    // Rough character threshold below which the system prompt won't fill the
+    // 1,024-token cache minimum for claude-sonnet-4-5. Log once so the caller
+    // knows production caching is not yet active (Phase 2 will fix this).
+    private static let cachingThresholdChars = 3_000
+    private nonisolated(unsafe) static var hasLoggedShortPromptWarning = false
 
     init(
         apiKey: String,
         model: String = "claude-sonnet-4-5",
         maxTokens: Int = 1024,
-        requestTimeout: TimeInterval = 30
+        requestTimeout: TimeInterval = 30,
+        enableCaching: Bool = true,
+        urlSession: URLSession? = nil
     ) {
         self.apiKey = apiKey
         self.model = model
         self.maxTokens = maxTokens
         self.requestTimeout = requestTimeout
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = requestTimeout
-        // Resource timeout must be at least as large as the request timeout.
-        config.timeoutIntervalForResource = max(requestTimeout, 660)
-        self.session = URLSession(configuration: config)
+        self.enableCaching = enableCaching
+        if let injected = urlSession {
+            self.session = injected
+        } else {
+            let config = URLSessionConfiguration.default
+            config.timeoutIntervalForRequest = requestTimeout
+            // Resource timeout must be at least as large as the request timeout.
+            config.timeoutIntervalForResource = max(requestTimeout, 660)
+            self.session = URLSession(configuration: config)
+        }
     }
 
+    // MARK: - LLMProvider
+
     func complete(systemPrompt: String, userPayload: String) async throws -> String {
+        let (text, _) = try await completeWithStats(systemPrompt: systemPrompt, userPayload: userPayload)
+        return text
+    }
+
+    // MARK: - Extended API
+
+    /// Calls the Anthropic Messages API and returns the response text together
+    /// with cache token counts from the `usage` block. Use this from tests or
+    /// any caller that needs to observe prompt-caching effectiveness.
+    func completeWithStats(
+        systemPrompt: String,
+        userPayload: String
+    ) async throws -> (text: String, cacheUsage: AnthropicCacheUsage) {
+
+        if enableCaching && !Self.hasLoggedShortPromptWarning
+            && systemPrompt.count < Self.cachingThresholdChars {
+            Self.hasLoggedShortPromptWarning = true
+            fputs(
+                "[AnthropicProvider] WARNING: system prompt is \(systemPrompt.count) chars " +
+                "(~\(systemPrompt.count / 4) tokens), likely below the 1,024-token cache minimum " +
+                "for \(model). Cache hits won't occur until Phase 2 adds TraineeModelDigest " +
+                "to the stable section.\n",
+                stderr
+            )
+        }
+
         let url = URL(string: "https://api.anthropic.com/v1/messages")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -144,10 +203,17 @@ nonisolated struct AnthropicProvider: LLMProvider {
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
 
+        // When caching is enabled, wrap the system prompt in a text block with
+        // cache_control so Anthropic can cache the stable section across calls.
+        // When disabled, send the plain string (original behaviour, no write overhead).
+        let systemValue: Any = enableCaching
+            ? [["type": "text", "text": systemPrompt, "cache_control": ["type": "ephemeral"]]]
+            : systemPrompt
+
         let body: [String: Any] = [
             "model": model,
             "max_tokens": maxTokens,
-            "system": systemPrompt,
+            "system": systemValue,
             "messages": [
                 ["role": "user", "content": userPayload]
             ]
@@ -175,7 +241,7 @@ nonisolated struct AnthropicProvider: LLMProvider {
             throw LLMProviderError.httpError(statusCode: http.statusCode, body: bodyString)
         }
 
-        // Anthropic envelope: {"content": [{"type": "text", "text": "..."}], ...}
+        // Anthropic envelope: {"content": [{"type": "text", "text": "..."}], "usage": {...}, ...}
         guard
             let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
             let contentArray = json["content"] as? [[String: Any]],
@@ -187,7 +253,14 @@ nonisolated struct AnthropicProvider: LLMProvider {
         }
 
         guard !text.isEmpty else { throw LLMProviderError.emptyResponse }
-        return text
+
+        let usageObj = json["usage"] as? [String: Any]
+        let cacheUsage = AnthropicCacheUsage(
+            cacheCreationInputTokens: usageObj?["cache_creation_input_tokens"] as? Int ?? 0,
+            cacheReadInputTokens: usageObj?["cache_read_input_tokens"] as? Int ?? 0
+        )
+
+        return (text, cacheUsage)
     }
 }
 

--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -111,11 +111,13 @@ final class AppDependencies {
         self.aiInferenceService = inferenceService
 
         // 8. Program Generation — uses opus model; no timeout (user waits explicitly)
+        // enableCaching: false — one-shot call, never repeats the same prompt, no cache benefit.
         self.programGenerationService = ProgramGenerationService(
             provider: AnthropicProvider.forProgramGeneration(apiKey: anthropicKey)
         )
 
         // 8b. MacroPlanService — Sonnet skeleton generation (one-shot at programme start)
+        // enableCaching: false — same reason as ProgramGenerationService above.
         self.macroPlanService = MacroPlanService(
             provider: AnthropicProvider.forProgramGeneration(apiKey: anthropicKey)
         )

--- a/ProjectApex/Services/ProgramGenerationService.swift
+++ b/ProjectApex/Services/ProgramGenerationService.swift
@@ -723,7 +723,8 @@ extension AnthropicProvider {
             apiKey: apiKey,
             model: "claude-sonnet-4-5",
             maxTokens: 16000,
-            requestTimeout: 180
+            requestTimeout: 180,
+            enableCaching: false   // one-shot, never repeats prompt — no cache benefit
         )
     }
 }

--- a/ProjectApexTests/AnthropicProviderCachingTests.swift
+++ b/ProjectApexTests/AnthropicProviderCachingTests.swift
@@ -1,0 +1,360 @@
+// AnthropicProviderCachingTests.swift
+// ProjectApexTests — Slice 7 (Issue #5)
+//
+// Tests for AnthropicProvider prompt-caching behaviour.
+//
+// Test categories:
+//   1. Unit tests (always run): use CachingMockURLProtocol to inspect HTTP
+//      request shape and parse mock responses — no real network calls.
+//   2. Smoke test (gated): APEX_INTEGRATION_TESTS=1 required.
+//      Two identical Anthropic calls in sequence; second must show
+//      cache_read_input_tokens > 0 confirming the mechanism works end-to-end.
+//
+// NOTE — production cache coverage:
+//   The real AIInferenceService.systemPrompt is ~550 tokens, below the
+//   1,024-token cache minimum for claude-sonnet-4-5. Production cache hits
+//   require Phase 2 to add TraineeModelDigest to the stable section. This
+//   smoke test uses a padded prompt to verify the mechanism independently.
+
+import XCTest
+@testable import ProjectApex
+
+// MARK: - CachingMockURLProtocol
+
+private final class CachingMockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = CachingMockURLProtocol.requestHandler else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+        // URLSession reifies httpBody → httpBodyStream for transport.
+        // Drain stream back into httpBody so handlers can inspect POST payloads.
+        // Same pattern as WAQMockURLProtocol (issue #23).
+        let canonical = Self.canonicalize(request)
+        do {
+            let (response, data) = try handler(canonical)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    private static func canonicalize(_ request: URLRequest) -> URLRequest {
+        guard request.httpBody == nil, let stream = request.httpBodyStream else {
+            return request
+        }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read > 0 { data.append(buffer, count: read) } else { break }
+        }
+        var copy = request
+        copy.httpBody = data
+        return copy
+    }
+}
+
+// MARK: - Helpers
+
+private func makeMockSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [CachingMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func makeSuccessResponse(
+    text: String,
+    cacheCreation: Int = 0,
+    cacheRead: Int = 0
+) throws -> Data {
+    let json: [String: Any] = [
+        "content": [["type": "text", "text": text]],
+        "usage": [
+            "input_tokens": 100,
+            "cache_creation_input_tokens": cacheCreation,
+            "cache_read_input_tokens": cacheRead,
+            "output_tokens": 20
+        ]
+    ]
+    return try JSONSerialization.data(withJSONObject: json)
+}
+
+private func http200() -> HTTPURLResponse {
+    HTTPURLResponse(
+        url: URL(string: "https://api.anthropic.com/v1/messages")!,
+        statusCode: 200, httpVersion: nil, headerFields: nil
+    )!
+}
+
+private func http(_ code: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+        url: URL(string: "https://api.anthropic.com/v1/messages")!,
+        statusCode: code, httpVersion: nil, headerFields: nil
+    )!
+}
+
+// MARK: - AnthropicProviderCachingTests
+
+final class AnthropicProviderCachingTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        CachingMockURLProtocol.requestHandler = nil
+    }
+
+    // MARK: ─── Helper ─────────────────────────────────────────────────────────
+
+    private func requireLiveAPI() throws {
+        guard ProcessInfo.processInfo.environment["APEX_INTEGRATION_TESTS"] == "1" else {
+            throw XCTSkip(
+                "Live cache smoke test skipped. Set APEX_INTEGRATION_TESTS=1 to enable."
+            )
+        }
+    }
+
+    private func requireAnthropicKey() throws -> String {
+        guard let key = try KeychainService.shared.retrieve(.anthropicAPIKey),
+              !key.isEmpty else {
+            throw XCTSkip(
+                "No Anthropic API key in Keychain. " +
+                "Add one via Settings → Developer Settings before running smoke tests."
+            )
+        }
+        return key
+    }
+
+    // MARK: ─── 1. system field is array with cache_control ───────────────────
+
+    func test_cachingEnabled_systemFieldIsArrayWithCacheControl() async throws {
+        var capturedBody: [String: Any]?
+
+        CachingMockURLProtocol.requestHandler = { request in
+            if let body = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] {
+                capturedBody = json
+            }
+            return (http200(), try makeSuccessResponse(text: "ok"))
+        }
+
+        let provider = AnthropicProvider(
+            apiKey: "test-key",
+            urlSession: makeMockSession()
+        )
+        _ = try await provider.complete(systemPrompt: "be helpful", userPayload: "hello")
+
+        let systemField = try XCTUnwrap(capturedBody?["system"])
+        let systemArray = try XCTUnwrap(systemField as? [[String: Any]],
+                                        "system must be an array of blocks, not a plain string")
+        let firstBlock = try XCTUnwrap(systemArray.first)
+
+        XCTAssertEqual(firstBlock["type"] as? String, "text")
+        XCTAssertEqual(firstBlock["text"] as? String, "be helpful")
+
+        let cacheControl = try XCTUnwrap(firstBlock["cache_control"] as? [String: Any],
+                                         "first system block must have cache_control")
+        XCTAssertEqual(cacheControl["type"] as? String, "ephemeral")
+    }
+
+    // MARK: ─── 2. messages carry userPayload unchanged ────────────────────────
+
+    func test_cachingEnabled_userPayloadUnchangedInMessages() async throws {
+        var capturedBody: [String: Any]?
+
+        CachingMockURLProtocol.requestHandler = { request in
+            if let body = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] {
+                capturedBody = json
+            }
+            return (http200(), try makeSuccessResponse(text: "ok"))
+        }
+
+        let provider = AnthropicProvider(
+            apiKey: "test-key",
+            urlSession: makeMockSession()
+        )
+        _ = try await provider.complete(systemPrompt: "sys", userPayload: "my-payload")
+
+        let messages = try XCTUnwrap(capturedBody?["messages"] as? [[String: Any]])
+        let first = try XCTUnwrap(messages.first)
+        XCTAssertEqual(first["role"] as? String, "user")
+        XCTAssertEqual(first["content"] as? String, "my-payload")
+    }
+
+    // MARK: ─── 3. text extracted from response ────────────────────────────────
+
+    func test_cachingEnabled_returnsTextFromResponseEnvelope() async throws {
+        CachingMockURLProtocol.requestHandler = { _ in
+            (http200(), try makeSuccessResponse(text: "the answer"))
+        }
+
+        let provider = AnthropicProvider(
+            apiKey: "test-key",
+            urlSession: makeMockSession()
+        )
+        let result = try await provider.complete(systemPrompt: "sys", userPayload: "q")
+        XCTAssertEqual(result, "the answer")
+    }
+
+    // MARK: ─── 4. HTTP non-2xx → LLMProviderError.httpError ──────────────────
+
+    func test_cachingEnabled_non2xxThrowsHTTPError() async throws {
+        CachingMockURLProtocol.requestHandler = { _ in
+            let body = #"{"error":{"type":"rate_limit_error"}}"#.data(using: .utf8)!
+            return (http(429), body)
+        }
+
+        let provider = AnthropicProvider(
+            apiKey: "test-key",
+            urlSession: makeMockSession()
+        )
+
+        do {
+            _ = try await provider.complete(systemPrompt: "sys", userPayload: "q")
+            XCTFail("Expected LLMProviderError.httpError to be thrown")
+        } catch let error as LLMProviderError {
+            if case .httpError(let code, _) = error {
+                XCTAssertEqual(code, 429)
+            } else {
+                XCTFail("Expected .httpError, got \(error)")
+            }
+        }
+    }
+
+    // MARK: ─── 5. cacheCreationInputTokens from usage ─────────────────────────
+
+    func test_completeWithStats_returnsCacheCreationTokens() async throws {
+        CachingMockURLProtocol.requestHandler = { _ in
+            (http200(), try makeSuccessResponse(text: "ok", cacheCreation: 1247, cacheRead: 0))
+        }
+
+        let provider = AnthropicProvider(
+            apiKey: "test-key",
+            urlSession: makeMockSession()
+        )
+        let (_, stats) = try await provider.completeWithStats(
+            systemPrompt: "sys", userPayload: "q"
+        )
+        XCTAssertEqual(stats.cacheCreationInputTokens, 1247)
+        XCTAssertEqual(stats.cacheReadInputTokens, 0)
+    }
+
+    // MARK: ─── 6. cacheReadInputTokens from usage ─────────────────────────────
+
+    func test_completeWithStats_returnsCacheReadTokens() async throws {
+        CachingMockURLProtocol.requestHandler = { _ in
+            (http200(), try makeSuccessResponse(text: "ok", cacheCreation: 0, cacheRead: 1247))
+        }
+
+        let provider = AnthropicProvider(
+            apiKey: "test-key",
+            urlSession: makeMockSession()
+        )
+        let (text, stats) = try await provider.completeWithStats(
+            systemPrompt: "sys", userPayload: "q"
+        )
+        XCTAssertEqual(text, "ok")
+        XCTAssertEqual(stats.cacheReadInputTokens, 1247)
+        XCTAssertEqual(stats.cacheCreationInputTokens, 0)
+    }
+
+    // MARK: ─── 7. enableCaching: false → system is plain string ──────────────
+
+    func test_cachingDisabled_systemFieldIsPlainString() async throws {
+        var capturedBody: [String: Any]?
+
+        CachingMockURLProtocol.requestHandler = { request in
+            if let body = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] {
+                capturedBody = json
+            }
+            return (http200(), try makeSuccessResponse(text: "ok"))
+        }
+
+        let provider = AnthropicProvider(
+            apiKey: "test-key",
+            enableCaching: false,
+            urlSession: makeMockSession()
+        )
+        _ = try await provider.complete(systemPrompt: "be helpful", userPayload: "hello")
+
+        let systemField = try XCTUnwrap(capturedBody?["system"])
+        XCTAssertNotNil(systemField as? String,
+                        "When enableCaching is false, system must be a plain string")
+        XCTAssertNil(systemField as? [[String: Any]],
+                     "When enableCaching is false, system must not be an array")
+    }
+
+    // MARK: ─── 8. Smoke test — cache-effectiveness (gated) ───────────────────
+
+    /// Makes two identical Anthropic calls with a system prompt long enough to
+    /// exceed the 1,024-token cache minimum for claude-sonnet-4-5 (~3,500 chars).
+    /// Asserts that the second call's cache_read_input_tokens > 0 — confirming
+    /// that cache_control is being accepted and processed by Anthropic.
+    ///
+    /// NOTE: Production cache hits depend on Phase 2 adding TraineeModelDigest
+    /// to the stable section. The real systemPrompt (~550 tokens) is below the
+    /// 1,024-token minimum. This test verifies the mechanism with a padded prompt.
+    func test_smokeTest_cacheEffectiveness_secondCallReadsCachedTokens() async throws {
+        try requireLiveAPI()
+        let apiKey = try requireAnthropicKey()
+
+        // ~3,500 chars ≈ ~875 tokens with Anthropic's tokenizer — well above the
+        // 1,024-token minimum for claude-sonnet-4-5. If this ever fails because the
+        // pad tokenizes short, increase the repeat count.
+        let basePad = String(repeating: "You are a helpful strength and conditioning coach assistant. ", count: 60)
+        let stableSystemPrompt = """
+            You are an elite AI strength and hypertrophy coach embedded in a workout app. \
+            Your sole job is to prescribe the next set for the user based on the provided \
+            WorkoutContext JSON. Return ONLY a valid JSON object matching the set_prescription schema. \
+            No prose, no markdown fences.
+
+            \(basePad)
+            """
+
+        let provider = AnthropicProvider(apiKey: apiKey)
+        let userPayload = #"{"request_type":"set_prescription","current_exercise":{"name":"Barbell Bench Press"}}"#
+
+        // Call 1 — expect cache write
+        let (_, stats1) = try await provider.completeWithStats(
+            systemPrompt: stableSystemPrompt,
+            userPayload: userPayload
+        )
+
+        // Call 2 — expect cache read (same system prompt prefix)
+        let (_, stats2) = try await provider.completeWithStats(
+            systemPrompt: stableSystemPrompt,
+            userPayload: userPayload
+        )
+
+        XCTContext.runActivity(named: "Cache stats — call 1") { _ in
+            XCTContext.runActivity(named: "cacheCreationInputTokens: \(stats1.cacheCreationInputTokens)") { _ in }
+            XCTContext.runActivity(named: "cacheReadInputTokens:     \(stats1.cacheReadInputTokens)") { _ in }
+        }
+        XCTContext.runActivity(named: "Cache stats — call 2") { _ in
+            XCTContext.runActivity(named: "cacheCreationInputTokens: \(stats2.cacheCreationInputTokens)") { _ in }
+            XCTContext.runActivity(named: "cacheReadInputTokens:     \(stats2.cacheReadInputTokens)") { _ in }
+        }
+
+        XCTAssertGreaterThan(
+            stats2.cacheReadInputTokens, 0,
+            "Second call must read from cache. " +
+            "Call 1 — creation: \(stats1.cacheCreationInputTokens), read: \(stats1.cacheReadInputTokens). " +
+            "Call 2 — creation: \(stats2.cacheCreationInputTokens), read: \(stats2.cacheReadInputTokens)."
+        )
+    }
+}

--- a/ProjectApexTests/AnthropicProviderCachingTests.swift
+++ b/ProjectApexTests/AnthropicProviderCachingTests.swift
@@ -313,10 +313,10 @@ final class AnthropicProviderCachingTests: XCTestCase {
         try requireLiveAPI()
         let apiKey = try requireAnthropicKey()
 
-        // ~3,500 chars ≈ ~875 tokens with Anthropic's tokenizer — well above the
-        // 1,024-token minimum for claude-sonnet-4-5. If this ever fails because the
-        // pad tokenizes short, increase the repeat count.
-        let basePad = String(repeating: "You are a helpful strength and conditioning coach assistant. ", count: 60)
+        // ~7,300 chars ≈ ~1,800 tokens with Anthropic's tokenizer — above the
+        // 1,024-token minimum for claude-sonnet-4-5.
+        // 60 repeats (~875 tokens) was below the threshold; bumped to 120.
+        let basePad = String(repeating: "You are a helpful strength and conditioning coach assistant. ", count: 120)
         let stableSystemPrompt = """
             You are an elite AI strength and hypertrophy coach embedded in a workout app. \
             Your sole job is to prescribe the next set for the user based on the provided \


### PR DESCRIPTION
## Summary

- Amends `AnthropicProvider` in-place to send `cache_control: {type:"ephemeral"}` on the system prompt block for every call
- Adds `enableCaching: Bool = true` init parameter; `forProgramGeneration` callers pass `false` (one-shot, no cache benefit, avoids 25% write overhead)
- Adds `urlSession: URLSession? = nil` init parameter for test-session injection
- Adds `completeWithStats(systemPrompt:userPayload:) -> (text:, cacheUsage:)` on the concrete type for smoke-test observability (not on the protocol)
- Adds `AnthropicCacheUsage` struct exposing `cacheCreationInputTokens` and `cacheReadInputTokens`
- Logs a one-time `stderr` warning when the system prompt appears below the 1,024-token cache minimum
- Documents `APEX_INTEGRATION_TESTS=1` flag in `CLAUDE.md`

## Production cache coverage note

The current `AIInferenceService.systemPrompt` is ~550 tokens, below the 1,024-token minimum for `claude-sonnet-4-5`. **Cache hits won't occur in production until Phase 2 adds `TraineeModelDigest` to the stable section.** This PR ships the mechanism; Phase 2 makes it pay off.

## Test plan

- [x] 7 unit tests (mock URLSession): system field shape, cache_control presence, payload passthrough, text extraction, HTTP error surfacing, `cacheCreationInputTokens`, `cacheReadInputTokens`
- [x] `enableCaching: false` path: system field is plain string, no cache_control
- [x] Full suite: 220 tests, 0 failures
- [ ] Smoke test (`test_smokeTest_cacheEffectiveness_secondCallReadsCachedTokens`): run with `APEX_INTEGRATION_TESTS=1` + valid Anthropic key to confirm `cache_read_input_tokens > 0` on second call

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)