### PR TITLE
feat: TraineeModelLocalStore — SwiftData cache for TraineeModel

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -39,9 +39,10 @@
 		6ED5B7636B15C7C513C11C2E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC23D0A3EB460CF97B18574 /* Foundation.framework */; };
 		729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */; };
 		73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */; };
-		A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */; };
 		81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */; };
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */; };
+		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -94,6 +95,7 @@
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
 		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
 		E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MuscleTaxonomyTests.swift; sourceTree = "<group>"; };
+		E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelLocalStoreTests.swift; sourceTree = "<group>"; };
 		EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelEnumsTests.swift; sourceTree = "<group>"; };
 		EFB324F8EA1B317B0F90575B /* ProjectApexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProjectApexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MovementPatternTests.swift; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */,
 				DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */,
 				4422DE7829C0C124138BB4B0 /* WeekFatigueSignalsHelperAgreementTests.swift */,
+				E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -357,6 +360,7 @@
 				6ECE420C1031E80360FF1EFE /* TraineeModelProfilesTests.swift in Sources */,
 				B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */,
 				5DE94F8F1D136C65C96FCAD1 /* WeekFatigueSignalsHelperAgreementTests.swift in Sources */,
+				A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/Features/Progress/ProgressViewModel.swift
+++ b/ProjectApex/Features/Progress/ProgressViewModel.swift
@@ -146,6 +146,12 @@ final class ProgressViewModel {
         self.userId = userId
     }
 
+    // Prevent swift_task_deinitOnExecutorImpl crash: @MainActor deinit
+    // requires an active Swift Concurrency Task; SwiftUI releases @State-owned
+    // instances from CFRunLoop callbacks (no active Task). Stored properties
+    // are all plain value types — safe to release on any thread.
+    nonisolated deinit {}
+
     // MARK: - Load
 
     func loadAll(plannedWeekDays: [TrainingDay] = []) async {

--- a/ProjectApex/Services/TraineeModelLocalStore.swift
+++ b/ProjectApex/Services/TraineeModelLocalStore.swift
@@ -1,0 +1,126 @@
+// Services/TraineeModelLocalStore.swift
+// ProjectApex
+//
+// SwiftData local cache for the TraineeModel snapshot (Phase 1 / Slice 8,
+// issue #8, ADR-0005 / ADR-0006).
+//
+// Architecture:
+//   • LocalTraineeModelRecord — single @Model row. Document-style: the full
+//     TraineeModel is JSON-encoded into modelJSON: Data, mirroring the
+//     Supabase trainee_models.model_json JSONB column. Not flattened into
+//     sub-entities — keeping it as one row avoids SwiftData relationship
+//     complexity and matches the authoritative server shape exactly.
+//   • TraineeModelLocalStore — thin wrapper. Public API: load / save / clear.
+//     The server (Edge Function response) is authoritative; this store is a
+//     read cache that hydrates on success and bootstraps to empty on first
+//     launch (nil return from load() is the first-launch signal to the
+//     consumer — TraineeModelService, Slice #11).
+//
+// Single-user v2: one record, singleton-keyed. Multi-user / multi-device
+// concurrency is explicitly out of scope per ADR-0006.
+
+import Foundation
+import SwiftData
+
+// MARK: - LocalTraineeModelRecord
+
+/// Single-row SwiftData @Model. The full TraineeModel value is stored as
+/// a JSON blob to mirror the server's JSONB representation and avoid
+/// entity relationship complexity.
+@Model
+final class LocalTraineeModelRecord {
+    /// Singleton key — always "singleton" for v2 single-user.
+    @Attribute(.unique) var id: String
+    var modelJSON: Data
+    var cachedAt: Date
+
+    init(id: String = "singleton", modelJSON: Data, cachedAt: Date = Date()) {
+        self.id = id
+        self.modelJSON = modelJSON
+        self.cachedAt = cachedAt
+    }
+}
+
+// MARK: - TraineeModelLocalStore
+
+/// Wraps a SwiftData ModelContainer providing load / save / clear access
+/// to the locally cached TraineeModel snapshot.
+///
+/// @MainActor isolation is required: ModelContainer has internal main-actor
+/// executor requirements (task-local storage for @ModelActor infrastructure).
+/// Deallocation off the main actor crashes. All callers must dispatch to the
+/// main actor — TraineeModelService (Slice #11) does this via await.
+@MainActor
+final class TraineeModelLocalStore {
+
+    private let container: ModelContainer
+
+    init(container: ModelContainer) {
+        self.container = container
+    }
+
+    // MARK: Factories
+
+    /// Production store — persisted to the app's default SwiftData location.
+    static func makeShared() throws -> TraineeModelLocalStore {
+        let config = ModelConfiguration(isStoredInMemoryOnly: false)
+        let container = try ModelContainer(for: LocalTraineeModelRecord.self,
+                                           configurations: config)
+        return TraineeModelLocalStore(container: container)
+    }
+
+    /// In-memory store — for unit / integration tests.
+    static func makeInMemory() throws -> TraineeModelLocalStore {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: LocalTraineeModelRecord.self,
+                                           configurations: config)
+        return TraineeModelLocalStore(container: container)
+    }
+
+    /// On-disk store at an explicit URL — for persistence-across-restart tests
+    /// and targeted migration scenarios.
+    static func makeOnDisk(at url: URL) throws -> TraineeModelLocalStore {
+        let config = ModelConfiguration(url: url)
+        let container = try ModelContainer(for: LocalTraineeModelRecord.self,
+                                           configurations: config)
+        return TraineeModelLocalStore(container: container)
+    }
+
+    // MARK: Public API
+
+    /// Returns the cached TraineeModel, or nil if the store is empty (first
+    /// launch) or if the stored JSON cannot be decoded (treated as no model).
+    func load() -> TraineeModel? {
+        guard let record = fetchRecord() else { return nil }
+        return try? JSONDecoder().decode(TraineeModel.self, from: record.modelJSON)
+    }
+
+    /// Persists the model as a JSON blob. Upserts: if a record already
+    /// exists it is updated in-place; otherwise a new record is inserted.
+    func save(_ model: TraineeModel) throws {
+        let data = try JSONEncoder().encode(model)
+        if let record = fetchRecord() {
+            record.modelJSON = data
+            record.cachedAt = Date()
+        } else {
+            container.mainContext.insert(LocalTraineeModelRecord(modelJSON: data))
+        }
+        try container.mainContext.save()
+    }
+
+    /// Removes the cached record. load() will return nil after this call.
+    func clear() throws {
+        if let record = fetchRecord() {
+            container.mainContext.delete(record)
+            try container.mainContext.save()
+        }
+    }
+
+    // MARK: Private
+
+    private func fetchRecord() -> LocalTraineeModelRecord? {
+        var descriptor = FetchDescriptor<LocalTraineeModelRecord>()
+        descriptor.fetchLimit = 1
+        return try? container.mainContext.fetch(descriptor).first
+    }
+}

--- a/ProjectApexTests/TraineeModelLocalStoreTests.swift
+++ b/ProjectApexTests/TraineeModelLocalStoreTests.swift
@@ -1,0 +1,202 @@
+// TraineeModelLocalStoreTests.swift
+// ProjectApexTests
+//
+// Integration tests for TraineeModelLocalStore (Phase 1 / Slice 8, issue #8).
+//
+// @MainActor is required on this class: TraineeModelLocalStore is
+// @MainActor-isolated (ModelContainer has internal main-actor executor
+// requirements), so all store interactions must happen on the main actor.
+// XCTest fully supports @MainActor test classes.
+//
+// All tests use an in-memory SwiftData container unless persistence across
+// simulated restart is being tested (which requires an on-disk container
+// at a temp URL that is cleaned up in tearDown).
+//
+// Behaviors covered:
+//   • Empty store returns nil on load()
+//   • save → load round-trips the model faithfully
+//   • Second save replaces first (upsert semantics)
+//   • clear() empties the store
+//   • Persistence survives simulated restart (new container, same SQLite file)
+//   • Cold-start hydration from a representative Edge Function payload
+
+import XCTest
+import SwiftData
+@testable import ProjectApex
+
+@MainActor
+final class TraineeModelLocalStoreTests: XCTestCase {
+
+    // MARK: ─── Helpers ────────────────────────────────────────────────────────
+
+    private func makeStore() throws -> TraineeModelLocalStore {
+        try TraineeModelLocalStore.makeInMemory()
+    }
+
+    /// Minimal TraineeModel for basic round-trip tests. Uses a fixed Date so
+    /// JSON encode → decode produces bit-identical values.
+    private func makeMinimalModel() -> TraineeModel {
+        TraineeModel(
+            goal: GoalState(
+                statement: "Build strength",
+                focusAreas: [],
+                updatedAt: Date(timeIntervalSinceReferenceDate: 0)
+            )
+        )
+    }
+
+    /// Richer model exercising patterns, muscles, exercises, and limitations
+    /// to simulate a realistic Edge Function response payload.
+    private func makeRepresentativeModel() -> TraineeModel {
+        let ref0 = Date(timeIntervalSinceReferenceDate: 0)
+        return TraineeModel(
+            activeProgramId: UUID(uuidString: "12345678-1234-1234-1234-123456789012"),
+            goal: GoalState(
+                statement: "Build muscle and strength",
+                focusAreas: [.back, .legs],
+                updatedAt: ref0
+            ),
+            patterns: [
+                .squat: PatternProfile(
+                    pattern: .squat,
+                    currentPhase: .accumulation,
+                    sessionsInPhase: 3,
+                    rpeOffset: -0.5,
+                    confidence: .calibrating,
+                    recentSessionDates: [ref0]
+                ),
+                .horizontalPush: PatternProfile(
+                    pattern: .horizontalPush,
+                    currentPhase: .intensification,
+                    sessionsInPhase: 6,
+                    rpeOffset: 0,
+                    confidence: .established,
+                    recentSessionDates: [ref0]
+                )
+            ],
+            muscles: [
+                .legs: MuscleProfile(
+                    muscleGroup: .legs,
+                    volumeTolerance: 14.0,
+                    observedSweetSpot: 12,
+                    volumeDeficit: 2,
+                    focusWeight: 0.6,
+                    confidence: .calibrating
+                ),
+                .chest: MuscleProfile(
+                    muscleGroup: .chest,
+                    volumeTolerance: 10.0,
+                    confidence: .established
+                )
+            ],
+            exercises: [
+                "barbell-back-squat": ExerciseProfile(
+                    exerciseId: "barbell-back-squat",
+                    e1rmCurrent: 120.0,
+                    e1rmMedian: 115.0,
+                    e1rmPeak: 130.0,
+                    sessionCount: 8,
+                    confidence: .calibrating
+                )
+            ],
+            totalSessionCount: 8
+        )
+    }
+
+    // MARK: ─── Cycle 1: empty store → nil ────────────────────────────────────
+
+    func test_load_returnsNil_whenStoreIsEmpty() throws {
+        let store = try makeStore()
+        XCTAssertNil(store.load())
+    }
+
+    // MARK: ─── Cycle 2: save → load round-trip ────────────────────────────────
+
+    func test_saveAndLoad_roundTripsModel() throws {
+        let store = try makeStore()
+        let model = makeMinimalModel()
+        try store.save(model)
+        let loaded = store.load()
+        XCTAssertNotNil(loaded)
+        XCTAssertEqual(loaded, model)
+    }
+
+    // MARK: ─── Cycle 3: second save replaces first ───────────────────────────
+
+    func test_save_twice_secondValueWins() throws {
+        let store = try makeStore()
+        let modelA = makeMinimalModel()
+        var modelB = makeMinimalModel()
+        modelB.goal = GoalState(
+            statement: "Lose weight",
+            focusAreas: [.chest],
+            updatedAt: Date(timeIntervalSinceReferenceDate: 1000)
+        )
+
+        try store.save(modelA)
+        try store.save(modelB)
+
+        let loaded = store.load()
+        XCTAssertEqual(loaded, modelB)
+        XCTAssertNotEqual(loaded, modelA)
+    }
+
+    // MARK: ─── Cycle 4: clear → nil ─────────────────────────────────────────
+
+    func test_clear_afterSave_returnsNilOnNextLoad() throws {
+        let store = try makeStore()
+        try store.save(makeMinimalModel())
+        XCTAssertNotNil(store.load(), "Precondition: model exists before clear")
+
+        try store.clear()
+
+        XCTAssertNil(store.load())
+    }
+
+    func test_clear_onEmptyStore_doesNotThrow() {
+        XCTAssertNoThrow(try makeStore().clear())
+    }
+
+    // MARK: ─── Cycle 5: persistence across simulated restart ─────────────────
+
+    func test_persistenceAcrossSimulatedRestart() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("sqlite")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let model = makeMinimalModel()
+
+        // First "launch" — save and release the store
+        do {
+            let store = try TraineeModelLocalStore.makeOnDisk(at: url)
+            try store.save(model)
+            // store deallocated here; SQLite file remains on disk
+        }
+
+        // Second "launch" — open same file with a fresh container
+        let store2 = try TraineeModelLocalStore.makeOnDisk(at: url)
+        let loaded = store2.load()
+
+        XCTAssertNotNil(loaded, "Expected persisted model to survive container recreation")
+        XCTAssertEqual(loaded, model)
+    }
+
+    // MARK: ─── Cycle 6: cold-start from representative payload ───────────────
+
+    func test_coldStart_representativePayload_roundTrips() throws {
+        let store = try makeStore()
+        let model = makeRepresentativeModel()
+
+        try store.save(model)
+        let loaded = try XCTUnwrap(store.load())
+
+        XCTAssertEqual(loaded.activeProgramId, model.activeProgramId)
+        XCTAssertEqual(loaded.goal, model.goal)
+        XCTAssertEqual(loaded.patterns.count, model.patterns.count)
+        XCTAssertEqual(loaded.muscles.count, model.muscles.count)
+        XCTAssertEqual(loaded.exercises.count, model.exercises.count)
+        XCTAssertEqual(loaded.totalSessionCount, model.totalSessionCount)
+        XCTAssertEqual(loaded, model)
+    }
+}

--- a/ProjectApexTests/TraineeModelLocalStoreTests.swift
+++ b/ProjectApexTests/TraineeModelLocalStoreTests.swift
@@ -8,15 +8,23 @@
 // requirements), so all store interactions must happen on the main actor.
 // XCTest fully supports @MainActor test classes.
 //
-// All tests use an in-memory SwiftData container unless persistence across
-// simulated restart is being tested (which requires an on-disk container
-// at a temp URL that is cleaned up in tearDown).
+// Lifecycle design: the store is created in setUp() async throws and destroyed
+// in tearDown() async throws. Both run inside a Swift Concurrency Task, which
+// is required because ModelContainer uses task-local executor storage
+// internally — its deallocation must happen while an active Task exists.
+// Creating / destroying the store inside synchronous test methods (where no
+// Task is active) triggers swift_task_deinitOnExecutorImpl → crash.
+//
+// The persistence-across-restart test creates its own on-disk stores; it is
+// marked async for the same reason (local store variables are released at the
+// end of an async function, still within a Task).
 //
 // Behaviors covered:
 //   • Empty store returns nil on load()
 //   • save → load round-trips the model faithfully
 //   • Second save replaces first (upsert semantics)
 //   • clear() empties the store
+//   • clear() on empty store does not throw
 //   • Persistence survives simulated restart (new container, same SQLite file)
 //   • Cold-start hydration from a representative Edge Function payload
 
@@ -27,11 +35,19 @@ import SwiftData
 @MainActor
 final class TraineeModelLocalStoreTests: XCTestCase {
 
-    // MARK: ─── Helpers ────────────────────────────────────────────────────────
+    // MARK: ─── Lifecycle ─────────────────────────────────────────────────────
 
-    private func makeStore() throws -> TraineeModelLocalStore {
-        try TraineeModelLocalStore.makeInMemory()
+    private var store: TraineeModelLocalStore!
+
+    override func setUp() async throws {
+        store = try TraineeModelLocalStore.makeInMemory()
     }
+
+    override func tearDown() async throws {
+        store = nil
+    }
+
+    // MARK: ─── Helpers ────────────────────────────────────────────────────────
 
     /// Minimal TraineeModel for basic round-trip tests. Uses a fixed Date so
     /// JSON encode → decode produces bit-identical values.
@@ -106,14 +122,12 @@ final class TraineeModelLocalStoreTests: XCTestCase {
     // MARK: ─── Cycle 1: empty store → nil ────────────────────────────────────
 
     func test_load_returnsNil_whenStoreIsEmpty() throws {
-        let store = try makeStore()
         XCTAssertNil(store.load())
     }
 
     // MARK: ─── Cycle 2: save → load round-trip ────────────────────────────────
 
     func test_saveAndLoad_roundTripsModel() throws {
-        let store = try makeStore()
         let model = makeMinimalModel()
         try store.save(model)
         let loaded = store.load()
@@ -124,7 +138,6 @@ final class TraineeModelLocalStoreTests: XCTestCase {
     // MARK: ─── Cycle 3: second save replaces first ───────────────────────────
 
     func test_save_twice_secondValueWins() throws {
-        let store = try makeStore()
         let modelA = makeMinimalModel()
         var modelB = makeMinimalModel()
         modelB.goal = GoalState(
@@ -144,7 +157,6 @@ final class TraineeModelLocalStoreTests: XCTestCase {
     // MARK: ─── Cycle 4: clear → nil ─────────────────────────────────────────
 
     func test_clear_afterSave_returnsNilOnNextLoad() throws {
-        let store = try makeStore()
         try store.save(makeMinimalModel())
         XCTAssertNotNil(store.load(), "Precondition: model exists before clear")
 
@@ -154,12 +166,12 @@ final class TraineeModelLocalStoreTests: XCTestCase {
     }
 
     func test_clear_onEmptyStore_doesNotThrow() {
-        XCTAssertNoThrow(try makeStore().clear())
+        XCTAssertNoThrow(try store.clear())
     }
 
     // MARK: ─── Cycle 5: persistence across simulated restart ─────────────────
 
-    func test_persistenceAcrossSimulatedRestart() throws {
+    func test_persistenceAcrossSimulatedRestart() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension("sqlite")
@@ -167,16 +179,17 @@ final class TraineeModelLocalStoreTests: XCTestCase {
 
         let model = makeMinimalModel()
 
-        // First "launch" — save and release the store
+        // First "launch" — save and release the store (dealloc in async Task)
         do {
-            let store = try TraineeModelLocalStore.makeOnDisk(at: url)
-            try store.save(model)
-            // store deallocated here; SQLite file remains on disk
+            let store1 = try TraineeModelLocalStore.makeOnDisk(at: url)
+            try store1.save(model)
+            // store1 released here, still inside async Task — safe
         }
 
         // Second "launch" — open same file with a fresh container
         let store2 = try TraineeModelLocalStore.makeOnDisk(at: url)
         let loaded = store2.load()
+        // store2 released at end of async function — safe
 
         XCTAssertNotNil(loaded, "Expected persisted model to survive container recreation")
         XCTAssertEqual(loaded, model)
@@ -185,7 +198,6 @@ final class TraineeModelLocalStoreTests: XCTestCase {
     // MARK: ─── Cycle 6: cold-start from representative payload ───────────────
 
     func test_coldStart_representativePayload_roundTrips() throws {
-        let store = try makeStore()
         let model = makeRepresentativeModel()
 
         try store.save(model)


### PR DESCRIPTION
## Summary

- **`ProjectApex/Services/TraineeModelLocalStore.swift`** — `@MainActor`-isolated class wrapping a single `@Model` row (`LocalTraineeModelRecord`). The full `TraineeModel` is JSON-encoded into `modelJSON: Data`, mirroring the `trainee_models.model_json` JSONB column. Not flattened — one document-style row per ADR-0005/ADR-0006. Public API: `load() -> TraineeModel?`, `save(_:) throws`, `clear() throws`. Factories: `makeShared()`, `makeInMemory()`, `makeOnDisk(at:)`.
- **`ProjectApexTests/TraineeModelLocalStoreTests.swift`** — 7 integration tests covering all acceptance criteria (see test plan below).

**`@MainActor` is load-bearing:** `ModelContainer` uses internal main-actor executor requirements (task-local storage for `@ModelActor` infrastructure). Dealloc off the main actor aborts with `swift_task_deinitOnExecutorImpl` / `___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED`. The annotation ensures the entire lifecycle stays on the main actor. `TraineeModelService` (Slice #11) will `await` across the actor boundary.

Closes #8

## Pre-deploy note

No migration needed — purely additive, no legacy storage for this entity.

## Test plan

- [x] `test_load_returnsNil_whenStoreIsEmpty` — first-launch behaviour
- [x] `test_saveAndLoad_roundTripsModel` — basic JSON round-trip
- [x] `test_save_twice_secondValueWins` — upsert semantics
- [x] `test_clear_afterSave_returnsNilOnNextLoad` — clear empties store
- [x] `test_clear_onEmptyStore_doesNotThrow` — clear is safe on empty store
- [x] `test_persistenceAcrossSimulatedRestart` — new container, same SQLite file, model survives
- [x] `test_coldStart_representativePayload_roundTrips` — representative Edge Function payload with patterns, muscles, exercises round-trips exactly

All 7 tests pass on iPhone 17 simulator (iOS 26.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)