### PR TITLE
feat: equipment_catalog seed — 42 entries + SQL loader + smoke tests

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -39,10 +39,11 @@
 		6ED5B7636B15C7C513C11C2E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC23D0A3EB460CF97B18574 /* Foundation.framework */; };
 		729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */; };
 		73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */; };
-		A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */; };
 		81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */; };
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
+		E50E3B4CBD53ED7ABE725DB8 /* EquipmentCatalogSeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,6 +57,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EquipmentCatalogSeedTests.swift; path = ProjectApexTests/EquipmentCatalogSeedTests.swift; sourceTree = "<group>"; };
 		1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MigrationDatesTests.swift; sourceTree = "<group>"; };
 		4422DE7829C0C124138BB4B0 /* WeekFatigueSignalsHelperAgreementTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeekFatigueSignalsHelperAgreementTests.swift; sourceTree = "<group>"; };
 		474B848C2F67D31C001E0879 /* MacroPlanServiceDayCountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroPlanServiceDayCountTests.swift; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */,
 				DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */,
 				4422DE7829C0C124138BB4B0 /* WeekFatigueSignalsHelperAgreementTests.swift */,
+				18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -357,6 +360,7 @@
 				6ECE420C1031E80360FF1EFE /* TraineeModelProfilesTests.swift in Sources */,
 				B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */,
 				5DE94F8F1D136C65C96FCAD1 /* WeekFatigueSignalsHelperAgreementTests.swift in Sources */,
+				E50E3B4CBD53ED7ABE725DB8 /* EquipmentCatalogSeedTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/Resources/equipment_catalog_seed.json
+++ b/ProjectApex/Resources/equipment_catalog_seed.json
@@ -1,0 +1,380 @@
+[
+  {
+    "id": "dumbbell-set",
+    "display_name": "Dumbbell Set",
+    "category": "fixed-weight",
+    "default_max_kg": 60,
+    "default_increment_kg": 2.5,
+    "primary_muscle_groups": ["chest", "back", "shoulders", "biceps", "triceps", "legs"],
+    "exercise_tags": ["dumbbell press", "dumbbell row", "dumbbell curl", "dumbbell fly", "lateral raise", "dumbbell lunge", "dumbbell shoulder press", "dumbbell tricep extension"]
+  },
+  {
+    "id": "barbell",
+    "display_name": "Barbell",
+    "category": "plate-loaded",
+    "default_max_kg": 200,
+    "default_increment_kg": 2.5,
+    "primary_muscle_groups": ["chest", "back", "shoulders", "legs", "biceps", "triceps"],
+    "exercise_tags": ["bench press", "squat", "deadlift", "barbell row", "overhead press", "Romanian deadlift", "barbell curl"]
+  },
+  {
+    "id": "ez-curl-bar",
+    "display_name": "EZ Curl Bar",
+    "category": "plate-loaded",
+    "default_max_kg": 80,
+    "default_increment_kg": 2.5,
+    "primary_muscle_groups": ["biceps", "triceps"],
+    "exercise_tags": ["EZ-bar curl", "EZ-bar skull crushers", "EZ-bar overhead extension"]
+  },
+  {
+    "id": "cable-machine",
+    "display_name": "Cable Machine",
+    "category": "weight-stack",
+    "default_max_kg": 100,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["chest", "back", "shoulders", "biceps", "triceps", "legs"],
+    "exercise_tags": ["cable fly", "cable row", "cable curl", "tricep pushdown", "cable lateral raise", "cable face pull", "cable kickback"]
+  },
+  {
+    "id": "cable-machine-dual",
+    "display_name": "Cable Machine (Dual)",
+    "category": "weight-stack",
+    "default_max_kg": 100,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["chest", "back", "shoulders", "biceps", "triceps"],
+    "exercise_tags": ["cable crossover", "cable fly", "cable row", "cable curl", "cable lateral raise", "cable face pull", "tricep pushdown"]
+  },
+  {
+    "id": "smith-machine",
+    "display_name": "Smith Machine",
+    "category": "plate-loaded",
+    "default_max_kg": 200,
+    "default_increment_kg": 2.5,
+    "primary_muscle_groups": ["chest", "back", "shoulders", "legs", "triceps"],
+    "exercise_tags": ["Smith machine squat", "Smith machine bench press", "Smith machine row", "Smith machine overhead press", "Smith machine Romanian deadlift"]
+  },
+  {
+    "id": "leg-press",
+    "display_name": "Leg Press",
+    "category": "plate-loaded",
+    "default_max_kg": 400,
+    "default_increment_kg": 10,
+    "primary_muscle_groups": ["legs"],
+    "exercise_tags": ["leg press", "high-foot leg press", "single-leg press", "narrow-stance leg press"]
+  },
+  {
+    "id": "hack-squat",
+    "display_name": "Hack Squat",
+    "category": "plate-loaded",
+    "default_max_kg": 300,
+    "default_increment_kg": 10,
+    "primary_muscle_groups": ["legs"],
+    "exercise_tags": ["hack squat", "reverse hack squat", "narrow-stance hack squat"]
+  },
+  {
+    "id": "adjustable-bench",
+    "display_name": "Adjustable Bench",
+    "category": "bodyweight",
+    "default_max_kg": null,
+    "default_increment_kg": null,
+    "primary_muscle_groups": ["chest", "shoulders", "back", "triceps", "biceps"],
+    "exercise_tags": ["dumbbell press", "dumbbell fly", "dumbbell row", "incline press", "seated curl", "step-up"]
+  },
+  {
+    "id": "flat-bench",
+    "display_name": "Flat Bench",
+    "category": "bodyweight",
+    "default_max_kg": null,
+    "default_increment_kg": null,
+    "primary_muscle_groups": ["chest", "triceps", "shoulders"],
+    "exercise_tags": ["barbell bench press", "dumbbell bench press", "dumbbell fly", "close-grip bench press"]
+  },
+  {
+    "id": "incline-bench",
+    "display_name": "Incline Bench",
+    "category": "bodyweight",
+    "default_max_kg": null,
+    "default_increment_kg": null,
+    "primary_muscle_groups": ["chest", "shoulders", "biceps"],
+    "exercise_tags": ["incline barbell press", "incline dumbbell press", "incline dumbbell fly", "incline curl"]
+  },
+  {
+    "id": "pull-up-bar",
+    "display_name": "Pull-Up Bar",
+    "category": "bodyweight",
+    "default_max_kg": null,
+    "default_increment_kg": null,
+    "primary_muscle_groups": ["back", "biceps"],
+    "exercise_tags": ["pull-up", "chin-up", "wide-grip pull-up", "hanging leg raise"]
+  },
+  {
+    "id": "dip-station",
+    "display_name": "Dip Station",
+    "category": "bodyweight",
+    "default_max_kg": null,
+    "default_increment_kg": null,
+    "primary_muscle_groups": ["chest", "triceps", "shoulders"],
+    "exercise_tags": ["tricep dip", "chest dip", "L-sit"]
+  },
+  {
+    "id": "resistance-bands",
+    "display_name": "Resistance Bands",
+    "category": "fixed-weight",
+    "default_max_kg": 50,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["back", "shoulders", "biceps", "chest", "legs", "triceps"],
+    "exercise_tags": ["band pull-apart", "band curl", "band face pull", "band lateral raise", "banded squat", "band tricep pushdown"]
+  },
+  {
+    "id": "kettlebell-set",
+    "display_name": "Kettlebell Set",
+    "category": "fixed-weight",
+    "default_max_kg": 40,
+    "default_increment_kg": 4,
+    "primary_muscle_groups": ["back", "shoulders", "legs", "biceps"],
+    "exercise_tags": ["kettlebell swing", "kettlebell goblet squat", "kettlebell press", "kettlebell row", "Turkish get-up"]
+  },
+  {
+    "id": "power-rack",
+    "display_name": "Power Rack",
+    "category": "plate-loaded",
+    "default_max_kg": 200,
+    "default_increment_kg": 2.5,
+    "primary_muscle_groups": ["chest", "back", "legs", "shoulders", "triceps"],
+    "exercise_tags": ["barbell squat", "barbell bench press", "overhead press", "rack pull", "barbell row", "pin press"]
+  },
+  {
+    "id": "squat-rack",
+    "display_name": "Squat Rack",
+    "category": "plate-loaded",
+    "default_max_kg": 200,
+    "default_increment_kg": 2.5,
+    "primary_muscle_groups": ["legs", "shoulders", "back"],
+    "exercise_tags": ["barbell squat", "overhead press", "front squat", "rack pull"]
+  },
+  {
+    "id": "lat-pulldown",
+    "display_name": "Lat Pulldown",
+    "category": "weight-stack",
+    "default_max_kg": 100,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["back", "biceps"],
+    "exercise_tags": ["lat pulldown", "close-grip pulldown", "wide-grip pulldown", "single-arm pulldown"]
+  },
+  {
+    "id": "seated-row",
+    "display_name": "Seated Row",
+    "category": "weight-stack",
+    "default_max_kg": 100,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["back", "biceps"],
+    "exercise_tags": ["seated cable row", "close-grip row", "wide-grip row", "single-arm seated row"]
+  },
+  {
+    "id": "chest-press-machine",
+    "display_name": "Chest Press Machine",
+    "category": "weight-stack",
+    "default_max_kg": 150,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["chest", "triceps", "shoulders"],
+    "exercise_tags": ["machine chest press", "machine incline press", "single-arm chest press"]
+  },
+  {
+    "id": "shoulder-press-machine",
+    "display_name": "Shoulder Press Machine",
+    "category": "weight-stack",
+    "default_max_kg": 120,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["shoulders", "triceps"],
+    "exercise_tags": ["machine shoulder press", "machine overhead press", "single-arm shoulder press"]
+  },
+  {
+    "id": "leg-extension",
+    "display_name": "Leg Extension",
+    "category": "weight-stack",
+    "default_max_kg": 120,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["legs"],
+    "exercise_tags": ["leg extension", "single-leg extension"]
+  },
+  {
+    "id": "leg-curl",
+    "display_name": "Leg Curl",
+    "category": "weight-stack",
+    "default_max_kg": 100,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["legs"],
+    "exercise_tags": ["lying leg curl", "seated leg curl", "single-leg curl"]
+  },
+  {
+    "id": "pec-deck",
+    "display_name": "Pec Deck",
+    "category": "weight-stack",
+    "default_max_kg": 100,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["chest"],
+    "exercise_tags": ["pec deck fly", "machine fly", "reverse pec deck"]
+  },
+  {
+    "id": "preacher-curl",
+    "display_name": "Preacher Curl",
+    "category": "weight-stack",
+    "default_max_kg": 80,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["biceps"],
+    "exercise_tags": ["preacher curl", "EZ-bar preacher curl", "dumbbell preacher curl", "machine preacher curl"]
+  },
+  {
+    "id": "cable-crossover",
+    "display_name": "Cable Crossover",
+    "category": "weight-stack",
+    "default_max_kg": 100,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["chest", "shoulders", "triceps"],
+    "exercise_tags": ["cable crossover", "cable fly", "low-to-high cable fly", "high-to-low cable fly"]
+  },
+  {
+    "id": "hip-thrust-machine",
+    "display_name": "Hip Thrust Machine",
+    "category": "weight-stack",
+    "default_max_kg": 200,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["legs"],
+    "exercise_tags": ["machine hip thrust", "glute bridge", "hip thrust"]
+  },
+  {
+    "id": "ghd-glute-ham-raise",
+    "display_name": "GHD / Glute-Ham Raise",
+    "category": "bodyweight",
+    "default_max_kg": null,
+    "default_increment_kg": null,
+    "primary_muscle_groups": ["legs", "back"],
+    "exercise_tags": ["glute-ham raise", "GHD sit-up", "Nordic curl", "GHD hyperextension"]
+  },
+  {
+    "id": "reverse-hyper",
+    "display_name": "Reverse Hyper",
+    "category": "plate-loaded",
+    "default_max_kg": 100,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["legs", "back"],
+    "exercise_tags": ["reverse hyperextension", "reverse hyper"]
+  },
+  {
+    "id": "t-bar-row",
+    "display_name": "T-Bar Row",
+    "category": "plate-loaded",
+    "default_max_kg": 150,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["back", "biceps"],
+    "exercise_tags": ["T-bar row", "landmine row", "chest-supported T-bar row"]
+  },
+  {
+    "id": "trap-bar",
+    "display_name": "Trap Bar",
+    "category": "plate-loaded",
+    "default_max_kg": 250,
+    "default_increment_kg": 2.5,
+    "primary_muscle_groups": ["legs", "back", "shoulders"],
+    "exercise_tags": ["trap bar deadlift", "trap bar squat", "trap bar shrug", "trap bar farmer carry"]
+  },
+  {
+    "id": "belt-squat-pendulum-squat",
+    "display_name": "Belt Squat / Pendulum Squat",
+    "category": "plate-loaded",
+    "default_max_kg": 300,
+    "default_increment_kg": 10,
+    "primary_muscle_groups": ["legs"],
+    "exercise_tags": ["belt squat", "pendulum squat", "belt squat split squat", "goblet belt squat"]
+  },
+  {
+    "id": "hs-chest-press",
+    "display_name": "Hammer Strength Chest Press",
+    "category": "plate-loaded",
+    "default_max_kg": 200,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["chest", "triceps", "shoulders"],
+    "exercise_tags": ["Hammer Strength chest press", "plate-loaded chest press", "unilateral chest press"]
+  },
+  {
+    "id": "hs-incline-press",
+    "display_name": "Hammer Strength Incline Press",
+    "category": "plate-loaded",
+    "default_max_kg": 180,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["chest", "shoulders", "triceps"],
+    "exercise_tags": ["Hammer Strength incline press", "plate-loaded incline press", "unilateral incline press"]
+  },
+  {
+    "id": "hs-lat-pulldown",
+    "display_name": "Hammer Strength Lat Pulldown",
+    "category": "plate-loaded",
+    "default_max_kg": 180,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["back", "biceps"],
+    "exercise_tags": ["Hammer Strength lat pulldown", "plate-loaded lat pulldown", "unilateral lat pulldown"]
+  },
+  {
+    "id": "hs-iso-row",
+    "display_name": "Hammer Strength ISO-Row",
+    "category": "plate-loaded",
+    "default_max_kg": 180,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["back", "biceps"],
+    "exercise_tags": ["Hammer Strength ISO row", "plate-loaded row", "unilateral row", "chest-supported row"]
+  },
+  {
+    "id": "hs-shoulder-press",
+    "display_name": "Hammer Strength Shoulder Press",
+    "category": "plate-loaded",
+    "default_max_kg": 150,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["shoulders", "triceps"],
+    "exercise_tags": ["Hammer Strength shoulder press", "plate-loaded shoulder press", "unilateral shoulder press"]
+  },
+  {
+    "id": "standing-calf-raise",
+    "display_name": "Standing Calf Raise",
+    "category": "plate-loaded",
+    "default_max_kg": 300,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["legs"],
+    "exercise_tags": ["standing calf raise", "single-leg calf raise", "donkey calf raise"]
+  },
+  {
+    "id": "seated-calf-raise",
+    "display_name": "Seated Calf Raise",
+    "category": "plate-loaded",
+    "default_max_kg": 150,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["legs"],
+    "exercise_tags": ["seated calf raise", "single-leg seated calf raise"]
+  },
+  {
+    "id": "abductor-machine",
+    "display_name": "Abductor Machine",
+    "category": "weight-stack",
+    "default_max_kg": 100,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["legs"],
+    "exercise_tags": ["hip abductor", "outer thigh machine"]
+  },
+  {
+    "id": "adductor-machine",
+    "display_name": "Adductor Machine",
+    "category": "weight-stack",
+    "default_max_kg": 100,
+    "default_increment_kg": 5,
+    "primary_muscle_groups": ["legs"],
+    "exercise_tags": ["hip adductor", "inner thigh machine", "adductor press"]
+  },
+  {
+    "id": "sissy-squat-machine",
+    "display_name": "Sissy Squat Machine",
+    "category": "bodyweight",
+    "default_max_kg": null,
+    "default_increment_kg": null,
+    "primary_muscle_groups": ["legs"],
+    "exercise_tags": ["sissy squat", "machine sissy squat"]
+  }
+]

--- a/ProjectApexTests/EquipmentCatalogSeedTests.swift
+++ b/ProjectApexTests/EquipmentCatalogSeedTests.swift
@@ -1,0 +1,140 @@
+// EquipmentCatalogSeedTests.swift
+// ProjectApexTests
+//
+// Smoke tests for Resources/equipment_catalog_seed.json (Phase 1 / Slice 4, issue #7).
+//
+// Covers:
+//   • Exactly 42 entries (count regression guard)
+//   • All 26 base EquipmentType IDs present
+//   • All 16 specialty IDs present
+//   • Every entry has required non-empty fields (id, display_name, category, arrays)
+//   • category is one of the four valid values
+//   • primary_muscle_groups references only the locked-six muscle groups
+//   • default_increment_kg (where non-null) is a positive number
+
+import XCTest
+
+final class EquipmentCatalogSeedTests: XCTestCase {
+
+    // MARK: ─── Helpers ────────────────────────────────────────────────────────
+
+    private struct CatalogEntry: Decodable {
+        let id: String
+        let display_name: String
+        let category: String
+        let default_max_kg: Double?
+        let default_increment_kg: Double?
+        let primary_muscle_groups: [String]
+        let exercise_tags: [String]
+    }
+
+    private static let seedFileURL: URL = {
+        URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()          // ProjectApexTests/
+            .deletingLastPathComponent()          // ProjectApex/ (repo root)
+            .appendingPathComponent("ProjectApex/Resources/equipment_catalog_seed.json")
+    }()
+
+    private static let entries: [CatalogEntry] = {
+        let data = try! Data(contentsOf: seedFileURL)
+        return try! JSONDecoder().decode([CatalogEntry].self, from: data)
+    }()
+
+    // MARK: ─── Count ──────────────────────────────────────────────────────────
+
+    func test_count_isExactly42() {
+        XCTAssertEqual(Self.entries.count, 42,
+            "Seed file must contain exactly 42 entries; edit count indicates unintended removal")
+    }
+
+    // MARK: ─── Base IDs (26) ──────────────────────────────────────────────────
+
+    func test_baseIDs_allPresent() {
+        let expected: Set<String> = [
+            "dumbbell-set", "barbell", "ez-curl-bar", "cable-machine", "cable-machine-dual",
+            "smith-machine", "leg-press", "hack-squat", "adjustable-bench", "flat-bench",
+            "incline-bench", "pull-up-bar", "dip-station", "resistance-bands", "kettlebell-set",
+            "power-rack", "squat-rack", "lat-pulldown", "seated-row", "chest-press-machine",
+            "shoulder-press-machine", "leg-extension", "leg-curl", "pec-deck", "preacher-curl",
+            "cable-crossover"
+        ]
+        let actual = Set(Self.entries.map(\.id))
+        XCTAssertTrue(expected.isSubset(of: actual),
+            "Missing base IDs: \(expected.subtracting(actual))")
+    }
+
+    // MARK: ─── Specialty IDs (16) ─────────────────────────────────────────────
+
+    func test_specialtyIDs_allPresent() {
+        let expected: Set<String> = [
+            "hip-thrust-machine", "ghd-glute-ham-raise", "reverse-hyper", "t-bar-row",
+            "trap-bar", "belt-squat-pendulum-squat", "hs-chest-press", "hs-incline-press",
+            "hs-lat-pulldown", "hs-iso-row", "hs-shoulder-press", "standing-calf-raise",
+            "seated-calf-raise", "abductor-machine", "adductor-machine", "sissy-squat-machine"
+        ]
+        let actual = Set(Self.entries.map(\.id))
+        XCTAssertTrue(expected.isSubset(of: actual),
+            "Missing specialty IDs: \(expected.subtracting(actual))")
+    }
+
+    // MARK: ─── Required Fields ────────────────────────────────────────────────
+
+    func test_requiredFields_noEmptyStrings() {
+        for entry in Self.entries {
+            XCTAssertFalse(entry.id.isEmpty,           "Empty id in entry")
+            XCTAssertFalse(entry.display_name.isEmpty, "Empty display_name for id=\(entry.id)")
+            XCTAssertFalse(entry.category.isEmpty,     "Empty category for id=\(entry.id)")
+        }
+    }
+
+    func test_requiredArrays_nonEmpty() {
+        for entry in Self.entries {
+            XCTAssertFalse(entry.primary_muscle_groups.isEmpty,
+                "primary_muscle_groups is empty for id=\(entry.id)")
+            XCTAssertFalse(entry.exercise_tags.isEmpty,
+                "exercise_tags is empty for id=\(entry.id)")
+        }
+    }
+
+    // MARK: ─── Category Values ────────────────────────────────────────────────
+
+    func test_category_validValues() {
+        let valid: Set<String> = ["plate-loaded", "weight-stack", "fixed-weight", "bodyweight"]
+        for entry in Self.entries {
+            XCTAssertTrue(valid.contains(entry.category),
+                "Invalid category '\(entry.category)' for id=\(entry.id)")
+        }
+    }
+
+    // MARK: ─── Muscle Groups ──────────────────────────────────────────────────
+
+    func test_primaryMuscleGroups_lockedSixOnly() {
+        let locked: Set<String> = ["back", "chest", "biceps", "shoulders", "triceps", "legs"]
+        for entry in Self.entries {
+            for muscle in entry.primary_muscle_groups {
+                XCTAssertTrue(locked.contains(muscle),
+                    "Unknown muscle group '\(muscle)' in id=\(entry.id)")
+            }
+        }
+    }
+
+    // MARK: ─── Numeric Increments ─────────────────────────────────────────────
+
+    func test_defaultIncrementKg_positiveWhereNonNull() {
+        for entry in Self.entries {
+            if let increment = entry.default_increment_kg {
+                XCTAssertGreaterThan(increment, 0,
+                    "default_increment_kg must be positive for id=\(entry.id); got \(increment)")
+            }
+        }
+    }
+
+    // MARK: ─── No Duplicate IDs ───────────────────────────────────────────────
+
+    func test_ids_unique() {
+        let ids = Self.entries.map(\.id)
+        let unique = Set(ids)
+        XCTAssertEqual(ids.count, unique.count,
+            "Duplicate IDs found in seed file")
+    }
+}

--- a/migrations/0003_equipment_catalog_seed.sql
+++ b/migrations/0003_equipment_catalog_seed.sql
@@ -1,0 +1,196 @@
+-- Migration: 0003_equipment_catalog_seed.sql
+-- Phase 1 / Slice 4 (#7) — seed equipment_catalog with 42 design-reviewed entries
+--
+-- Idempotent: INSERT … ON CONFLICT (id) DO NOTHING means re-running never
+-- overwrites existing rows and never fails on a database that already has the
+-- seed applied.
+--
+-- Authoritative row data mirrors Resources/equipment_catalog_seed.json.
+-- Categories: plate-loaded | weight-stack | fixed-weight | bodyweight
+-- Locked muscle groups: back | chest | biceps | shoulders | triceps | legs
+
+-- ---------------------------------------------------------------------------
+-- 26 base entries — sourced from EquipmentType enum (excluding unknown(String))
+-- ---------------------------------------------------------------------------
+
+INSERT INTO public.equipment_catalog
+    (id, display_name, category, default_max_kg, default_increment_kg, primary_muscle_groups, exercise_tags)
+VALUES
+    ('dumbbell-set',          'Dumbbell Set',          'fixed-weight',  60,   2.5,
+     ARRAY['chest','back','shoulders','biceps','triceps','legs'],
+     ARRAY['dumbbell press','dumbbell row','dumbbell curl','dumbbell fly','lateral raise','dumbbell lunge','dumbbell shoulder press','dumbbell tricep extension']),
+
+    ('barbell',               'Barbell',               'plate-loaded',  200,  2.5,
+     ARRAY['chest','back','shoulders','legs','biceps','triceps'],
+     ARRAY['bench press','squat','deadlift','barbell row','overhead press','Romanian deadlift','barbell curl']),
+
+    ('ez-curl-bar',           'EZ Curl Bar',           'plate-loaded',  80,   2.5,
+     ARRAY['biceps','triceps'],
+     ARRAY['EZ-bar curl','EZ-bar skull crushers','EZ-bar overhead extension']),
+
+    ('cable-machine',         'Cable Machine',         'weight-stack',  100,  5,
+     ARRAY['chest','back','shoulders','biceps','triceps','legs'],
+     ARRAY['cable fly','cable row','cable curl','tricep pushdown','cable lateral raise','cable face pull','cable kickback']),
+
+    ('cable-machine-dual',    'Cable Machine (Dual)',  'weight-stack',  100,  5,
+     ARRAY['chest','back','shoulders','biceps','triceps'],
+     ARRAY['cable crossover','cable fly','cable row','cable curl','cable lateral raise','cable face pull','tricep pushdown']),
+
+    ('smith-machine',         'Smith Machine',         'plate-loaded',  200,  2.5,
+     ARRAY['chest','back','shoulders','legs','triceps'],
+     ARRAY['Smith machine squat','Smith machine bench press','Smith machine row','Smith machine overhead press','Smith machine Romanian deadlift']),
+
+    ('leg-press',             'Leg Press',             'plate-loaded',  400,  10,
+     ARRAY['legs'],
+     ARRAY['leg press','high-foot leg press','single-leg press','narrow-stance leg press']),
+
+    ('hack-squat',            'Hack Squat',            'plate-loaded',  300,  10,
+     ARRAY['legs'],
+     ARRAY['hack squat','reverse hack squat','narrow-stance hack squat']),
+
+    ('adjustable-bench',      'Adjustable Bench',      'bodyweight',    NULL, NULL,
+     ARRAY['chest','shoulders','back','triceps','biceps'],
+     ARRAY['dumbbell press','dumbbell fly','dumbbell row','incline press','seated curl','step-up']),
+
+    ('flat-bench',            'Flat Bench',            'bodyweight',    NULL, NULL,
+     ARRAY['chest','triceps','shoulders'],
+     ARRAY['barbell bench press','dumbbell bench press','dumbbell fly','close-grip bench press']),
+
+    ('incline-bench',         'Incline Bench',         'bodyweight',    NULL, NULL,
+     ARRAY['chest','shoulders','biceps'],
+     ARRAY['incline barbell press','incline dumbbell press','incline dumbbell fly','incline curl']),
+
+    ('pull-up-bar',           'Pull-Up Bar',           'bodyweight',    NULL, NULL,
+     ARRAY['back','biceps'],
+     ARRAY['pull-up','chin-up','wide-grip pull-up','hanging leg raise']),
+
+    ('dip-station',           'Dip Station',           'bodyweight',    NULL, NULL,
+     ARRAY['chest','triceps','shoulders'],
+     ARRAY['tricep dip','chest dip','L-sit']),
+
+    ('resistance-bands',      'Resistance Bands',      'fixed-weight',  50,   5,
+     ARRAY['back','shoulders','biceps','chest','legs','triceps'],
+     ARRAY['band pull-apart','band curl','band face pull','band lateral raise','banded squat','band tricep pushdown']),
+
+    ('kettlebell-set',        'Kettlebell Set',        'fixed-weight',  40,   4,
+     ARRAY['back','shoulders','legs','biceps'],
+     ARRAY['kettlebell swing','kettlebell goblet squat','kettlebell press','kettlebell row','Turkish get-up']),
+
+    ('power-rack',            'Power Rack',            'plate-loaded',  200,  2.5,
+     ARRAY['chest','back','legs','shoulders','triceps'],
+     ARRAY['barbell squat','barbell bench press','overhead press','rack pull','barbell row','pin press']),
+
+    ('squat-rack',            'Squat Rack',            'plate-loaded',  200,  2.5,
+     ARRAY['legs','shoulders','back'],
+     ARRAY['barbell squat','overhead press','front squat','rack pull']),
+
+    ('lat-pulldown',          'Lat Pulldown',          'weight-stack',  100,  5,
+     ARRAY['back','biceps'],
+     ARRAY['lat pulldown','close-grip pulldown','wide-grip pulldown','single-arm pulldown']),
+
+    ('seated-row',            'Seated Row',            'weight-stack',  100,  5,
+     ARRAY['back','biceps'],
+     ARRAY['seated cable row','close-grip row','wide-grip row','single-arm seated row']),
+
+    ('chest-press-machine',   'Chest Press Machine',   'weight-stack',  150,  5,
+     ARRAY['chest','triceps','shoulders'],
+     ARRAY['machine chest press','machine incline press','single-arm chest press']),
+
+    ('shoulder-press-machine','Shoulder Press Machine','weight-stack',  120,  5,
+     ARRAY['shoulders','triceps'],
+     ARRAY['machine shoulder press','machine overhead press','single-arm shoulder press']),
+
+    ('leg-extension',         'Leg Extension',         'weight-stack',  120,  5,
+     ARRAY['legs'],
+     ARRAY['leg extension','single-leg extension']),
+
+    ('leg-curl',              'Leg Curl',              'weight-stack',  100,  5,
+     ARRAY['legs'],
+     ARRAY['lying leg curl','seated leg curl','single-leg curl']),
+
+    ('pec-deck',              'Pec Deck',              'weight-stack',  100,  5,
+     ARRAY['chest'],
+     ARRAY['pec deck fly','machine fly','reverse pec deck']),
+
+    ('preacher-curl',         'Preacher Curl',         'weight-stack',  80,   5,
+     ARRAY['biceps'],
+     ARRAY['preacher curl','EZ-bar preacher curl','dumbbell preacher curl','machine preacher curl']),
+
+    ('cable-crossover',       'Cable Crossover',       'weight-stack',  100,  5,
+     ARRAY['chest','shoulders','triceps'],
+     ARRAY['cable crossover','cable fly','low-to-high cable fly','high-to-low cable fly'])
+
+ON CONFLICT (id) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- 16 specialty entries — per ADR-0004
+-- ---------------------------------------------------------------------------
+
+INSERT INTO public.equipment_catalog
+    (id, display_name, category, default_max_kg, default_increment_kg, primary_muscle_groups, exercise_tags)
+VALUES
+    ('hip-thrust-machine',        'Hip Thrust Machine',              'weight-stack',  200,  5,
+     ARRAY['legs'],
+     ARRAY['machine hip thrust','glute bridge','hip thrust']),
+
+    ('ghd-glute-ham-raise',       'GHD / Glute-Ham Raise',           'bodyweight',    NULL, NULL,
+     ARRAY['legs','back'],
+     ARRAY['glute-ham raise','GHD sit-up','Nordic curl','GHD hyperextension']),
+
+    ('reverse-hyper',             'Reverse Hyper',                   'plate-loaded',  100,  5,
+     ARRAY['legs','back'],
+     ARRAY['reverse hyperextension','reverse hyper']),
+
+    ('t-bar-row',                 'T-Bar Row',                       'plate-loaded',  150,  5,
+     ARRAY['back','biceps'],
+     ARRAY['T-bar row','landmine row','chest-supported T-bar row']),
+
+    ('trap-bar',                  'Trap Bar',                        'plate-loaded',  250,  2.5,
+     ARRAY['legs','back','shoulders'],
+     ARRAY['trap bar deadlift','trap bar squat','trap bar shrug','trap bar farmer carry']),
+
+    ('belt-squat-pendulum-squat', 'Belt Squat / Pendulum Squat',     'plate-loaded',  300,  10,
+     ARRAY['legs'],
+     ARRAY['belt squat','pendulum squat','belt squat split squat','goblet belt squat']),
+
+    ('hs-chest-press',            'Hammer Strength Chest Press',     'plate-loaded',  200,  5,
+     ARRAY['chest','triceps','shoulders'],
+     ARRAY['Hammer Strength chest press','plate-loaded chest press','unilateral chest press']),
+
+    ('hs-incline-press',          'Hammer Strength Incline Press',   'plate-loaded',  180,  5,
+     ARRAY['chest','shoulders','triceps'],
+     ARRAY['Hammer Strength incline press','plate-loaded incline press','unilateral incline press']),
+
+    ('hs-lat-pulldown',           'Hammer Strength Lat Pulldown',    'plate-loaded',  180,  5,
+     ARRAY['back','biceps'],
+     ARRAY['Hammer Strength lat pulldown','plate-loaded lat pulldown','unilateral lat pulldown']),
+
+    ('hs-iso-row',                'Hammer Strength ISO-Row',         'plate-loaded',  180,  5,
+     ARRAY['back','biceps'],
+     ARRAY['Hammer Strength ISO row','plate-loaded row','unilateral row','chest-supported row']),
+
+    ('hs-shoulder-press',         'Hammer Strength Shoulder Press',  'plate-loaded',  150,  5,
+     ARRAY['shoulders','triceps'],
+     ARRAY['Hammer Strength shoulder press','plate-loaded shoulder press','unilateral shoulder press']),
+
+    ('standing-calf-raise',       'Standing Calf Raise',             'plate-loaded',  300,  5,
+     ARRAY['legs'],
+     ARRAY['standing calf raise','single-leg calf raise','donkey calf raise']),
+
+    ('seated-calf-raise',         'Seated Calf Raise',               'plate-loaded',  150,  5,
+     ARRAY['legs'],
+     ARRAY['seated calf raise','single-leg seated calf raise']),
+
+    ('abductor-machine',          'Abductor Machine',                'weight-stack',  100,  5,
+     ARRAY['legs'],
+     ARRAY['hip abductor','outer thigh machine']),
+
+    ('adductor-machine',          'Adductor Machine',                'weight-stack',  100,  5,
+     ARRAY['legs'],
+     ARRAY['hip adductor','inner thigh machine','adductor press']),
+
+    ('sissy-squat-machine',       'Sissy Squat Machine',             'bodyweight',    NULL, NULL,
+     ARRAY['legs'],
+     ARRAY['sissy squat','machine sissy squat'])
+
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary

- **`ProjectApex/Resources/equipment_catalog_seed.json`** — 42 design-reviewed entries: 26 base entries from the `EquipmentType` enum (excluding `unknown(String)`) + 16 specialty entries per ADR-0004. Each entry carries `id` (kebab-case), `display_name`, `category`, `default_max_kg`, `default_increment_kg`, `primary_muscle_groups` (locked-six only), and `exercise_tags`.
- **`migrations/0003_equipment_catalog_seed.sql`** — idempotent SQL loader using `INSERT … ON CONFLICT (id) DO NOTHING`. Two batches (26 base, 16 specialty) for readability.
- **`ProjectApexTests/EquipmentCatalogSeedTests.swift`** — smoke tests: count == 42 regression guard, all 26 base IDs present, all 16 specialty IDs present, no empty required fields, valid categories, locked-six muscle groups only, positive increments where non-null, no duplicate IDs.

Closes #7

## Pre-deploy reminder

Run `migrations/0003_equipment_catalog_seed.sql` against the Supabase project (or let the migration runner pick it up). Idempotent — safe to run on a database that already has the seed applied.

## Test plan

- [ ] `EquipmentCatalogSeedTests` suite passes (all 8 tests green)
- [ ] `SELECT COUNT(*) FROM equipment_catalog` returns 42 after migration applies
- [ ] Re-running the migration has no effect (idempotency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)