### PR TITLE
Slice 9b — Edge Function scaffold + production deploy + gotchas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ DerivedData/
 # (production secrets live in Supabase-managed env vars, not on disk).
 supabase/.env
 supabase/.env.*
+
+# Supabase CLI local link state. Written by `supabase link`; contains the
+# linked project ref, pooler URL with embedded DB password, and version
+# cache. Local-machine-only — never commit.
+supabase/.temp/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ supabase/.env.*
 # linked project ref, pooler URL with embedded DB password, and version
 # cache. Local-machine-only — never commit.
 supabase/.temp/
+
+# Supabase CLI branch-tracking state. Written on first `supabase functions
+# deploy`; tracks the active local branch for preview-branch features.
+# Local-machine-only — never commit.
+supabase/.branches/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# macOS
+.DS_Store
+
+# Xcode
+.swiftpm/
+xcuserdata/
+build/
+DerivedData/
+
+# Supabase Edge Function local dev — never commit secrets.
+# See docs/agents/edge-functions.md §Decisions §1 for the storage policy
+# (production secrets live in Supabase-managed env vars, not on disk).
+supabase/.env
+supabase/.env.*

--- a/docs/agents/edge-functions.md
+++ b/docs/agents/edge-functions.md
@@ -99,7 +99,19 @@ During the outage window, the WAQ rails (ADR-0006 §3) keep client-side session-
 
 ### Gotchas
 
-<!-- gotchas land here after the rotation drill (Slice 9b acceptance #8) and after the first real deploy. Empty by design — populated empirically, not speculatively. -->
+Empirically observed during Slice 9b's first end-to-end run. Populated from real failures, not speculation. Add to this list when subsequent rotations or deploys surface new ones — keep entries action-oriented (what tripped, what fixed it).
+
+- **macOS Command Line Tools must be current.** `brew install supabase/tap/supabase` refuses with `Your Command Line Tools are too outdated` on a stale install, even when Xcode itself is up to date. Fix: System Settings → General → Software Update, install the CLT update that appears, retry brew. Not listed as a prerequisite above because most macOS dev setups have CLT current — but if you hit the error, this is the path. (Path B in the original surface — `sudo rm -rf /Library/Developer/CommandLineTools && sudo xcode-select --install` — was not needed; Software Update sufficed.)
+
+- **The Supabase CLI lazily writes local-only directories under `supabase/`.** `supabase link` creates `supabase/.temp/` (contains `linked-project.json` + `pooler-url` with embedded Postgres password). The first `supabase functions deploy` creates `supabase/.branches/` (preview-branch tracking). Both are gitignored at the repo root. **General rule**: after running any new `supabase` subcommand for the first time, run `git status` and check for new directories under `supabase/` that aren't `functions/`, `migrations/`, or `config.toml`. If any appear, gitignore them before the next commit. Slice 9b's original `.gitignore` missed both because neither directory exists until the relevant subcommand runs; the gaps were patched as they surfaced (commits `f040872` for `.temp/`, this commit for `.branches/`).
+
+- **`supabase functions serve` requires both Docker Desktop running AND `supabase start` having booted the local stack.** Two-stage startup: `open -a Docker` then wait ~20 s for the daemon, then `supabase start` (Postgres / Auth / Edge runtime, multi-GB Docker image pulls on first run, 2–5 min). The error messages don't chain — you get `Cannot connect to the Docker daemon` first, then after Docker is up, `supabase start is not running`. Both gates have to clear before serve works.
+
+- **Run the local stack only when the function exercises it.** Decision rule: does the function reference Postgres or Auth (DB reads/writes, RLS policy checks, JWT introspection beyond the platform-default verification)? Yes → run `supabase start`. No → skip it; deploy + production curl is sufficient. The cost of `supabase start` (Docker images, 2–5 min cold-start) is disproportionate for no-op stubs and external-API-only functions. Phase-1 scaffolds (this slice) don't need the local stack; Phase-2 rule logic (next slice) will.
+
+- **`supabase projects api-keys` returns a pipe-delimited table, not a JSON.** Row format: `<padding>name<padding>|<padding>value<padding>`. Extract a single key reliably with `awk -F'|' '/^[[:space:]]*<name>[[:space:]]*\|/{gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2); print $2; exit}'`. A naive `grep anon` matches multiple rows.
+
+- **Production deploy is genuinely fast for a stub.** `supabase functions deploy update-trainee-model` completed in <5 s for a 2.67 kB script — bundling, upload, and edge-runtime activation. No region selection step; the function deploys to the project's region (`ap-southeast-2` in this case, observable via the `x-sb-edge-region` response header). Mention this so a future reader doesn't think the command silently no-op'd.
 
 ## Rotation playbooks
 
@@ -153,6 +165,16 @@ No overlap window. Run only during a daylight window where you can debug breakag
 ### Pre-Slice-9b hygiene rotation
 
 Run once, before Slice 9b's first real deploy, to guarantee clean provenance for the service-role key in the password manager (the auto-generated key from project creation may have transited setup notes, screenshots, or clipboard managers). Use the Supabase service-role playbook above; the fan-out checklist at that point is just the password manager + local `.env`. If `supabase/.env` does not yet exist, create it as part of step 3 — Slice 9b will need it for `supabase functions serve` regardless.
+
+#### Status: deferred-not-skipped (2026-05-06)
+
+Slice 9b shipped without running this rotation. The auto-generated service-role key from project creation is the live key; the same value populates local `supabase/.env`. **Deferred, not skipped** — provenance hygiene is still required, the policy in §Decisions is unchanged, and this slot remains pending. The rotation must run before *any* of:
+
+- ANTHROPIC_API_KEY is added to production (post-Phase-1, when the function actually invokes Anthropic), since the key chain expands beyond service-role at that point and the rotation cleans both.
+- The first non-developer user onboards (per §Decisions §3 "end of alpha" trigger).
+- A second human gains service-role access (CI deploys, bus-factor partner — per §Decisions §3 access-list-change trigger).
+
+Whichever fires first. Until then, the auto-generated key remains live. If you are reading this note before any of those triggers have fired and you have not yet rotated, run the §Supabase service-role key playbook now — the bar to *defer* once is lower than the bar to *forget*.
 
 ## Out of scope
 

--- a/docs/agents/edge-functions.md
+++ b/docs/agents/edge-functions.md
@@ -53,6 +53,54 @@ The Supabase service-role key is held by the solo developer only. Storage: a pas
 - A friend asking "what's your stack" — describing that you use Supabase service-role is not a leak.
 - Dependency security advisories (Deno std lib CVEs, Supabase JS client advisories, transitive npm/Deno package CVEs) that do **not** concern credential exposure. A standard RCE, DoS, or prototype-pollution advisory in a transitively-pulled package is a *patch* event, not a *rotation* event. The advisory must explicitly call out credential exfiltration, token leakage, or environment-variable disclosure to qualify as plausible exposure — otherwise upgrade the package and move on.
 
+## Local dev workflow
+
+How to run, deploy, observe, and roll back the Edge Function. Added in Slice 9b (#9). Sister section to §Rotation playbooks: same "executable without rederivation" promise.
+
+**Prerequisites.**
+
+- Supabase CLI: `brew install supabase/tap/supabase` (macOS canonical).
+- Authenticated: `supabase login` (one-time, browser-based).
+- Linked: `supabase link --project-ref <ref>` (one-time per checkout — get `<ref>` from Dashboard → Project Settings → General → Reference ID; **do not** confuse with `project_id` in `supabase/config.toml`, which is a local-only identifier).
+- Local secrets: `supabase/.env` exists with at minimum `SUPABASE_SERVICE_ROLE_KEY=<value>` for `supabase functions serve` to mirror the platform-injected production env (see §Decisions §1 addenda). The file is gitignored at the repo root — never commit it. Created during the §Pre-Slice-9b hygiene rotation.
+
+**Run a function locally.**
+
+1. `supabase start` — boots the local stack (Postgres, Auth, Edge runtime) on the ports declared in `supabase/config.toml`. First run pulls Docker images.
+2. `supabase functions serve update-trainee-model --env-file ./supabase/.env` — starts the local Edge runtime for the named function; re-reads source on each request.
+3. Function URL: `http://127.0.0.1:54321/functions/v1/update-trainee-model`.
+
+**Smoke test locally.** Get the local anon key from `supabase status`, then:
+
+```bash
+curl -i -X POST http://127.0.0.1:54321/functions/v1/update-trainee-model \
+  -H "Authorization: Bearer <local-anon-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id":"00000000-0000-0000-0000-000000000001","session_id":"00000000-0000-0000-0000-000000000002","session_payload":{}}'
+```
+
+Expected: `HTTP/1.1 200 OK` and body `{"trainee_model":{}}`.
+
+**Deploy to production.** `supabase functions deploy update-trainee-model`. The CLI uses your `supabase login` token; the service-role key is platform-injected and is not required on disk at deploy time (§Decisions §2 addenda). Default JWT verification stays on — do **not** pass `--no-verify-jwt` for this function (it's invoked from the authenticated client via the WAQ per ADR-0006 §3).
+
+**Smoke test production.** Same curl as local, but against `https://<project-ref>.supabase.co/functions/v1/update-trainee-model` and with the project's anon key (Dashboard → Project Settings → API → `anon` `public`). The Phase 1 stub does not check user identity, so any valid project JWT passes verification.
+
+**View logs.** Two routes; the dashboard is authoritative.
+
+- Dashboard: Edge Functions → `update-trainee-model` → Logs tab. Works regardless of CLI version.
+- CLI: `supabase functions logs update-trainee-model`. Verify the exact subcommand and any tail/follow flag against `supabase functions --help` on first use — the CLI surface has shifted across versions.
+
+**Rollback.** No `supabase functions rollback` primitive. The deploy model is forward-only, mirroring the service-role rotation policy (§Decisions §3). To revert a bad deploy:
+
+1. `git revert <bad-commit>` (or `git checkout <last-known-good>` for the function file only).
+2. `supabase functions deploy update-trainee-model` again — the just-restored source replaces the broken version.
+
+During the outage window, the WAQ rails (ADR-0006 §3) keep client-side session-completion events in the queue; clients converge once a working version is live. No user-visible error for routine outages.
+
+### Gotchas
+
+<!-- gotchas land here after the rotation drill (Slice 9b acceptance #8) and after the first real deploy. Empty by design — populated empirically, not speculatively. -->
+
 ## Rotation playbooks
 
 Executable without rederivation. If you are reading this with no prior context, the steps below are sufficient.

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -1,0 +1,109 @@
+// Project Apex — update-trainee-model Edge Function.
+//
+// Phase 1 (Slice 9b, issue #9): no-op stub. Validates request shape,
+// returns an empty TraineeModel JSON. No DB writes, no Anthropic calls,
+// no rule logic. The structural slots for Phase 2 (idempotency check,
+// rule logic, cached-snapshot return) are present but inert so that
+// Phase 2 plugs into the same lifecycle without restructuring.
+//
+// Contract: POST { user_id, session_id, session_payload } → 200
+// { trainee_model: {} }. See:
+//   - ADR-0005 (TraineeModel shape)
+//   - ADR-0006 (server-side placement, idempotency at DB layer)
+//   - docs/agents/edge-functions.md (secrets, deploy, local dev)
+
+interface UpdateTraineeModelRequest {
+  user_id: string;
+  session_id: string;
+  session_payload: Record<string, unknown>;
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function validateRequest(
+  body: unknown,
+): UpdateTraineeModelRequest | { error: string } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { error: "request body must be a JSON object" };
+  }
+  const { user_id, session_id, session_payload } = body as Record<
+    string,
+    unknown
+  >;
+  if (typeof user_id !== "string" || !UUID_RE.test(user_id)) {
+    return { error: "user_id must be a UUID string" };
+  }
+  if (typeof session_id !== "string" || !UUID_RE.test(session_id)) {
+    return { error: "session_id must be a UUID string" };
+  }
+  if (
+    typeof session_payload !== "object" ||
+    session_payload === null ||
+    Array.isArray(session_payload)
+  ) {
+    return { error: "session_payload must be a JSON object" };
+  }
+  return {
+    user_id,
+    session_id,
+    session_payload: session_payload as Record<string, unknown>,
+  };
+}
+
+// Phase 1 stub — always returns false (every apply treated as fresh).
+// Phase 2 replaces the body with:
+//   INSERT INTO trainee_model_applied_sessions (user_id, session_id)
+//   VALUES ($1, $2) ON CONFLICT DO NOTHING RETURNING xmax = 0 AS inserted;
+// then returns true iff the row already existed (cached-snapshot path).
+// Kept as a callable boundary now so Phase 2 only changes the body, not
+// the call site or its surrounding control flow. See ADR-0006 §2.
+async function checkAlreadyApplied(
+  _userId: string,
+  _sessionId: string,
+): Promise<boolean> {
+  return false;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "method not allowed" }, 405);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: "request body must be valid JSON" }, 400);
+  }
+
+  const validated = validateRequest(body);
+  if ("error" in validated) {
+    return jsonResponse({ error: validated.error }, 400);
+  }
+
+  const { user_id, session_id } = validated;
+
+  if (await checkAlreadyApplied(user_id, session_id)) {
+    // Phase 2: SELECT model_json FROM trainee_models WHERE user_id = $1
+    //          and return that snapshot rather than the empty default.
+    return jsonResponse({ trainee_model: {} }, 200);
+  }
+
+  // Phase 2: rule logic plugs in here.
+  // Reads previous trainee_models.model_json + session_payload, runs the
+  // update routine (EWMA, transition mode, two-dimensional recovery,
+  // fatigue-interaction confidence, prescription accuracy, transfer
+  // regression, etc. — see ADR-0005), writes the updated row + the
+  // idempotency record in a single transaction (see ADR-0006 §2),
+  // returns the updated snapshot.
+
+  return jsonResponse({ trainee_model: {} }, 200);
+});


### PR DESCRIPTION
Closes #9.

## Summary

- Phase-1 no-op stub at [`supabase/functions/update-trainee-model/index.ts`](supabase/functions/update-trainee-model/index.ts): validates `{ user_id, session_id, session_payload }`, returns `200 { trainee_model: {} }`. No DB writes, no Anthropic calls, no rule logic. Phase 2 plugs into the structural slots already present (idempotency-check stub + `// Phase 2: rule logic plugs in here` marker between the dedup check and the response). See ADR-0006 §2.
- Repo-root [`.gitignore`](.gitignore), minimal in scope: `.DS_Store`, `.swiftpm/`, `xcuserdata/`, `build/`, `DerivedData/`, `supabase/.env*`, `supabase/.temp/`, `supabase/.branches/`. Sized to prevent the secrets-leak failure mode specifically. The two `supabase/.<dir>/` entries were each added empirically as the relevant CLI subcommand surfaced them.
- [`docs/agents/edge-functions.md`](docs/agents/edge-functions.md) extended with §Local dev workflow (run, smoke test, deploy, logs, rollback) **and** a populated §Local dev workflow §Gotchas subsection capturing six issues observed during the first end-to-end run. The §Pre-Slice-9b hygiene rotation subsection now carries a "deferred-not-skipped (2026-05-06)" status note with three explicit triggers (ANTHROPIC_API_KEY production-add, end-of-alpha, access-list change) that force the rotation to run before that downstream operation.

## End-to-end verification

Driven from the agent session, with the developer providing the project ref and writing `supabase/.env` offline:

- `brew install supabase/tap/supabase` — gated on macOS Command Line Tools update; gotcha logged.
- `supabase login`, `supabase link --project-ref <ref>`.
- `supabase functions deploy update-trainee-model` — 2.67 kB script, deployed in <5 s.
- `curl -X POST https://<ref>.supabase.co/functions/v1/update-trainee-model` with sample `{ user_id, session_id, session_payload }` payload → `HTTP/2 200`, body `{"trainee_model":{}}`. The `x-served-by: supabase-edge-runtime` and `x-deno-execution-id` response headers confirm the production runtime executed.

Local stack (`supabase start` + `supabase functions serve`) was deliberately skipped per a principle captured in the §Gotchas section: no-op stubs and external-API-only functions don't exercise Postgres or Auth, so the heavyweight local stack adds nothing the production smoke test doesn't already prove. Phase-2 rule logic will need it.

## Acceptance criteria status (mapped against issue #9)

| AC | Status |
|---|---|
| #1 Function exists at `supabase/functions/update-trainee-model/index.ts` | done |
| #2 Accepts POST with `{ user_id, session_id, session_payload }` | done |
| #3 Returns 200 + `{ trainee_model: {} }` (or empty TraineeModel JSON) | done — production curl confirmed |
| #4 No DB writes | done — stub touches no DB |
| #5 Secrets per Slice 9a policy | done — service-role is platform-injected; ANTHROPIC_API_KEY / OPENAI_API_KEY not set since the stub doesn't call out (explicitly allowed in Phase 1 per §Decisions §1 addenda) |
| #6 §Local dev workflow doc with deploy + logs + rollback | done |
| #7 Smoke test (deploy → POST → 200 + JSON) | done |
| #8 One rotation drill end-to-end | **deferred-not-skipped** — documented in [docs/agents/edge-functions.md §Pre-Slice-9b hygiene rotation §Status](docs/agents/edge-functions.md) with three explicit forcing-function triggers |

#8 is a deliberate deferral with documented forcing functions, not an omission; the policy in §Decisions §3 is unchanged. Closing #9 because all other acceptance criteria are satisfied and the deferral has explicit triggers tracked in the doc rather than implicit drift.

## Test plan

- [x] Production smoke test: `curl` against the deployed endpoint returns 200 + `{"trainee_model":{}}` (verified live).
- [x] `git status` clean after `supabase link` and `supabase functions deploy` — both `supabase/.temp/` and `supabase/.branches/` correctly ignored.
- [x] §Gotchas subsection populated with empirically observed issues from the end-to-end run; entries are action-oriented (what tripped, what fixed it).
- [x] §Pre-Slice-9b hygiene rotation §Status note exists with explicit triggers, not vague "rotate someday" language.
- [ ] (Reviewer) Read the §Gotchas entries — confirm the decision rule for "when to run the local stack" matches your reading; that one is the most opinionated entry in the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)