### PR TITLE
Slice 6: set-intent three-phase migration + redesigned picker

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -62,7 +62,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EquipmentCatalogSeedTests.swift; path = EquipmentCatalogSeedTests.swift; sourceTree = "<group>"; };
+		18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EquipmentCatalogSeedTests.swift; sourceTree = "<group>"; };
 		1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MigrationDatesTests.swift; sourceTree = "<group>"; };
 		4422DE7829C0C124138BB4B0 /* WeekFatigueSignalsHelperAgreementTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeekFatigueSignalsHelperAgreementTests.swift; sourceTree = "<group>"; };
 		474B848C2F67D31C001E0879 /* MacroPlanServiceDayCountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroPlanServiceDayCountTests.swift; sourceTree = "<group>"; };
@@ -114,8 +114,6 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		47D91BC22F60266A007B3B34 /* ProjectApex */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = ProjectApex;
 			sourceTree = "<group>";
 		};

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0CFD5EC802FC7842DCAC24AE /* SetCompletionFormStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1E4BCA9CBB3EDBB8068E06 /* SetCompletionFormStateTests.swift */; };
 		32736E74E3F688020744DE5E /* EquipmentRounderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E3BA94C76430CACFD657B5 /* EquipmentRounderTests.swift */; };
 		39E16C19CFE1B1EF9BE00A32 /* TraineeModelEnumsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */; };
 		474B848D2F67D31C001E0879 /* MacroPlanServiceDayCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474B848C2F67D31C001E0879 /* MacroPlanServiceDayCountTests.swift */; };
@@ -26,10 +27,10 @@
 		47D91CB32F61A8CB007B3B34 /* GymProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D91CB22F61A8CB007B3B34 /* GymProfileTests.swift */; };
 		47D91CC12F61A9E7007B3B34 /* WorkoutContextAssemblyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D91CC02F61A9E7007B3B34 /* WorkoutContextAssemblyTests.swift */; };
 		47D91CC32F61AADC007B3B34 /* AIInferenceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D91CC22F61AADC007B3B34 /* AIInferenceServiceTests.swift */; };
-		47DFED092F99B001006F4B62 /* AnthropicProviderCachingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DFED082F99B001006F4B62 /* AnthropicProviderCachingTests.swift */; };
 		47DFECFD2F72C1FC006F4B62 /* ExerciseLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DFECFC2F72C1FC006F4B62 /* ExerciseLibraryTests.swift */; };
 		47DFED052F73D858006F4B62 /* StagnationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DFED042F73D858006F4B62 /* StagnationServiceTests.swift */; };
 		47DFED072F73D887006F4B62 /* VolumeValidationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DFED062F73D887006F4B62 /* VolumeValidationServiceTests.swift */; };
+		47DFED092F99B001006F4B62 /* AnthropicProviderCachingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DFED082F99B001006F4B62 /* AnthropicProviderCachingTests.swift */; };
 		47E356CB2F61BA7300C69CD6 /* SupabaseClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356CA2F61BA7300C69CD6 /* SupabaseClientTests.swift */; };
 		47E356CF2F61BFCF00C69CD6 /* EquipmentMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356CE2F61BFCF00C69CD6 /* EquipmentMergerTests.swift */; };
 		47E356DA2F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356D92F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift */; };
@@ -42,6 +43,7 @@
 		73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */; };
 		81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */; };
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
+		8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */; };
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
@@ -59,7 +61,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EquipmentCatalogSeedTests.swift; path = ProjectApexTests/EquipmentCatalogSeedTests.swift; sourceTree = "<group>"; };
+		18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EquipmentCatalogSeedTests.swift; path = EquipmentCatalogSeedTests.swift; sourceTree = "<group>"; };
 		1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MigrationDatesTests.swift; sourceTree = "<group>"; };
 		4422DE7829C0C124138BB4B0 /* WeekFatigueSignalsHelperAgreementTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WeekFatigueSignalsHelperAgreementTests.swift; sourceTree = "<group>"; };
 		474B848C2F67D31C001E0879 /* MacroPlanServiceDayCountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroPlanServiceDayCountTests.swift; sourceTree = "<group>"; };
@@ -80,13 +82,13 @@
 		47D91CB22F61A8CB007B3B34 /* GymProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymProfileTests.swift; sourceTree = "<group>"; };
 		47D91CC02F61A9E7007B3B34 /* WorkoutContextAssemblyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutContextAssemblyTests.swift; sourceTree = "<group>"; };
 		47D91CC22F61AADC007B3B34 /* AIInferenceServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIInferenceServiceTests.swift; sourceTree = "<group>"; };
-		47DFED082F99B001006F4B62 /* AnthropicProviderCachingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicProviderCachingTests.swift; sourceTree = "<group>"; };
 		47DFECED2F723975006F4B62 /* InferenceRetrySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceRetrySheet.swift; sourceTree = "<group>"; };
 		47DFECF42F7261C1006F4B62 /* ExerciseSwapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSwapViewModel.swift; sourceTree = "<group>"; };
 		47DFECF52F7261EE006F4B62 /* ExerciseSwapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSwapView.swift; sourceTree = "<group>"; };
 		47DFECFC2F72C1FC006F4B62 /* ExerciseLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseLibraryTests.swift; sourceTree = "<group>"; };
 		47DFED042F73D858006F4B62 /* StagnationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagnationServiceTests.swift; sourceTree = "<group>"; };
 		47DFED062F73D887006F4B62 /* VolumeValidationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeValidationServiceTests.swift; sourceTree = "<group>"; };
+		47DFED082F99B001006F4B62 /* AnthropicProviderCachingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicProviderCachingTests.swift; sourceTree = "<group>"; };
 		47E356CA2F61BA7300C69CD6 /* SupabaseClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClientTests.swift; sourceTree = "<group>"; };
 		47E356CE2F61BFCF00C69CD6 /* EquipmentMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquipmentMergerTests.swift; sourceTree = "<group>"; };
 		47E356D92F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultWeightIncrementsTests.swift; sourceTree = "<group>"; };
@@ -97,9 +99,11 @@
 		878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelProfilesTests.swift; sourceTree = "<group>"; };
 		993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelSnapshotsTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
+		DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetPrescriptionIntentValidationTests.swift; sourceTree = "<group>"; };
 		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
 		E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MuscleTaxonomyTests.swift; sourceTree = "<group>"; };
 		E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelLocalStoreTests.swift; sourceTree = "<group>"; };
+		ED1E4BCA9CBB3EDBB8068E06 /* SetCompletionFormStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetCompletionFormStateTests.swift; sourceTree = "<group>"; };
 		EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelEnumsTests.swift; sourceTree = "<group>"; };
 		EFB324F8EA1B317B0F90575B /* ProjectApexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProjectApexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MovementPatternTests.swift; sourceTree = "<group>"; };
@@ -229,6 +233,8 @@
 				4422DE7829C0C124138BB4B0 /* WeekFatigueSignalsHelperAgreementTests.swift */,
 				E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */,
 				18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */,
+				ED1E4BCA9CBB3EDBB8068E06 /* SetCompletionFormStateTests.swift */,
+				DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -369,6 +375,8 @@
 				5DE94F8F1D136C65C96FCAD1 /* WeekFatigueSignalsHelperAgreementTests.swift in Sources */,
 				A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */,
 				E50E3B4CBD53ED7ABE725DB8 /* EquipmentCatalogSeedTests.swift in Sources */,
+				0CFD5EC802FC7842DCAC24AE /* SetCompletionFormStateTests.swift in Sources */,
+				8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		6ED5B7636B15C7C513C11C2E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC23D0A3EB460CF97B18574 /* Foundation.framework */; };
 		729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */; };
 		73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */; };
+		7D8C4E6ADC8DEDCA31B72B1D /* ManualLogIntentGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */; };
 		81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */; };
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
 		8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */; };
@@ -104,6 +105,7 @@
 		E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MuscleTaxonomyTests.swift; sourceTree = "<group>"; };
 		E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelLocalStoreTests.swift; sourceTree = "<group>"; };
 		ED1E4BCA9CBB3EDBB8068E06 /* SetCompletionFormStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetCompletionFormStateTests.swift; sourceTree = "<group>"; };
+		ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualLogIntentGateTests.swift; sourceTree = "<group>"; };
 		EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelEnumsTests.swift; sourceTree = "<group>"; };
 		EFB324F8EA1B317B0F90575B /* ProjectApexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProjectApexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MovementPatternTests.swift; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 				18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */,
 				ED1E4BCA9CBB3EDBB8068E06 /* SetCompletionFormStateTests.swift */,
 				DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */,
+				ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -377,6 +380,7 @@
 				E50E3B4CBD53ED7ABE725DB8 /* EquipmentCatalogSeedTests.swift in Sources */,
 				0CFD5EC802FC7842DCAC24AE /* SetCompletionFormStateTests.swift in Sources */,
 				8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */,
+				7D8C4E6ADC8DEDCA31B72B1D /* ManualLogIntentGateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/AICoach/AIInferenceService.swift
+++ b/ProjectApex/AICoach/AIInferenceService.swift
@@ -221,6 +221,23 @@ nonisolated struct CompletedSet: Codable, Sendable {
     /// How many days ago this set was completed (0 = today, 1 = yesterday, etc.).
     /// Used by the AI to weight recent performance more heavily than older sets.
     let daysAgo: Int?
+    /// What the user actually did on this set (Slice 6 / #10). For AI-prescribed
+    /// sets without deviation: equals `prescribedIntent`. For deviated sets: the
+    /// user's explicit pick. For freestyle sets: the user's pick. Nil only for
+    /// pre-Slice-6 historical rows that were never tagged.
+    let intent: String?
+    /// What the AI prescribed for this set, captured for in-prompt deviation
+    /// reasoning. Nil for freestyle (no prescription). Slice 6 / #10.
+    let prescribedIntent: String?
+    /// Materialized boolean — true when `intent != prescribedIntent` and both
+    /// are non-nil. Derivable from the two fields above; carried explicitly so
+    /// the AI prompt has unambiguous deviation signal without having to compare
+    /// strings. Nil for freestyle (no prescription to deviate from).
+    let isDeviation: Bool?
+    /// User-raised flags on the rep/RPE sheet immediately post-set.
+    /// Empty array (or nil) = no flags raised. Slice 6 / #10. Cross-session
+    /// persistence via DB column tracked separately as #43.
+    let completionFlags: [String]?
 
     enum CodingKeys: String, CodingKey {
         case setNumber              = "set_number"
@@ -233,6 +250,45 @@ nonisolated struct CompletedSet: Codable, Sendable {
         case completedAt            = "completed_at"
         case userCorrectedWeight    = "user_corrected_weight"
         case daysAgo                = "days_ago"
+        case intent
+        case prescribedIntent       = "prescribed_intent"
+        case isDeviation            = "is_deviation"
+        case completionFlags        = "completion_flags"
+    }
+
+    /// Memberwise init with the four Slice 6 (#10) fields defaulted to nil so
+    /// existing call sites that don't yet know about intent/deviation/flags
+    /// continue to compile. New call sites supply them explicitly.
+    nonisolated init(
+        setNumber: Int,
+        weightKg: Double,
+        reps: Int,
+        rirActual: Int?,
+        rpe: Double?,
+        tempo: String?,
+        restTakenSeconds: Int?,
+        completedAt: Date?,
+        userCorrectedWeight: Bool?,
+        daysAgo: Int?,
+        intent: String? = nil,
+        prescribedIntent: String? = nil,
+        isDeviation: Bool? = nil,
+        completionFlags: [String]? = nil
+    ) {
+        self.setNumber = setNumber
+        self.weightKg = weightKg
+        self.reps = reps
+        self.rirActual = rirActual
+        self.rpe = rpe
+        self.tempo = tempo
+        self.restTakenSeconds = restTakenSeconds
+        self.completedAt = completedAt
+        self.userCorrectedWeight = userCorrectedWeight
+        self.daysAgo = daysAgo
+        self.intent = intent
+        self.prescribedIntent = prescribedIntent
+        self.isDeviation = isDeviation
+        self.completionFlags = completionFlags
     }
 }
 
@@ -378,6 +434,13 @@ nonisolated struct SetPrescription: Codable, Sendable {
     /// (e.g. `"intent": "bogus"`) is rethrown from `init(from:)` as
     /// `PrescriptionValidationError.invalidIntent`.
     var intent: SetIntent?
+    /// 1-line mental-set framing for this specific set, distinct from
+    /// `coachingCue`. Sets the user's frame BEFORE they lift; rendered on the
+    /// active set view's prescription card as a brief italic line under the
+    /// intent label. Required (no silent default), max 80 chars. Slice 6 / #10.
+    /// Same Codable-optional shape as `intent` so `validate()` produces a
+    /// typed `.missingSetFraming` rather than a raw `DecodingError`.
+    var setFraming: String?
 
     enum CodingKeys: String, CodingKey {
         case weightKg            = "weight_kg"
@@ -392,6 +455,7 @@ nonisolated struct SetPrescription: Codable, Sendable {
         case userCorrectedWeight = "user_corrected_weight"
         case isManualFallback    = "is_manual_fallback"
         case intent
+        case setFraming          = "set_framing"
     }
 
     nonisolated init(
@@ -406,7 +470,8 @@ nonisolated struct SetPrescription: Codable, Sendable {
         confidence: Double? = nil,
         userCorrectedWeight: Bool? = nil,
         isManualFallback: Bool? = nil,
-        intent: SetIntent? = nil
+        intent: SetIntent? = nil,
+        setFraming: String? = nil
     ) {
         self.weightKg            = weightKg
         self.reps                = reps
@@ -420,6 +485,7 @@ nonisolated struct SetPrescription: Codable, Sendable {
         self.userCorrectedWeight = userCorrectedWeight
         self.isManualFallback    = isManualFallback
         self.intent              = intent
+        self.setFraming          = setFraming
     }
 
     nonisolated init(from decoder: Decoder) throws {
@@ -460,6 +526,22 @@ nonisolated struct SetPrescription: Codable, Sendable {
         } else {
             intent = nil
         }
+
+        // setFraming: same Codable-optional shape as intent. Missing surfaces
+        // as nil → caught by validate() as `.missingSetFraming`. Non-string
+        // surfaces as a typed `.invalidSetFraming` so the AIInferenceService
+        // fail-fast path treats it as a permanent error per ADR-0007 §1.
+        if c.contains(.setFraming) {
+            let raw: String
+            do {
+                raw = try c.decode(String.self, forKey: .setFraming)
+            } catch {
+                throw PrescriptionValidationError.invalidSetFraming
+            }
+            setFraming = raw
+        } else {
+            setFraming = nil
+        }
     }
 
     nonisolated func encode(to encoder: Encoder) throws {
@@ -476,6 +558,7 @@ nonisolated struct SetPrescription: Codable, Sendable {
         try c.encodeIfPresent(userCorrectedWeight, forKey: .userCorrectedWeight)
         try c.encodeIfPresent(isManualFallback,    forKey: .isManualFallback)
         try c.encodeIfPresent(intent,              forKey: .intent)
+        try c.encodeIfPresent(setFraming,          forKey: .setFraming)
     }
 }
 
@@ -505,6 +588,15 @@ nonisolated enum PrescriptionValidationError: LocalizedError, Equatable {
     /// `intent` field present but unparseable (unknown raw value or wrong
     /// JSON type). Permanent per ADR-0007 §1.
     case invalidIntent(String)
+    /// `set_framing` field absent from the AI's JSON response. Permanent per
+    /// ADR-0007 §1. Slice 6 / #10.
+    case missingSetFraming
+    /// `set_framing` field present but wrong type (e.g. number instead of
+    /// string). Permanent per ADR-0007 §1.
+    case invalidSetFraming
+    /// `set_framing` longer than 80 chars. Permanent per ADR-0007 §1 —
+    /// retry without prompt change won't fix.
+    case setFramingTooLong(Int)
 
     var errorDescription: String? {
         switch self {
@@ -526,6 +618,12 @@ nonisolated enum PrescriptionValidationError: LocalizedError, Equatable {
             return "intent field missing — required per ADR-0005 with no silent default."
         case .invalidIntent(let raw):
             return "intent '\(raw)' is not one of warmup/top/backoff/technique/amrap."
+        case .missingSetFraming:
+            return "set_framing field missing — required per Slice 6 with no silent default."
+        case .invalidSetFraming:
+            return "set_framing must be a string."
+        case .setFramingTooLong(let v):
+            return "set_framing is \(v) chars (max 80)."
         }
     }
 }
@@ -541,6 +639,14 @@ extension SetPrescription {
         // (`AIInferenceService.prescribe`) treats it as fail-fast.
         guard intent != nil else {
             throw PrescriptionValidationError.missingIntent
+        }
+        // Set-framing gate fires next, before field-level checks. Same
+        // no-silent-default regime as intent.
+        guard let framing = setFraming else {
+            throw PrescriptionValidationError.missingSetFraming
+        }
+        guard framing.count <= 80 else {
+            throw PrescriptionValidationError.setFramingTooLong(framing.count)
         }
         guard weightKg >= 0, weightKg <= 500 else {
             throw PrescriptionValidationError.invalidWeight(weightKg)
@@ -1058,7 +1164,8 @@ actor AIInferenceService {
             "reasoning": "<string, max 200 chars>",
             "safety_flags": ["shoulder_caution"|"joint_concern"|"fatigue_high"|"pain_reported"|"deload_recommended"],
             "confidence": <number 0.0–1.0, optional>,
-            "intent": "warmup"|"top"|"backoff"|"technique"|"amrap"
+            "intent": "warmup"|"top"|"backoff"|"technique"|"amrap",
+            "set_framing": "<string, max 80 chars>"
           }
         }
 
@@ -1074,6 +1181,30 @@ actor AIInferenceService {
             * backoff:   secondary working set following a top set, typically 70–85% of top weight.
             * technique: tempo/form-focused practice; load is incidental, may be light.
             * amrap:     last-set-as-many-reps-as-possible at the prescribed weight.
+        - set_framing is REQUIRED. A 1-line mental-set framing for THIS specific set, distinct from
+          coaching_cue. Sets the user's frame BEFORE they lift; not a form reminder during. Max 80 chars.
+
+        GOOD set_framings (set the mental frame, typed by intent):
+            top:       "Heaviest work of the day. Brace and grind."
+            top:       "This is the set that moves the needle. Treat it that way."
+            warmup:    "Groove the pattern. Don't fight the bar."
+            warmup:    "Wake up the muscles. Save the effort for later."
+            backoff:   "Build volume on a manageable load."
+            backoff:   "More reps, less weight. Stay tight throughout."
+            technique: "Slow the tempo. Quality over load."
+            technique: "Feel the right muscles working. Forget the number."
+            amrap:     "Push to genuine failure with form intact."
+            amrap:     "Last set, no reservations. Stop only when reps break."
+
+        BAD set_framings to avoid:
+            - Generic encouragement: "You got this!", "Make it count!", "Crush it!"
+              These add no information and condescend.
+            - Form cues that belong in coaching_cue: "Drive through your heels",
+              "Retract your scapulae", "Brace your core".
+              coaching_cue is the form note for the reps; set_framing is the frame for the set.
+            - Long sentences. Hard cap 80 chars; aim for ~50–70.
+            - Restating reps/weight: "Do 8 reps at 80kg." The user can already see those numbers.
+            - Repeating the intent word: "This is your top set." The intent label is already shown.
 
         EQUIPMENT-AWARE WEIGHT INCREMENTS:
         - barbell: minimum 5 kg increment. Use 2.5 kg only near a natural plate boundary (20/60/100 kg).

--- a/ProjectApex/AICoach/AIInferenceService.swift
+++ b/ProjectApex/AICoach/AIInferenceService.swift
@@ -371,6 +371,13 @@ nonisolated struct SetPrescription: Codable, Sendable {
     /// True when the user tapped "Continue with last weights" on InferenceRetrySheet
     /// because AI inference was unavailable. Stored in the ai_prescribed JSONB blob.
     var isManualFallback: Bool?
+    /// Required field per ADR-0005 Slice 6 — gates which sets contribute to e1RM,
+    /// volume aggregation, and RPE calibration. Codable-optional so a missing key
+    /// surfaces as a typed `PrescriptionValidationError.missingIntent` from
+    /// `validate()` rather than a raw `DecodingError`. An invalid raw string
+    /// (e.g. `"intent": "bogus"`) is rethrown from `init(from:)` as
+    /// `PrescriptionValidationError.invalidIntent`.
+    var intent: SetIntent?
 
     enum CodingKeys: String, CodingKey {
         case weightKg            = "weight_kg"
@@ -384,6 +391,91 @@ nonisolated struct SetPrescription: Codable, Sendable {
         case confidence
         case userCorrectedWeight = "user_corrected_weight"
         case isManualFallback    = "is_manual_fallback"
+        case intent
+    }
+
+    nonisolated init(
+        weightKg: Double,
+        reps: Int,
+        tempo: String,
+        rirTarget: Int,
+        restSeconds: Int,
+        coachingCue: String,
+        reasoning: String,
+        safetyFlags: [SafetyFlag],
+        confidence: Double? = nil,
+        userCorrectedWeight: Bool? = nil,
+        isManualFallback: Bool? = nil,
+        intent: SetIntent? = nil
+    ) {
+        self.weightKg            = weightKg
+        self.reps                = reps
+        self.tempo               = tempo
+        self.rirTarget           = rirTarget
+        self.restSeconds         = restSeconds
+        self.coachingCue         = coachingCue
+        self.reasoning           = reasoning
+        self.safetyFlags         = safetyFlags
+        self.confidence          = confidence
+        self.userCorrectedWeight = userCorrectedWeight
+        self.isManualFallback    = isManualFallback
+        self.intent              = intent
+    }
+
+    nonisolated init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        weightKg            = try c.decode(Double.self,        forKey: .weightKg)
+        reps                = try c.decode(Int.self,           forKey: .reps)
+        tempo               = try c.decode(String.self,        forKey: .tempo)
+        rirTarget           = try c.decode(Int.self,           forKey: .rirTarget)
+        restSeconds         = try c.decode(Int.self,           forKey: .restSeconds)
+        coachingCue         = try c.decode(String.self,        forKey: .coachingCue)
+        reasoning           = try c.decode(String.self,        forKey: .reasoning)
+        safetyFlags         = try c.decode([SafetyFlag].self,  forKey: .safetyFlags)
+        confidence          = try c.decodeIfPresent(Double.self, forKey: .confidence)
+        userCorrectedWeight = try c.decodeIfPresent(Bool.self,   forKey: .userCorrectedWeight)
+        isManualFallback    = try c.decodeIfPresent(Bool.self,   forKey: .isManualFallback)
+
+        // Intent: decode as Optional<String> so we can route a missing key to
+        // `nil` (caught by `validate()` as `.missingIntent`) and a present-but-
+        // invalid value to a typed `.invalidIntent`. Both are permanent errors
+        // per ADR-0007 §1 — the LLM's response was malformed and a same-prompt
+        // retry will not fix it.
+        if c.contains(.intent) {
+            // contains(.intent) is true even when the value is JSON null;
+            // decodeIfPresent returns nil only on missing-key OR null, so
+            // pull the raw String through decode(...) to surface a type
+            // mismatch (e.g. `"intent": 42`) as `.invalidIntent` rather
+            // than a raw DecodingError.
+            let raw: String
+            do {
+                raw = try c.decode(String.self, forKey: .intent)
+            } catch {
+                throw PrescriptionValidationError.invalidIntent("<non-string>")
+            }
+            guard let parsed = SetIntent(rawValue: raw) else {
+                throw PrescriptionValidationError.invalidIntent(raw)
+            }
+            intent = parsed
+        } else {
+            intent = nil
+        }
+    }
+
+    nonisolated func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(weightKg,                forKey: .weightKg)
+        try c.encode(reps,                    forKey: .reps)
+        try c.encode(tempo,                   forKey: .tempo)
+        try c.encode(rirTarget,               forKey: .rirTarget)
+        try c.encode(restSeconds,             forKey: .restSeconds)
+        try c.encode(coachingCue,             forKey: .coachingCue)
+        try c.encode(reasoning,               forKey: .reasoning)
+        try c.encode(safetyFlags,             forKey: .safetyFlags)
+        try c.encodeIfPresent(confidence,          forKey: .confidence)
+        try c.encodeIfPresent(userCorrectedWeight, forKey: .userCorrectedWeight)
+        try c.encodeIfPresent(isManualFallback,    forKey: .isManualFallback)
+        try c.encodeIfPresent(intent,              forKey: .intent)
     }
 }
 
@@ -399,7 +491,7 @@ nonisolated enum SafetyFlag: String, Codable, Sendable {
 
 // MARK: Validation
 
-nonisolated enum PrescriptionValidationError: LocalizedError {
+nonisolated enum PrescriptionValidationError: LocalizedError, Equatable {
     case invalidWeight(Double)
     case invalidReps(Int)
     case invalidTempo(String)
@@ -407,6 +499,12 @@ nonisolated enum PrescriptionValidationError: LocalizedError {
     case coachingCueTooLong(Int)
     case reasoningTooLong(Int)
     case confidenceOutOfRange(Double)
+    /// `intent` field absent from the AI's JSON response. Permanent per
+    /// ADR-0007 §1 — same-prompt retry will not fix.
+    case missingIntent
+    /// `intent` field present but unparseable (unknown raw value or wrong
+    /// JSON type). Permanent per ADR-0007 §1.
+    case invalidIntent(String)
 
     var errorDescription: String? {
         switch self {
@@ -424,6 +522,10 @@ nonisolated enum PrescriptionValidationError: LocalizedError {
             return "reasoning is \(v) chars (max 200)."
         case .confidenceOutOfRange(let v):
             return "confidence \(v) is outside 0.0...1.0."
+        case .missingIntent:
+            return "intent field missing — required per ADR-0005 with no silent default."
+        case .invalidIntent(let raw):
+            return "intent '\(raw)' is not one of warmup/top/backoff/technique/amrap."
         }
     }
 }
@@ -433,6 +535,13 @@ extension SetPrescription {
     private nonisolated static let tempoRegex = try! NSRegularExpression(pattern: #"^\d-\d-\d-\d$"#)
 
     nonisolated func validate() throws {
+        // Intent gate fires first per Slice 6 / ADR-0005 — the no-silent-defaults
+        // contract is the load-bearing invariant for this slice. A missing-intent
+        // failure is a permanent malformed-response per ADR-0007 §1; the caller
+        // (`AIInferenceService.prescribe`) treats it as fail-fast.
+        guard intent != nil else {
+            throw PrescriptionValidationError.missingIntent
+        }
         guard weightKg >= 0, weightKg <= 500 else {
             throw PrescriptionValidationError.invalidWeight(weightKg)
         }
@@ -467,6 +576,12 @@ nonisolated enum FallbackReason: Sendable {
     case maxRetriesExceeded(lastError: String)
     case llmProviderError(String)
     case encodingFailed(String)
+    /// LLM returned a response that cannot be turned into a valid
+    /// SetPrescription — JSON decode failure, missing intent, invalid
+    /// intent, or any other validation rule. Permanent per ADR-0007 §1;
+    /// no same-prompt retry. Surfaced via `InferenceRetrySheet` so the
+    /// user gets agency rather than a silent default.
+    case malformedResponse(String)
 }
 
 nonisolated enum PrescriptionResult: Sendable {
@@ -656,112 +771,133 @@ actor AIInferenceService {
         }
 
         let systemPrompt = Self.systemPrompt
-        var userPayload = contextJSON
-        var lastErrorDescription: String = ""
+        let userPayload = contextJSON
 
-        for attempt in 0...maxRetries {
-            // Append correction instruction on retries
-            if attempt > 0 {
-                userPayload = """
-                    \(contextJSON)
-
-                    --- CORRECTION REQUIRED ---
-                    Your previous response failed validation with this error:
-                    \(lastErrorDescription)
-                    Please fix the issue and return only the corrected JSON object.
-                    """
-            }
-
-            // 2. Call LLM with 8-second timeout (retries for transient HTTP errors happen
-            //    inside the timeout so the product patience threshold is always respected).
-            // Snapshot `userPayload` into an immutable let so the closure
-            // captures a value rather than a mutable variable (Swift 6 safety).
-            let payloadSnapshot = userPayload
-            let rawResponse: String
-            do {
-                rawResponse = try await withTimeout(seconds: 8.0) {
-                    try await TransientRetryPolicy.execute {
-                        try await self.provider.complete(
-                            systemPrompt: systemPrompt,
-                            userPayload: payloadSnapshot
-                        )
-                    }
+        // Per ADR-0007 §1: malformed-response and validation errors are
+        // PERMANENT — same-prompt retry will not fix the LLM's output. Slice 6
+        // (#10) removed the prior maxRetries-on-validate loop; transient
+        // HTTP errors are still retried inside `TransientRetryPolicy`, but
+        // any decode/validate failure here returns `.fallback(.malformedResponse)`
+        // immediately and surfaces `InferenceRetrySheet` to the user.
+        // History: the prior loop appended a "CORRECTION REQUIRED" addendum and
+        // re-ran. Sometimes worked for malformed JSON; ADR-0007 §1 nevertheless
+        // classes malformed responses as permanent because the same prompt is
+        // unlikely to yield a different shape, and a fail-fast surface gives
+        // the user agency rather than burning the 8-second budget on a
+        // probably-doomed retry. See spinoff issue for the broader audit.
+        // 2. Call LLM with 8-second timeout (transient HTTP retries happen
+        //    inside the timeout per ADR-0007 §2).
+        let rawResponse: String
+        do {
+            rawResponse = try await withTimeout(seconds: 8.0) {
+                try await TransientRetryPolicy.execute {
+                    try await self.provider.complete(
+                        systemPrompt: systemPrompt,
+                        userPayload: userPayload
+                    )
                 }
-            } catch is TimeoutError {
-                FallbackLogRecord(
+            }
+        } catch is TimeoutError {
+            FallbackLogRecord(
+                callSite: FallbackLogRecord.prescribeCallSite,
+                reason: "timeout (8s)",
+                sessionId: context.sessionMetadata.sessionId
+            ).emit()
+            return .fallback(reason: .timeout)
+        } catch {
+            if let llmError = error as? LLMProviderError {
+                FallbackLogRecord.from(
                     callSite: FallbackLogRecord.prescribeCallSite,
-                    reason: "timeout (8s)",
+                    error: llmError,
                     sessionId: context.sessionMetadata.sessionId
                 ).emit()
-                return .fallback(reason: .timeout)
-            } catch {
-                if let llmError = error as? LLMProviderError {
-                    FallbackLogRecord.from(
-                        callSite: FallbackLogRecord.prescribeCallSite,
-                        error: llmError,
-                        sessionId: context.sessionMetadata.sessionId
-                    ).emit()
-                } else {
-                    FallbackLogRecord(
-                        callSite: FallbackLogRecord.prescribeCallSite,
-                        reason: error.localizedDescription,
-                        sessionId: context.sessionMetadata.sessionId
-                    ).emit()
-                }
-                return .fallback(reason: .llmProviderError(error.localizedDescription))
+            } else {
+                FallbackLogRecord(
+                    callSite: FallbackLogRecord.prescribeCallSite,
+                    reason: error.localizedDescription,
+                    sessionId: context.sessionMetadata.sessionId
+                ).emit()
             }
-
-            // 3. Strip ```json … ``` markdown fences if present
-            let stripped = Self.stripMarkdownFences(rawResponse)
-
-            // 4. Decode {"set_prescription": SetPrescription}
-            guard let responseData = stripped.data(using: .utf8) else {
-                lastErrorDescription = "Response could not be converted to UTF-8 data."
-                continue
-            }
-
-            // Construct decoder inline (same reason as encoder above).
-            let decoder: JSONDecoder = {
-                let d = JSONDecoder()
-                d.dateDecodingStrategy = .iso8601
-                return d
-            }()
-            let wrapper: SetPrescriptionWrapper
-            do {
-                wrapper = try decoder.decode(SetPrescriptionWrapper.self, from: responseData)
-            } catch {
-                lastErrorDescription = "JSON decode failed: \(error.localizedDescription). Raw: \(stripped.prefix(300))"
-                continue
-            }
-
-            var prescription = wrapper.setPrescription
-
-            // 5. Validate
-            do {
-                try prescription.validate()
-            } catch {
-                lastErrorDescription = error.localizedDescription
-                continue
-            }
-
-            // 6. Safety gate: pain reported → rest ≥ 180 s
-            if prescription.safetyFlags.contains(.painReported) {
-                prescription.restSeconds = max(prescription.restSeconds, 180)
-            }
-
-            // 7. Return successful prescription.
-            // Note: weight availability is handled at runtime via GymFactStore
-            // + WeightCorrectionView — not here.
-            return .success(prescription)
+            return .fallback(reason: .llmProviderError(error.localizedDescription))
         }
 
-        let fallback = PrescriptionResult.fallback(reason: .maxRetriesExceeded(lastError: lastErrorDescription))
-        FallbackLogRecord(
-            callSite: FallbackLogRecord.prescribeCallSite,
-            reason: "maxRetriesExceeded: \(lastErrorDescription.prefix(200))",
-            sessionId: context.sessionMetadata.sessionId
-        ).emit()
-        return fallback
+        // 3. Strip ```json … ``` markdown fences if present
+        let stripped = Self.stripMarkdownFences(rawResponse)
+
+        // 4. Decode {"set_prescription": SetPrescription}
+        guard let responseData = stripped.data(using: .utf8) else {
+            return failPermanent(
+                "Response could not be converted to UTF-8 data.",
+                sessionId: context.sessionMetadata.sessionId,
+                callSite: FallbackLogRecord.prescribeCallSite
+            )
+        }
+
+        let decoder: JSONDecoder = {
+            let d = JSONDecoder()
+            d.dateDecodingStrategy = .iso8601
+            return d
+        }()
+        let wrapper: SetPrescriptionWrapper
+        do {
+            wrapper = try decoder.decode(SetPrescriptionWrapper.self, from: responseData)
+        } catch let validationError as PrescriptionValidationError {
+            // Custom `init(from:)` rethrows invalid-intent shapes as a typed
+            // PrescriptionValidationError. Same fail-fast treatment.
+            return failPermanent(
+                "decode/validate: \(validationError.errorDescription ?? "\(validationError)")",
+                sessionId: context.sessionMetadata.sessionId,
+                callSite: FallbackLogRecord.prescribeCallSite
+            )
+        } catch {
+            return failPermanent(
+                "JSON decode failed: \(error.localizedDescription). Raw: \(stripped.prefix(300))",
+                sessionId: context.sessionMetadata.sessionId,
+                callSite: FallbackLogRecord.prescribeCallSite
+            )
+        }
+
+        var prescription = wrapper.setPrescription
+
+        // 5. Validate
+        do {
+            try prescription.validate()
+        } catch {
+            return failPermanent(
+                error.localizedDescription,
+                sessionId: context.sessionMetadata.sessionId,
+                callSite: FallbackLogRecord.prescribeCallSite
+            )
+        }
+
+        // 6. Safety gate: pain reported → rest ≥ 180 s
+        if prescription.safetyFlags.contains(.painReported) {
+            prescription.restSeconds = max(prescription.restSeconds, 180)
+        }
+
+        // 7. Return successful prescription.
+        return .success(prescription)
+    }
+
+    /// Maps the ADR-0007 fail-fast hook (`emitPermanentFailureFallback`,
+    /// declared at file scope in `FallbackLogRecord.swift`) onto this
+    /// service's `PrescriptionResult`. The hook does the emission; this
+    /// wrapper builds the typed result.
+    ///
+    /// Audit hook for the spinoff "Audit retry-on-validate sites against
+    /// ADR-0007" — `emitPermanentFailureFallback` is the canonical
+    /// greppable inventory of fail-fast adoptions across services.
+    private func failPermanent(
+        _ description: String,
+        sessionId: String,
+        callSite: String
+    ) -> PrescriptionResult {
+        emitPermanentFailureFallback(
+            callSite: callSite,
+            description: description,
+            sessionId: sessionId
+        )
+        return .fallback(reason: .malformedResponse(description))
     }
 
     // MARK: - Public API: Weight Adaptation
@@ -791,7 +927,11 @@ actor AIInferenceService {
 
             let stripped = Self.stripMarkdownFences(rawResponse)
             guard let responseData = stripped.data(using: .utf8) else {
-                return .fallback(reason: .encodingFailed("Adaptation response could not be decoded."))
+                return failPermanent(
+                    "Adaptation response could not be decoded.",
+                    sessionId: workoutContext.sessionMetadata.sessionId,
+                    callSite: FallbackLogRecord.prescribeAdaptationCallSite
+                )
             }
 
             let decoder: JSONDecoder = {
@@ -800,15 +940,37 @@ actor AIInferenceService {
                 return d
             }()
 
-            guard let wrapper = try? decoder.decode(SetPrescriptionWrapper.self, from: responseData) else {
-                return .fallback(reason: .maxRetriesExceeded(lastError: "Adaptation decode failed."))
+            // Per ADR-0007 §1: malformed-response and validation errors are
+            // PERMANENT. prescribeAdaptation aligns with prescribe() — any
+            // decode or validate failure returns `.fallback(.malformedResponse)`
+            // immediately so the foreground call site surfaces an error UI
+            // rather than silently degrading.
+            let wrapper: SetPrescriptionWrapper
+            do {
+                wrapper = try decoder.decode(SetPrescriptionWrapper.self, from: responseData)
+            } catch let validationError as PrescriptionValidationError {
+                return failPermanent(
+                    "Adaptation decode/validate: \(validationError.errorDescription ?? "\(validationError)")",
+                    sessionId: workoutContext.sessionMetadata.sessionId,
+                    callSite: FallbackLogRecord.prescribeAdaptationCallSite
+                )
+            } catch {
+                return failPermanent(
+                    "Adaptation decode failed: \(error.localizedDescription)",
+                    sessionId: workoutContext.sessionMetadata.sessionId,
+                    callSite: FallbackLogRecord.prescribeAdaptationCallSite
+                )
             }
 
             var prescription = wrapper.setPrescription
             do {
                 try prescription.validate()
             } catch {
-                return .fallback(reason: .maxRetriesExceeded(lastError: "Adaptation validation failed: \(error.localizedDescription)"))
+                return failPermanent(
+                    "Adaptation validation failed: \(error.localizedDescription)",
+                    sessionId: workoutContext.sessionMetadata.sessionId,
+                    callSite: FallbackLogRecord.prescribeAdaptationCallSite
+                )
             }
 
             if prescription.safetyFlags.contains(.painReported) {
@@ -895,7 +1057,8 @@ actor AIInferenceService {
             "coaching_cue": "<string, max 100 chars>",
             "reasoning": "<string, max 200 chars>",
             "safety_flags": ["shoulder_caution"|"joint_concern"|"fatigue_high"|"pain_reported"|"deload_recommended"],
-            "confidence": <number 0.0–1.0, optional>
+            "confidence": <number 0.0–1.0, optional>,
+            "intent": "warmup"|"top"|"backoff"|"technique"|"amrap"
           }
         }
 
@@ -905,6 +1068,12 @@ actor AIInferenceService {
         - weight_kg must be achievable on the equipment described in current_exercise.equipment_type_key.
         - coaching_cue must be ≤ 100 characters. reasoning must be ≤ 200 characters.
         - Always consider safety flags from qualitative notes (pain → slow down, fatigue → reduce load).
+        - intent is REQUIRED on every prescription. No silent default. Choose deliberately:
+            * top:       the working set that drives capability (3–10 reps, max effort within RIR target).
+            * warmup:    sub-maximal preparation set; lighter load, higher reps, low RIR risk.
+            * backoff:   secondary working set following a top set, typically 70–85% of top weight.
+            * technique: tempo/form-focused practice; load is incidental, may be light.
+            * amrap:     last-set-as-many-reps-as-possible at the prescribed weight.
 
         EQUIPMENT-AWARE WEIGHT INCREMENTS:
         - barbell: minimum 5 kg increment. Use 2.5 kg only near a natural plate boundary (20/60/100 kg).

--- a/ProjectApex/AICoach/InferenceSpike.swift
+++ b/ProjectApex/AICoach/InferenceSpike.swift
@@ -116,6 +116,8 @@ enum InferenceSpike {
                 print("\(tag) ❌ Fallback: LLM provider error — \(msg)")
             case .encodingFailed(let msg):
                 print("\(tag) ❌ Fallback: encoding failed — \(msg)")
+            case .malformedResponse(let msg):
+                print("\(tag) ❌ Fallback: malformed response — \(msg)")
             }
         }
 

--- a/ProjectApex/Features/Workout/ActiveSetView.swift
+++ b/ProjectApex/Features/Workout/ActiveSetView.swift
@@ -1103,6 +1103,18 @@ struct RepRPEIntentConfirmationSheet: View {
     @ViewBuilder
     private var intentSection: some View {
         VStack(spacing: 10) {
+            // The "Did something different?" / "Never mind" toggle. Only
+            // shown for AI-prescribed sets — freestyle has no prescription
+            // to deviate from, so the picker is always visible and there's
+            // nothing to toggle. One tappable element, two states:
+            //   collapsed: "Did something different?" + chevron.down → reveals picker
+            //   expanded:  "Never mind" + chevron.up → collapses picker AND resets
+            //                                          resolvedIntent to prescribedIntent
+            //                                          (discards any tentative deviation)
+            if formState.prescribedIntent != nil {
+                deviationToggleLink
+            }
+
             if formState.isDeviationPickerVisible {
                 // Picker visible — either freestyle (always) or
                 // AI-prescribed after the user revealed it. Header text
@@ -1117,30 +1129,47 @@ struct RepRPEIntentConfirmationSheet: View {
                     Spacer()
                 }
                 intentChipRow
-            } else {
-                // AI-prescribed set, picker collapsed. Show a subtle
-                // "Did something different?" affordance — primary path
-                // is just to tap Log Set without touching this.
-                Button {
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                    withAnimation(.easeInOut(duration: 0.22)) {
-                        formState.revealDeviationPicker()
-                    }
-                } label: {
-                    HStack(spacing: 6) {
-                        Text("Did something different?")
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundStyle(.white.opacity(0.45))
-                        Image(systemName: "chevron.down")
-                            .font(.system(size: 9, weight: .semibold))
-                            .foregroundStyle(.white.opacity(0.35))
-                        Spacer()
-                    }
-                }
-                .buttonStyle(.plain)
-                .accessibilityHint("Reveal the intent picker if you did a different kind of set than prescribed")
             }
         }
+    }
+
+    /// Toggle link that reveals or dismisses the deviation picker. Lives
+    /// in a stable position regardless of expansion state — same element,
+    /// two labels, two chevron orientations. Auto-discoverable: the label
+    /// flips to "Never mind" on expansion, signalling the dismiss path.
+    /// Dismissing forgives any tentative deviation (resolvedIntent resets
+    /// to prescribedIntent) per the "forgiving over strict" rule.
+    @ViewBuilder
+    private var deviationToggleLink: some View {
+        let isExpanded = formState.isDeviationPickerVisible
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            withAnimation(.easeInOut(duration: 0.22)) {
+                if isExpanded {
+                    formState.dismissDeviationPicker()
+                } else {
+                    formState.revealDeviationPicker()
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Text(isExpanded ? "Never mind" : "Did something different?")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.45))
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.35))
+                Spacer()
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isExpanded
+                            ? "Never mind — collapse the deviation picker and use the prescribed intent"
+                            : "Did something different? — reveal the intent picker")
+        .accessibilityHint(isExpanded
+                           ? "Resets the intent to what was prescribed"
+                           : "Reveals chips for picking a different kind of set than prescribed")
+        .animation(.easeInOut(duration: 0.18), value: isExpanded)
     }
 
     /// Chip ordering is deliberate, not incidental. Order locks in user
@@ -1327,6 +1356,28 @@ private let previewTint = StreakResult.compute(currentStreakDays: 7, longestStre
     var seed = SetCompletionFormState(actualReps: 12, prescribedIntent: .top)
     seed.revealDeviationPicker()
     seed.selectIntent(.amrap)
+    return RepRPEIntentConfirmationSheet(
+        initialState: seed,
+        tintColor: previewTint,
+        onCommit: { _ in }
+    )
+}
+
+#Preview("Sheet — AI prescribed, deviation picked then dismissed") {
+    // The "forgiving over strict" reset path. User revealed the picker,
+    // tapped AMRAP (tentative deviation), then tapped "Never mind".
+    // Result: picker collapsed, resolvedIntent reset to prescribed
+    // (.top), isDeviation back to false. The toggle link reads
+    // "Did something different?" again, ready to re-reveal if needed.
+    //
+    // NOTE: SwiftUI #Preview blocks render the seed state — the
+    // preview shows the post-dismiss state, NOT the dismiss animation.
+    // To see the animation, tap "Did something different?" → AMRAP →
+    // "Never mind" within an interactive Xcode canvas (Live Preview).
+    var seed = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+    seed.revealDeviationPicker()
+    seed.selectIntent(.amrap)         // tentative deviation
+    seed.dismissDeviationPicker()     // → reset to prescribed, picker collapsed
     return RepRPEIntentConfirmationSheet(
         initialState: seed,
         tintColor: previewTint,

--- a/ProjectApex/Features/Workout/ActiveSetView.swift
+++ b/ProjectApex/Features/Workout/ActiveSetView.swift
@@ -293,7 +293,7 @@ struct ActiveSetView: View {
     private func prescriptionCard(_ prescription: SetPrescription) -> some View {
         VStack(alignment: .leading, spacing: 0) {
 
-            // Header: exercise name + set badge
+            // Header: exercise name + set badge + intent pill (Slice 6 / #10)
             HStack(alignment: .center) {
                 VStack(alignment: .leading, spacing: 3) {
                     Text(exercise.name)
@@ -305,16 +305,45 @@ struct ActiveSetView: View {
                         .foregroundStyle(muscleColor(for: exercise.primaryMuscle))
                 }
                 Spacer()
-                Text("SET \(setNumber)/\(exercise.sets)")
-                    .font(.system(size: 13, weight: .bold))
-                    .foregroundStyle(streak.tintColor)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(streak.tintColor.opacity(0.14), in: Capsule())
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text("SET \(setNumber)/\(exercise.sets)")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(streak.tintColor)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(streak.tintColor.opacity(0.14), in: Capsule())
+                    if let intent = prescription.intent {
+                        // Intent pill — uppercased, smaller. Slice 6 / #10.
+                        // Sets the user's frame for what kind of set this is
+                        // BEFORE they read weight/reps.
+                        Text(RepRPEIntentConfirmationSheet.label(for: intent).uppercased())
+                            .font(.system(size: 10, weight: .heavy))
+                            .tracking(1.2)
+                            .foregroundStyle(.white.opacity(0.85))
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 4)
+                            .background(Color.white.opacity(0.10), in: Capsule())
+                            .overlay(Capsule().stroke(.white.opacity(0.18), lineWidth: 0.5))
+                            .accessibilityLabel("Intent: \(RepRPEIntentConfirmationSheet.label(for: intent))")
+                    }
+                }
             }
             .padding(.horizontal, 24)
             .padding(.top, 22)
-            .padding(.bottom, 16)
+            .padding(.bottom, 8)
+
+            // Set framing — 1-line mental-set framing under the header
+            // (Slice 6 / #10). Italic 14pt. Italics carry the "thought,
+            // not instruction" tone; the form cue (which IS instruction)
+            // lives below the metrics row in regular weight.
+            if let framing = prescription.setFraming, !framing.isEmpty {
+                Text(framing)
+                    .font(.system(size: 14, weight: .regular).italic())
+                    .foregroundStyle(.white.opacity(0.78))
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 12)
+                    .accessibilityLabel("Set framing: \(framing)")
+            }
 
             // Weight / Reps hero numbers
             HStack(alignment: .firstTextBaseline, spacing: 4) {
@@ -909,37 +938,48 @@ struct ActiveSetView: View {
     }
 
     /// Called by `RepRPEIntentConfirmationSheet` when the user taps Log Set.
-    /// The sheet's gate guarantees `state.canSubmit == true` — we still
-    /// guard defensively in case the closure is invoked from a future code
-    /// path that didn't come through the gate.
+    /// The sheet's gate guarantees `state.canSubmit == true` (resolvedIntent
+    /// non-nil) — we still guard defensively in case the closure is invoked
+    /// from a future code path that didn't come through the gate.
     private func commitSetComplete(_ state: SetCompletionFormState) {
-        guard state.canSubmit, let chosenIntent = state.intent else { return }
+        guard state.canSubmit, let chosenIntent = state.resolvedIntent else { return }
         showRepConfirmation = false
         // Map 0/1/2 picker to a rough RPE value: too easy = 5, on target = 7, too hard = 9
         let rpeValue: Int = [5, 7, 9][state.rpeFelt]
         viewModel.onSetComplete(
             actualReps: state.actualReps,
             rpeFelt: rpeValue,
-            intent: chosenIntent
+            intent: chosenIntent,
+            completionFlags: Array(state.completionFlags)
         )
     }
 
 }
 
 // MARK: - RepRPEIntentConfirmationSheet (Slice 6 / #10)
+//
+// REDESIGN NOTE (supersedes 7bac17b's chip-tap-required UX):
+//   The prior shape asked the user to confirm an intent the AI had
+//   already explicitly told them via the prescription. That's
+//   redundant data entry, not no-silent-defaults enforcement.
+//
+//   This shape captures DEVIATION, not confirmation:
+//     - AI-prescribed sets: zero friction. resolvedIntent defaults to
+//       prescribedIntent. Save Set always enabled. A subtle "Did
+//       something different?" link reveals the chip row for users who
+//       actually deviated. Deviation gets recorded distinctly via
+//       `formState.isDeviation`.
+//     - Freestyle sets: chip row visible by default — the only path to
+//       an intent. Save disabled until picked.
+//
+//   The sheet also captures user-reported flags (pain / form_breakdown)
+//   via toggles below the picker. High-signal for AI adaptation.
 
-/// The rep / RPE / intent confirmation sheet's content, extracted from
-/// `ActiveSetView` so it's previewable in isolation. Owns its own
+/// The rep / RPE / intent / flag confirmation sheet's content, extracted
+/// from `ActiveSetView` so it's previewable in isolation. Owns its own
 /// `@State formState` — the parent supplies `initialState` once at
 /// construction and gets the final value back via `onCommit` when the
 /// user taps "Log Set".
-///
-/// HITL visual review uses the `#Preview` blocks below to render the
-/// three states the AC ("Save disabled until explicit intent tap, even
-/// if the initial selection matches their intent") covers:
-///   - AI prefilled, awaiting confirmation
-///   - Freestyle, untouched (Log Set disabled)
-///   - Confirmed selection (Log Set enabled, chip solid)
 struct RepRPEIntentConfirmationSheet: View {
 
     let initialState: SetCompletionFormState
@@ -962,7 +1002,7 @@ struct RepRPEIntentConfirmationSheet: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 24) {
-                // Header — no auto-dismiss countdown per Slice 6 AC.
+                // Header — no auto-dismiss countdown.
                 HStack {
                     Text("How did that feel?")
                         .font(.system(size: 20, weight: .semibold))
@@ -1022,14 +1062,16 @@ struct RepRPEIntentConfirmationSheet: View {
                     .pickerStyle(.segmented)
                 }
 
-                // Intent picker (Slice 6 / #10) — required, no silent default.
-                intentPickerSection
+                // Intent picker (deviation affordance for AI-prescribed,
+                // visible-by-default for freestyle).
+                intentSection
 
-                // Log button — disabled until intent is explicitly selected.
-                // Disabled state dims the whole pill monolithically (background
-                // and label together) at ~35% opacity; conventional disabled
-                // affordance, avoids the "transparent fill + opaque text"
-                // visual ambiguity.
+                // Pain / form-breakdown flags. Always visible; both flags
+                // independently togglable.
+                flagsSection
+
+                // Log button. AI-prescribed: always enabled. Freestyle:
+                // enabled once an intent is picked.
                 Button {
                     onCommit(formState)
                 } label: {
@@ -1056,130 +1098,179 @@ struct RepRPEIntentConfirmationSheet: View {
         .preferredColorScheme(.dark)
     }
 
-    // MARK: - Intent Picker (Slice 6 / #10)
+    // MARK: - Intent section (Slice 6 redesign)
 
     @ViewBuilder
-    private var intentPickerSection: some View {
+    private var intentSection: some View {
         VStack(spacing: 10) {
-            HStack(spacing: 6) {
-                Text("What kind of set?")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.50))
-                    .tracking(0.5)
-                if formState.hasUnconfirmedAIPrefill {
-                    Image(systemName: "sparkles")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(tintColor.opacity(0.90))
-                    Text("Coach suggested — tap to confirm")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(tintColor.opacity(0.90))
+            if formState.isDeviationPickerVisible {
+                // Picker visible — either freestyle (always) or
+                // AI-prescribed after the user revealed it. Header text
+                // adapts to the path.
+                HStack {
+                    Text(formState.prescribedIntent == nil
+                         ? "What kind of set?"
+                         : "What did you actually do?")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.50))
+                        .tracking(0.5)
+                    Spacer()
                 }
-                Spacer()
+                intentChipRow
+            } else {
+                // AI-prescribed set, picker collapsed. Show a subtle
+                // "Did something different?" affordance — primary path
+                // is just to tap Log Set without touching this.
+                Button {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    withAnimation(.easeInOut(duration: 0.22)) {
+                        formState.revealDeviationPicker()
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Text("Did something different?")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.45))
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.35))
+                        Spacer()
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityHint("Reveal the intent picker if you did a different kind of set than prescribed")
             }
+        }
+    }
 
-            // Two rows: 3 + 2 chips. Centred. Wrapping is deterministic and
-            // works across iPhone widths (5 chips × ~80pt > 375pt).
-            //
-            // Ordering is deliberate, not incidental. Order locks in user
-            // muscle memory once shipped; getting it right at v1 is cheap.
-            //   Row 1: warmup → top → backoff
-            //     Mirrors typical within-exercise session progression
-            //     (lighter prep set → heavy working set → secondary set
-            //     after the top). Top sits in the centre of row 1 because
-            //     it is by far the most common AI prefill — placing it on
-            //     the user's natural thumb path minimises tap travel for
-            //     the modal case.
-            //   Row 2: technique → amrap
-            //     Less common intents, demoted to the second row.
-            //     Technique on the left because it's the more common of
-            //     the two for hypertrophy programmes; AMRAP is a
-            //     last-set-of-block surface.
-            VStack(spacing: 8) {
-                HStack(spacing: 8) {
-                    ForEach([SetIntent.warmup, .top, .backoff], id: \.self) { intent in
-                        intentChip(intent)
-                    }
+    /// Chip ordering is deliberate, not incidental. Order locks in user
+    /// muscle memory once shipped; getting it right at v1 is cheap.
+    ///   Row 1: warmup → top → backoff
+    ///     Mirrors typical within-exercise session progression. Top sits
+    ///     in the centre because it is by far the most common AI
+    ///     prescription — natural thumb path for the deviation case
+    ///     where the user often picks adjacent values.
+    ///   Row 2: technique → amrap
+    ///     Less common intents, demoted to the second row.
+    @ViewBuilder
+    private var intentChipRow: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                ForEach([SetIntent.warmup, .top, .backoff], id: \.self) { intent in
+                    intentChip(intent)
                 }
-                HStack(spacing: 8) {
-                    ForEach([SetIntent.technique, .amrap], id: \.self) { intent in
-                        intentChip(intent)
-                    }
+            }
+            HStack(spacing: 8) {
+                ForEach([SetIntent.technique, .amrap], id: \.self) { intent in
+                    intentChip(intent)
                 }
             }
         }
     }
 
-    /// Three visual states drive chip rendering, derived from `formState`:
-    ///   - **Confirmed**         (`intentTouched && intent == case`): solid
-    ///                            tint background, white bold text — the
-    ///                            user's explicit choice.
-    ///   - **AI-suggested-pending** (`hasUnconfirmedAIPrefill && intent == case`):
-    ///                            tint outline + low-opacity tint fill +
-    ///                            sparkles icon. Visually distinct from
-    ///                            "confirmed" so the user knows a tap is
-    ///                            still required (Slice 6 AC).
-    ///   - **Unselected**         (everything else): white-on-glass-low.
+    /// Two visual states (no AI-pending state in the redesign — pickers
+    /// only render after the user has agency over the value):
+    ///   - **Selected** (`resolvedIntent == case`): solid tint, white bold.
+    ///   - **Unselected** (everything else): white-on-glass-low.
     @ViewBuilder
     private func intentChip(_ intent: SetIntent) -> some View {
-        let isConfirmed = formState.intentTouched && formState.intent == intent
-        let isAISuggested = formState.hasUnconfirmedAIPrefill && formState.intent == intent
+        let isSelected = formState.resolvedIntent == intent
 
         Button {
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            formState.recordIntentTap(intent)
+            formState.selectIntent(intent)
         } label: {
-            HStack(spacing: 4) {
-                if isAISuggested {
-                    Image(systemName: "sparkles")
-                        .font(.system(size: 10, weight: .bold))
-                }
-                Text(Self.label(for: intent))
-                    .font(.system(size: 13, weight: isConfirmed ? .bold : .semibold))
-                    .tracking(0.3)
+            Text(Self.label(for: intent))
+                .font(.system(size: 13, weight: isSelected ? .bold : .semibold))
+                .tracking(0.3)
+                .foregroundStyle(isSelected ? Color.white : Color.white.opacity(0.65))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(
+                    ZStack {
+                        Capsule()
+                            .fill(isSelected ? tintColor : Color.white.opacity(0.06))
+                        Capsule()
+                            .stroke(
+                                isSelected ? tintColor : Color.white.opacity(0.18),
+                                lineWidth: 0.5
+                            )
+                    }
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Self.label(for: intent))
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .animation(.easeInOut(duration: 0.18), value: formState.resolvedIntent)
+    }
+
+    // MARK: - Flags section (Slice 6 / #10)
+
+    @ViewBuilder
+    private var flagsSection: some View {
+        VStack(spacing: 10) {
+            HStack {
+                Text("Anything to flag?")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.50))
+                    .tracking(0.5)
+                Spacer()
             }
-            .foregroundStyle(
-                isConfirmed
-                    ? Color.white
-                    : (isAISuggested
-                        ? tintColor
-                        : Color.white.opacity(0.65))
-            )
+            HStack(spacing: 8) {
+                flagToggle(.pain, label: "Something hurt", icon: "exclamationmark.triangle.fill")
+                flagToggle(.formBreakdown, label: "Form broke down", icon: "figure.strengthtraining.traditional")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func flagToggle(
+        _ flag: SetCompletionFlag,
+        label: String,
+        icon: String
+    ) -> some View {
+        let isOn = formState.completionFlags.contains(flag)
+        // Pain uses red (urgent); form_breakdown uses amber (warning).
+        let onColor: Color = (flag == .pain)
+            ? Color(red: 1.0, green: 0.40, blue: 0.30)
+            : Color(red: 1.0, green: 0.75, blue: 0.10)
+
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            formState.toggleFlag(flag)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .bold))
+                Text(label)
+                    .font(.system(size: 12, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+            }
+            .foregroundStyle(isOn ? Color.white : Color.white.opacity(0.55))
             .frame(maxWidth: .infinity)
             .padding(.vertical, 10)
             .background(
                 ZStack {
                     Capsule()
-                        .fill(
-                            isConfirmed
-                                ? tintColor
-                                : (isAISuggested
-                                    ? tintColor.opacity(0.14)
-                                    : Color.white.opacity(0.06))
-                        )
+                        .fill(isOn ? onColor.opacity(0.85) : Color.white.opacity(0.06))
                     Capsule()
                         .stroke(
-                            isConfirmed
-                                ? tintColor
-                                : (isAISuggested
-                                    ? tintColor.opacity(0.55)
-                                    : Color.white.opacity(0.18)),
-                            lineWidth: isAISuggested ? 1.0 : 0.5
+                            isOn ? onColor : Color.white.opacity(0.18),
+                            lineWidth: 0.5
                         )
                 }
             )
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(Self.label(for: intent))
-        .accessibilityValue(isConfirmed
-                            ? "selected"
-                            : (isAISuggested ? "AI suggested, awaiting confirmation" : ""))
-        .accessibilityAddTraits(isConfirmed ? .isSelected : [])
-        .animation(.easeInOut(duration: 0.18), value: formState.intent)
-        .animation(.easeInOut(duration: 0.18), value: formState.intentTouched)
+        .accessibilityLabel(label)
+        .accessibilityValue(isOn ? "on" : "off")
+        .accessibilityAddTraits(isOn ? .isSelected : [])
+        .animation(.easeInOut(duration: 0.18), value: isOn)
     }
 
     /// Display label for a SetIntent. Static so the same labels can be
-    /// reused if a future surface needs them.
+    /// reused across surfaces.
     static func label(for intent: SetIntent) -> String {
         switch intent {
         case .warmup:    return "Warmup"
@@ -1200,12 +1291,10 @@ struct RepRPEIntentConfirmationSheet: View {
 
 private let previewTint = StreakResult.compute(currentStreakDays: 7, longestStreak: 10).tintColor
 
-#Preview("Sheet — AI prefilled, awaiting confirmation") {
-    // hasUnconfirmedAIPrefill == true, canSubmit == false.
-    // The "Top" chip should render with sparkles + low-opacity tint fill.
-    // The "Coach suggested — tap to confirm" hint should appear next to
-    // the "What kind of set?" header. Log Set should be muted (35%
-    // opacity).
+#Preview("Sheet — AI prescribed, default state") {
+    // The common case — AI prescribed Top, picker is collapsed behind
+    // the "Did something different?" affordance. Log Set is enabled
+    // immediately. User logs in 1 tap if they did the prescribed thing.
     RepRPEIntentConfirmationSheet(
         initialState: SetCompletionFormState(
             actualReps: 8,
@@ -1216,10 +1305,39 @@ private let previewTint = StreakResult.compute(currentStreakDays: 7, longestStre
     )
 }
 
-#Preview("Sheet — Freestyle, untouched (Log Set disabled)") {
-    // intent == nil, intentTouched == false, canSubmit == false.
-    // No chip is highlighted; no AI-suggested hint. Log Set is muted
-    // (35% opacity) because the gate is closed.
+#Preview("Sheet — AI prescribed, deviation picker expanded") {
+    // After tapping "Did something different?", the chip row appears.
+    // The prescribed intent (Top) is pre-selected. User can tap a
+    // different chip to record a deviation; tapping the same chip is
+    // a no-op (reaffirms the prescription).
+    var seed = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+    seed.revealDeviationPicker()
+    return RepRPEIntentConfirmationSheet(
+        initialState: seed,
+        tintColor: previewTint,
+        onCommit: { _ in }
+    )
+}
+
+#Preview("Sheet — AI prescribed, deviation recorded (AMRAP over Top)") {
+    // User tapped "Did something different?" → picker → AMRAP. The
+    // chip is now solid (selected); resolvedIntent == .amrap;
+    // isDeviation == true. The SetLog and WorkoutContext reflect the
+    // user's actual choice.
+    var seed = SetCompletionFormState(actualReps: 12, prescribedIntent: .top)
+    seed.revealDeviationPicker()
+    seed.selectIntent(.amrap)
+    return RepRPEIntentConfirmationSheet(
+        initialState: seed,
+        tintColor: previewTint,
+        onCommit: { _ in }
+    )
+}
+
+#Preview("Sheet — Freestyle, no intent picked (Log Set disabled)") {
+    // No prescription → picker visible by default. resolvedIntent is
+    // nil until the user picks one chip. Log Set is muted at 35%
+    // opacity because the gate is closed.
     RepRPEIntentConfirmationSheet(
         initialState: SetCompletionFormState(
             actualReps: 8,
@@ -1230,12 +1348,34 @@ private let previewTint = StreakResult.compute(currentStreakDays: 7, longestStre
     )
 }
 
-#Preview("Sheet — Confirmed selection (Log Set enabled)") {
-    // intent == .top, intentTouched == true, canSubmit == true.
-    // The "Top" chip renders solid tint + white bold; no AI-suggested
-    // hint. Log Set renders solid tint at 100% opacity.
+#Preview("Sheet — Freestyle, intent picked (Log Set enabled)") {
+    // Same as above after one chip tap. The picked chip is solid;
+    // Log Set is at 100% opacity.
     var seed = SetCompletionFormState(actualReps: 8, prescribedIntent: nil)
-    seed.recordIntentTap(.top)
+    seed.selectIntent(.backoff)
+    return RepRPEIntentConfirmationSheet(
+        initialState: seed,
+        tintColor: previewTint,
+        onCommit: { _ in }
+    )
+}
+
+#Preview("Sheet — Pain flag raised") {
+    // Both flags togglable independently. Pain shows as red; form
+    // breakdown shows as amber. Both can be raised on the same set.
+    var seed = SetCompletionFormState(actualReps: 6, prescribedIntent: .top)
+    seed.toggleFlag(.pain)
+    return RepRPEIntentConfirmationSheet(
+        initialState: seed,
+        tintColor: previewTint,
+        onCommit: { _ in }
+    )
+}
+
+#Preview("Sheet — Both flags raised") {
+    var seed = SetCompletionFormState(actualReps: 6, prescribedIntent: .top)
+    seed.toggleFlag(.pain)
+    seed.toggleFlag(.formBreakdown)
     return RepRPEIntentConfirmationSheet(
         initialState: seed,
         tintColor: previewTint,
@@ -1372,7 +1512,8 @@ private extension AnyTransition {
         reasoning: "HRV -22% · pain_reported in previous note → load reduced 15%.",
         safetyFlags: [.painReported, .shoulderCaution],
         confidence: 0.72,
-        intent: .top
+        intent: .top,
+        setFraming: "Heaviest work of the day. Brace and grind."
     )
     return ActiveSetView(
         viewModel: vm,

--- a/ProjectApex/Features/Workout/ActiveSetView.swift
+++ b/ProjectApex/Features/Workout/ActiveSetView.swift
@@ -47,15 +47,11 @@ struct ActiveSetView: View {
     /// ViewModel driving the exercise swap chat sheet (P3-T10).
     @State private var swapViewModel: ExerciseSwapViewModel?
 
-    /// True after "Set Complete" tap — shows rep/RPE confirmation sheet
+    /// True after "Set Complete" tap — shows rep/RPE confirmation sheet.
+    /// The sheet's content lives in `RepRPEIntentConfirmationSheet`, which
+    /// owns its own form state — see Slice 6 / #10 for the rationale and
+    /// the unit-testable state struct (`SetCompletionFormState`).
     @State private var showRepConfirmation: Bool = false
-
-    /// Reps / RPE / intent state for the active rep-confirmation sheet.
-    /// Initialised on sheet appearance from the live prescription. Slice 6
-    /// (#10) replaced the previous individual @State fields and the
-    /// 5-second auto-dismiss timer with this unit-testable struct so the
-    /// "Save disabled until explicit intent tap" AC is observable.
-    @State private var formState: SetCompletionFormState = SetCompletionFormState(actualReps: 8)
 
     /// Controls the collapsible reasoning section
     @State private var reasoningExpanded: Bool = false
@@ -124,9 +120,23 @@ struct ActiveSetView: View {
 
         }
         .sheet(isPresented: $showRepConfirmation) {
-            repRPEConfirmationSheet
-                .presentationDetents([.medium])
-                .presentationCornerRadius(24)
+            // Sheet content extracted to a previewable struct (Slice 6 / #10).
+            // The struct owns its own @State form, seeded once on construction
+            // from the live prescription. The struct calls back via `onCommit`
+            // when the user taps Log Set; the parent then dispatches to the
+            // session manager.
+            RepRPEIntentConfirmationSheet(
+                initialState: SetCompletionFormState(
+                    actualReps: viewModel.currentPrescription?.reps ?? 8,
+                    prescribedIntent: viewModel.currentPrescription?.intent
+                ),
+                tintColor: streak.tintColor,
+                onCommit: { state in
+                    commitSetComplete(state)
+                }
+            )
+            .presentationDetents([.medium, .large])
+            .presentationCornerRadius(24)
         }
         .sheet(isPresented: $showVoiceNoteModal) {
             voiceNoteModal
@@ -608,230 +618,6 @@ struct ActiveSetView: View {
         }
     }
 
-    // MARK: - Rep / RPE / Intent Confirmation Sheet (Slice 6 / #10)
-
-    private var repRPEConfirmationSheet: some View {
-        ScrollView {
-            VStack(spacing: 24) {
-                // Header — no auto-dismiss countdown per Slice 6 AC.
-                HStack {
-                    Text("How did that feel?")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundStyle(.white)
-                    Spacer()
-                }
-                .padding(.top, 4)
-
-                // Actual reps stepper
-                VStack(spacing: 10) {
-                    Text("Actual Reps")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(.white.opacity(0.50))
-                        .tracking(0.5)
-
-                    HStack(spacing: 24) {
-                        Button {
-                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                            if formState.actualReps > 1 { formState.actualReps -= 1 }
-                        } label: {
-                            Image(systemName: "minus.circle.fill")
-                                .font(.system(size: 36))
-                                .foregroundStyle(.white.opacity(0.55))
-                        }
-                        .frame(minWidth: 44, minHeight: 44)
-
-                        Text("\(formState.actualReps)")
-                            .font(.system(size: 48, weight: .bold, design: .rounded).monospacedDigit())
-                            .foregroundStyle(.white)
-                            .contentTransition(.numericText())
-                            .frame(minWidth: 72)
-
-                        Button {
-                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                            if formState.actualReps < 30 { formState.actualReps += 1 }
-                        } label: {
-                            Image(systemName: "plus.circle.fill")
-                                .font(.system(size: 36))
-                                .foregroundStyle(streak.tintColor.opacity(0.90))
-                        }
-                        .frame(minWidth: 44, minHeight: 44)
-                    }
-                }
-
-                // RPE/RIR felt — 3-option segmented picker
-                VStack(spacing: 10) {
-                    Text("How hard was it?")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(.white.opacity(0.50))
-                        .tracking(0.5)
-
-                    Picker("RPE felt", selection: $formState.rpeFelt) {
-                        Text("Too Easy").tag(0)
-                        Text("On Target").tag(1)
-                        Text("Too Hard").tag(2)
-                    }
-                    .pickerStyle(.segmented)
-                }
-
-                // Intent picker (Slice 6 / #10) — required, no silent default.
-                intentPickerSection
-
-                // Log button — disabled until intent is explicitly selected.
-                Button {
-                    commitSetComplete()
-                } label: {
-                    Text("Log Set")
-                        .font(.system(size: 17, weight: .bold))
-                        .foregroundStyle(.white)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 56)
-                        .background(
-                            (formState.canSubmit
-                                ? streak.tintColor
-                                : Color.white.opacity(0.10)),
-                            in: RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        )
-                }
-                .disabled(!formState.canSubmit)
-                .accessibilityHint(formState.canSubmit
-                                   ? "Log this set"
-                                   : "Pick an intent to enable logging")
-                .animation(.easeInOut(duration: 0.18), value: formState.canSubmit)
-            }
-            .padding(24)
-        }
-        .background(Color(red: 0.07, green: 0.08, blue: 0.10))
-        .preferredColorScheme(.dark)
-        .onAppear {
-            // Initialise form state from the live prescription. Intent
-            // pre-fills from prescription.intent when present (AI-prescribed
-            // sets) and stays nil for freestyle. `intentTouched` starts
-            // false in both cases — Slice 6 AC: even a matching prefill
-            // requires explicit interaction.
-            formState = SetCompletionFormState(
-                actualReps: viewModel.currentPrescription?.reps ?? formState.actualReps,
-                prescribedIntent: viewModel.currentPrescription?.intent
-            )
-        }
-    }
-
-    // MARK: - Intent Picker (Slice 6 / #10)
-
-    @ViewBuilder
-    private var intentPickerSection: some View {
-        VStack(spacing: 10) {
-            HStack(spacing: 6) {
-                Text("What kind of set?")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.50))
-                    .tracking(0.5)
-                if formState.hasUnconfirmedAIPrefill {
-                    Image(systemName: "sparkles")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(streak.tintColor.opacity(0.90))
-                    Text("Coach suggested — tap to confirm")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(streak.tintColor.opacity(0.90))
-                }
-                Spacer()
-            }
-
-            // Two rows: 3 + 2 chips. Centred. Wrapping is deterministic and
-            // works across iPhone widths (5 chips × ~80pt > 375pt).
-            VStack(spacing: 8) {
-                HStack(spacing: 8) {
-                    ForEach([SetIntent.warmup, .top, .backoff], id: \.self) { intent in
-                        intentChip(intent)
-                    }
-                }
-                HStack(spacing: 8) {
-                    ForEach([SetIntent.technique, .amrap], id: \.self) { intent in
-                        intentChip(intent)
-                    }
-                }
-            }
-        }
-    }
-
-    /// Three visual states drive chip rendering, derived from `formState`:
-    ///   - **Confirmed**         (`intentTouched && intent == case`): solid
-    ///                            tint background, white bold text — the
-    ///                            user's explicit choice.
-    ///   - **AI-suggested-pending** (`hasUnconfirmedAIPrefill && intent == case`):
-    ///                            tint outline + low-opacity tint fill +
-    ///                            sparkles icon. Visually distinct from
-    ///                            "confirmed" so the user knows a tap is
-    ///                            still required (Slice 6 AC).
-    ///   - **Unselected**         (everything else): white-on-glass-low.
-    @ViewBuilder
-    private func intentChip(_ intent: SetIntent) -> some View {
-        let isConfirmed = formState.intentTouched && formState.intent == intent
-        let isAISuggested = formState.hasUnconfirmedAIPrefill && formState.intent == intent
-
-        Button {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            formState.recordIntentTap(intent)
-        } label: {
-            HStack(spacing: 4) {
-                if isAISuggested {
-                    Image(systemName: "sparkles")
-                        .font(.system(size: 10, weight: .bold))
-                }
-                Text(intentLabel(intent))
-                    .font(.system(size: 13, weight: isConfirmed ? .bold : .semibold))
-                    .tracking(0.3)
-            }
-            .foregroundStyle(
-                isConfirmed
-                    ? Color.white
-                    : (isAISuggested
-                        ? streak.tintColor
-                        : Color.white.opacity(0.65))
-            )
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 10)
-            .background(
-                ZStack {
-                    Capsule()
-                        .fill(
-                            isConfirmed
-                                ? streak.tintColor
-                                : (isAISuggested
-                                    ? streak.tintColor.opacity(0.14)
-                                    : Color.white.opacity(0.06))
-                        )
-                    Capsule()
-                        .stroke(
-                            isConfirmed
-                                ? streak.tintColor
-                                : (isAISuggested
-                                    ? streak.tintColor.opacity(0.55)
-                                    : Color.white.opacity(0.18)),
-                            lineWidth: isAISuggested ? 1.0 : 0.5
-                        )
-                }
-            )
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(intentLabel(intent))
-        .accessibilityValue(isConfirmed
-                            ? "selected"
-                            : (isAISuggested ? "AI suggested, awaiting confirmation" : ""))
-        .accessibilityAddTraits(isConfirmed ? .isSelected : [])
-        .animation(.easeInOut(duration: 0.18), value: formState.intent)
-        .animation(.easeInOut(duration: 0.18), value: formState.intentTouched)
-    }
-
-    private func intentLabel(_ intent: SetIntent) -> String {
-        switch intent {
-        case .warmup:    return "Warmup"
-        case .top:       return "Top"
-        case .backoff:   return "Backoff"
-        case .technique: return "Technique"
-        case .amrap:     return "AMRAP"
-        }
-    }
-
     // MARK: - Voice Note Modal (P4-T06)
 
     private var voiceNoteModal: some View {
@@ -1119,27 +905,342 @@ struct ActiveSetView: View {
 
     private func handleSetCompleteTap() {
         UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
-        // Sheet's onAppear seeds the formState from the prescription —
-        // resetting here would race with that. The sheet is single-shot
-        // per Set Complete tap.
         showRepConfirmation = true
     }
 
-    private func commitSetComplete() {
-        // Slice 6 AC: this path is only reachable when formState.canSubmit
-        // is true (button is disabled otherwise). Defensive guard left in
-        // case the path is invoked programmatically in the future.
-        guard formState.canSubmit, let chosenIntent = formState.intent else { return }
+    /// Called by `RepRPEIntentConfirmationSheet` when the user taps Log Set.
+    /// The sheet's gate guarantees `state.canSubmit == true` — we still
+    /// guard defensively in case the closure is invoked from a future code
+    /// path that didn't come through the gate.
+    private func commitSetComplete(_ state: SetCompletionFormState) {
+        guard state.canSubmit, let chosenIntent = state.intent else { return }
         showRepConfirmation = false
         // Map 0/1/2 picker to a rough RPE value: too easy = 5, on target = 7, too hard = 9
-        let rpeValue: Int = [5, 7, 9][formState.rpeFelt]
+        let rpeValue: Int = [5, 7, 9][state.rpeFelt]
         viewModel.onSetComplete(
-            actualReps: formState.actualReps,
+            actualReps: state.actualReps,
             rpeFelt: rpeValue,
             intent: chosenIntent
         )
     }
 
+}
+
+// MARK: - RepRPEIntentConfirmationSheet (Slice 6 / #10)
+
+/// The rep / RPE / intent confirmation sheet's content, extracted from
+/// `ActiveSetView` so it's previewable in isolation. Owns its own
+/// `@State formState` — the parent supplies `initialState` once at
+/// construction and gets the final value back via `onCommit` when the
+/// user taps "Log Set".
+///
+/// HITL visual review uses the `#Preview` blocks below to render the
+/// three states the AC ("Save disabled until explicit intent tap, even
+/// if the initial selection matches their intent") covers:
+///   - AI prefilled, awaiting confirmation
+///   - Freestyle, untouched (Log Set disabled)
+///   - Confirmed selection (Log Set enabled, chip solid)
+struct RepRPEIntentConfirmationSheet: View {
+
+    let initialState: SetCompletionFormState
+    let tintColor: Color
+    let onCommit: (SetCompletionFormState) -> Void
+
+    @State private var formState: SetCompletionFormState
+
+    init(
+        initialState: SetCompletionFormState,
+        tintColor: Color,
+        onCommit: @escaping (SetCompletionFormState) -> Void
+    ) {
+        self.initialState = initialState
+        self.tintColor = tintColor
+        self.onCommit = onCommit
+        self._formState = State(initialValue: initialState)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                // Header — no auto-dismiss countdown per Slice 6 AC.
+                HStack {
+                    Text("How did that feel?")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(.white)
+                    Spacer()
+                }
+                .padding(.top, 4)
+
+                // Actual reps stepper
+                VStack(spacing: 10) {
+                    Text("Actual Reps")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.50))
+                        .tracking(0.5)
+
+                    HStack(spacing: 24) {
+                        Button {
+                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                            if formState.actualReps > 1 { formState.actualReps -= 1 }
+                        } label: {
+                            Image(systemName: "minus.circle.fill")
+                                .font(.system(size: 36))
+                                .foregroundStyle(.white.opacity(0.55))
+                        }
+                        .frame(minWidth: 44, minHeight: 44)
+
+                        Text("\(formState.actualReps)")
+                            .font(.system(size: 48, weight: .bold, design: .rounded).monospacedDigit())
+                            .foregroundStyle(.white)
+                            .contentTransition(.numericText())
+                            .frame(minWidth: 72)
+
+                        Button {
+                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                            if formState.actualReps < 30 { formState.actualReps += 1 }
+                        } label: {
+                            Image(systemName: "plus.circle.fill")
+                                .font(.system(size: 36))
+                                .foregroundStyle(tintColor.opacity(0.90))
+                        }
+                        .frame(minWidth: 44, minHeight: 44)
+                    }
+                }
+
+                // RPE/RIR felt — 3-option segmented picker
+                VStack(spacing: 10) {
+                    Text("How hard was it?")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.50))
+                        .tracking(0.5)
+
+                    Picker("RPE felt", selection: $formState.rpeFelt) {
+                        Text("Too Easy").tag(0)
+                        Text("On Target").tag(1)
+                        Text("Too Hard").tag(2)
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                // Intent picker (Slice 6 / #10) — required, no silent default.
+                intentPickerSection
+
+                // Log button — disabled until intent is explicitly selected.
+                // Disabled state dims the whole pill monolithically (background
+                // and label together) at ~35% opacity; conventional disabled
+                // affordance, avoids the "transparent fill + opaque text"
+                // visual ambiguity.
+                Button {
+                    onCommit(formState)
+                } label: {
+                    Text("Log Set")
+                        .font(.system(size: 17, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 56)
+                        .background(
+                            tintColor,
+                            in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        )
+                        .opacity(formState.canSubmit ? 1.0 : 0.35)
+                }
+                .disabled(!formState.canSubmit)
+                .accessibilityHint(formState.canSubmit
+                                   ? "Log this set"
+                                   : "Pick an intent to enable logging")
+                .animation(.easeInOut(duration: 0.18), value: formState.canSubmit)
+            }
+            .padding(24)
+        }
+        .background(Color(red: 0.07, green: 0.08, blue: 0.10))
+        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Intent Picker (Slice 6 / #10)
+
+    @ViewBuilder
+    private var intentPickerSection: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 6) {
+                Text("What kind of set?")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.50))
+                    .tracking(0.5)
+                if formState.hasUnconfirmedAIPrefill {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(tintColor.opacity(0.90))
+                    Text("Coach suggested — tap to confirm")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(tintColor.opacity(0.90))
+                }
+                Spacer()
+            }
+
+            // Two rows: 3 + 2 chips. Centred. Wrapping is deterministic and
+            // works across iPhone widths (5 chips × ~80pt > 375pt).
+            //
+            // Ordering is deliberate, not incidental. Order locks in user
+            // muscle memory once shipped; getting it right at v1 is cheap.
+            //   Row 1: warmup → top → backoff
+            //     Mirrors typical within-exercise session progression
+            //     (lighter prep set → heavy working set → secondary set
+            //     after the top). Top sits in the centre of row 1 because
+            //     it is by far the most common AI prefill — placing it on
+            //     the user's natural thumb path minimises tap travel for
+            //     the modal case.
+            //   Row 2: technique → amrap
+            //     Less common intents, demoted to the second row.
+            //     Technique on the left because it's the more common of
+            //     the two for hypertrophy programmes; AMRAP is a
+            //     last-set-of-block surface.
+            VStack(spacing: 8) {
+                HStack(spacing: 8) {
+                    ForEach([SetIntent.warmup, .top, .backoff], id: \.self) { intent in
+                        intentChip(intent)
+                    }
+                }
+                HStack(spacing: 8) {
+                    ForEach([SetIntent.technique, .amrap], id: \.self) { intent in
+                        intentChip(intent)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Three visual states drive chip rendering, derived from `formState`:
+    ///   - **Confirmed**         (`intentTouched && intent == case`): solid
+    ///                            tint background, white bold text — the
+    ///                            user's explicit choice.
+    ///   - **AI-suggested-pending** (`hasUnconfirmedAIPrefill && intent == case`):
+    ///                            tint outline + low-opacity tint fill +
+    ///                            sparkles icon. Visually distinct from
+    ///                            "confirmed" so the user knows a tap is
+    ///                            still required (Slice 6 AC).
+    ///   - **Unselected**         (everything else): white-on-glass-low.
+    @ViewBuilder
+    private func intentChip(_ intent: SetIntent) -> some View {
+        let isConfirmed = formState.intentTouched && formState.intent == intent
+        let isAISuggested = formState.hasUnconfirmedAIPrefill && formState.intent == intent
+
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            formState.recordIntentTap(intent)
+        } label: {
+            HStack(spacing: 4) {
+                if isAISuggested {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 10, weight: .bold))
+                }
+                Text(Self.label(for: intent))
+                    .font(.system(size: 13, weight: isConfirmed ? .bold : .semibold))
+                    .tracking(0.3)
+            }
+            .foregroundStyle(
+                isConfirmed
+                    ? Color.white
+                    : (isAISuggested
+                        ? tintColor
+                        : Color.white.opacity(0.65))
+            )
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .background(
+                ZStack {
+                    Capsule()
+                        .fill(
+                            isConfirmed
+                                ? tintColor
+                                : (isAISuggested
+                                    ? tintColor.opacity(0.14)
+                                    : Color.white.opacity(0.06))
+                        )
+                    Capsule()
+                        .stroke(
+                            isConfirmed
+                                ? tintColor
+                                : (isAISuggested
+                                    ? tintColor.opacity(0.55)
+                                    : Color.white.opacity(0.18)),
+                            lineWidth: isAISuggested ? 1.0 : 0.5
+                        )
+                }
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Self.label(for: intent))
+        .accessibilityValue(isConfirmed
+                            ? "selected"
+                            : (isAISuggested ? "AI suggested, awaiting confirmation" : ""))
+        .accessibilityAddTraits(isConfirmed ? .isSelected : [])
+        .animation(.easeInOut(duration: 0.18), value: formState.intent)
+        .animation(.easeInOut(duration: 0.18), value: formState.intentTouched)
+    }
+
+    /// Display label for a SetIntent. Static so the same labels can be
+    /// reused if a future surface needs them.
+    static func label(for intent: SetIntent) -> String {
+        switch intent {
+        case .warmup:    return "Warmup"
+        case .top:       return "Top"
+        case .backoff:   return "Backoff"
+        case .technique: return "Technique"
+        case .amrap:     return "AMRAP"
+        }
+    }
+}
+
+// MARK: - Picker previews (Slice 6 / #10)
+//
+// These render in Xcode's SwiftUI canvas without needing a workout
+// session, programme, or API key — the whole point is a self-contained
+// HITL surface for visual review. The streak tint colour matches what
+// `mockActive()` uses elsewhere in this file.
+
+private let previewTint = StreakResult.compute(currentStreakDays: 7, longestStreak: 10).tintColor
+
+#Preview("Sheet — AI prefilled, awaiting confirmation") {
+    // hasUnconfirmedAIPrefill == true, canSubmit == false.
+    // The "Top" chip should render with sparkles + low-opacity tint fill.
+    // The "Coach suggested — tap to confirm" hint should appear next to
+    // the "What kind of set?" header. Log Set should be muted (35%
+    // opacity).
+    RepRPEIntentConfirmationSheet(
+        initialState: SetCompletionFormState(
+            actualReps: 8,
+            prescribedIntent: .top
+        ),
+        tintColor: previewTint,
+        onCommit: { _ in }
+    )
+}
+
+#Preview("Sheet — Freestyle, untouched (Log Set disabled)") {
+    // intent == nil, intentTouched == false, canSubmit == false.
+    // No chip is highlighted; no AI-suggested hint. Log Set is muted
+    // (35% opacity) because the gate is closed.
+    RepRPEIntentConfirmationSheet(
+        initialState: SetCompletionFormState(
+            actualReps: 8,
+            prescribedIntent: nil
+        ),
+        tintColor: previewTint,
+        onCommit: { _ in }
+    )
+}
+
+#Preview("Sheet — Confirmed selection (Log Set enabled)") {
+    // intent == .top, intentTouched == true, canSubmit == true.
+    // The "Top" chip renders solid tint + white bold; no AI-suggested
+    // hint. Log Set renders solid tint at 100% opacity.
+    var seed = SetCompletionFormState(actualReps: 8, prescribedIntent: nil)
+    seed.recordIntentTap(.top)
+    return RepRPEIntentConfirmationSheet(
+        initialState: seed,
+        tintColor: previewTint,
+        onCommit: { _ in }
+    )
 }
 
 // MARK: - LiquidWaveModifier

--- a/ProjectApex/Features/Workout/ActiveSetView.swift
+++ b/ProjectApex/Features/Workout/ActiveSetView.swift
@@ -50,15 +50,12 @@ struct ActiveSetView: View {
     /// True after "Set Complete" tap — shows rep/RPE confirmation sheet
     @State private var showRepConfirmation: Bool = false
 
-    /// Actual reps completed (pre-filled from prescription)
-    @State private var actualReps: Int = 8
-
-    /// RPE felt: 0 = Too easy, 1 = On target, 2 = Too hard
-    @State private var rpeFelt: Int = 1
-
-    /// Auto-dismiss timer for the rep/RPE sheet (counts down from 5)
-    @State private var dismissCountdown: Int = 5
-    @State private var dismissTask: Task<Void, Never>?
+    /// Reps / RPE / intent state for the active rep-confirmation sheet.
+    /// Initialised on sheet appearance from the live prescription. Slice 6
+    /// (#10) replaced the previous individual @State fields and the
+    /// 5-second auto-dismiss timer with this unit-testable struct so the
+    /// "Save disabled until explicit intent tap" AC is observable.
+    @State private var formState: SetCompletionFormState = SetCompletionFormState(actualReps: 8)
 
     /// Controls the collapsible reasoning section
     @State private var reasoningExpanded: Bool = false
@@ -196,13 +193,6 @@ struct ActiveSetView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Your progress so far will be saved. You can review your partial session summary.")
-        }
-        // Sync prescription reps into stepper when it changes
-        .onChange(of: viewModel.currentPrescription?.reps) { _, newReps in
-            if let r = newReps { actualReps = r }
-        }
-        .onAppear {
-            if let r = viewModel.currentPrescription?.reps { actualReps = r }
         }
     }
 
@@ -618,95 +608,228 @@ struct ActiveSetView: View {
         }
     }
 
-    // MARK: - Rep / RPE Confirmation Sheet
+    // MARK: - Rep / RPE / Intent Confirmation Sheet (Slice 6 / #10)
 
     private var repRPEConfirmationSheet: some View {
-        VStack(spacing: 28) {
-            // Header with auto-dismiss countdown
-            HStack {
-                Text("How did that feel?")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundStyle(.white)
-                Spacer()
-                if dismissCountdown > 0 {
-                    Text("Auto-logging in \(dismissCountdown)s")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(.white.opacity(0.40))
-                }
-            }
-            .padding(.top, 4)
-
-            // Actual reps stepper
-            VStack(spacing: 10) {
-                Text("Actual Reps")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.50))
-                    .tracking(0.5)
-
-                HStack(spacing: 24) {
-                    Button {
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                        if actualReps > 1 { actualReps -= 1 }
-                        resetDismissCountdown()
-                    } label: {
-                        Image(systemName: "minus.circle.fill")
-                            .font(.system(size: 36))
-                            .foregroundStyle(.white.opacity(0.55))
-                    }
-                    .frame(minWidth: 44, minHeight: 44)
-
-                    Text("\(actualReps)")
-                        .font(.system(size: 48, weight: .bold, design: .rounded).monospacedDigit())
+        ScrollView {
+            VStack(spacing: 24) {
+                // Header — no auto-dismiss countdown per Slice 6 AC.
+                HStack {
+                    Text("How did that feel?")
+                        .font(.system(size: 20, weight: .semibold))
                         .foregroundStyle(.white)
-                        .contentTransition(.numericText())
-                        .frame(minWidth: 72)
+                    Spacer()
+                }
+                .padding(.top, 4)
 
-                    Button {
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                        if actualReps < 30 { actualReps += 1 }
-                        resetDismissCountdown()
-                    } label: {
-                        Image(systemName: "plus.circle.fill")
-                            .font(.system(size: 36))
-                            .foregroundStyle(streak.tintColor.opacity(0.90))
+                // Actual reps stepper
+                VStack(spacing: 10) {
+                    Text("Actual Reps")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.50))
+                        .tracking(0.5)
+
+                    HStack(spacing: 24) {
+                        Button {
+                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                            if formState.actualReps > 1 { formState.actualReps -= 1 }
+                        } label: {
+                            Image(systemName: "minus.circle.fill")
+                                .font(.system(size: 36))
+                                .foregroundStyle(.white.opacity(0.55))
+                        }
+                        .frame(minWidth: 44, minHeight: 44)
+
+                        Text("\(formState.actualReps)")
+                            .font(.system(size: 48, weight: .bold, design: .rounded).monospacedDigit())
+                            .foregroundStyle(.white)
+                            .contentTransition(.numericText())
+                            .frame(minWidth: 72)
+
+                        Button {
+                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                            if formState.actualReps < 30 { formState.actualReps += 1 }
+                        } label: {
+                            Image(systemName: "plus.circle.fill")
+                                .font(.system(size: 36))
+                                .foregroundStyle(streak.tintColor.opacity(0.90))
+                        }
+                        .frame(minWidth: 44, minHeight: 44)
                     }
-                    .frame(minWidth: 44, minHeight: 44)
                 }
-            }
 
-            // RPE/RIR felt — 3-option segmented picker
-            VStack(spacing: 10) {
-                Text("How hard was it?")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.50))
-                    .tracking(0.5)
+                // RPE/RIR felt — 3-option segmented picker
+                VStack(spacing: 10) {
+                    Text("How hard was it?")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.50))
+                        .tracking(0.5)
 
-                Picker("RPE felt", selection: $rpeFelt) {
-                    Text("Too Easy").tag(0)
-                    Text("On Target").tag(1)
-                    Text("Too Hard").tag(2)
+                    Picker("RPE felt", selection: $formState.rpeFelt) {
+                        Text("Too Easy").tag(0)
+                        Text("On Target").tag(1)
+                        Text("Too Hard").tag(2)
+                    }
+                    .pickerStyle(.segmented)
                 }
-                .pickerStyle(.segmented)
-                .onChange(of: rpeFelt) { _, _ in resetDismissCountdown() }
-            }
 
-            // Log button
-            Button {
-                commitSetComplete()
-            } label: {
-                Text("Log Set")
-                    .font(.system(size: 17, weight: .bold))
-                    .foregroundStyle(.white)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 56)
-                    .background(streak.tintColor, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                // Intent picker (Slice 6 / #10) — required, no silent default.
+                intentPickerSection
+
+                // Log button — disabled until intent is explicitly selected.
+                Button {
+                    commitSetComplete()
+                } label: {
+                    Text("Log Set")
+                        .font(.system(size: 17, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 56)
+                        .background(
+                            (formState.canSubmit
+                                ? streak.tintColor
+                                : Color.white.opacity(0.10)),
+                            in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        )
+                }
+                .disabled(!formState.canSubmit)
+                .accessibilityHint(formState.canSubmit
+                                   ? "Log this set"
+                                   : "Pick an intent to enable logging")
+                .animation(.easeInOut(duration: 0.18), value: formState.canSubmit)
             }
+            .padding(24)
         }
-        .padding(24)
         .background(Color(red: 0.07, green: 0.08, blue: 0.10))
         .preferredColorScheme(.dark)
-        .onAppear { startDismissCountdown() }
-        .onDisappear { dismissTask?.cancel() }
+        .onAppear {
+            // Initialise form state from the live prescription. Intent
+            // pre-fills from prescription.intent when present (AI-prescribed
+            // sets) and stays nil for freestyle. `intentTouched` starts
+            // false in both cases — Slice 6 AC: even a matching prefill
+            // requires explicit interaction.
+            formState = SetCompletionFormState(
+                actualReps: viewModel.currentPrescription?.reps ?? formState.actualReps,
+                prescribedIntent: viewModel.currentPrescription?.intent
+            )
+        }
+    }
+
+    // MARK: - Intent Picker (Slice 6 / #10)
+
+    @ViewBuilder
+    private var intentPickerSection: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 6) {
+                Text("What kind of set?")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.50))
+                    .tracking(0.5)
+                if formState.hasUnconfirmedAIPrefill {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(streak.tintColor.opacity(0.90))
+                    Text("Coach suggested — tap to confirm")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(streak.tintColor.opacity(0.90))
+                }
+                Spacer()
+            }
+
+            // Two rows: 3 + 2 chips. Centred. Wrapping is deterministic and
+            // works across iPhone widths (5 chips × ~80pt > 375pt).
+            VStack(spacing: 8) {
+                HStack(spacing: 8) {
+                    ForEach([SetIntent.warmup, .top, .backoff], id: \.self) { intent in
+                        intentChip(intent)
+                    }
+                }
+                HStack(spacing: 8) {
+                    ForEach([SetIntent.technique, .amrap], id: \.self) { intent in
+                        intentChip(intent)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Three visual states drive chip rendering, derived from `formState`:
+    ///   - **Confirmed**         (`intentTouched && intent == case`): solid
+    ///                            tint background, white bold text — the
+    ///                            user's explicit choice.
+    ///   - **AI-suggested-pending** (`hasUnconfirmedAIPrefill && intent == case`):
+    ///                            tint outline + low-opacity tint fill +
+    ///                            sparkles icon. Visually distinct from
+    ///                            "confirmed" so the user knows a tap is
+    ///                            still required (Slice 6 AC).
+    ///   - **Unselected**         (everything else): white-on-glass-low.
+    @ViewBuilder
+    private func intentChip(_ intent: SetIntent) -> some View {
+        let isConfirmed = formState.intentTouched && formState.intent == intent
+        let isAISuggested = formState.hasUnconfirmedAIPrefill && formState.intent == intent
+
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            formState.recordIntentTap(intent)
+        } label: {
+            HStack(spacing: 4) {
+                if isAISuggested {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 10, weight: .bold))
+                }
+                Text(intentLabel(intent))
+                    .font(.system(size: 13, weight: isConfirmed ? .bold : .semibold))
+                    .tracking(0.3)
+            }
+            .foregroundStyle(
+                isConfirmed
+                    ? Color.white
+                    : (isAISuggested
+                        ? streak.tintColor
+                        : Color.white.opacity(0.65))
+            )
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .background(
+                ZStack {
+                    Capsule()
+                        .fill(
+                            isConfirmed
+                                ? streak.tintColor
+                                : (isAISuggested
+                                    ? streak.tintColor.opacity(0.14)
+                                    : Color.white.opacity(0.06))
+                        )
+                    Capsule()
+                        .stroke(
+                            isConfirmed
+                                ? streak.tintColor
+                                : (isAISuggested
+                                    ? streak.tintColor.opacity(0.55)
+                                    : Color.white.opacity(0.18)),
+                            lineWidth: isAISuggested ? 1.0 : 0.5
+                        )
+                }
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(intentLabel(intent))
+        .accessibilityValue(isConfirmed
+                            ? "selected"
+                            : (isAISuggested ? "AI suggested, awaiting confirmation" : ""))
+        .accessibilityAddTraits(isConfirmed ? .isSelected : [])
+        .animation(.easeInOut(duration: 0.18), value: formState.intent)
+        .animation(.easeInOut(duration: 0.18), value: formState.intentTouched)
+    }
+
+    private func intentLabel(_ intent: SetIntent) -> String {
+        switch intent {
+        case .warmup:    return "Warmup"
+        case .top:       return "Top"
+        case .backoff:   return "Backoff"
+        case .technique: return "Technique"
+        case .amrap:     return "AMRAP"
+        }
     }
 
     // MARK: - Voice Note Modal (P4-T06)
@@ -996,36 +1119,25 @@ struct ActiveSetView: View {
 
     private func handleSetCompleteTap() {
         UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
-        actualReps = viewModel.currentPrescription?.reps ?? actualReps
-        rpeFelt = 1
+        // Sheet's onAppear seeds the formState from the prescription —
+        // resetting here would race with that. The sheet is single-shot
+        // per Set Complete tap.
         showRepConfirmation = true
     }
 
     private func commitSetComplete() {
-        dismissTask?.cancel()
+        // Slice 6 AC: this path is only reachable when formState.canSubmit
+        // is true (button is disabled otherwise). Defensive guard left in
+        // case the path is invoked programmatically in the future.
+        guard formState.canSubmit, let chosenIntent = formState.intent else { return }
         showRepConfirmation = false
         // Map 0/1/2 picker to a rough RPE value: too easy = 5, on target = 7, too hard = 9
-        let rpeValue: Int = [5, 7, 9][rpeFelt]
-        viewModel.onSetComplete(actualReps: actualReps, rpeFelt: rpeValue)
-    }
-
-    private func startDismissCountdown() {
-        dismissCountdown = 5
-        dismissTask = Task {
-            while dismissCountdown > 0 {
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-                if Task.isCancelled { return }
-                dismissCountdown -= 1
-            }
-            // Auto-commit on expiry
-            commitSetComplete()
-        }
-    }
-
-    private func resetDismissCountdown() {
-        dismissTask?.cancel()
-        dismissCountdown = 5
-        startDismissCountdown()
+        let rpeValue: Int = [5, 7, 9][formState.rpeFelt]
+        viewModel.onSetComplete(
+            actualReps: formState.actualReps,
+            rpeFelt: rpeValue,
+            intent: chosenIntent
+        )
     }
 
 }

--- a/ProjectApex/Features/Workout/ActiveSetView.swift
+++ b/ProjectApex/Features/Workout/ActiveSetView.swift
@@ -1158,7 +1158,8 @@ private extension AnyTransition {
         coachingCue: "Reduce ROM slightly — pain flag active",
         reasoning: "HRV -22% · pain_reported in previous note → load reduced 15%.",
         safetyFlags: [.painReported, .shoulderCaution],
-        confidence: 0.72
+        confidence: 0.72,
+        intent: .top
     )
     return ActiveSetView(
         viewModel: vm,

--- a/ProjectApex/Features/Workout/ManualSessionLogView.swift
+++ b/ProjectApex/Features/Workout/ManualSessionLogView.swift
@@ -31,6 +31,43 @@ struct ManualSetEntry: Identifiable {
     // Formatted weight string for the text field
     var weightString: String = ""
     var rpeString: String = ""
+
+    // Slice 6 (#10) — set-intent capture for manual log entries.
+    /// Selected intent. Nil until the user picks one — no silent default.
+    var intent: SetIntent? = nil
+    /// Whether the user has explicitly interacted with the intent picker
+    /// for this set. Save is gated on this flag for every non-empty entry.
+    /// The flag is the load-bearing rule from issue #10 — even if a future
+    /// flow pre-fills `intent`, the user must still tap.
+    var intentTouched: Bool = false
+
+    /// True when this entry has weight or reps and therefore counts toward
+    /// the manual-log submission. Mirrors the
+    /// `guard reps > 0 || weight > 0 else { continue }` filter applied at
+    /// submit time (see `submitSession`). Empty entries are skipped — they
+    /// neither gate nor contribute.
+    var hasContent: Bool {
+        let parsedWeight = Double(weightString.replacingOccurrences(of: ",", with: ".")) ?? weightKg
+        return reps > 0 || parsedWeight > 0
+    }
+}
+
+// MARK: - Submit gate (Slice 6 / #10) — unit-testable helper
+
+/// Returns true when every non-empty set entry across every exercise has
+/// a touched intent. Pulled out as a top-level function so the gate is
+/// observable from XCTest without a SwiftUI / @State harness.
+///
+/// AC from issue #10: Save disabled until each non-empty set entry has
+/// an explicitly-tapped intent. Empty entries (no weight, no reps) do
+/// not gate — they're filtered out at submit.
+func manualLogCanSubmit(entries: [ManualExerciseEntry]) -> Bool {
+    for entry in entries {
+        for setEntry in entry.sets where setEntry.hasContent {
+            if !setEntry.intentTouched { return false }
+        }
+    }
+    return true
 }
 
 // MARK: - ManualExerciseEntry
@@ -194,9 +231,33 @@ struct ManualSessionLogView: View {
 
     // MARK: - Submit Button
 
+    /// Slice 6 (#10): Save is disabled until every non-empty set entry has
+    /// a touched intent. Gating logic lives in the file-scope helper
+    /// `manualLogCanSubmit(entries:)` so it's unit-testable.
+    private var canSubmit: Bool {
+        !isSubmitting && manualLogCanSubmit(entries: entries)
+    }
+
     private var submitButton: some View {
         VStack(spacing: 0) {
             Divider().background(Color.white.opacity(0.06))
+
+            // Inline hint when the gate is closed by missing intents — gives
+            // the user a reason for the disabled state rather than a silent
+            // dead button.
+            if !isSubmitting && !manualLogCanSubmit(entries: entries) {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.circle")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("Pick an intent for every logged set before saving")
+                        .font(.system(size: 12, weight: .medium))
+                    Spacer()
+                }
+                .foregroundStyle(Color(red: 1.0, green: 0.75, blue: 0.0).opacity(0.85))
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+            }
+
             Button(action: {
                 Task { await submitSession() }
             }) {
@@ -216,17 +277,21 @@ struct ManualSessionLogView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 18)
                 .background(
-                    isSubmitting
-                        ? Color(red: 0.23, green: 0.56, blue: 1.00).opacity(0.60)
-                        : Color(red: 0.23, green: 0.56, blue: 1.00),
+                    canSubmit
+                        ? Color(red: 0.23, green: 0.56, blue: 1.00)
+                        : Color(red: 0.23, green: 0.56, blue: 1.00).opacity(0.30),
                     in: RoundedRectangle(cornerRadius: 16, style: .continuous)
                 )
                 .foregroundStyle(.white)
             }
-            .disabled(isSubmitting)
+            .disabled(!canSubmit)
+            .accessibilityHint(canSubmit
+                               ? "Save this manual session"
+                               : "Pick an intent for every logged set first")
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
             .background(Color(red: 0.04, green: 0.04, blue: 0.06))
+            .animation(.easeInOut(duration: 0.18), value: canSubmit)
         }
     }
 
@@ -318,7 +383,14 @@ struct ManualSessionLogView: View {
                     rirEstimated: rpe.map { max(0, 10 - $0) },
                     aiPrescribed: nil,
                     loggedAt: sessionDate,
-                    primaryMuscle: ExerciseLibrary.primaryMuscle(for: entry.exercise.exerciseId)?.rawValue ?? entry.exercise.primaryMuscle
+                    primaryMuscle: ExerciseLibrary.primaryMuscle(for: entry.exercise.exerciseId)?.rawValue ?? entry.exercise.primaryMuscle,
+                    // Slice 6 (#10): picker-captured intent threaded into
+                    // the SetLog client-side. ManualSetLogPayload encoder
+                    // does NOT serialise this in Phase 0 (γ — top-level
+                    // column doesn't exist; user-truthful intent for
+                    // pre-cutoff freestyle rows is the documented
+                    // trade-off). Phase 1+ Swift release will promote.
+                    intent: setEntry.intent
                 )
                 allSetLogs.append((setLog, entry.exercise))
             }
@@ -428,18 +500,20 @@ private struct ExerciseLogCard: View {
             // Column headers
             HStack(spacing: 0) {
                 Text("SET")
-                    .frame(width: 40, alignment: .center)
+                    .frame(width: 32, alignment: .center)
                 Text("WEIGHT (KG)")
                     .frame(maxWidth: .infinity, alignment: .center)
                 Text("REPS")
-                    .frame(width: 64, alignment: .center)
+                    .frame(width: 56, alignment: .center)
                 Text("RPE")
-                    .frame(width: 64, alignment: .center)
+                    .frame(width: 48, alignment: .center)
+                Text("INTENT")
+                    .frame(width: 80, alignment: .center)
             }
             .font(.system(size: 10, weight: .semibold))
             .foregroundStyle(.white.opacity(0.35))
             .kerning(0.4)
-            .padding(.horizontal, 16)
+            .padding(.horizontal, 12)
             .padding(.vertical, 8)
 
             Divider().background(Color.white.opacity(0.06))
@@ -529,7 +603,7 @@ private struct SetInputRow: View {
             Text("\(setNumber)")
                 .font(.system(size: 14, weight: .bold, design: .rounded))
                 .foregroundStyle(.white.opacity(0.45))
-                .frame(width: 40, alignment: .center)
+                .frame(width: 32, alignment: .center)
 
             // Weight input
             TextField("0", text: $setEntry.weightString)
@@ -541,22 +615,22 @@ private struct SetInputRow: View {
                 .padding(.vertical, 10)
 
             // Reps stepper
-            HStack(spacing: 6) {
+            HStack(spacing: 4) {
                 Button(action: {
                     setEntry.reps = max(0, setEntry.reps - 1)
                 }) {
                     Image(systemName: "minus")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundStyle(.white.opacity(0.50))
-                        .frame(width: 24, height: 24)
+                        .frame(width: 20, height: 20)
                         .background(Color.white.opacity(0.08), in: Circle())
                 }
                 .buttonStyle(.plain)
 
                 Text("\(setEntry.reps)")
-                    .font(.system(size: 16, weight: .semibold, design: .rounded).monospacedDigit())
+                    .font(.system(size: 14, weight: .semibold, design: .rounded).monospacedDigit())
                     .foregroundStyle(.white)
-                    .frame(width: 30, alignment: .center)
+                    .frame(width: 24, alignment: .center)
 
                 Button(action: {
                     setEntry.reps = setEntry.reps + 1
@@ -564,23 +638,93 @@ private struct SetInputRow: View {
                     Image(systemName: "plus")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundStyle(.white.opacity(0.50))
-                        .frame(width: 24, height: 24)
+                        .frame(width: 20, height: 20)
                         .background(Color.white.opacity(0.08), in: Circle())
                 }
                 .buttonStyle(.plain)
             }
-            .frame(width: 64)
+            .frame(width: 56)
 
             // RPE input (optional, 1-10)
             TextField("—", text: $setEntry.rpeString)
                 .keyboardType(.numberPad)
-                .font(.system(size: 16, weight: .semibold, design: .rounded).monospacedDigit())
+                .font(.system(size: 14, weight: .semibold, design: .rounded).monospacedDigit())
                 .foregroundStyle(.white.opacity(0.70))
                 .multilineTextAlignment(.center)
-                .frame(width: 64)
+                .frame(width: 48)
                 .padding(.vertical, 10)
+
+            // Intent picker (Slice 6 / #10).
+            // Compact menu — fits the existing dense-row visual rhythm. Shows
+            // "—" while untouched (visual cue that the field is required);
+            // shows the selected intent name once tapped. Empty rows
+            // (weight = 0 AND reps = 0) don't gate at submit, but the
+            // picker is still tappable in case the user wants to fill the
+            // intent before the numbers.
+            intentMenu
+                .frame(width: 80)
         }
-        .padding(.horizontal, 16)
+        .padding(.horizontal, 12)
+    }
+
+    @ViewBuilder
+    private var intentMenu: some View {
+        Menu {
+            ForEach(SetIntent.allCases, id: \.self) { intent in
+                Button {
+                    setEntry.intent = intent
+                    setEntry.intentTouched = true
+                } label: {
+                    if setEntry.intent == intent {
+                        Label(intentLabel(intent), systemImage: "checkmark")
+                    } else {
+                        Text(intentLabel(intent))
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(setEntry.intentTouched
+                     ? (setEntry.intent.map(intentLabel) ?? "—")
+                     : "—")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(setEntry.intentTouched
+                                     ? Color(red: 0.23, green: 0.56, blue: 1.00)
+                                     : .white.opacity(0.45))
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.40))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .background(
+                Capsule()
+                    .fill(Color.white.opacity(0.06))
+            )
+            .overlay(
+                Capsule()
+                    .stroke(
+                        setEntry.intentTouched
+                            ? Color(red: 0.23, green: 0.56, blue: 1.00).opacity(0.50)
+                            : Color.white.opacity(0.15),
+                        lineWidth: 0.5
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Set \(setNumber) intent")
+        .accessibilityValue(setEntry.intent.map(intentLabel) ?? "Not selected")
+    }
+
+    private func intentLabel(_ intent: SetIntent) -> String {
+        switch intent {
+        case .warmup:    return "Warmup"
+        case .top:       return "Top"
+        case .backoff:   return "Backoff"
+        case .technique: return "Technique"
+        case .amrap:     return "AMRAP"
+        }
     }
 }
 

--- a/ProjectApex/Features/Workout/ManualSessionLogView.swift
+++ b/ProjectApex/Features/Workout/ManualSessionLogView.swift
@@ -655,12 +655,30 @@ private struct SetInputRow: View {
                 .padding(.vertical, 10)
 
             // Intent picker (Slice 6 / #10).
-            // Compact menu — fits the existing dense-row visual rhythm. Shows
-            // "—" while untouched (visual cue that the field is required);
-            // shows the selected intent name once tapped. Empty rows
-            // (weight = 0 AND reps = 0) don't gate at submit, but the
-            // picker is still tappable in case the user wants to fill the
-            // intent before the numbers.
+            //
+            // Deliberate asymmetry with ActiveSetView's chip-row picker:
+            // ActiveSetView dedicates the full screen width to one set,
+            // so a 5-chip row is thumb-friendly and visually rich. This
+            // surface packs N exercises × M sets per exercise into a
+            // dense table — adding a 5-chip row per set would either
+            // double the table height (a chip row below each input row)
+            // or wrap-fail at iPhone widths (5 × ~80pt chip > 375pt
+            // available row width minus the existing 4 columns). A
+            // compact Menu fits as a 5th column in the existing row
+            // rhythm.
+            //
+            // The trade-off is one of two interaction patterns for the
+            // same data type — chips elsewhere, dropdown here. Documented
+            // in the PR description so future maintainers understand the
+            // intent. If the manual log is ever redesigned to a per-set
+            // expanded layout (e.g. card per set), revisit and unify on
+            // chips.
+            //
+            // Visual: shows "—" while untouched (cue that the field is
+            // required); shows the selected intent name once tapped.
+            // Empty rows (weight = 0 AND reps = 0) don't gate at submit,
+            // but the picker is still tappable so the user can fill the
+            // intent before the numbers if they prefer that order.
             intentMenu
                 .frame(width: 80)
         }
@@ -816,4 +834,72 @@ private extension String {
         programId: UUID()
     )
     .environment(AppDependencies())
+}
+
+// MARK: - Slice 6 picker previews (#10)
+//
+// Exercises the per-set intent picker (compact Menu in the rightmost
+// column) under realistic mixed-state data. HITL visual review uses
+// these to verify column readability at iPhone Pro widths and the
+// touched/untouched visual distinction.
+
+private struct ManualLogIntentPickerPreview: View {
+    @State private var entry: ManualExerciseEntry
+
+    init() {
+        let exercise = PlannedExercise(
+            id: UUID(),
+            exerciseId: "barbell_bench_press",
+            name: "Barbell Bench Press",
+            primaryMuscle: "pectoralis_major",
+            synergists: ["anterior_deltoid", "triceps_brachii"],
+            equipmentRequired: .barbell,
+            sets: 4,
+            repRange: RepRange(min: 6, max: 10),
+            tempo: "3-1-1-0",
+            restSeconds: 150,
+            rirTarget: 2,
+            coachingCues: []
+        )
+        var e = ManualExerciseEntry(exercise: exercise)
+        // Replace auto-generated empties with a realistic mixed-state set.
+        // Set 1: confirmed top (touched) — picker shows "Top" in blue.
+        var s1 = ManualSetEntry(); s1.weightString = "80"; s1.reps = 10
+        s1.rpeString = "7"; s1.intent = .top; s1.intentTouched = true
+        // Set 2: non-empty but UNTOUCHED — gates the Save button. Picker
+        // shows "—" in muted white. This is the case the AC hangs on.
+        var s2 = ManualSetEntry(); s2.weightString = "80"; s2.reps = 10
+        s2.rpeString = "8"
+        // Set 3: empty — does not gate, picker still tappable but stays "—".
+        let s3 = ManualSetEntry()
+        // Set 4: confirmed backoff (touched) — picker shows "Backoff" in blue.
+        var s4 = ManualSetEntry(); s4.weightString = "70"; s4.reps = 8
+        s4.rpeString = "7"; s4.intent = .backoff; s4.intentTouched = true
+        e.sets = [s1, s2, s3, s4]
+        _entry = State(initialValue: e)
+    }
+
+    var body: some View {
+        ZStack {
+            Color(red: 0.04, green: 0.04, blue: 0.06).ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: 16) {
+                    ExerciseLogCard(entry: $entry)
+                        .padding(.horizontal, 16)
+                }
+                .padding(.top, 16)
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+}
+
+#Preview("Manual log — 4 sets, mixed touched/untouched") {
+    // Row 1 (touched, .top):       Picker shows "Top"     in app-blue.
+    // Row 2 (NON-EMPTY, untouched): Picker shows "—" muted — the gating case.
+    // Row 3 (empty):                Picker shows "—" muted — does not gate.
+    // Row 4 (touched, .backoff):    Picker shows "Backoff" in app-blue.
+    // The Save Session button (not visible in this card-only preview) would
+    // be DISABLED by row 2's untouched intent.
+    ManualLogIntentPickerPreview()
 }

--- a/ProjectApex/Features/Workout/RestTimerView.swift
+++ b/ProjectApex/Features/Workout/RestTimerView.swift
@@ -579,7 +579,8 @@ private struct LiquidWaveMiniModifier: ViewModifier {
         coachingCue: "Drive through the bar",
         reasoning: "Up 2.5 kg from last session — HRV trending positive.",
         safetyFlags: [],
-        confidence: 0.91
+        confidence: 0.91,
+        intent: .top
     )
     return RestTimerView(
         viewModel: vm,

--- a/ProjectApex/Features/Workout/RestTimerView.swift
+++ b/ProjectApex/Features/Workout/RestTimerView.swift
@@ -580,7 +580,8 @@ private struct LiquidWaveMiniModifier: ViewModifier {
         reasoning: "Up 2.5 kg from last session — HRV trending positive.",
         safetyFlags: [],
         confidence: 0.91,
-        intent: .top
+        intent: .top,
+        setFraming: "Heaviest work of the day. Brace and grind."
     )
     return RestTimerView(
         viewModel: vm,

--- a/ProjectApex/Features/Workout/SetCompletionFormState.swift
+++ b/ProjectApex/Features/Workout/SetCompletionFormState.swift
@@ -1,0 +1,102 @@
+// SetCompletionFormState.swift
+// ProjectApex — Features/Workout
+//
+// Unit-testable state model for the rep / RPE / intent confirmation sheet
+// shown when the user taps "Set Complete" (Slice 6, issue #10).
+//
+// The shape exists to make the AC "Save is disabled until the user has
+// explicitly interacted with the picker, even if the initial selection
+// matches their intent" observable from XCTest. ActiveSetView consumes
+// this struct via `@State`; tests construct it directly and drive
+// transitions through `recordIntentTap(_:)`.
+//
+// Visual distinction between an AI-prefilled-pending-confirmation chip and
+// a user-explicitly-tapped chip is HITL territory and lives in the SwiftUI
+// view; this struct only carries the boolean separation that distinguishes
+// the two states.
+//
+// LIFECYCLE ASSUMPTION (load-bearing):
+//   The form is constructed once when the rep/RPE sheet appears (user taps
+//   "Set Complete") and discarded when the sheet dismisses on commit. While
+//   the sheet is on-screen, `prescribedIntent` does NOT change — every path
+//   that mutates `WorkoutViewModel.currentPrescription` (AI re-prescribe,
+//   weight correction, weight override, manual fallback) operates on the
+//   underlying ActiveSetView card BEFORE Set Complete is tapped, not while
+//   the rep/RPE sheet is presented modally.
+//
+//   If a future flow introduces a path where `prescribedIntent` can change
+//   while the form is open, that path MUST reset `intentTouched` to false on
+//   meaningful prefill change — otherwise the AC silently breaks (the user
+//   would see a NEW AI suggestion already "confirmed" without explicit tap,
+//   defeating the no-silent-default rule). The reset hook would live as a
+//   new mutating method like `noteRePrefill(_ next: SetIntent?)` that wipes
+//   `intentTouched`. Add a unit test alongside it that asserts
+//   `canSubmit == false` after re-prefill.
+
+import Foundation
+
+struct SetCompletionFormState: Equatable {
+
+    // MARK: - User-entered fields
+
+    /// Reps the user actually completed. Pre-filled from the prescription at
+    /// init; mutated by the +/- stepper.
+    var actualReps: Int
+
+    /// 0 = too easy, 1 = on target, 2 = too hard. Mapped to RPE 5/7/9 at
+    /// commit time (matches the existing ActiveSetView mapping).
+    var rpeFelt: Int
+
+    /// The selected SetIntent. Pre-filled from `prescription.intent` for AI-
+    /// prescribed sets so the picker can highlight the AI's suggestion;
+    /// `nil` for freestyle sets where there is no AI pre-fill.
+    var intent: SetIntent?
+
+    /// Whether the user has explicitly tapped a chip in this session of the
+    /// sheet. The "even if initial selection matches their intent" rule from
+    /// issue #10 forces this to be a separate signal from `intent != nil`.
+    /// Once true, never resets within the sheet's lifetime — re-tapping
+    /// keeps it true.
+    private(set) var intentTouched: Bool
+
+    // MARK: - Derived
+
+    /// Whether "Log Set" should enable. Both conditions are required:
+    ///   1. An intent is selected (`intent != nil`).
+    ///   2. The user has explicitly interacted with the picker
+    ///      (`intentTouched == true`).
+    /// The second condition is the load-bearing rule for Slice 6.
+    var canSubmit: Bool {
+        intent != nil && intentTouched
+    }
+
+    /// True when an AI prefill is sitting un-confirmed. Used by the view to
+    /// render the prefilled chip in a visually distinct "AI suggested,
+    /// awaiting confirmation" state vs. a confirmed selection.
+    var hasUnconfirmedAIPrefill: Bool {
+        intent != nil && !intentTouched
+    }
+
+    // MARK: - Init
+
+    /// Construct fresh state for a new sheet appearance.
+    /// - Parameter prescribedIntent: when non-nil, the AI's suggested intent
+    ///   pre-fills the picker selection. `intentTouched` stays `false` until
+    ///   the user explicitly taps.
+    init(actualReps: Int, rpeFelt: Int = 1, prescribedIntent: SetIntent? = nil) {
+        self.actualReps    = actualReps
+        self.rpeFelt       = rpeFelt
+        self.intent        = prescribedIntent
+        self.intentTouched = false
+    }
+
+    // MARK: - Mutators
+
+    /// Record an explicit picker tap. Sets `intent` and flips
+    /// `intentTouched` to true. Subsequent taps keep `intentTouched` true
+    /// even if the user changes selection.
+    mutating func recordIntentTap(_ next: SetIntent) {
+        self.intent        = next
+        self.intentTouched = true
+    }
+}

--- a/ProjectApex/Features/Workout/SetCompletionFormState.swift
+++ b/ProjectApex/Features/Workout/SetCompletionFormState.swift
@@ -114,6 +114,24 @@ struct SetCompletionFormState: Equatable {
         isDeviationPickerVisible = true
     }
 
+    /// User tapped the dismiss affordance ("Never mind") on the
+    /// expanded deviation picker. Collapses the picker AND resets
+    /// `resolvedIntent` to `prescribedIntent` — discards any deviation
+    /// the user expressed but then thought better of. The "forgiving
+    /// over strict" rule: users change their minds about whether they
+    /// deviated; don't trap them in tentative selections.
+    ///
+    /// No-op for freestyle (`prescribedIntent == nil`) — the picker is
+    /// the only path to an intent in that case, so dismissing it would
+    /// strand the user with a non-submittable form. The UI affordance
+    /// is also hidden in that case (only AI-prescribed sets show the
+    /// "Did something different?" / "Never mind" link).
+    mutating func dismissDeviationPicker() {
+        guard prescribedIntent != nil else { return }
+        isDeviationPickerVisible = false
+        resolvedIntent = prescribedIntent
+    }
+
     /// User picked an intent from the chip row. Updates resolvedIntent.
     /// For AI-prescribed sets where this matches `prescribedIntent`,
     /// `isDeviation` stays false (re-affirming the prescription is not

--- a/ProjectApex/Features/Workout/SetCompletionFormState.swift
+++ b/ProjectApex/Features/Workout/SetCompletionFormState.swift
@@ -4,34 +4,28 @@
 // Unit-testable state model for the rep / RPE / intent confirmation sheet
 // shown when the user taps "Set Complete" (Slice 6, issue #10).
 //
-// The shape exists to make the AC "Save is disabled until the user has
-// explicitly interacted with the picker, even if the initial selection
-// matches their intent" observable from XCTest. ActiveSetView consumes
-// this struct via `@State`; tests construct it directly and drive
-// transitions through `recordIntentTap(_:)`.
+// REDESIGN NOTE (supersedes the prior intentTouched-based shape):
+//   The prior model was wrong — it asked the user to confirm an intent
+//   the AI had already explicitly told them via the prescription. That's
+//   redundant data entry, not no-silent-defaults enforcement.
 //
-// Visual distinction between an AI-prefilled-pending-confirmation chip and
-// a user-explicitly-tapped chip is HITL territory and lives in the SwiftUI
-// view; this struct only carries the boolean separation that distinguishes
-// the two states.
+//   The correct model is: the AI's prescription IS the explicit intent.
+//   The picker captures DEVIATION (when the user actually did something
+//   different), not confirmation. AI-prescribed sets default to the
+//   prescribed intent — zero friction, Save Set always enabled.
+//   Freestyle sets (no AI prescription) still require an explicit pick
+//   before Save Set enables (the picker is the only source of intent
+//   in that case).
 //
-// LIFECYCLE ASSUMPTION (load-bearing):
-//   The form is constructed once when the rep/RPE sheet appears (user taps
-//   "Set Complete") and discarded when the sheet dismisses on commit. While
-//   the sheet is on-screen, `prescribedIntent` does NOT change — every path
-//   that mutates `WorkoutViewModel.currentPrescription` (AI re-prescribe,
-//   weight correction, weight override, manual fallback) operates on the
-//   underlying ActiveSetView card BEFORE Set Complete is tapped, not while
-//   the rep/RPE sheet is presented modally.
-//
-//   If a future flow introduces a path where `prescribedIntent` can change
-//   while the form is open, that path MUST reset `intentTouched` to false on
-//   meaningful prefill change — otherwise the AC silently breaks (the user
-//   would see a NEW AI suggestion already "confirmed" without explicit tap,
-//   defeating the no-silent-default rule). The reset hook would live as a
-//   new mutating method like `noteRePrefill(_ next: SetIntent?)` that wipes
-//   `intentTouched`. Add a unit test alongside it that asserts
-//   `canSubmit == false` after re-prefill.
+// LIFECYCLE ASSUMPTION (load-bearing, unchanged from prior version):
+//   The form is constructed once when the rep/RPE sheet appears (user
+//   taps "Set Complete") and discarded when the sheet dismisses on
+//   commit. While the sheet is on-screen, `prescribedIntent` does NOT
+//   change. If a future flow introduces a path where it can change,
+//   that path must reset `resolvedIntent` to the new prescribed value
+//   (collapsing any deviation the user already expressed) — otherwise
+//   the user's deviation gets silently re-attached to a different
+//   prescription, which is meaningless data.
 
 import Foundation
 
@@ -39,64 +33,103 @@ struct SetCompletionFormState: Equatable {
 
     // MARK: - User-entered fields
 
-    /// Reps the user actually completed. Pre-filled from the prescription at
-    /// init; mutated by the +/- stepper.
+    /// Reps the user actually completed. Pre-filled from the prescription
+    /// at init; mutated by the +/- stepper.
     var actualReps: Int
 
     /// 0 = too easy, 1 = on target, 2 = too hard. Mapped to RPE 5/7/9 at
     /// commit time (matches the existing ActiveSetView mapping).
     var rpeFelt: Int
 
-    /// The selected SetIntent. Pre-filled from `prescription.intent` for AI-
-    /// prescribed sets so the picker can highlight the AI's suggestion;
-    /// `nil` for freestyle sets where there is no AI pre-fill.
-    var intent: SetIntent?
+    // MARK: - Intent (Slice 6 redesign)
 
-    /// Whether the user has explicitly tapped a chip in this session of the
-    /// sheet. The "even if initial selection matches their intent" rule from
-    /// issue #10 forces this to be a separate signal from `intent != nil`.
-    /// Once true, never resets within the sheet's lifetime — re-tapping
-    /// keeps it true.
-    private(set) var intentTouched: Bool
+    /// What the AI prescribed, captured immutably at construction.
+    /// Nil for freestyle sets (no AI prescription).
+    let prescribedIntent: SetIntent?
+
+    /// What ends up persisted to SetLog. Defaults to `prescribedIntent`
+    /// for AI-prescribed sets; nil for freestyle until the user picks.
+    var resolvedIntent: SetIntent?
+
+    /// True when the deviation chip-row is currently visible.
+    /// AI-prescribed: false by default; flips true when the user taps
+    /// "Did something different?". Cannot revert to false (no need to
+    /// re-hide; user just picks the prescribed value if they change their
+    /// mind).
+    /// Freestyle: true by default — picker is the only path to an intent.
+    var isDeviationPickerVisible: Bool
+
+    /// User-reported flags raised on the rep/RPE sheet immediately
+    /// post-set. Multi-select; default empty. Slice 6 / #10.
+    var completionFlags: Set<SetCompletionFlag>
 
     // MARK: - Derived
 
-    /// Whether "Log Set" should enable. Both conditions are required:
-    ///   1. An intent is selected (`intent != nil`).
-    ///   2. The user has explicitly interacted with the picker
-    ///      (`intentTouched == true`).
-    /// The second condition is the load-bearing rule for Slice 6.
-    var canSubmit: Bool {
-        intent != nil && intentTouched
+    /// True when the user explicitly picked an intent that differs from
+    /// the prescribed value. Drives the `is_deviation` analytics signal
+    /// surfaced in `WorkoutContext` for in-session AI reasoning.
+    /// Always false for freestyle (no prescription to deviate from).
+    var isDeviation: Bool {
+        guard let prescribed = prescribedIntent,
+              let resolved = resolvedIntent else { return false }
+        return prescribed != resolved
     }
 
-    /// True when an AI prefill is sitting un-confirmed. Used by the view to
-    /// render the prefilled chip in a visually distinct "AI suggested,
-    /// awaiting confirmation" state vs. a confirmed selection.
-    var hasUnconfirmedAIPrefill: Bool {
-        intent != nil && !intentTouched
+    /// Whether "Log Set" should enable.
+    ///   AI-prescribed: always submittable (resolvedIntent always set
+    ///                  to prescribedIntent on init; the user can change
+    ///                  it but cannot make it nil).
+    ///   Freestyle:     requires resolvedIntent != nil — i.e., the user
+    ///                  has made an explicit pick.
+    var canSubmit: Bool {
+        resolvedIntent != nil
     }
 
     // MARK: - Init
 
     /// Construct fresh state for a new sheet appearance.
-    /// - Parameter prescribedIntent: when non-nil, the AI's suggested intent
-    ///   pre-fills the picker selection. `intentTouched` stays `false` until
-    ///   the user explicitly taps.
-    init(actualReps: Int, rpeFelt: Int = 1, prescribedIntent: SetIntent? = nil) {
-        self.actualReps    = actualReps
-        self.rpeFelt       = rpeFelt
-        self.intent        = prescribedIntent
-        self.intentTouched = false
+    ///   - prescribedIntent: AI's intent for this set, or nil for freestyle.
+    ///     Sets `resolvedIntent` to the same value (zero-friction default
+    ///     for AI-prescribed) and seeds `isDeviationPickerVisible` based
+    ///     on whether the picker is the only path (freestyle: yes;
+    ///     AI-prescribed: hidden behind the "Did something different?"
+    ///     affordance).
+    init(actualReps: Int, rpeFelt: Int = 1, prescribedIntent: SetIntent?) {
+        self.actualReps = actualReps
+        self.rpeFelt = rpeFelt
+        self.prescribedIntent = prescribedIntent
+        self.resolvedIntent = prescribedIntent
+        self.isDeviationPickerVisible = (prescribedIntent == nil)
+        self.completionFlags = []
     }
 
     // MARK: - Mutators
 
-    /// Record an explicit picker tap. Sets `intent` and flips
-    /// `intentTouched` to true. Subsequent taps keep `intentTouched` true
-    /// even if the user changes selection.
-    mutating func recordIntentTap(_ next: SetIntent) {
-        self.intent        = next
-        self.intentTouched = true
+    /// User tapped "Did something different?" on an AI-prescribed set.
+    /// Reveals the chip row. The prescribed intent is already selected
+    /// (resolvedIntent == prescribedIntent at this point) — the chip
+    /// row gives the user a way to change it. Idempotent: calling on
+    /// an already-visible picker is a no-op.
+    mutating func revealDeviationPicker() {
+        isDeviationPickerVisible = true
+    }
+
+    /// User picked an intent from the chip row. Updates resolvedIntent.
+    /// For AI-prescribed sets where this matches `prescribedIntent`,
+    /// `isDeviation` stays false (re-affirming the prescription is not
+    /// deviation). For freestyle, this is the ONLY path to a non-nil
+    /// resolvedIntent.
+    mutating func selectIntent(_ next: SetIntent) {
+        self.resolvedIntent = next
+    }
+
+    /// Toggle a completion flag on or off. Multi-select — pain and
+    /// formBreakdown can both be raised.
+    mutating func toggleFlag(_ flag: SetCompletionFlag) {
+        if completionFlags.contains(flag) {
+            completionFlags.remove(flag)
+        } else {
+            completionFlags.insert(flag)
+        }
     }
 }

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -683,6 +683,11 @@ actor WorkoutSessionManager {
             .filter { $0.exerciseId == exercise.exerciseId }
             .max(by: { $0.setNumber < $1.setNumber })
 
+        // Intent carry-over: when the user opts into the manual fallback
+        // ("Continue with last weights"), inherit the prior set's intent as a
+        // *suggestion* for the picker to prefill. Stays `nil` when there's no
+        // prior set in the session — the picker then has no prefill and the
+        // user must pick explicitly per Slice 6's no-silent-default rule.
         let prescription = SetPrescription(
             weightKg:          lastSet?.weightKg ?? 0.0,
             reps:              lastSet?.repsCompleted ?? exercise.repRange.min,
@@ -694,7 +699,8 @@ actor WorkoutSessionManager {
             safetyFlags:       [],
             confidence:        nil,
             userCorrectedWeight: nil,
-            isManualFallback:  true
+            isManualFallback:  true,
+            intent:            lastSet?.intent
         )
         currentPrescription = prescription
         inferenceRetryNeeded = false

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -281,7 +281,12 @@ actor WorkoutSessionManager {
     ///   3. Assemble WorkoutContext
     ///   4. Await AI prescription on a child Task
     ///   5. On result: update currentPrescription; when timer expires → .active
-    func completeSet(actualReps: Int, rpeFelt: Int?, intent: SetIntent) async {
+    func completeSet(
+        actualReps: Int,
+        rpeFelt: Int?,
+        intent: SetIntent,
+        completionFlags: [SetCompletionFlag] = []
+    ) async {
         guard case .active(let exercise, let setNumber) = sessionState,
               let session = session else { return }
 
@@ -292,12 +297,14 @@ actor WorkoutSessionManager {
         let capturedGeneration = inferenceGeneration
 
         // Build and store set log.
-        // Slice 6 (#10): intent comes from the AI prescription in this
-        // (auto-driven) flow. Currently NOT exposed to the rep/RPE sheet
-        // for user override at completion time — completeSet is invoked
-        // with the prescription's intent implicit. If the picker UI ever
-        // grows the ability to override the AI's intent at completion,
-        // thread the picker's value here instead of `currentPrescription?.intent`.
+        // Slice 6 (#10): intent is the RESOLVED value from the rep/RPE
+        // sheet — defaults to the prescription's intent for AI-prescribed
+        // sets, or the user's deviation pick if they tapped "Did
+        // something different?". `is_deviation` is derivable from
+        // `setLog.intent != setLog.aiPrescribed?.intent`, so we don't
+        // store it as a separate field on SetLog — single source of
+        // truth principle. CompletedSet (the WorkoutContext shape) DOES
+        // materialize the boolean for AI prompt clarity.
         let setLog = SetLog(
             id: UUID(),
             sessionId: session.id,
@@ -310,7 +317,8 @@ actor WorkoutSessionManager {
             aiPrescribed: currentPrescription,
             loggedAt: Date(),
             primaryMuscle: ExerciseLibrary.primaryMuscle(for: exercise.exerciseId)?.rawValue ?? exercise.primaryMuscle,
-            intent: intent
+            intent: intent,
+            completionFlags: completionFlags
         )
         completedSets.append(setLog)
 
@@ -707,7 +715,12 @@ actor WorkoutSessionManager {
             confidence:        nil,
             userCorrectedWeight: nil,
             isManualFallback:  true,
-            intent:            lastSet?.intent
+            intent:            lastSet?.intent,
+            // Manual-fallback path uses a generic framing — there's no AI
+            // call to produce one. Inherits intent from last set; framing
+            // mirrors that. No silent default at the AI layer; this is
+            // the explicit fallback shape.
+            setFraming:        "Using last session weights. No AI guidance."
         )
         currentPrescription = prescription
         inferenceRetryNeeded = false
@@ -817,20 +830,7 @@ actor WorkoutSessionManager {
         exercises.prefix(upToExerciseIndex).map { exercise in
             let sets = setLogs
                 .filter { $0.exerciseId == exercise.exerciseId }
-                .map { log in
-                    CompletedSet(
-                        setNumber: log.setNumber,
-                        weightKg: log.weightKg,
-                        reps: log.repsCompleted,
-                        rirActual: log.rirEstimated,
-                        rpe: log.rpeFelt.map(Double.init),
-                        tempo: log.aiPrescribed?.tempo,
-                        restTakenSeconds: nil,
-                        completedAt: log.loggedAt,
-                        userCorrectedWeight: log.aiPrescribed?.userCorrectedWeight,
-                        daysAgo: 0
-                    )
-                }
+                .map { $0.toCompletedSet(daysAgo: 0) }
             return ExerciseHistoryItem(exerciseName: exercise.name, sets: sets)
         }
     }
@@ -1039,38 +1039,12 @@ actor WorkoutSessionManager {
 
         let currentExSets = completedSets
             .filter { $0.exerciseId == exercise.exerciseId }
-            .map { log in
-                CompletedSet(
-                    setNumber: log.setNumber,
-                    weightKg: log.weightKg,
-                    reps: log.repsCompleted,
-                    rirActual: log.rirEstimated,
-                    rpe: log.rpeFelt.map(Double.init),
-                    tempo: log.aiPrescribed?.tempo,
-                    restTakenSeconds: nil,
-                    completedAt: log.loggedAt,
-                    userCorrectedWeight: log.aiPrescribed?.userCorrectedWeight,
-                    daysAgo: 0
-                )
-            }
+            .map { $0.toCompletedSet(daysAgo: 0) }
 
         // within_session_performance: all prior sets for this exercise (FB-006)
         let withinSessionSets = completedSets
             .filter { $0.exerciseId == exercise.exerciseId }
-            .map { log in
-                CompletedSet(
-                    setNumber: log.setNumber,
-                    weightKg: log.weightKg,
-                    reps: log.repsCompleted,
-                    rirActual: log.rirEstimated,
-                    rpe: log.rpeFelt.map(Double.init),
-                    tempo: log.aiPrescribed?.tempo,
-                    restTakenSeconds: nil,
-                    completedAt: log.loggedAt,
-                    userCorrectedWeight: log.aiPrescribed?.userCorrectedWeight,
-                    daysAgo: 0
-                )
-            }
+            .map { $0.toCompletedSet(daysAgo: 0) }
 
         // Read confirmed unavailable weights for this equipment type from GymFactStore.
         // These are injected as hard constraints so the AI never prescribes unavailable loads.
@@ -1261,20 +1235,7 @@ actor WorkoutSessionManager {
     private func buildExerciseHistoryItem(for exercise: PlannedExercise) -> ExerciseHistoryItem {
         let sets = completedSets
             .filter { $0.exerciseId == exercise.exerciseId }
-            .map { log in
-                CompletedSet(
-                    setNumber: log.setNumber,
-                    weightKg: log.weightKg,
-                    reps: log.repsCompleted,
-                    rirActual: log.rirEstimated,
-                    rpe: log.rpeFelt.map(Double.init),
-                    tempo: log.aiPrescribed?.tempo,
-                    restTakenSeconds: nil,
-                    completedAt: log.loggedAt,
-                    userCorrectedWeight: log.aiPrescribed?.userCorrectedWeight,
-                    daysAgo: 0
-                )
-            }
+            .map { $0.toCompletedSet(daysAgo: 0) }
         return ExerciseHistoryItem(exerciseName: exercise.name, sets: sets)
     }
 

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -281,7 +281,7 @@ actor WorkoutSessionManager {
     ///   3. Assemble WorkoutContext
     ///   4. Await AI prescription on a child Task
     ///   5. On result: update currentPrescription; when timer expires → .active
-    func completeSet(actualReps: Int, rpeFelt: Int?) async {
+    func completeSet(actualReps: Int, rpeFelt: Int?, intent: SetIntent) async {
         guard case .active(let exercise, let setNumber) = sessionState,
               let session = session else { return }
 
@@ -291,7 +291,13 @@ actor WorkoutSessionManager {
         inflightRequestCount += 1
         let capturedGeneration = inferenceGeneration
 
-        // Build and store set log
+        // Build and store set log.
+        // Slice 6 (#10): intent comes from the AI prescription in this
+        // (auto-driven) flow. Currently NOT exposed to the rep/RPE sheet
+        // for user override at completion time — completeSet is invoked
+        // with the prescription's intent implicit. If the picker UI ever
+        // grows the ability to override the AI's intent at completion,
+        // thread the picker's value here instead of `currentPrescription?.intent`.
         let setLog = SetLog(
             id: UUID(),
             sessionId: session.id,
@@ -303,7 +309,8 @@ actor WorkoutSessionManager {
             rirEstimated: rpeFelt.map { max(0, 10 - $0) },
             aiPrescribed: currentPrescription,
             loggedAt: Date(),
-            primaryMuscle: ExerciseLibrary.primaryMuscle(for: exercise.exerciseId)?.rawValue ?? exercise.primaryMuscle
+            primaryMuscle: ExerciseLibrary.primaryMuscle(for: exercise.exerciseId)?.rawValue ?? exercise.primaryMuscle,
+            intent: intent
         )
         completedSets.append(setLog)
 

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -105,11 +105,14 @@ final class WorkoutViewModel {
 
     /// Called when the user taps "Set Complete".
     /// Disables the button during the async call to prevent double-taps.
-    func onSetComplete(actualReps: Int, rpeFelt: Int?) {
+    /// `intent` is non-optional because the rep/RPE sheet's "Log Set"
+    /// button is gated on an explicit picker tap (Slice 6 / #10) — by the
+    /// time this method is invoked, the user has chosen.
+    func onSetComplete(actualReps: Int, rpeFelt: Int?, intent: SetIntent) {
         guard !isCompletingSet else { return }
         isCompletingSet = true
         Task {
-            await manager.completeSet(actualReps: actualReps, rpeFelt: rpeFelt)
+            await manager.completeSet(actualReps: actualReps, rpeFelt: rpeFelt, intent: intent)
             await pullState()
             isCompletingSet = false
         }

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -418,6 +418,8 @@ final class WorkoutViewModel {
             return "Coach offline — using program defaults"
         case .encodingFailed:
             return "Coach offline — using program defaults"
+        case .malformedResponse:
+            return "Coach offline — using program defaults"
         }
     }
 
@@ -433,6 +435,8 @@ final class WorkoutViewModel {
             return ".networkUnavailable(\(msg.prefix(80)))"
         case .encodingFailed(let detail):
             return ".encodingFailed(\(detail.prefix(80)))"
+        case .malformedResponse(let detail):
+            return ".malformedResponse(\(detail.prefix(80)))"
         }
     }
 
@@ -447,6 +451,8 @@ final class WorkoutViewModel {
             return "Network error: \(String(m.prefix(80)))"
         case .encodingFailed(let d):
             return "Internal error: \(String(d.prefix(80)))"
+        case .malformedResponse(let d):
+            return "Invalid response: \(String(d.prefix(80)))"
         }
     }
 
@@ -555,7 +561,8 @@ extension WorkoutViewModel {
             coachingCue: "Control descent, pause at chest",
             reasoning: "Up 2.5 kg from last session — HRV trending positive.",
             safetyFlags: [],
-            confidence: 0.87
+            confidence: 0.87,
+            intent: .top
         )
         mock.isAIOffline = false
         return mock
@@ -632,7 +639,8 @@ private struct PreviewLLMProvider: LLMProvider {
             "rest_seconds": 120,
             "coaching_cue": "Preview prescription",
             "reasoning": "Preview mode — no real AI.",
-            "safety_flags": []
+            "safety_flags": [],
+            "intent": "top"
           }
         }
         """

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -103,16 +103,28 @@ final class WorkoutViewModel {
         }
     }
 
-    /// Called when the user taps "Set Complete".
-    /// Disables the button during the async call to prevent double-taps.
-    /// `intent` is non-optional because the rep/RPE sheet's "Log Set"
-    /// button is gated on an explicit picker tap (Slice 6 / #10) — by the
-    /// time this method is invoked, the user has chosen.
-    func onSetComplete(actualReps: Int, rpeFelt: Int?, intent: SetIntent) {
+    /// Called when the user taps "Log Set" on the rep/RPE confirmation
+    /// sheet. Disables the button during the async call to prevent
+    /// double-taps. Slice 6 / #10:
+    ///   - `intent` is the resolved intent (deviated value if the user
+    ///     used the deviation picker; prescribed value otherwise).
+    ///   - `completionFlags` is the user-reported flag set raised on
+    ///     this specific set (pain / form_breakdown). Empty by default.
+    func onSetComplete(
+        actualReps: Int,
+        rpeFelt: Int?,
+        intent: SetIntent,
+        completionFlags: [SetCompletionFlag] = []
+    ) {
         guard !isCompletingSet else { return }
         isCompletingSet = true
         Task {
-            await manager.completeSet(actualReps: actualReps, rpeFelt: rpeFelt, intent: intent)
+            await manager.completeSet(
+                actualReps: actualReps,
+                rpeFelt: rpeFelt,
+                intent: intent,
+                completionFlags: completionFlags
+            )
             await pullState()
             isCompletingSet = false
         }
@@ -565,7 +577,8 @@ extension WorkoutViewModel {
             reasoning: "Up 2.5 kg from last session — HRV trending positive.",
             safetyFlags: [],
             confidence: 0.87,
-            intent: .top
+            intent: .top,
+        setFraming: "Heaviest work of the day. Brace and grind."
         )
         mock.isAIOffline = false
         return mock
@@ -643,7 +656,8 @@ private struct PreviewLLMProvider: LLMProvider {
             "coaching_cue": "Preview prescription",
             "reasoning": "Preview mode — no real AI.",
             "safety_flags": [],
-            "intent": "top"
+            "intent": "top",
+            "set_framing": "Heaviest work of the day. Brace and grind."
           }
         }
         """

--- a/ProjectApex/Models/SetCompletionFlag.swift
+++ b/ProjectApex/Models/SetCompletionFlag.swift
@@ -1,0 +1,31 @@
+// SetCompletionFlag.swift
+// ProjectApex — Models
+//
+// User-reported flags raised on the rep/RPE confirmation sheet
+// post-set (Slice 6 / #10). High-signal for AI adaptation — the user
+// has the most accurate information about their own state immediately
+// after completing the set.
+//
+// IMPORTANT: this is the USER's output (post-set self-report), distinct
+// from `SafetyFlag` (the AI's input — "the AI noted user mentioned pain
+// in earlier voice notes"). Different concepts, different fields, both
+// kept. The semantic context (which DTO carries them) disambiguates:
+//   - SafetyFlag    on SetPrescription (AI → user)
+//   - SetCompletionFlag on SetLog       (user → AI)
+//
+// Persistence: Slice 6 ships these CLIENT-SIDE only (γ pattern, same as
+// SetLog.intent). Threaded into the in-memory WorkoutContext so the
+// AI's next-set prescription within the same session can react. The
+// DB column + cross-session reasoning land in #43.
+
+import Foundation
+
+enum SetCompletionFlag: String, Codable, Sendable, Hashable, CaseIterable {
+    /// "Something hurt during this set." High-priority signal — should
+    /// reduce load or modify movement next set; consider adding
+    /// `painReported` to the next prescription's safety_flags.
+    case pain
+    /// "Form broke down." User reports their technique degraded under
+    /// load. Consider reducing reps or weight to restore quality.
+    case formBreakdown = "form_breakdown"
+}

--- a/ProjectApex/Models/WorkoutSession.swift
+++ b/ProjectApex/Models/WorkoutSession.swift
@@ -124,6 +124,14 @@ nonisolated struct SetLog: Codable, Identifiable, Sendable {
     /// (analytics, in-flight reasoning) and so a Phase-1+ Swift release can
     /// promote the field to the REST payload without restructuring the type.
     let intent: SetIntent?
+    /// User-reported flags raised on the rep/RPE sheet immediately
+    /// post-set per Slice 6 / #10. Client-side carrier only in Slice 6
+    /// (γ pattern, like `intent`). Threaded into in-session
+    /// `WorkoutContext.withinSessionPerformance[].completion_flags` so
+    /// the AI can react to pain / form-breakdown signals when generating
+    /// the next set's prescription. Cross-session DB persistence tracked
+    /// as #43.
+    let completionFlags: [SetCompletionFlag]
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -138,6 +146,7 @@ nonisolated struct SetLog: Codable, Identifiable, Sendable {
         case loggedAt        = "logged_at"
         case primaryMuscle   = "primary_muscle"
         case intent
+        case completionFlags = "completion_flags"
     }
 
     // Memberwise initialiser — used by WorkoutSessionManager, ManualSessionLogView, etc.
@@ -153,20 +162,22 @@ nonisolated struct SetLog: Codable, Identifiable, Sendable {
         aiPrescribed: SetPrescription?,
         loggedAt: Date,
         primaryMuscle: String? = nil,
-        intent: SetIntent? = nil
+        intent: SetIntent? = nil,
+        completionFlags: [SetCompletionFlag] = []
     ) {
-        self.id            = id
-        self.sessionId     = sessionId
-        self.exerciseId    = exerciseId
-        self.setNumber     = setNumber
-        self.weightKg      = weightKg
-        self.repsCompleted = repsCompleted
-        self.rpeFelt       = rpeFelt
-        self.rirEstimated  = rirEstimated
-        self.aiPrescribed  = aiPrescribed
-        self.loggedAt      = loggedAt
-        self.primaryMuscle = primaryMuscle
-        self.intent        = intent
+        self.id              = id
+        self.sessionId       = sessionId
+        self.exerciseId      = exerciseId
+        self.setNumber       = setNumber
+        self.weightKg        = weightKg
+        self.repsCompleted   = repsCompleted
+        self.rpeFelt         = rpeFelt
+        self.rirEstimated    = rirEstimated
+        self.aiPrescribed    = aiPrescribed
+        self.loggedAt        = loggedAt
+        self.primaryMuscle   = primaryMuscle
+        self.intent          = intent
+        self.completionFlags = completionFlags
     }
 
     // Custom decoder so that optional columns (absent from older rows) decode
@@ -185,6 +196,7 @@ nonisolated struct SetLog: Codable, Identifiable, Sendable {
         loggedAt       = try c.decode(Date.self,   forKey: .loggedAt)
         primaryMuscle  = try c.decodeIfPresent(String.self,          forKey: .primaryMuscle)
         intent         = try c.decodeIfPresent(SetIntent.self,       forKey: .intent)
+        completionFlags = try c.decodeIfPresent([SetCompletionFlag].self, forKey: .completionFlags) ?? []
     }
 }
 
@@ -490,5 +502,46 @@ nonisolated struct PausedSessionState: Codable, Sendable {
             pausedAt:         Date()
         )
         state.save()
+    }
+}
+
+// MARK: - SetLog → CompletedSet bridge (Slice 6 / #10)
+
+extension SetLog {
+    /// Build the WorkoutContext-shape `CompletedSet` from a stored SetLog.
+    /// Threads the Slice 6 fields (`intent`, `prescribedIntent`, derived
+    /// `isDeviation`, `completionFlags`) into the AI prompt so in-session
+    /// reasoning can react to the user's actual choices and reported
+    /// signals from earlier sets in the same session.
+    ///
+    /// `is_deviation` is materialized here (rather than left for the AI to
+    /// derive) so the AI prompt has unambiguous deviation signal — the
+    /// reasoning text in the system prompt teaches the AI how to react to
+    /// it, and an explicit boolean is easier to reason about than a
+    /// string-comparison expectation.
+    nonisolated func toCompletedSet(daysAgo: Int) -> CompletedSet {
+        let prescribedIntentRaw = aiPrescribed?.intent?.rawValue
+        let actualIntentRaw     = intent?.rawValue
+        let isDeviationValue: Bool? = {
+            guard let p = prescribedIntentRaw, let a = actualIntentRaw else { return nil }
+            return p != a
+        }()
+        let flags = completionFlags.isEmpty ? nil : completionFlags.map(\.rawValue)
+        return CompletedSet(
+            setNumber: setNumber,
+            weightKg: weightKg,
+            reps: repsCompleted,
+            rirActual: rirEstimated,
+            rpe: rpeFelt.map(Double.init),
+            tempo: aiPrescribed?.tempo,
+            restTakenSeconds: nil,
+            completedAt: loggedAt,
+            userCorrectedWeight: aiPrescribed?.userCorrectedWeight,
+            daysAgo: daysAgo,
+            intent: actualIntentRaw,
+            prescribedIntent: prescribedIntentRaw,
+            isDeviation: isDeviationValue,
+            completionFlags: flags
+        )
     }
 }

--- a/ProjectApex/Models/WorkoutSession.swift
+++ b/ProjectApex/Models/WorkoutSession.swift
@@ -115,6 +115,15 @@ nonisolated struct SetLog: Codable, Identifiable, Sendable {
     /// Populated from ExerciseLibrary at write time. Nullable for rows that
     /// pre-date the column or use non-canonical exercise IDs.
     let primaryMuscle: String?
+    /// SetIntent captured at log time per Slice 6 / ADR-0005. Client-side
+    /// only in Phase 0 — the `set_logs.intent` column does not exist until
+    /// Phase 1 lands the migration, so the encoder for the REST write
+    /// (`SetLogPayload` / `ManualSetLogPayload`) does NOT serialise this
+    /// field. Carried on the Swift type so the picker / freestyle path can
+    /// thread the user's selection through to other client-side consumers
+    /// (analytics, in-flight reasoning) and so a Phase-1+ Swift release can
+    /// promote the field to the REST payload without restructuring the type.
+    let intent: SetIntent?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -128,6 +137,7 @@ nonisolated struct SetLog: Codable, Identifiable, Sendable {
         case aiPrescribed    = "ai_prescribed"
         case loggedAt        = "logged_at"
         case primaryMuscle   = "primary_muscle"
+        case intent
     }
 
     // Memberwise initialiser — used by WorkoutSessionManager, ManualSessionLogView, etc.
@@ -142,7 +152,8 @@ nonisolated struct SetLog: Codable, Identifiable, Sendable {
         rirEstimated: Int?,
         aiPrescribed: SetPrescription?,
         loggedAt: Date,
-        primaryMuscle: String? = nil
+        primaryMuscle: String? = nil,
+        intent: SetIntent? = nil
     ) {
         self.id            = id
         self.sessionId     = sessionId
@@ -155,6 +166,7 @@ nonisolated struct SetLog: Codable, Identifiable, Sendable {
         self.aiPrescribed  = aiPrescribed
         self.loggedAt      = loggedAt
         self.primaryMuscle = primaryMuscle
+        self.intent        = intent
     }
 
     // Custom decoder so that optional columns (absent from older rows) decode
@@ -172,6 +184,7 @@ nonisolated struct SetLog: Codable, Identifiable, Sendable {
         aiPrescribed   = try c.decodeIfPresent(SetPrescription.self, forKey: .aiPrescribed)
         loggedAt       = try c.decode(Date.self,   forKey: .loggedAt)
         primaryMuscle  = try c.decodeIfPresent(String.self,          forKey: .primaryMuscle)
+        intent         = try c.decodeIfPresent(SetIntent.self,       forKey: .intent)
     }
 }
 

--- a/ProjectApex/Resources/Prompts/SystemPrompt_Inference.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_Inference.txt
@@ -1,4 +1,9 @@
-// VERSION: 4.7 — 2026-03-30
+// VERSION: 4.8 — 2026-05-06
+// CHANGES FROM v4.7 (v4.8):
+//   • Added required `intent` field to set_prescription response shape per
+//     ADR-0005 / Slice 6 (#10). Must be one of warmup/top/backoff/technique/amrap.
+//     No silent default — missing intent fails validation, no retry.
+//   • Definitions for each intent value documented in CORE RULES.
 // CHANGES FROM v4.6 (v4.7):
 //   • GYM WEIGHT CONSTRAINTS block rewritten to use permanent-absence language.
 //     gym_weight_facts entries now state "does not exist in this gym. Never prescribe it."
@@ -36,7 +41,8 @@ RESPONSE FORMAT — you must return ONLY a JSON object with this exact structure
     "coaching_cue": "<string, max 100 chars>",
     "reasoning": "<string, max 200 chars>",
     "safety_flags": ["shoulder_caution"|"joint_concern"|"fatigue_high"|"pain_reported"|"deload_recommended"],
-    "confidence": <number 0.0–1.0, optional>
+    "confidence": <number 0.0–1.0, optional>,
+    "intent": "warmup"|"top"|"backoff"|"technique"|"amrap"
   }
 }
 
@@ -47,6 +53,12 @@ CORE RULES:
 - coaching_cue must be ≤ 100 characters.
 - reasoning must be ≤ 200 characters.
 - Always consider safety flags from qualitative notes (pain → slow down, fatigue → reduce load).
+- intent is REQUIRED on every prescription. No silent default. Choose deliberately:
+    * top:       the working set that drives capability (3–10 reps, max effort within RIR target).
+    * warmup:    sub-maximal preparation set; lighter load, higher reps, low RIR risk.
+    * backoff:   secondary working set following a top set, typically 70–85% of top weight.
+    * technique: tempo/form-focused practice; load is incidental, may be light.
+    * amrap:     last-set-as-many-reps-as-possible at the prescribed weight.
 
 EQUIPMENT-AWARE WEIGHT INCREMENTS (FB-002, updated v4.1):
 Weight changes must respect practical loading steps for each equipment type:

--- a/ProjectApex/Resources/Prompts/SystemPrompt_Inference.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_Inference.txt
@@ -1,4 +1,12 @@
-// VERSION: 4.8 — 2026-05-06
+// VERSION: 4.9 — 2026-05-06
+// CHANGES FROM v4.8 (v4.9):
+//   • Added required `set_framing` field per Slice 6 (#10) — a 1-line
+//     mental-set framing distinct from coaching_cue. ≤80 chars.
+//     No silent default — missing set_framing fails validation, no retry.
+//   • Good/bad set_framing examples added to CORE RULES so the AI knows
+//     what shape to produce (and what shapes to avoid: generic
+//     encouragement, form cues that belong in coaching_cue, long
+//     sentences, restating reps/weight, repeating the intent word).
 // CHANGES FROM v4.7 (v4.8):
 //   • Added required `intent` field to set_prescription response shape per
 //     ADR-0005 / Slice 6 (#10). Must be one of warmup/top/backoff/technique/amrap.
@@ -42,7 +50,8 @@ RESPONSE FORMAT — you must return ONLY a JSON object with this exact structure
     "reasoning": "<string, max 200 chars>",
     "safety_flags": ["shoulder_caution"|"joint_concern"|"fatigue_high"|"pain_reported"|"deload_recommended"],
     "confidence": <number 0.0–1.0, optional>,
-    "intent": "warmup"|"top"|"backoff"|"technique"|"amrap"
+    "intent": "warmup"|"top"|"backoff"|"technique"|"amrap",
+    "set_framing": "<string, max 80 chars>"
   }
 }
 
@@ -59,6 +68,54 @@ CORE RULES:
     * backoff:   secondary working set following a top set, typically 70–85% of top weight.
     * technique: tempo/form-focused practice; load is incidental, may be light.
     * amrap:     last-set-as-many-reps-as-possible at the prescribed weight.
+- set_framing is REQUIRED. A 1-line mental-set framing for THIS specific set, distinct from
+  coaching_cue. Sets the user's frame BEFORE they lift; not a form reminder during. Max 80 chars.
+
+  GOOD set_framings (set the mental frame, typed by intent):
+      top:       "Heaviest work of the day. Brace and grind."
+      top:       "This is the set that moves the needle. Treat it that way."
+      warmup:    "Groove the pattern. Don't fight the bar."
+      warmup:    "Wake up the muscles. Save the effort for later."
+      backoff:   "Build volume on a manageable load."
+      backoff:   "More reps, less weight. Stay tight throughout."
+      technique: "Slow the tempo. Quality over load."
+      technique: "Feel the right muscles working. Forget the number."
+      amrap:     "Push to genuine failure with form intact."
+      amrap:     "Last set, no reservations. Stop only when reps break."
+
+  BAD set_framings to avoid:
+      - Generic encouragement: "You got this!", "Make it count!", "Crush it!"
+        These add no information and condescend.
+      - Form cues that belong in coaching_cue: "Drive through your heels",
+        "Retract your scapulae", "Brace your core".
+        coaching_cue is the form note for the reps; set_framing is the frame for the set.
+      - Long sentences. Hard cap 80 chars; aim for ~50–70.
+      - Restating reps/weight: "Do 8 reps at 80kg." The user can already see those numbers.
+      - Repeating the intent word: "This is your top set." The intent label is already shown.
+
+REACTING TO USER-REPORTED SIGNALS FROM PRIOR SETS (Slice 6 / #10):
+The session_log and within_session_performance arrays may carry, on each set:
+  - intent              — what the user actually did (the resolved intent).
+  - prescribed_intent   — what you prescribed for that set (nil if freestyle).
+  - is_deviation        — true when intent ≠ prescribed_intent. The user explicitly chose
+                          a different set type than what you suggested. High signal.
+  - completion_flags    — array drawn from "pain", "form_breakdown". User-reported,
+                          immediately post-set.
+
+How to react:
+  - completion_flags includes "pain": treat as the highest-priority signal. Reduce load
+    on the next set of this pattern, consider modifying movement, surface "pain_reported"
+    in safety_flags. Pain is a one-strike rule; do not push through.
+  - completion_flags includes "form_breakdown": user reports their form degraded under
+    load. Reduce reps or weight on the next set to restore quality.
+  - is_deviation=true with the user picking AMRAP when you prescribed Top: they pushed
+    harder than asked. Next set, consider reducing if fatigue is showing in RPE.
+  - is_deviation=true with the user picking Backoff when you prescribed Top: they pulled
+    back. Consider whether the target was too aggressive; bias future top sets cautious.
+  - is_deviation=true with the user picking Warmup or Technique when you prescribed work:
+    something's off — either the user is signalling they're not ready for working sets, or
+    they re-classified mid-set after a poor first attempt. Bias next prescription light;
+    consider raising deload_recommended if the pattern repeats across exercises.
 
 EQUIPMENT-AWARE WEIGHT INCREMENTS (FB-002, updated v4.1):
 Weight changes must respect practical loading steps for each equipment type:

--- a/ProjectApex/Services/FallbackLogRecord.swift
+++ b/ProjectApex/Services/FallbackLogRecord.swift
@@ -112,6 +112,8 @@ nonisolated struct FallbackLogRecord: Codable, Sendable {
             reason = "llmProviderError: \(msg.prefix(200))"
         case .encodingFailed(let msg):
             reason = "encodingFailed: \(msg)"
+        case .malformedResponse(let msg):
+            reason = "malformedResponse: \(msg.prefix(200))"
         }
         return FallbackLogRecord(
             callSite: callSite,
@@ -119,4 +121,47 @@ nonisolated struct FallbackLogRecord: Codable, Sendable {
             sessionId: sessionId
         )
     }
+}
+
+// MARK: - Permanent-failure fallback hook (Slice 6 / ADR-0007 §1) ───────────
+//
+// AUDIT HOOK — spinoff issue "Audit retry-on-validate sites against ADR-0007":
+//   Grep for callers of `emitPermanentFailureFallback` to inventory which
+//   foreground services have adopted the ADR-0007 fail-fast pattern. Sites
+//   that decode/validate LLM responses but DO NOT call this helper are
+//   candidates for the audit — they likely either retry-on-validate
+//   (pre-Slice-6 behaviour) or silently swallow the failure.
+//
+// Slice 6 call sites (initial inventory):
+//   - AIInferenceService.prescribe (decode failure, validate failure)
+//   - AIInferenceService.prescribeAdaptation (decode failure, validate failure)
+//
+// Foreground call sites flagged by ADR-0007 §3 that the audit should check:
+//   - SessionPlanService.callAndDecodeSession
+//   - ExerciseSwapService.sendMessage
+//
+// Foreground services map the returned `FallbackLogRecord` (already emitted)
+// onto their own fallback-result type — this helper is intentionally
+// generic over result type so each service stays in control of its own
+// fallback DTOs.
+
+/// Emits a `FallbackLogRecord` for a permanent (malformed-response or
+/// validation) error per ADR-0007 §1 and returns the record. The caller
+/// maps to its own fallback result type.
+///
+/// Use this anywhere a foreground LLM call site would otherwise have to
+/// decide between (wrong) silent retry and (correct) fail-fast surface.
+@discardableResult
+nonisolated func emitPermanentFailureFallback(
+    callSite: String,
+    description: String,
+    sessionId: String? = nil
+) -> FallbackLogRecord {
+    let record = FallbackLogRecord(
+        callSite: callSite,
+        reason: "malformedResponse: \(description.prefix(200))",
+        sessionId: sessionId
+    )
+    record.emit()
+    return record
 }

--- a/ProjectApexTests/AIInferenceServiceTests.swift
+++ b/ProjectApexTests/AIInferenceServiceTests.swift
@@ -75,7 +75,8 @@ private let validPrescriptionJSON = """
     "reasoning": "Last set at 2 RIR; maintaining load for consistent volume.",
     "safety_flags": [],
     "confidence": 0.87,
-    "intent": "top"
+    "intent": "top",
+    "set_framing": "Heaviest work of the day. Brace and grind."
   }
 }
 """
@@ -98,7 +99,8 @@ private let painFlagPrescriptionJSON = """
     "reasoning": "Pain flag active; reduce load and increase rest.",
     "safety_flags": ["pain_reported"],
     "confidence": 0.70,
-    "intent": "top"
+    "intent": "top",
+    "set_framing": "Heaviest work of the day. Brace and grind."
   }
 }
 """
@@ -117,7 +119,8 @@ private let invalidTempoPrescriptionJSON = """
     "coaching_cue": "Tight arch.",
     "reasoning": "Progressive overload.",
     "safety_flags": [],
-    "intent": "top"
+    "intent": "top",
+    "set_framing": "Heaviest work of the day. Brace and grind."
   }
 }
 """

--- a/ProjectApexTests/AIInferenceServiceTests.swift
+++ b/ProjectApexTests/AIInferenceServiceTests.swift
@@ -62,6 +62,7 @@ private struct NetworkFailProvider: LLMProvider {
 // MARK: - Test fixtures
 
 /// A valid SetPrescription JSON envelope that passes all validation rules.
+/// Includes `intent` per Slice 6 (#10) — required field with no silent default.
 private let validPrescriptionJSON = """
 {
   "set_prescription": {
@@ -73,13 +74,18 @@ private let validPrescriptionJSON = """
     "coaching_cue": "Retract scapula, drive through the bar.",
     "reasoning": "Last set at 2 RIR; maintaining load for consistent volume.",
     "safety_flags": [],
-    "confidence": 0.87
+    "confidence": 0.87,
+    "intent": "top"
   }
 }
 """
 
 /// A valid prescription that includes `pain_reported` — exercises the
 /// rest-seconds safety gate (must be clamped to ≥ 180).
+/// Intent is `top` because the scenario is "the working set with reduced
+/// load due to pain" — not a backoff (which by definition follows a top
+/// set in the same exercise). Reduced load on a top set still classifies
+/// as a top set.
 private let painFlagPrescriptionJSON = """
 {
   "set_prescription": {
@@ -91,12 +97,15 @@ private let painFlagPrescriptionJSON = """
     "coaching_cue": "Ease off — shoulder discomfort reported.",
     "reasoning": "Pain flag active; reduce load and increase rest.",
     "safety_flags": ["pain_reported"],
-    "confidence": 0.70
+    "confidence": 0.70,
+    "intent": "top"
   }
 }
 """
 
 /// JSON that decodes but fails validate() — tempo has only 3 segments.
+/// Carries a valid intent so `.invalidTempo` is the surfaced error rather
+/// than the (now-prior-precedence) `.missingIntent` gate.
 private let invalidTempoPrescriptionJSON = """
 {
   "set_prescription": {
@@ -107,7 +116,8 @@ private let invalidTempoPrescriptionJSON = """
     "rest_seconds": 150,
     "coaching_cue": "Tight arch.",
     "reasoning": "Progressive overload.",
-    "safety_flags": []
+    "safety_flags": [],
+    "intent": "top"
   }
 }
 """
@@ -223,39 +233,67 @@ final class AIInferenceServiceTests: XCTestCase {
                                     "restSeconds must be ≥ 180 when painReported is set.")
     }
 
-    // MARK: ─── 2. Retry path test ─────────────────────────────────────────────
+    // MARK: ─── 2. Permanent-error fail-fast (ADR-0007 / Slice 6) ────────────
+    //
+    // ████████████████████████████████████████████████████████████████████████
+    // BEHAVIOUR CHANGE — Slice 6 (#10):
+    //   Pre-Slice-6, prescribe() RETRIED on JSON decode failures and on
+    //   validate() failures, appending a "CORRECTION REQUIRED" addendum and
+    //   re-running up to maxRetries+1 times. The two tests below previously
+    //   asserted that 2 invalid responses followed by 1 valid response
+    //   produced .success after 3 calls.
+    //
+    //   ADR-0007 §1 classifies malformed-response and validation errors as
+    //   PERMANENT — same-prompt retry will not fix the LLM's output. Slice 6
+    //   removes the retry-on-validate loop, replacing it with fail-fast
+    //   `.fallback(.malformedResponse)` after a single call. The user-facing
+    //   surface is `InferenceRetrySheet`, giving the user agency rather than
+    //   silently burning the 8-second budget.
+    //
+    //   The old "invalid twice then succeed" assertions are now invariant
+    //   violations. The replacement tests below assert callCount == 1 and
+    //   `.fallback(.malformedResponse)` instead. Spinoff issue tracks the
+    //   broader audit of retry-on-validate sites against ADR-0007.
+    // ████████████████████████████████████████████████████████████████████████
 
-    /// MockLLMProvider returns unparsable JSON on attempts 1 and 2, valid JSON
-    /// on attempt 3.  Result must be .success — verifying maxRetries=2 works.
-    func test_retryPath_invalidJSONTwice_thenSuccess() async {
+    /// B4 — Slice 6 fail-fast: structurally invalid JSON returns
+    /// `.fallback(.malformedResponse)` after exactly ONE provider call.
+    func test_failFast_invalidJSON_oneCall_returnsMalformedResponse() async {
         let provider = RetryOnceProvider(
-            failCount: 2,
+            failCount: 999,                  // never serve a success
             failResponse: unparsableJSON,
             successResponse: validPrescriptionJSON
         )
         let service = AIInferenceService(
             provider: provider,
             gymProfile: GymProfile.mockProfile(),
-            maxRetries: 2
+            maxRetries: 2                    // intentionally non-zero — must be ignored
         )
 
         let result = await service.prescribe(context: WorkoutContext.mockContext())
 
-        switch result {
-        case .success(let prescription):
-            XCTAssertEqual(provider.callCount, 3,
-                           "Provider must have been called exactly 3 times (1 initial + 2 retries).")
-            XCTAssertNoThrow(try prescription.validate(),
-                             "Prescription from the third attempt must pass validation.")
-        case .fallback(let reason):
-            XCTFail("Expected .success on attempt 3, got fallback: \(reason)")
+        XCTAssertEqual(
+            provider.callCount, 1,
+            "Slice 6 fail-fast: malformed JSON must NOT trigger same-prompt retry. " +
+            "If callCount > 1, the prescribe() retry loop has regressed to pre-ADR-0007 behaviour."
+        )
+        guard case .fallback(let reason) = result,
+              case .malformedResponse = reason
+        else {
+            return XCTFail(
+                "Slice 6 fail-fast expected .fallback(.malformedResponse), got \(result). " +
+                "ADR-0007 §1 classifies decode failure as permanent."
+            )
         }
     }
 
-    /// Same as above but uses a bad tempo (structurally valid JSON, fails validate()).
-    func test_retryPath_invalidTempoTwice_thenSuccess() async {
+    /// B4 — Slice 6 fail-fast: validation failure (non-intent) returns
+    /// `.fallback(.malformedResponse)` after exactly ONE provider call.
+    /// Locks the broader scope of the behaviour change — the fail-fast rule
+    /// applies to ALL PrescriptionValidationError variants, not just intent.
+    func test_failFast_invalidTempo_oneCall_returnsMalformedResponse() async {
         let provider = RetryOnceProvider(
-            failCount: 2,
+            failCount: 999,
             failResponse: invalidTempoPrescriptionJSON,
             successResponse: validPrescriptionJSON
         )
@@ -267,13 +305,179 @@ final class AIInferenceServiceTests: XCTestCase {
 
         let result = await service.prescribe(context: WorkoutContext.mockContext())
 
-        switch result {
-        case .success(let prescription):
-            XCTAssertEqual(provider.callCount, 3)
-            XCTAssertEqual(prescription.tempo, "3-1-1-0",
-                           "Winning prescription must have the valid tempo from attempt 3.")
-        case .fallback(let reason):
-            XCTFail("Expected .success on attempt 3, got fallback: \(reason)")
+        XCTAssertEqual(
+            provider.callCount, 1,
+            "Slice 6 fail-fast: validate() failure on tempo must NOT trigger retry. " +
+            "If callCount > 1, the prescribe() retry-on-validate loop has regressed."
+        )
+        guard case .fallback(let reason) = result,
+              case .malformedResponse(let detail) = reason
+        else {
+            return XCTFail("Expected .malformedResponse, got \(result)")
+        }
+        XCTAssertTrue(
+            detail.lowercased().contains("tempo"),
+            "Fallback detail should name the offending field. Got: \(detail)"
+        )
+    }
+
+    /// B1 — Slice 6 fail-fast: missing `intent` in AI response triggers
+    /// `.fallback(.malformedResponse)` carrying the typed PrescriptionValidationError
+    /// description, and the provider is called exactly once. The most direct
+    /// test of the new no-silent-defaults invariant.
+    func test_failFast_missingIntent_oneCall_returnsMalformedResponse() async {
+        let missingIntentJSON = """
+        {
+          "set_prescription": {
+            "weight_kg": 80.0,
+            "reps": 8,
+            "tempo": "3-1-1-0",
+            "rir_target": 2,
+            "rest_seconds": 120,
+            "coaching_cue": "Drive through.",
+            "reasoning": "Standard top set.",
+            "safety_flags": [],
+            "confidence": 0.85
+          }
+        }
+        """
+        let provider = RetryOnceProvider(
+            failCount: 999,
+            failResponse: missingIntentJSON,
+            successResponse: validPrescriptionJSON
+        )
+        let service = AIInferenceService(
+            provider: provider,
+            gymProfile: GymProfile.mockProfile(),
+            maxRetries: 2
+        )
+
+        let result = await service.prescribe(context: WorkoutContext.mockContext())
+
+        XCTAssertEqual(provider.callCount, 1,
+                       "Missing intent must fail fast — exactly one provider call.")
+        guard case .fallback(let reason) = result,
+              case .malformedResponse(let detail) = reason
+        else {
+            return XCTFail("Expected .malformedResponse, got \(result)")
+        }
+        XCTAssertTrue(
+            detail.lowercased().contains("intent"),
+            "Fallback detail should name 'intent'. Got: \(detail)"
+        )
+    }
+
+    /// B2 — Slice 6 fail-fast: invalid intent string (e.g. "bogus") triggers
+    /// `.fallback(.malformedResponse)` after exactly one provider call. The
+    /// custom Codable init rethrows DecodingError as
+    /// PrescriptionValidationError.invalidIntent, which is caught at the
+    /// decode site as a permanent error.
+    func test_failFast_invalidIntentString_oneCall_returnsMalformedResponse() async {
+        let invalidIntentJSON = """
+        {
+          "set_prescription": {
+            "weight_kg": 80.0,
+            "reps": 8,
+            "tempo": "3-1-1-0",
+            "rir_target": 2,
+            "rest_seconds": 120,
+            "coaching_cue": "Drive through.",
+            "reasoning": "Standard top set.",
+            "safety_flags": [],
+            "confidence": 0.85,
+            "intent": "bogus"
+          }
+        }
+        """
+        let provider = RetryOnceProvider(
+            failCount: 999,
+            failResponse: invalidIntentJSON,
+            successResponse: validPrescriptionJSON
+        )
+        let service = AIInferenceService(
+            provider: provider,
+            gymProfile: GymProfile.mockProfile(),
+            maxRetries: 2
+        )
+
+        let result = await service.prescribe(context: WorkoutContext.mockContext())
+
+        XCTAssertEqual(provider.callCount, 1,
+                       "Invalid intent must fail fast — exactly one provider call.")
+        guard case .fallback(let reason) = result,
+              case .malformedResponse(let detail) = reason
+        else {
+            return XCTFail("Expected .malformedResponse, got \(result)")
+        }
+        XCTAssertTrue(
+            detail.lowercased().contains("intent"),
+            "Fallback detail should name 'intent'. Got: \(detail)"
+        )
+    }
+
+    /// B3 — Happy path: valid prescription with intent returns `.success`
+    /// on the first call (regression coverage; the validPrescriptionJSON
+    /// fixture now carries `"intent": "top"`).
+    func test_validPrescription_returnsSuccess_oneCall() async {
+        let provider = RetryOnceProvider(
+            failCount: 0,
+            failResponse: "",
+            successResponse: validPrescriptionJSON
+        )
+        let service = AIInferenceService(
+            provider: provider,
+            gymProfile: GymProfile.mockProfile(),
+            maxRetries: 0
+        )
+
+        let result = await service.prescribe(context: WorkoutContext.mockContext())
+
+        XCTAssertEqual(provider.callCount, 1)
+        guard case .success(let prescription) = result else {
+            return XCTFail("Expected .success, got \(result)")
+        }
+        XCTAssertEqual(prescription.intent, .top,
+                       "Decoded intent must round-trip from the fixture.")
+    }
+
+    /// B6 — prescribeAdaptation aligns with prescribe() on the fail-fast
+    /// rule. A missing-intent response from the LLM during adaptation must
+    /// also fail fast as `.malformedResponse`.
+    func test_failFast_prescribeAdaptation_missingIntent_returnsMalformedResponse() async {
+        let missingIntentJSON = """
+        {
+          "set_prescription": {
+            "weight_kg": 75.0,
+            "reps": 8,
+            "tempo": "3-1-1-0",
+            "rir_target": 2,
+            "rest_seconds": 120,
+            "coaching_cue": "x",
+            "reasoning": "y",
+            "safety_flags": []
+          }
+        }
+        """
+        let provider = RetryOnceProvider(
+            failCount: 0,
+            failResponse: "",
+            successResponse: missingIntentJSON
+        )
+        let service = AIInferenceService(
+            provider: provider,
+            gymProfile: GymProfile.mockProfile(),
+            maxRetries: 0
+        )
+
+        let result = await service.prescribeAdaptation(
+            userPayload: "irrelevant for the mock",
+            workoutContext: WorkoutContext.mockContext()
+        )
+
+        guard case .fallback(let reason) = result,
+              case .malformedResponse = reason
+        else {
+            return XCTFail("Expected .malformedResponse from prescribeAdaptation, got \(result)")
         }
     }
 

--- a/ProjectApexTests/AIInferenceSpikeTests.swift
+++ b/ProjectApexTests/AIInferenceSpikeTests.swift
@@ -73,6 +73,7 @@ private struct PermanentThrowingMockProvider: LLMProvider {
 // MARK: - Test helpers
 
 /// A valid JSON response string wrapping a SetPrescription that passes validation.
+/// Includes `intent` per Slice 6 (#10) — required field with no silent default.
 private let validJSONResponse = """
 {
   "set_prescription": {
@@ -84,7 +85,8 @@ private let validJSONResponse = """
     "coaching_cue": "Retract scapula before unracking.",
     "reasoning": "Previous set at 85 kg with 2 RIR; small load increase is appropriate.",
     "safety_flags": [],
-    "confidence": 0.88
+    "confidence": 0.88,
+    "intent": "top"
   }
 }
 """
@@ -95,6 +97,8 @@ private let invalidJSONResponse = """
 """
 
 /// JSON that decodes but fails SetPrescription.validate() — tempo has 3 parts.
+/// Carries a valid intent so `.invalidTempo` surfaces (intent gate has prior
+/// precedence per Slice 6).
 private let invalidTempoJSONResponse = """
 {
   "set_prescription": {
@@ -106,7 +110,8 @@ private let invalidTempoJSONResponse = """
     "coaching_cue": "Keep tight arch.",
     "reasoning": "Progressive overload from last session.",
     "safety_flags": [],
-    "confidence": 0.8
+    "confidence": 0.8,
+    "intent": "top"
   }
 }
 """
@@ -115,12 +120,27 @@ private let invalidTempoJSONResponse = """
 
 final class AIInferenceSpikeTests: XCTestCase {
 
-    // MARK: - Retry path A: decode failure × 2 → success
+    // MARK: - Permanent-error fail-fast (ADR-0007 / Slice 6) ─────────────────
+    //
+    // ████████████████████████████████████████████████████████████████████████
+    // BEHAVIOUR CHANGE — Slice 6 (#10):
+    //   Pre-Slice-6, prescribe() RETRIED on JSON decode and validate()
+    //   failures, appending a "CORRECTION REQUIRED" addendum until either a
+    //   valid response arrived or maxRetries+1 attempts had been made.
+    //
+    //   ADR-0007 §1 classifies malformed responses as PERMANENT — same-prompt
+    //   retry will not fix the LLM's output. Slice 6 removes the
+    //   retry-on-validate loop. The tests below previously asserted "2
+    //   failures → 3rd succeeds"; they now assert "first failure → fail fast"
+    //   to lock the new contract. Spinoff issue tracks audit of all
+    //   retry-on-validate sites against ADR-0007.
+    // ████████████████████████████████████████████████████████████████████████
 
-    /// The provider returns two un-decodable JSON responses, then a valid one.
-    /// AIInferenceService must retry twice and ultimately return .success.
-    func test_retryPath_decodeFailureTwiceThenSuccess() async throws {
+    /// Slice 6: malformed JSON fails fast on the first attempt.
+    /// Pre-Slice-6 this test asserted retry-then-success after 2 failures.
+    func test_failFast_decodeFailure_oneCall_returnsMalformedResponse() async throws {
         let mock = RetryMockProvider(
+            // Multiple failures queued — only the first should ever be served.
             failureResponses: [invalidJSONResponse, invalidJSONResponse],
             successResponse: validJSONResponse
         )
@@ -132,23 +152,22 @@ final class AIInferenceSpikeTests: XCTestCase {
 
         let result = await service.prescribe(context: InferenceSpike.minimalWorkoutContext())
 
-        switch result {
-        case .success(let prescription):
-            XCTAssertTrue(mock.didSucceed, "Mock provider should have reached the success response.")
-            XCTAssertNoThrow(try prescription.validate(),
-                             "Prescription returned after retries must be valid.")
-            XCTAssertEqual(prescription.reps, 7)
-        case .fallback(let reason):
-            XCTFail("Expected .success after retries, got fallback: \(reason)")
+        XCTAssertFalse(
+            mock.didSucceed,
+            "Slice 6 fail-fast: malformed JSON must not trigger retry. " +
+            "If didSucceed=true, the retry-on-decode loop has regressed."
+        )
+        guard case .fallback(let reason) = result,
+              case .malformedResponse = reason
+        else {
+            return XCTFail("Expected .malformedResponse, got \(result)")
         }
     }
 
-    // MARK: - Retry path B: validation failure × 2 → success
-
-    /// The provider returns two structurally-valid JSON objects that contain an
-    /// invalid tempo field, causing validate() to throw. On the third call it
-    /// returns a fully-valid prescription.
-    func test_retryPath_validationFailureTwiceThenSuccess() async throws {
+    /// Slice 6: validate() failure on tempo fails fast on the first attempt.
+    /// Pre-Slice-6 this test asserted retry-then-success after 2 validation
+    /// failures.
+    func test_failFast_validationFailure_oneCall_returnsMalformedResponse() async throws {
         let mock = RetryMockProvider(
             failureResponses: [invalidTempoJSONResponse, invalidTempoJSONResponse],
             successResponse: validJSONResponse
@@ -161,16 +180,20 @@ final class AIInferenceSpikeTests: XCTestCase {
 
         let result = await service.prescribe(context: InferenceSpike.minimalWorkoutContext())
 
-        switch result {
-        case .success(let prescription):
-            XCTAssertTrue(mock.didSucceed)
-            // Verify the winning prescription has a valid tempo.
-            XCTAssertNoThrow(try prescription.validate())
-            // The valid response has tempo "3-1-1-0".
-            XCTAssertEqual(prescription.tempo, "3-1-1-0")
-        case .fallback(let reason):
-            XCTFail("Expected .success after validation retries, got fallback: \(reason)")
+        XCTAssertFalse(
+            mock.didSucceed,
+            "Slice 6 fail-fast: validate() failure must not trigger retry. " +
+            "If didSucceed=true, the retry-on-validate loop has regressed."
+        )
+        guard case .fallback(let reason) = result,
+              case .malformedResponse(let detail) = reason
+        else {
+            return XCTFail("Expected .malformedResponse, got \(result)")
         }
+        XCTAssertTrue(
+            detail.lowercased().contains("tempo"),
+            "Fallback detail should name the offending field. Got: \(detail)"
+        )
     }
 
     // MARK: - Retry path C: provider throws on every attempt → fallback
@@ -213,6 +236,8 @@ final class AIInferenceSpikeTests: XCTestCase {
                 break  // expected
             case .encodingFailed:
                 XCTFail("Encoding should not have failed in this test path: \(reason)")
+            case .malformedResponse:
+                XCTFail("Transient HTTP errors should not surface as malformedResponse: \(reason)")
             }
         }
     }
@@ -253,42 +278,15 @@ final class AIInferenceSpikeTests: XCTestCase {
         }
     }
 
-    // MARK: - Retry exhaustion (all attempts fail)
+    // MARK: - Prescription value correctness on the happy path
 
-    /// When all attempts return un-decodable JSON, the service must exhaust
-    /// maxRetries and return .fallback(reason: .maxRetriesExceeded).
-    func test_allRetriesExhausted_returnsFallbackWithMaxRetriesExceeded() async {
+    /// Slice 6: confirms that a valid first-attempt response decodes
+    /// faithfully. Pre-Slice-6 this test allowed one decode failure before
+    /// success; the retry-on-validate loop is gone, so the fixture starts
+    /// clean.
+    func test_prescriptionValues_validResponse_decodesFaithfully() async throws {
         let mock = RetryMockProvider(
-            failureResponses: [invalidJSONResponse, invalidJSONResponse, invalidJSONResponse],
-            successResponse: validJSONResponse // never reached
-        )
-        let service = AIInferenceService(
-            provider: mock,
-            gymProfile: GymProfile.mockProfile(),
-            maxRetries: 2   // 1 initial + 2 retries = 3 total attempts
-        )
-
-        let result = await service.prescribe(context: InferenceSpike.minimalWorkoutContext())
-
-        switch result {
-        case .success:
-            XCTFail("Expected fallback when all attempts fail.")
-        case .fallback(let reason):
-            if case .maxRetriesExceeded(let lastError) = reason {
-                XCTAssertFalse(lastError.isEmpty, "lastError must describe the final failure.")
-            } else {
-                XCTFail("Expected .maxRetriesExceeded, got \(reason).")
-            }
-        }
-    }
-
-    // MARK: - Prescription value correctness after retries
-
-    /// Confirms that the prescription values from the valid response are
-    /// decoded faithfully even when preceded by retry failures.
-    func test_prescriptionValues_correctAfterRetries() async throws {
-        let mock = RetryMockProvider(
-            failureResponses: [invalidJSONResponse],
+            failureResponses: [],
             successResponse: validJSONResponse
         )
         let service = AIInferenceService(
@@ -309,6 +307,8 @@ final class AIInferenceSpikeTests: XCTestCase {
         XCTAssertEqual(prescription.rirTarget, 2)
         XCTAssertEqual(prescription.restSeconds, 150)
         XCTAssertTrue(prescription.safetyFlags.isEmpty)
+        XCTAssertEqual(prescription.intent, .top,
+                       "Decoded intent must round-trip from the fixture.")
     }
 
     // MARK: - Equipment rounding applied after retries

--- a/ProjectApexTests/AIInferenceSpikeTests.swift
+++ b/ProjectApexTests/AIInferenceSpikeTests.swift
@@ -86,7 +86,8 @@ private let validJSONResponse = """
     "reasoning": "Previous set at 85 kg with 2 RIR; small load increase is appropriate.",
     "safety_flags": [],
     "confidence": 0.88,
-    "intent": "top"
+    "intent": "top",
+    "set_framing": "Heaviest work of the day. Brace and grind."
   }
 }
 """
@@ -111,7 +112,8 @@ private let invalidTempoJSONResponse = """
     "reasoning": "Progressive overload from last session.",
     "safety_flags": [],
     "confidence": 0.8,
-    "intent": "top"
+    "intent": "top",
+    "set_framing": "Heaviest work of the day. Brace and grind."
   }
 }
 """

--- a/ProjectApexTests/EquipmentRounderTests.swift
+++ b/ProjectApexTests/EquipmentRounderTests.swift
@@ -24,7 +24,8 @@ private func validPrescription() -> SetPrescription {
         coachingCue: "Drive through the floor on the concentric.",
         reasoning: "Load is within previous session range; slight volume increase.",
         safetyFlags: [],
-        confidence: 0.9
+        confidence: 0.9,
+        intent: .top
     )
 }
 

--- a/ProjectApexTests/EquipmentRounderTests.swift
+++ b/ProjectApexTests/EquipmentRounderTests.swift
@@ -25,7 +25,8 @@ private func validPrescription() -> SetPrescription {
         reasoning: "Load is within previous session range; slight volume increase.",
         safetyFlags: [],
         confidence: 0.9,
-        intent: .top
+        intent: .top,
+        setFraming: "Heaviest work of the day. Brace and grind."
     )
 }
 

--- a/ProjectApexTests/ManualLogIntentGateTests.swift
+++ b/ProjectApexTests/ManualLogIntentGateTests.swift
@@ -1,0 +1,146 @@
+// ManualLogIntentGateTests.swift
+// ProjectApexTests — Slice 6 (#10)
+//
+// Unit tests for the manual-session-log Save-button gate.
+// AC from issue #10:
+//   "Save button on freestyle completion is disabled until the user has
+//    explicitly interacted with the intent picker."
+//
+// In ManualSessionLogView this is per-set: every non-empty entry
+// (weight > 0 OR reps > 0) must have `intentTouched == true`. Empty
+// entries (no weight, no reps) are skipped — they don't gate and don't
+// contribute at submit time.
+//
+// The gating logic lives in `manualLogCanSubmit(entries:)` — pulled to
+// file scope so it's testable without a SwiftUI / @State harness.
+
+import XCTest
+@testable import ProjectApex
+
+final class ManualLogIntentGateTests: XCTestCase {
+
+    // MARK: - Test factories
+
+    private func entry(
+        sets: [(weightString: String, reps: Int, intent: SetIntent?, touched: Bool)]
+    ) -> ManualExerciseEntry {
+        let exercise = PlannedExercise(
+            id: UUID(),
+            exerciseId: "test_exercise",
+            name: "Test",
+            primaryMuscle: "pectoralis_major",
+            synergists: [],
+            equipmentRequired: .barbell,
+            sets: max(1, sets.count),
+            repRange: RepRange(min: 5, max: 10),
+            tempo: "3-1-1-0",
+            restSeconds: 120,
+            rirTarget: 2,
+            coachingCues: []
+        )
+        var built = ManualExerciseEntry(exercise: exercise)
+        // Override the auto-generated empty sets with the test fixture.
+        built.sets = sets.map { tuple in
+            var e = ManualSetEntry()
+            e.weightString  = tuple.weightString
+            e.reps          = tuple.reps
+            e.intent        = tuple.intent
+            e.intentTouched = tuple.touched
+            return e
+        }
+        return built
+    }
+
+    // MARK: - Empty entries don't gate
+
+    func test_noEntries_canSubmit() {
+        XCTAssertTrue(manualLogCanSubmit(entries: []),
+                      "Empty entry list (degenerate) does not gate submission.")
+    }
+
+    func test_allEmptySets_canSubmit() {
+        let e = entry(sets: [
+            ("",   0, nil, false),
+            ("",   0, nil, false),
+        ])
+        XCTAssertTrue(manualLogCanSubmit(entries: [e]),
+                      "Entries with all-empty sets do not gate.")
+    }
+
+    // MARK: - Non-empty without touched intent → gated
+
+    func test_nonEmptySet_withoutTouchedIntent_blocksSubmit() {
+        let e = entry(sets: [
+            ("80", 10, nil, false),
+        ])
+        XCTAssertFalse(manualLogCanSubmit(entries: [e]),
+                       "Non-empty set without touched intent must block save.")
+    }
+
+    func test_nonEmptySet_withIntentButNotTouched_blocksSubmit() {
+        // The "even if initial selection matches their intent" rule —
+        // having `intent` set without an explicit tap doesn't pass the gate.
+        let e = entry(sets: [
+            ("80", 10, .top, false),
+        ])
+        XCTAssertFalse(manualLogCanSubmit(entries: [e]),
+                       "Intent assigned but not touched still blocks save.")
+    }
+
+    // MARK: - Non-empty with touched intent → submittable
+
+    func test_nonEmptySet_withTouchedIntent_canSubmit() {
+        let e = entry(sets: [
+            ("80", 10, .top, true),
+        ])
+        XCTAssertTrue(manualLogCanSubmit(entries: [e]))
+    }
+
+    func test_weightOnlyNoReps_isNonEmpty_andGates() {
+        // weight > 0 alone counts as content — the user has typed
+        // something. They must pick an intent before saving.
+        let e = entry(sets: [
+            ("80", 0, nil, false),
+        ])
+        XCTAssertFalse(manualLogCanSubmit(entries: [e]))
+    }
+
+    func test_repsOnlyNoWeight_isNonEmpty_andGates() {
+        // Bodyweight exercises log reps with weight = 0. They must still
+        // pick an intent — no silent default.
+        let e = entry(sets: [
+            ("0", 8, nil, false),
+        ])
+        XCTAssertFalse(manualLogCanSubmit(entries: [e]))
+    }
+
+    // MARK: - Mixed empty + non-empty
+
+    func test_mixedSets_emptyDoesntGate_butNonEmptyDoes() {
+        let e = entry(sets: [
+            ("80", 10, .top, true),       // touched OK
+            ("",    0, nil,  false),      // empty — skipped
+            ("70",  8, nil,  false),      // non-empty, NOT touched → gates
+        ])
+        XCTAssertFalse(manualLogCanSubmit(entries: [e]),
+                       "One ungated non-empty set blocks the whole submission.")
+    }
+
+    func test_mixedSets_allNonEmptyTouched_canSubmit() {
+        let e = entry(sets: [
+            ("80", 10, .top,     true),
+            ("",    0, nil,      false),  // empty — skipped, no gate
+            ("70",  8, .backoff, true),
+        ])
+        XCTAssertTrue(manualLogCanSubmit(entries: [e]))
+    }
+
+    // MARK: - Cross-exercise gate (any one entry blocks all)
+
+    func test_crossExercise_oneUntouched_blocksSubmit() {
+        let ok = entry(sets: [("80", 10, .top, true)])
+        let bad = entry(sets: [("60", 8, nil, false)])
+        XCTAssertFalse(manualLogCanSubmit(entries: [ok, bad]),
+                       "An untouched non-empty set in any entry blocks save.")
+    }
+}

--- a/ProjectApexTests/SetCompletionFormStateTests.swift
+++ b/ProjectApexTests/SetCompletionFormStateTests.swift
@@ -81,6 +81,78 @@ final class SetCompletionFormStateTests: XCTestCase {
                       "backoff still differs from prescribed top.")
     }
 
+    // MARK: - Dismiss deviation picker (forgiving over strict)
+
+    /// Reveal then dismiss without picking → state matches the
+    /// post-init shape. The user changed their mind about deviating;
+    /// the deviation affordance must be reversible.
+    func test_aiPrescribed_revealThenDismiss_withoutPick_resetsToInitial() {
+        let initial = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+        var state = initial
+        state.revealDeviationPicker()
+        XCTAssertTrue(state.isDeviationPickerVisible)
+        state.dismissDeviationPicker()
+        XCTAssertFalse(state.isDeviationPickerVisible,
+                       "Dismiss collapses the picker.")
+        XCTAssertEqual(state.resolvedIntent, .top,
+                       "Dismiss resets resolvedIntent to the prescription.")
+        XCTAssertFalse(state.isDeviation)
+        XCTAssertEqual(state, initial,
+                       "After reveal+dismiss-without-pick, state matches the init shape.")
+    }
+
+    /// Reveal, pick a deviation, dismiss → resolvedIntent resets to
+    /// prescribed; isDeviation goes back to false. Forgiving rule: a
+    /// tentative deviation pick that the user backs out of must not
+    /// persist on the SetLog.
+    func test_aiPrescribed_revealPickDeviation_dismiss_resetsResolvedIntent() {
+        var state = SetCompletionFormState(actualReps: 10, prescribedIntent: .top)
+        state.revealDeviationPicker()
+        state.selectIntent(.amrap)
+        XCTAssertEqual(state.resolvedIntent, .amrap)
+        XCTAssertTrue(state.isDeviation)
+
+        state.dismissDeviationPicker()
+        XCTAssertFalse(state.isDeviationPickerVisible)
+        XCTAssertEqual(state.resolvedIntent, .top,
+                       "Dismiss after deviation must reset to prescribed.")
+        XCTAssertFalse(state.isDeviation,
+                       "After dismiss, the set is no longer a deviation.")
+    }
+
+    /// Reveal → dismiss → reveal again. Each cycle starts from the
+    /// prescribed-intent baseline. Cycling the picker doesn't accumulate
+    /// stale state.
+    func test_aiPrescribed_revealDismissReveal_picksUpFreshFromPrescribed() {
+        var state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+        state.revealDeviationPicker()
+        state.selectIntent(.warmup)            // tentative deviation
+        state.dismissDeviationPicker()         // discard it
+        state.revealDeviationPicker()          // open again
+
+        XCTAssertTrue(state.isDeviationPickerVisible)
+        XCTAssertEqual(state.resolvedIntent, .top,
+                       "After dismiss, the next reveal starts from prescribed, not from the discarded warmup.")
+        XCTAssertFalse(state.isDeviation,
+                       "Re-revealing the picker doesn't restore the discarded deviation.")
+    }
+
+    /// Freestyle has no prescribed intent to fall back to — dismiss
+    /// must be a no-op (otherwise resolvedIntent could be wiped to nil
+    /// after the user picked, stranding them in a non-submittable form).
+    /// The UI also hides the dismiss affordance for freestyle, but the
+    /// state struct guard is defence in depth.
+    func test_freestyle_dismissDeviationPicker_isNoop() {
+        var state = SetCompletionFormState(actualReps: 8, prescribedIntent: nil)
+        state.selectIntent(.warmup)
+        state.dismissDeviationPicker()
+        XCTAssertTrue(state.isDeviationPickerVisible,
+                      "Freestyle picker stays visible — no dismiss path.")
+        XCTAssertEqual(state.resolvedIntent, .warmup,
+                       "Freestyle resolvedIntent is preserved on dismiss.")
+        XCTAssertTrue(state.canSubmit)
+    }
+
     // MARK: - Freestyle path (no prescription)
 
     func test_freestyle_pickerVisibleByDefault() {

--- a/ProjectApexTests/SetCompletionFormStateTests.swift
+++ b/ProjectApexTests/SetCompletionFormStateTests.swift
@@ -1,0 +1,98 @@
+// SetCompletionFormStateTests.swift
+// ProjectApexTests — Slice 6 (#10)
+//
+// Unit tests for the rep / RPE / intent confirmation sheet's state model.
+// Encodes the AC from issue #10:
+//   "Save button on freestyle completion is disabled until the user
+//    explicitly interacts with the intent picker (UI test asserts this)"
+// Since the project has no UITests target, the rule is enforced via
+// SetCompletionFormState — `canSubmit` is false until `recordIntentTap`
+// has been called at least once, even when an AI prefill provides
+// `intent != nil`.
+
+import XCTest
+@testable import ProjectApex
+
+final class SetCompletionFormStateTests: XCTestCase {
+
+    // MARK: - C1: default state cannot submit
+
+    func test_freshState_noPrefill_cannotSubmit() {
+        let state = SetCompletionFormState(actualReps: 8)
+        XCTAssertNil(state.intent)
+        XCTAssertFalse(state.canSubmit, "Save must be disabled before any tap.")
+        XCTAssertFalse(state.hasUnconfirmedAIPrefill,
+                       "No prefill means no unconfirmed prefill.")
+    }
+
+    // MARK: - C2: AI-prefilled state still requires explicit interaction
+
+    func test_aiPrefilledState_stillRequiresTouch() {
+        // The "even if the initial selection matches their intent" rule —
+        // a prefilled SetIntent must not auto-enable Save.
+        let state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+        XCTAssertEqual(state.intent, .top,
+                       "Prefill should populate the picker selection.")
+        XCTAssertFalse(state.canSubmit,
+                       "Prefilled selection must NOT enable Save before touch.")
+        XCTAssertTrue(state.hasUnconfirmedAIPrefill,
+                      "Prefill present but un-tapped — render distinct visual.")
+    }
+
+    // MARK: - C3: explicit tap promotes to submittable
+
+    func test_recordTap_enablesSubmit() {
+        var state = SetCompletionFormState(actualReps: 8)
+        state.recordIntentTap(.top)
+        XCTAssertEqual(state.intent, .top)
+        XCTAssertTrue(state.canSubmit,
+                      "Tap on a chip must enable Save.")
+        XCTAssertFalse(state.hasUnconfirmedAIPrefill,
+                       "After tap, the prefill is confirmed.")
+    }
+
+    // MARK: - C4: changing selection after first tap stays submittable
+
+    func test_changeSelectionAfterFirstTap_remainsSubmittable() {
+        var state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+        state.recordIntentTap(.top)
+        XCTAssertTrue(state.canSubmit)
+
+        state.recordIntentTap(.backoff)
+        XCTAssertEqual(state.intent, .backoff,
+                       "Re-tap should change the selection.")
+        XCTAssertTrue(state.canSubmit,
+                      "Re-tapping a different chip stays submittable.")
+    }
+
+    // MARK: - C5 (variant): tapping the same prefilled chip confirms
+
+    func test_tapMatchingPrefilledChip_confirms() {
+        var state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+        XCTAssertFalse(state.canSubmit)
+        state.recordIntentTap(.top)   // tap the already-prefilled selection
+        XCTAssertTrue(state.canSubmit,
+                      "Confirming the prefill via tap must enable Save.")
+    }
+
+    // MARK: - All five SetIntent cases route through cleanly
+
+    func test_recordTap_eachSetIntentCase() {
+        for intent in SetIntent.allCases {
+            var state = SetCompletionFormState(actualReps: 5)
+            state.recordIntentTap(intent)
+            XCTAssertEqual(state.intent, intent)
+            XCTAssertTrue(state.canSubmit, "Should submit for \(intent)")
+        }
+    }
+
+    // MARK: - Other picker fields don't toggle the gate
+
+    func test_repsAndRpeChanges_doNotEnableSubmit_withoutTap() {
+        var state = SetCompletionFormState(actualReps: 8)
+        state.actualReps = 10
+        state.rpeFelt    = 2
+        XCTAssertFalse(state.canSubmit,
+                       "Reps/RPE changes must not bypass the intent gate.")
+    }
+}

--- a/ProjectApexTests/SetCompletionFormStateTests.swift
+++ b/ProjectApexTests/SetCompletionFormStateTests.swift
@@ -1,98 +1,170 @@
 // SetCompletionFormStateTests.swift
 // ProjectApexTests — Slice 6 (#10)
 //
-// Unit tests for the rep / RPE / intent confirmation sheet's state model.
-// Encodes the AC from issue #10:
-//   "Save button on freestyle completion is disabled until the user
-//    explicitly interacts with the intent picker (UI test asserts this)"
-// Since the project has no UITests target, the rule is enforced via
-// SetCompletionFormState — `canSubmit` is false until `recordIntentTap`
-// has been called at least once, even when an AI prefill provides
-// `intent != nil`.
+// Unit tests for the redesigned rep/RPE/intent/flag state struct.
+//
+// REDESIGN NOTE (supersedes the prior intentTouched-based test set):
+//   The prior tests asserted that AI-prescribed sets required an explicit
+//   chip tap before Save enabled — the wrong model. The correct model is:
+//     - AI-prescribed: zero friction. resolvedIntent defaults to
+//       prescribedIntent. canSubmit immediately true.
+//     - Freestyle: requires explicit pick. canSubmit false until selectIntent.
+//   Deviation is captured separately via `isDeviation` (true when
+//   resolvedIntent differs from prescribedIntent).
+//   Pain / form_breakdown flags are independent multi-select toggles.
 
 import XCTest
 @testable import ProjectApex
 
 final class SetCompletionFormStateTests: XCTestCase {
 
-    // MARK: - C1: default state cannot submit
+    // MARK: - AI-prescribed default path (zero friction)
 
-    func test_freshState_noPrefill_cannotSubmit() {
-        let state = SetCompletionFormState(actualReps: 8)
-        XCTAssertNil(state.intent)
-        XCTAssertFalse(state.canSubmit, "Save must be disabled before any tap.")
-        XCTAssertFalse(state.hasUnconfirmedAIPrefill,
-                       "No prefill means no unconfirmed prefill.")
-    }
-
-    // MARK: - C2: AI-prefilled state still requires explicit interaction
-
-    func test_aiPrefilledState_stillRequiresTouch() {
-        // The "even if the initial selection matches their intent" rule —
-        // a prefilled SetIntent must not auto-enable Save.
+    /// The most important assertion in the file: AI-prescribed sets
+    /// can submit immediately with no picker friction.
+    func test_aiPrescribed_resolvesToPrescribedIntent_canSubmitImmediately() {
         let state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
-        XCTAssertEqual(state.intent, .top,
-                       "Prefill should populate the picker selection.")
-        XCTAssertFalse(state.canSubmit,
-                       "Prefilled selection must NOT enable Save before touch.")
-        XCTAssertTrue(state.hasUnconfirmedAIPrefill,
-                      "Prefill present but un-tapped — render distinct visual.")
-    }
-
-    // MARK: - C3: explicit tap promotes to submittable
-
-    func test_recordTap_enablesSubmit() {
-        var state = SetCompletionFormState(actualReps: 8)
-        state.recordIntentTap(.top)
-        XCTAssertEqual(state.intent, .top)
+        XCTAssertEqual(state.prescribedIntent, .top)
+        XCTAssertEqual(state.resolvedIntent, .top,
+                       "Default resolvedIntent should mirror the prescription.")
         XCTAssertTrue(state.canSubmit,
-                      "Tap on a chip must enable Save.")
-        XCTAssertFalse(state.hasUnconfirmedAIPrefill,
-                       "After tap, the prefill is confirmed.")
+                      "AI-prescribed sets must be submittable without picker interaction.")
+        XCTAssertFalse(state.isDeviation,
+                       "Default state is not a deviation.")
+        XCTAssertFalse(state.isDeviationPickerVisible,
+                       "Picker is collapsed by default for AI-prescribed sets.")
     }
 
-    // MARK: - C4: changing selection after first tap stays submittable
-
-    func test_changeSelectionAfterFirstTap_remainsSubmittable() {
+    func test_aiPrescribed_revealDeviationPicker_doesNotChangeIntent() {
         var state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
-        state.recordIntentTap(.top)
+        state.revealDeviationPicker()
+        XCTAssertTrue(state.isDeviationPickerVisible,
+                      "revealDeviationPicker flips the visibility.")
+        XCTAssertEqual(state.resolvedIntent, .top,
+                       "Revealing the picker does not change the resolved intent.")
+        XCTAssertFalse(state.isDeviation,
+                       "Revealing the picker is not by itself a deviation.")
+        XCTAssertTrue(state.canSubmit,
+                      "Revealing the picker keeps the gate open.")
+    }
+
+    func test_aiPrescribed_recordDeviation_resolvedIntentChanges_isDeviationTrue() {
+        var state = SetCompletionFormState(actualReps: 12, prescribedIntent: .top)
+        state.revealDeviationPicker()
+        state.selectIntent(.amrap)
+        XCTAssertEqual(state.resolvedIntent, .amrap,
+                       "selectIntent updates the resolved value.")
+        XCTAssertTrue(state.isDeviation,
+                      "User picked amrap when prescribed top — deviation true.")
+        XCTAssertTrue(state.canSubmit,
+                      "Deviation is still submittable.")
+    }
+
+    func test_aiPrescribed_pickSamePrescribed_isDeviationFalse() {
+        // Reaffirming the prescription is NOT a deviation. The user just
+        // tapped the same chip; nothing actually differs.
+        var state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+        state.revealDeviationPicker()
+        state.selectIntent(.top)
+        XCTAssertFalse(state.isDeviation,
+                       "Picking the same intent the AI prescribed is not a deviation.")
+    }
+
+    func test_aiPrescribed_pickThenChangeMind_lastSelectionWins() {
+        var state = SetCompletionFormState(actualReps: 10, prescribedIntent: .top)
+        state.revealDeviationPicker()
+        state.selectIntent(.amrap)
+        state.selectIntent(.backoff)
+        XCTAssertEqual(state.resolvedIntent, .backoff,
+                       "Last selection wins; previous deviation is overwritten.")
+        XCTAssertTrue(state.isDeviation,
+                      "backoff still differs from prescribed top.")
+    }
+
+    // MARK: - Freestyle path (no prescription)
+
+    func test_freestyle_pickerVisibleByDefault() {
+        let state = SetCompletionFormState(actualReps: 8, prescribedIntent: nil)
+        XCTAssertNil(state.prescribedIntent)
+        XCTAssertNil(state.resolvedIntent,
+                     "Freestyle starts with no resolved intent.")
+        XCTAssertTrue(state.isDeviationPickerVisible,
+                      "Freestyle shows the picker by default — only path to an intent.")
+        XCTAssertFalse(state.canSubmit,
+                       "Freestyle blocks submission until an intent is picked.")
+        XCTAssertFalse(state.isDeviation,
+                       "Freestyle is never a deviation (nothing to deviate from).")
+    }
+
+    func test_freestyle_pickIntent_canSubmit() {
+        var state = SetCompletionFormState(actualReps: 8, prescribedIntent: nil)
+        state.selectIntent(.warmup)
+        XCTAssertEqual(state.resolvedIntent, .warmup)
         XCTAssertTrue(state.canSubmit)
-
-        state.recordIntentTap(.backoff)
-        XCTAssertEqual(state.intent, .backoff,
-                       "Re-tap should change the selection.")
-        XCTAssertTrue(state.canSubmit,
-                      "Re-tapping a different chip stays submittable.")
+        XCTAssertFalse(state.isDeviation,
+                       "Freestyle never has isDeviation=true regardless of selection.")
     }
 
-    // MARK: - C5 (variant): tapping the same prefilled chip confirms
+    // MARK: - Completion flags
 
-    func test_tapMatchingPrefilledChip_confirms() {
+    func test_completionFlags_emptyByDefault() {
+        let state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+        XCTAssertTrue(state.completionFlags.isEmpty)
+    }
+
+    func test_completionFlags_toggleAddsAndRemoves() {
         var state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
-        XCTAssertFalse(state.canSubmit)
-        state.recordIntentTap(.top)   // tap the already-prefilled selection
-        XCTAssertTrue(state.canSubmit,
-                      "Confirming the prefill via tap must enable Save.")
+        state.toggleFlag(.pain)
+        XCTAssertTrue(state.completionFlags.contains(.pain))
+        state.toggleFlag(.pain)
+        XCTAssertFalse(state.completionFlags.contains(.pain),
+                       "Toggle is symmetric — second tap removes.")
     }
 
-    // MARK: - All five SetIntent cases route through cleanly
-
-    func test_recordTap_eachSetIntentCase() {
-        for intent in SetIntent.allCases {
-            var state = SetCompletionFormState(actualReps: 5)
-            state.recordIntentTap(intent)
-            XCTAssertEqual(state.intent, intent)
-            XCTAssertTrue(state.canSubmit, "Should submit for \(intent)")
-        }
+    func test_completionFlags_multipleAllowedSimultaneously() {
+        // Pain AND form_breakdown can be raised on the same set.
+        var state = SetCompletionFormState(actualReps: 6, prescribedIntent: .top)
+        state.toggleFlag(.pain)
+        state.toggleFlag(.formBreakdown)
+        XCTAssertTrue(state.completionFlags.contains(.pain))
+        XCTAssertTrue(state.completionFlags.contains(.formBreakdown))
+        XCTAssertEqual(state.completionFlags.count, 2)
     }
 
-    // MARK: - Other picker fields don't toggle the gate
-
-    func test_repsAndRpeChanges_doNotEnableSubmit_withoutTap() {
-        var state = SetCompletionFormState(actualReps: 8)
+    func test_completionFlags_persistAcrossOtherStateChanges() {
+        var state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+        state.toggleFlag(.pain)
+        // Other state changes must not clobber flags.
         state.actualReps = 10
-        state.rpeFelt    = 2
+        state.rpeFelt = 2
+        state.revealDeviationPicker()
+        state.selectIntent(.backoff)
+        XCTAssertTrue(state.completionFlags.contains(.pain),
+                      "Flags persist across reps/RPE/picker changes.")
+    }
+
+    // MARK: - Sanity: gate-and-fields don't entangle
+
+    func test_repsAndRpeChanges_doNotChangeIntent() {
+        var state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+        state.actualReps = 10
+        state.rpeFelt = 2
+        XCTAssertEqual(state.resolvedIntent, .top,
+                       "Reps/RPE mutations don't touch the intent value.")
+    }
+
+    func test_repsAndRpeChanges_canSubmitUnaffected_aiPrescribed() {
+        var state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+        state.actualReps = 10
+        XCTAssertTrue(state.canSubmit)
+    }
+
+    func test_repsAndRpeChanges_canSubmitUnaffected_freestyle() {
+        // Freestyle gate is intent-only; reps/RPE changes don't open it.
+        var state = SetCompletionFormState(actualReps: 8, prescribedIntent: nil)
+        state.actualReps = 10
+        state.rpeFelt = 2
         XCTAssertFalse(state.canSubmit,
-                       "Reps/RPE changes must not bypass the intent gate.")
+                       "Freestyle without a picked intent stays blocked.")
     }
 }

--- a/ProjectApexTests/SetPrescriptionIntentValidationTests.swift
+++ b/ProjectApexTests/SetPrescriptionIntentValidationTests.swift
@@ -1,0 +1,194 @@
+// SetPrescriptionIntentValidationTests.swift
+// ProjectApexTests — Slice 6 (#10)
+//
+// Codable + validate() coverage for the new `intent` field on
+// SetPrescription per ADR-0005:
+//   * each SetIntent case round-trips via JSON
+//   * missing intent surfaces typed `.missingIntent` from validate()
+//   * invalid intent string is rethrown from init(from:) as `.invalidIntent`
+//   * intent type-mismatch (e.g. number) is rethrown as `.invalidIntent`
+//   * intent gate has prior precedence over field-level validation
+//
+// Field-level validation rules are covered by the existing
+// SetPrescriptionValidationTests in EquipmentRounderTests.swift; this file
+// focuses on the new intent-specific behaviour.
+
+import XCTest
+@testable import ProjectApex
+
+final class SetPrescriptionIntentValidationTests: XCTestCase {
+
+    // MARK: - JSON helpers
+
+    /// Builds the JSON envelope shape that the LLM returns. `intent` is
+    /// embedded literally so callers can omit / corrupt it in tests.
+    private func envelope(intent: String?, extras: String = "") -> Data {
+        let intentLine = intent.map { ",\n    \"intent\": \"\($0)\"" } ?? ""
+        let json = """
+        {
+          "weight_kg": 80.0,
+          "reps": 8,
+          "tempo": "3-1-1-0",
+          "rir_target": 2,
+          "rest_seconds": 120,
+          "coaching_cue": "Drive through.",
+          "reasoning": "Standard top set.",
+          "safety_flags": [],
+          "confidence": 0.85\(intentLine)\(extras)
+        }
+        """
+        return Data(json.utf8)
+    }
+
+    /// Same shape as `envelope(intent:)` but with `intent` as a raw JSON
+    /// fragment (used for type-mismatch tests where we want `42`, `null`,
+    /// etc. rather than a string).
+    private func envelopeRaw(intentFragment: String) -> Data {
+        let json = """
+        {
+          "weight_kg": 80.0,
+          "reps": 8,
+          "tempo": "3-1-1-0",
+          "rir_target": 2,
+          "rest_seconds": 120,
+          "coaching_cue": "Drive through.",
+          "reasoning": "Standard top set.",
+          "safety_flags": [],
+          "confidence": 0.85,
+          "intent": \(intentFragment)
+        }
+        """
+        return Data(json.utf8)
+    }
+
+    private func decode(_ data: Data) throws -> SetPrescription {
+        try JSONDecoder().decode(SetPrescription.self, from: data)
+    }
+
+    // MARK: - A1: every valid intent round-trips
+
+    func test_decode_each_intent_case_round_trips() throws {
+        for intent in SetIntent.allCases {
+            let p = try decode(envelope(intent: intent.rawValue))
+            XCTAssertEqual(p.intent, intent,
+                           "Round-trip failed for \(intent.rawValue)")
+            XCTAssertNoThrow(try p.validate(),
+                             "validate() should accept intent=\(intent.rawValue)")
+        }
+    }
+
+    // MARK: - A2: missing intent → validate throws .missingIntent
+
+    func test_decode_missing_intent_validate_throws_missingIntent() throws {
+        let p = try decode(envelope(intent: nil))
+        XCTAssertNil(p.intent,
+                     "Missing intent key should decode to nil, not throw at decode time.")
+        XCTAssertThrowsError(try p.validate()) { error in
+            guard case .missingIntent = error as? PrescriptionValidationError else {
+                return XCTFail("Expected .missingIntent, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - A3: invalid intent string → init(from:) throws .invalidIntent
+
+    func test_decode_invalid_intent_string_throws_invalidIntent() {
+        let data = envelope(intent: "bogus")
+        XCTAssertThrowsError(try decode(data)) { error in
+            guard case .invalidIntent(let raw) = error as? PrescriptionValidationError else {
+                return XCTFail("Expected .invalidIntent, got \(error)")
+            }
+            XCTAssertEqual(raw, "bogus",
+                           "Error should preserve the offending raw value.")
+        }
+    }
+
+    // MARK: - A4: intent type-mismatch → init(from:) throws .invalidIntent
+
+    func test_decode_intent_typeMismatch_number_throws_invalidIntent() {
+        let data = envelopeRaw(intentFragment: "42")
+        XCTAssertThrowsError(try decode(data)) { error in
+            guard case .invalidIntent = error as? PrescriptionValidationError else {
+                return XCTFail("Expected .invalidIntent for non-string, got \(error)")
+            }
+        }
+    }
+
+    func test_decode_intent_typeMismatch_array_throws_invalidIntent() {
+        let data = envelopeRaw(intentFragment: "[\"top\"]")
+        XCTAssertThrowsError(try decode(data)) { error in
+            guard case .invalidIntent = error as? PrescriptionValidationError else {
+                return XCTFail("Expected .invalidIntent for array, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - A5: intent gate fires before field-level checks
+
+    func test_intentGate_hasPriorPrecedenceOverInvalidTempo() throws {
+        // Build a prescription with both a missing intent AND an invalid
+        // tempo. The intent gate should fire first, surfacing
+        // `.missingIntent` rather than `.invalidTempo`. This locks the
+        // precedence — the no-silent-defaults invariant takes priority over
+        // field-format validation.
+        let json = """
+        {
+          "weight_kg": 80.0,
+          "reps": 8,
+          "tempo": "1-2-3",
+          "rir_target": 2,
+          "rest_seconds": 120,
+          "coaching_cue": "x",
+          "reasoning": "y",
+          "safety_flags": []
+        }
+        """
+        let p = try decode(Data(json.utf8))
+        XCTAssertThrowsError(try p.validate()) { error in
+            guard case .missingIntent = error as? PrescriptionValidationError else {
+                return XCTFail("Intent gate must fire first, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Encode round-trip preserves intent
+
+    func test_encode_then_decode_preserves_intent() throws {
+        let original = SetPrescription(
+            weightKg: 80.0,
+            reps: 8,
+            tempo: "3-1-1-0",
+            rirTarget: 2,
+            restSeconds: 120,
+            coachingCue: "x",
+            reasoning: "y",
+            safetyFlags: [],
+            confidence: 0.9,
+            intent: .backoff
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SetPrescription.self, from: encoded)
+        XCTAssertEqual(decoded.intent, .backoff)
+        XCTAssertNoThrow(try decoded.validate())
+    }
+
+    // MARK: - Intent absent in encode when nil (Codable optional shape)
+
+    func test_encode_nilIntent_omitsKey() throws {
+        let p = SetPrescription(
+            weightKg: 80.0,
+            reps: 8,
+            tempo: "3-1-1-0",
+            rirTarget: 2,
+            restSeconds: 120,
+            coachingCue: "x",
+            reasoning: "y",
+            safetyFlags: [],
+            intent: nil
+        )
+        let encoded = try JSONEncoder().encode(p)
+        let json = String(data: encoded, encoding: .utf8) ?? ""
+        XCTAssertFalse(json.contains("\"intent\""),
+                       "Encoder must omit intent when nil.")
+    }
+}

--- a/ProjectApexTests/SetPrescriptionIntentValidationTests.swift
+++ b/ProjectApexTests/SetPrescriptionIntentValidationTests.swift
@@ -22,8 +22,13 @@ final class SetPrescriptionIntentValidationTests: XCTestCase {
 
     /// Builds the JSON envelope shape that the LLM returns. `intent` is
     /// embedded literally so callers can omit / corrupt it in tests.
-    private func envelope(intent: String?, extras: String = "") -> Data {
+    private func envelope(
+        intent: String?,
+        setFraming: String? = "Heaviest work of the day. Brace and grind.",
+        extras: String = ""
+    ) -> Data {
         let intentLine = intent.map { ",\n    \"intent\": \"\($0)\"" } ?? ""
+        let framingLine = setFraming.map { ",\n    \"set_framing\": \"\($0)\"" } ?? ""
         let json = """
         {
           "weight_kg": 80.0,
@@ -34,7 +39,7 @@ final class SetPrescriptionIntentValidationTests: XCTestCase {
           "coaching_cue": "Drive through.",
           "reasoning": "Standard top set.",
           "safety_flags": [],
-          "confidence": 0.85\(intentLine)\(extras)
+          "confidence": 0.85\(intentLine)\(framingLine)\(extras)
         }
         """
         return Data(json.utf8)
@@ -55,7 +60,28 @@ final class SetPrescriptionIntentValidationTests: XCTestCase {
           "reasoning": "Standard top set.",
           "safety_flags": [],
           "confidence": 0.85,
-          "intent": \(intentFragment)
+          "intent": \(intentFragment),
+          "set_framing": "Heaviest work of the day. Brace and grind."
+        }
+        """
+        return Data(json.utf8)
+    }
+
+    /// Envelope with raw `set_framing` fragment for type-mismatch tests.
+    private func envelopeRawSetFraming(framingFragment: String) -> Data {
+        let json = """
+        {
+          "weight_kg": 80.0,
+          "reps": 8,
+          "tempo": "3-1-1-0",
+          "rir_target": 2,
+          "rest_seconds": 120,
+          "coaching_cue": "Drive through.",
+          "reasoning": "Standard top set.",
+          "safety_flags": [],
+          "confidence": 0.85,
+          "intent": "top",
+          "set_framing": \(framingFragment)
         }
         """
         return Data(json.utf8)
@@ -164,11 +190,13 @@ final class SetPrescriptionIntentValidationTests: XCTestCase {
             reasoning: "y",
             safetyFlags: [],
             confidence: 0.9,
-            intent: .backoff
+            intent: .backoff,
+            setFraming: "Build volume on a manageable load."
         )
         let encoded = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(SetPrescription.self, from: encoded)
         XCTAssertEqual(decoded.intent, .backoff)
+        XCTAssertEqual(decoded.setFraming, "Build volume on a manageable load.")
         XCTAssertNoThrow(try decoded.validate())
     }
 
@@ -184,11 +212,70 @@ final class SetPrescriptionIntentValidationTests: XCTestCase {
             coachingCue: "x",
             reasoning: "y",
             safetyFlags: [],
-            intent: nil
+            intent: nil,
+            setFraming: nil
         )
         let encoded = try JSONEncoder().encode(p)
         let json = String(data: encoded, encoding: .utf8) ?? ""
         XCTAssertFalse(json.contains("\"intent\""),
                        "Encoder must omit intent when nil.")
+        XCTAssertFalse(json.contains("\"set_framing\""),
+                       "Encoder must omit set_framing when nil.")
+    }
+
+    // MARK: - set_framing required, validated (Slice 6 redesign)
+
+    /// Missing set_framing surfaces .missingSetFraming from validate().
+    /// Same regime as intent: typed error, fires after the intent gate.
+    func test_decode_missing_setFraming_validate_throws_missingSetFraming() throws {
+        let p = try decode(envelope(intent: "top", setFraming: nil))
+        XCTAssertEqual(p.intent, .top)
+        XCTAssertNil(p.setFraming)
+        XCTAssertThrowsError(try p.validate()) { error in
+            guard case .missingSetFraming = error as? PrescriptionValidationError else {
+                return XCTFail("Expected .missingSetFraming, got \(error)")
+            }
+        }
+    }
+
+    /// set_framing > 80 chars throws .setFramingTooLong with the offending count.
+    func test_setFraming_tooLong_throws_setFramingTooLong() throws {
+        // 100-char framing — well over the 80 limit.
+        let longFraming = String(repeating: "a", count: 100)
+        let p = try decode(envelope(intent: "top", setFraming: longFraming))
+        XCTAssertThrowsError(try p.validate()) { error in
+            guard case .setFramingTooLong(let count) = error as? PrescriptionValidationError else {
+                return XCTFail("Expected .setFramingTooLong, got \(error)")
+            }
+            XCTAssertEqual(count, 100)
+        }
+    }
+
+    /// set_framing exactly 80 chars is valid (boundary).
+    func test_setFraming_at80Chars_valid() throws {
+        let framing = String(repeating: "a", count: 80)
+        let p = try decode(envelope(intent: "top", setFraming: framing))
+        XCTAssertNoThrow(try p.validate())
+    }
+
+    /// Type mismatch (e.g. number) → .invalidSetFraming, not raw DecodingError.
+    func test_decode_setFraming_typeMismatch_number_throws_invalidSetFraming() {
+        let data = envelopeRawSetFraming(framingFragment: "42")
+        XCTAssertThrowsError(try decode(data)) { error in
+            guard case .invalidSetFraming = error as? PrescriptionValidationError else {
+                return XCTFail("Expected .invalidSetFraming for non-string, got \(error)")
+            }
+        }
+    }
+
+    /// Intent gate has prior precedence over set_framing — both missing
+    /// surfaces .missingIntent first.
+    func test_intentGate_firesBefore_setFramingGate() throws {
+        let p = try decode(envelope(intent: nil, setFraming: nil))
+        XCTAssertThrowsError(try p.validate()) { error in
+            guard case .missingIntent = error as? PrescriptionValidationError else {
+                return XCTFail("Expected .missingIntent (gate precedence), got \(error)")
+            }
+        }
     }
 }

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -104,7 +104,8 @@ private func prescriptionJSON(
         "coaching_cue": "Drive through the bar",
         "reasoning": "Based on recent performance trend.",
         "safety_flags": [\(flags)],
-        "intent": "\(intent)"
+        "intent": "\(intent)",
+        "set_framing": "Heaviest work of the day. Brace and grind."
       }
     }
     """

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -211,7 +211,7 @@ final class WorkoutSessionManagerTests: XCTestCase {
             return
         }
 
-        await manager.completeSet(actualReps: 8, rpeFelt: 7)
+        await manager.completeSet(actualReps: 8, rpeFelt: 7, intent: .top)
 
         let stateAfter = await manager.sessionState
         guard case .resting = stateAfter else {
@@ -290,7 +290,7 @@ final class WorkoutSessionManagerTests: XCTestCase {
         try await Task.sleep(nanoseconds: 200_000_000)
 
         // Complete one set, then exit early
-        await manager.completeSet(actualReps: 10, rpeFelt: 6)
+        await manager.completeSet(actualReps: 10, rpeFelt: 6, intent: .top)
         await manager.endSessionEarly()
 
         let state = await manager.sessionState
@@ -326,7 +326,7 @@ final class WorkoutSessionManagerTests: XCTestCase {
         // Capture the generation counter before completeSet
         let generationBefore = await manager.inflightRequestCount
 
-        await manager.completeSet(actualReps: 8, rpeFelt: 7)
+        await manager.completeSet(actualReps: 8, rpeFelt: 7, intent: .top)
 
         // After completeSet, at least one new inference should have been launched
         // (for the next set of the same exercise)
@@ -388,7 +388,7 @@ final class WorkoutSessionManagerTests: XCTestCase {
         await manager.startSession(trainingDay: day, programId: UUID())
         try await Task.sleep(nanoseconds: 200_000_000)
 
-        await manager.completeSet(actualReps: 5, rpeFelt: 8)
+        await manager.completeSet(actualReps: 5, rpeFelt: 8, intent: .top)
         await manager.endSession()
 
         let state = await manager.sessionState

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -84,11 +84,13 @@ private func makeTestSupabase() -> SupabaseClient {
 // MARK: - JSON Fixture Builders
 
 /// Builds a valid set_prescription JSON response string.
+/// Includes `intent` per Slice 6 (#10).
 private func prescriptionJSON(
     weightKg: Double = 80.0,
     reps: Int = 8,
     restSeconds: Int = 120,
-    safetyFlags: [String] = []
+    safetyFlags: [String] = [],
+    intent: String = "top"
 ) -> String {
     let flags = safetyFlags.map { "\"\($0)\"" }.joined(separator: ", ")
     return """
@@ -101,7 +103,8 @@ private func prescriptionJSON(
         "rest_seconds": \(restSeconds),
         "coaching_cue": "Drive through the bar",
         "reasoning": "Based on recent performance trend.",
-        "safety_flags": [\(flags)]
+        "safety_flags": [\(flags)],
+        "intent": "\(intent)"
       }
     }
     """

--- a/migrations/0004_add_intent_to_set_logs_with_default_and_backfill.sql
+++ b/migrations/0004_add_intent_to_set_logs_with_default_and_backfill.sql
@@ -1,0 +1,161 @@
+-- Migration: 0004_add_intent_to_set_logs_with_default_and_backfill.sql
+-- Phase 1 / Slice 6 — set-intent column add + heuristic backfill
+-- Issue: #10  ·  ADR-0005  ·  PR: #<TBD — fill in after Slice 6 PR opens>
+--
+-- ████████████████████████████████████████████████████████████████████████
+-- DEPLOYMENT GATE — do NOT apply until ALL of the following steps complete
+-- in order:
+--
+-- STEP 1. Phase 0 code (SetPrescription.intent validation, freestyle picker,
+--   Edge Function payload validator) is merged to main and shipped to
+--   TestFlight.
+--
+-- STEP 2. Each alpha user has confirmed via DM the EXACT question:
+--
+--   > Have you logged at least one set in the new build (Slice 6 / Phase 0)?
+--
+--   "Have you updated" is NOT sufficient — the build can be installed but
+--   never exercised. Capture each confirmation in the Slice 6 PR thread
+--   before proceeding to step 3. At alpha scale (n ≤ 5) this manual gate is
+--   the agreed workaround for the absence of `app_build` telemetry; see
+--   issue #41 for the beta-scale replacement.
+--
+-- STEP 3. Race-window mitigation — DM the alpha cohort to pause logging for
+--   the apply window, BEFORE running the SQL below. A Phase-0 write that
+--   lands AFTER Pass 1 evaluates but BEFORE Pass 2 evaluates would receive
+--   the column DEFAULT 'top' and miss the heuristic re-labelling. Cheap to
+--   prevent at n ≤ 5; expensive to detect after the fact.
+--
+--   Pre-written DM text — copy verbatim, fill in the two [HH:MM] times
+--   (give yourself a 30-minute buffer; the actual SQL runs in seconds but
+--   the human round-trip on acknowledgments takes longer):
+--
+--   > Apex maintenance: I'm running the set-intent DB migration in ~10 min
+--   > and need ~30 min of clear writes — please don't log any sets between
+--   > [HH:MM] and [HH:MM] [TZ] (about 30 min). Reason: any sets logged
+--   > during the apply window may receive default 'top' labels instead of
+--   > the heuristic-derived label. I'll DM you when it's done. Thanks!
+--
+--   Wait for ALL alpha users to acknowledge before proceeding to step 4.
+--
+-- STEP 4. Apply this migration via Supabase SQL editor or psql against the
+--   production project URL. Top-level `migrations/` is not picked up by
+--   `supabase db push` (see project memory note; path-drift fix is its own
+--   separate slice).
+--
+-- STEP 5. After the SQL completes, DM the alpha cohort that the maintenance
+--   window is over and logging can resume. (Out of the gate but in the
+--   deploy sequence — see the Slice 6 PR description for the full
+--   per-phase ordering.)
+--
+-- ████████████████████████████████████████████████████████████████████████
+--
+-- Phase 1 of the three-phase set-intent migration:
+--   Phase 0 (Swift, already shipped): SetPrescription.validate() requires
+--     intent; rep/RPE picker requires explicit interaction; Edge Function
+--     payload validator rejects set_logs without intent. No DB schema
+--     change. No silent default at any layer.
+--   Phase 1 (this file): adds `intent TEXT NOT NULL DEFAULT 'top'` to
+--     set_logs as a backfill safety-net, then heuristically labels
+--     historical rows from weight/rep pattern.
+--   Phase 2 (next migration: 0005): drops the DEFAULT so post-cutoff
+--     writes must populate intent explicitly. Defence-in-depth — the
+--     Phase 0 client-side validation already enforces, this adds DB-
+--     level enforcement.
+--
+-- Heuristic backfill (per ADR-0005 / issue #10):
+--   For each (session_id, exercise_id) group:
+--     * Highest weight_kg → 'top'. Tie-break: highest reps_completed wins
+--       (closest to AMRAP shape — but stays 'top' since the heuristic
+--       cannot distinguish AMRAP from a heavy top set), then lowest
+--       set_number (earliest performed) for stability.
+--     * Other sets ≥ 50% of top weight → 'backoff'.
+--     * Other sets < 50% of top weight → 'warmup'.
+--     * Bodyweight groups (top_weight = 0): rn=1 set stays 'top'; all
+--       others 'warmup' (the 0.50 * 0 boundary cannot match anything,
+--       defensible default for legacy bodyweight rows).
+--
+--   AMRAP and technique are NOT recoverable from logged data alone —
+--   pre-cutoff rows that were AMRAP get labelled 'top'; pre-cutoff
+--   technique rows get labelled by weight pattern. Analytics consumers
+--   that break out per-intent must filter via
+--   MigrationDates.v2SetIntentBackfill in Swift to exclude pre-cutoff
+--   rows from per-intent breakdowns.
+--
+-- Idempotency: ADD COLUMN IF NOT EXISTS makes the schema change
+-- re-runnable. Both UPDATE passes filter `intent = 'top'` so they only
+-- touch rows still at the column DEFAULT — Pass-1-written real values
+-- and Pass-2 heuristic labels are never overwritten on re-run.
+
+-- ─── 1. Schema change ───────────────────────────────────────────────────────
+ALTER TABLE public.set_logs
+  ADD COLUMN IF NOT EXISTS intent TEXT NOT NULL DEFAULT 'top';
+
+COMMENT ON COLUMN public.set_logs.intent IS
+  'SetIntent (warmup/top/backoff/technique/amrap) per ADR-0005. The DEFAULT '
+  '''top'' is a Phase-1 backfill safety net only and is dropped in Phase 2 '
+  '(0005_drop_intent_default_from_set_logs.sql) so post-cutoff writes must '
+  'populate intent explicitly. Pre-cutoff rows (see '
+  'MigrationDates.v2SetIntentBackfill in Swift) carry approximate labels '
+  'from the heuristic backfill in 0004: top = highest weight per '
+  '(session, exercise); backoff ≥ 50%% of top weight; warmup < 50%%. '
+  'AMRAP and technique are NOT recoverable from logged data alone and '
+  'remain labelled by weight pattern for pre-cutoff rows; analytics that '
+  'break out per-intent must filter pre-cutoff via '
+  'MigrationDates.v2SetIntentBackfill.';
+
+-- ─── 2. Pass 1 — pull intent from ai_prescribed JSONB where Phase 0 stashed it.
+--
+--   AI-prescribed sets carry intent inside the `ai_prescribed` JSONB blob
+--   from the moment Phase 0 ships, because SetPrescription.intent is a
+--   field on the SetPrescription Codable shape and gets serialised into
+--   ai_prescribed without a schema change.
+--
+--   (Freestyle / manual sets do NOT stash intent here per Slice 6 design
+--   choice γ — the picker captures intent client-side as enforcement
+--   theatre during the rollout window; pre-cutoff freestyle rows fall
+--   through to the heuristic in Pass 2. See Slice 6 PR for the rationale.)
+--
+--   Idempotent: only touches rows still at the column DEFAULT.
+UPDATE public.set_logs
+SET intent = ai_prescribed->>'intent'
+WHERE intent = 'top'
+  AND ai_prescribed IS NOT NULL
+  AND ai_prescribed ? 'intent'
+  AND ai_prescribed->>'intent' IN ('warmup','top','backoff','technique','amrap');
+
+-- ─── 3. Pass 2 — heuristic for the remainder ────────────────────────────────
+--
+--   Window over (session_id, exercise_id), pick the highest weight as 'top',
+--   and partition the rest by 50%-of-top into 'backoff' / 'warmup'.
+--   Only touches rows still at the column DEFAULT so Pass-1-written real
+--   values are preserved.
+WITH ranked AS (
+    SELECT
+        id,
+        weight_kg,
+        MAX(weight_kg) OVER (PARTITION BY session_id, exercise_id) AS top_weight,
+        ROW_NUMBER() OVER (
+            PARTITION BY session_id, exercise_id
+            ORDER BY weight_kg DESC, reps_completed DESC, set_number ASC
+        ) AS rn
+    FROM public.set_logs
+    WHERE intent = 'top'
+),
+labelled AS (
+    SELECT
+        id,
+        CASE
+            WHEN rn = 1                         THEN 'top'
+            WHEN top_weight = 0                 THEN 'warmup'
+            WHEN weight_kg >= 0.50 * top_weight THEN 'backoff'
+            ELSE                                     'warmup'
+        END AS new_intent
+    FROM ranked
+)
+UPDATE public.set_logs sl
+SET intent = labelled.new_intent
+FROM labelled
+WHERE sl.id = labelled.id
+  AND sl.intent = 'top'
+  AND labelled.new_intent <> 'top';

--- a/migrations/0004_add_intent_to_set_logs_with_default_and_backfill.sql
+++ b/migrations/0004_add_intent_to_set_logs_with_default_and_backfill.sql
@@ -1,6 +1,6 @@
 -- Migration: 0004_add_intent_to_set_logs_with_default_and_backfill.sql
 -- Phase 1 / Slice 6 — set-intent column add + heuristic backfill
--- Issue: #10  ·  ADR-0005  ·  PR: #<TBD — fill in after Slice 6 PR opens>
+-- Issue: #10  ·  ADR-0005  ·  PR: #47
 --
 -- ████████████████████████████████████████████████████████████████████████
 -- DEPLOYMENT GATE — do NOT apply until ALL of the following steps complete

--- a/migrations/0005_drop_intent_default_from_set_logs.sql
+++ b/migrations/0005_drop_intent_default_from_set_logs.sql
@@ -1,0 +1,44 @@
+-- Migration: 0005_drop_intent_default_from_set_logs.sql
+-- Phase 2 / Slice 6 — drop set_logs.intent DEFAULT
+-- Issue: #10  ·  ADR-0005  ·  PR: #<TBD — fill in after Slice 6 PR opens>
+--
+-- ████████████████████████████████████████████████████████████████████████
+-- DEPLOYMENT GATE — do NOT apply until ALL of:
+--
+-- 1. 0004 (Phase 1) has been applied successfully and the apply was
+--    captured in the Slice 6 PR thread.
+--
+-- 2. Spot-check confirms backfill labels look reasonable. Suggested checks:
+--
+--      -- Distribution sanity check — expect majority 'top' and 'backoff'
+--      -- on a strength/hypertrophy programme; warmup/technique/amrap
+--      -- counts depend on programme shape. AMRAP and technique should
+--      -- both be 0 for pre-cutoff rows (heuristic cannot recover them).
+--      SELECT intent, COUNT(*)
+--      FROM public.set_logs
+--      GROUP BY intent
+--      ORDER BY 2 DESC;
+--
+--      -- Sample inspection — pull 50 rows ordered by session/exercise/set
+--      -- and eyeball whether the top set in each group is the heaviest.
+--      SELECT session_id, exercise_id, set_number, weight_kg,
+--             reps_completed, intent
+--      FROM public.set_logs
+--      ORDER BY session_id, exercise_id, set_number
+--      LIMIT 50;
+--
+-- 3. MigrationDates.v2SetIntentBackfill in Swift is updated to the
+--    0004-apply timestamp in a follow-up commit (existing pattern from
+--    Slice 5's local_date migration — see Models/MigrationDates.swift).
+--
+-- See the Slice 6 PR description for the full deploy sequence.
+-- ████████████████████████████████████████████████████████████████████████
+--
+-- After this migration applies, post-cutoff INSERTs into set_logs MUST
+-- populate intent explicitly — a write without intent yields a NOT NULL
+-- violation rather than a silent 'top' default. Combined with the Phase 0
+-- client-side validation, this gives layered enforcement of the
+-- no-silent-defaults invariant from ADR-0005.
+
+ALTER TABLE public.set_logs
+  ALTER COLUMN intent DROP DEFAULT;

--- a/migrations/0005_drop_intent_default_from_set_logs.sql
+++ b/migrations/0005_drop_intent_default_from_set_logs.sql
@@ -1,6 +1,6 @@
 -- Migration: 0005_drop_intent_default_from_set_logs.sql
 -- Phase 2 / Slice 6 — drop set_logs.intent DEFAULT
--- Issue: #10  ·  ADR-0005  ·  PR: #<TBD — fill in after Slice 6 PR opens>
+-- Issue: #10  ·  ADR-0005  ·  PR: #47
 --
 -- ████████████████████████████████████████████████████████████████████████
 -- DEPLOYMENT GATE — do NOT apply until ALL of:

--- a/scripts/slice6_register_files.rb
+++ b/scripts/slice6_register_files.rb
@@ -55,6 +55,7 @@ raise 'ProjectApexTests group not found' unless tests_group
 %w[
   SetCompletionFormStateTests.swift
   SetPrescriptionIntentValidationTests.swift
+  ManualLogIntentGateTests.swift
 ].each do |name|
   ensure_file(
     project:  project,

--- a/scripts/slice6_register_files.rb
+++ b/scripts/slice6_register_files.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+# scripts/slice6_register_files.rb
+#
+# Registers Slice 6 (#10) source files with the Xcode project:
+#   - ProjectApex/Features/Workout/SetCompletionFormState.swift  → ProjectApex target
+#   - ProjectApexTests/SetCompletionFormStateTests.swift          → ProjectApexTests target
+#   - ProjectApexTests/SetPrescriptionIntentValidationTests.swift → ProjectApexTests target
+#
+# Also fixes a pre-existing pbxproj path bug introduced in Slice 7 (b7ae033):
+# EquipmentCatalogSeedTests.swift has `path = ProjectApexTests/...` instead of
+# just the basename, which makes it resolve to a doubled path inside the
+# ProjectApexTests group. The bug was undetected on main because no recent
+# commit ran the test target. Slice 6 needs the test target to build.
+#
+# Idempotent — safe to re-run.
+
+require 'xcodeproj'
+
+PROJECT_PATH = 'ProjectApex.xcodeproj'
+project = Xcodeproj::Project.open(PROJECT_PATH)
+
+main_target  = project.targets.find { |t| t.name == 'ProjectApex' }
+test_target  = project.targets.find { |t| t.name == 'ProjectApexTests' }
+raise 'ProjectApex target not found'      unless main_target
+raise 'ProjectApexTests target not found' unless test_target
+
+# ── 1. Fix the EquipmentCatalogSeedTests path bug ────────────────────────────
+project.files.each do |f|
+  next unless f.path == 'ProjectApexTests/EquipmentCatalogSeedTests.swift'
+  puts "Fixing pbxproj path for EquipmentCatalogSeedTests.swift " \
+       "('#{f.path}' → 'EquipmentCatalogSeedTests.swift')"
+  f.path = 'EquipmentCatalogSeedTests.swift'
+end
+
+# ── 2. Helper: ensure a file is registered with a target/group ───────────────
+def ensure_file(project:, target:, group:, relpath:, basename:)
+  if group.files.any? { |f| f.path == basename }
+    puts "Already registered: #{basename}"
+    return
+  end
+  ref = group.new_file(relpath)
+  target.source_build_phase.add_file_reference(ref)
+  puts "Registered: #{basename} → #{target.name}"
+end
+
+# NOTE: SetCompletionFormState.swift in the main app target is picked up
+# automatically — the ProjectApex group is a PBXFileSystemSynchronizedRootGroup
+# (Xcode's synchronized-folder mode), so any file placed in the on-disk
+# folder structure is included without explicit registration.
+
+# ── 3. Register new test files in test target ────────────────────────────────
+tests_group = project.main_group['ProjectApexTests']
+raise 'ProjectApexTests group not found' unless tests_group
+
+%w[
+  SetCompletionFormStateTests.swift
+  SetPrescriptionIntentValidationTests.swift
+].each do |name|
+  ensure_file(
+    project:  project,
+    target:   test_target,
+    group:    tests_group,
+    relpath:  name,
+    basename: name
+  )
+end
+
+project.save
+puts 'Saved ProjectApex.xcodeproj'

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -6,13 +6,20 @@
 // rule logic, cached-snapshot return) are present but inert so that
 // Phase 2 plugs into the same lifecycle without restructuring.
 //
+// Slice 6 (issue #10): payload validator now descends into
+// session_payload.set_logs[] (when present) and rejects any element
+// missing or carrying an invalid `intent` field. Forward-compatible —
+// the actual set_logs[] payload is wired in Slice 9c+; this validator
+// is the contract that wiring will satisfy. See ADR-0005 (no silent
+// defaults at any layer).
+//
 // Contract: POST { user_id, session_id, session_payload } → 200
 // { trainee_model: {} }. See:
-//   - ADR-0005 (TraineeModel shape)
+//   - ADR-0005 (TraineeModel shape, set-intent invariant)
 //   - ADR-0006 (server-side placement, idempotency at DB layer)
 //   - docs/agents/edge-functions.md (secrets, deploy, local dev)
 
-interface UpdateTraineeModelRequest {
+export interface UpdateTraineeModelRequest {
   user_id: string;
   session_id: string;
   session_payload: Record<string, unknown>;
@@ -21,6 +28,17 @@ interface UpdateTraineeModelRequest {
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// SetIntent — must mirror the Swift `SetIntent` enum (TraineeModelEnums.swift)
+// and the eventual `set_logs.intent` CHECK constraint. Any drift breaks the
+// no-silent-defaults invariant.
+const VALID_INTENTS = new Set([
+  "warmup",
+  "top",
+  "backoff",
+  "technique",
+  "amrap",
+]);
+
 function jsonResponse(body: unknown, status: number): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -28,7 +46,7 @@ function jsonResponse(body: unknown, status: number): Response {
   });
 }
 
-function validateRequest(
+export function validateRequest(
   body: unknown,
 ): UpdateTraineeModelRequest | { error: string } {
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
@@ -51,10 +69,44 @@ function validateRequest(
   ) {
     return { error: "session_payload must be a JSON object" };
   }
+  const payload = session_payload as Record<string, unknown>;
+
+  // Slice 6 — validate set_logs[] when present. Forward-compatible: when
+  // session_payload omits set_logs entirely, the request still passes (the
+  // actual call site is wired in Slice 9c+). When the array is present,
+  // every element must carry a valid intent — no silent default.
+  if ("set_logs" in payload) {
+    const setLogs = payload.set_logs;
+    if (!Array.isArray(setLogs)) {
+      return { error: "session_payload.set_logs must be an array" };
+    }
+    for (let i = 0; i < setLogs.length; i++) {
+      const entry = setLogs[i];
+      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+        return {
+          error: `session_payload.set_logs[${i}] must be a JSON object`,
+        };
+      }
+      const intent = (entry as Record<string, unknown>).intent;
+      if (intent === undefined || intent === null) {
+        return {
+          error: `session_payload.set_logs[${i}] missing required field 'intent'`,
+        };
+      }
+      if (typeof intent !== "string" || !VALID_INTENTS.has(intent)) {
+        return {
+          error:
+            `session_payload.set_logs[${i}].intent must be one of ` +
+            `warmup/top/backoff/technique/amrap (got ${JSON.stringify(intent)})`,
+        };
+      }
+    }
+  }
+
   return {
     user_id,
     session_id,
-    session_payload: session_payload as Record<string, unknown>,
+    session_payload: payload,
   };
 }
 
@@ -72,7 +124,7 @@ async function checkAlreadyApplied(
   return false;
 }
 
-Deno.serve(async (req: Request) => {
+export async function handleRequest(req: Request): Promise<Response> {
   if (req.method !== "POST") {
     return jsonResponse({ error: "method not allowed" }, 405);
   }
@@ -106,4 +158,12 @@ Deno.serve(async (req: Request) => {
   // returns the updated snapshot.
 
   return jsonResponse({ trainee_model: {} }, 200);
-});
+}
+
+// Only boot the server when this module is invoked as the entrypoint —
+// `deno test` and other importers can pull in `validateRequest` /
+// `handleRequest` without binding to a port. Slice 6 (#10) added this
+// gate so the validator could be tested in isolation.
+if (import.meta.main) {
+  Deno.serve(handleRequest);
+}

--- a/supabase/functions/update-trainee-model/index_test.ts
+++ b/supabase/functions/update-trainee-model/index_test.ts
@@ -1,0 +1,145 @@
+// Project Apex — update-trainee-model Edge Function — validator tests.
+//
+// Covers the Slice 6 (issue #10) extension to `validateRequest` that
+// descends into `session_payload.set_logs[]` and rejects rows missing
+// or carrying an invalid `intent` field. The Edge Function itself remains
+// a Phase-1 no-op stub; these tests exercise the validator in isolation.
+//
+// Run locally:
+//   deno test supabase/functions/update-trainee-model/index_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { validateRequest } from "./index.ts";
+
+const VALID_USER_ID = "11111111-1111-4111-8111-111111111111";
+const VALID_SESSION_ID = "22222222-2222-4222-8222-222222222222";
+
+function baseRequest(payloadOverrides: Record<string, unknown> = {}) {
+  return {
+    user_id: VALID_USER_ID,
+    session_id: VALID_SESSION_ID,
+    session_payload: payloadOverrides,
+  };
+}
+
+// ─── D1: no set_logs key — passes ────────────────────────────────────────────
+Deno.test("validateRequest_no_set_logs_field_returns_ok", () => {
+  const result = validateRequest(baseRequest({}));
+  assertEquals("error" in result, false);
+});
+
+// ─── D2: every valid intent — passes ─────────────────────────────────────────
+Deno.test("validateRequest_set_logs_each_with_valid_intent_returns_ok", () => {
+  const intents = ["warmup", "top", "backoff", "technique", "amrap"];
+  const setLogs = intents.map((intent, i) => ({
+    set_number: i + 1,
+    weight_kg: 80,
+    reps_completed: 8,
+    intent,
+  }));
+  const result = validateRequest(baseRequest({ set_logs: setLogs }));
+  assertEquals("error" in result, false);
+});
+
+// ─── D3: missing intent — 400 ────────────────────────────────────────────────
+Deno.test("validateRequest_set_log_missing_intent_returns_400", () => {
+  const setLogs = [
+    { set_number: 1, weight_kg: 80, reps_completed: 8, intent: "top" },
+    { set_number: 2, weight_kg: 70, reps_completed: 10 }, // intent missing
+  ];
+  const result = validateRequest(baseRequest({ set_logs: setLogs }));
+  if (!("error" in result)) {
+    throw new Error("expected error response");
+  }
+  // Error message must name the offending index so an operator debugging
+  // the rejection knows which row to fix.
+  assertEquals(
+    result.error.includes("set_logs[1]") &&
+      result.error.includes("missing required field 'intent'"),
+    true,
+    `unexpected error text: ${result.error}`,
+  );
+});
+
+// ─── D4: invalid intent string — 400 ─────────────────────────────────────────
+Deno.test("validateRequest_set_log_invalid_intent_string_returns_400", () => {
+  const setLogs = [
+    { set_number: 1, weight_kg: 80, reps_completed: 8, intent: "bogus" },
+  ];
+  const result = validateRequest(baseRequest({ set_logs: setLogs }));
+  if (!("error" in result)) {
+    throw new Error("expected error response");
+  }
+  assertEquals(
+    result.error.includes("set_logs[0].intent") &&
+      result.error.includes("warmup/top/backoff/technique/amrap"),
+    true,
+    `unexpected error text: ${result.error}`,
+  );
+});
+
+// ─── D5: set_logs not an array — 400 ─────────────────────────────────────────
+Deno.test("validateRequest_set_logs_not_array_returns_400", () => {
+  const result = validateRequest(baseRequest({ set_logs: { foo: 1 } }));
+  if (!("error" in result)) {
+    throw new Error("expected error response");
+  }
+  assertEquals(result.error, "session_payload.set_logs must be an array");
+});
+
+// ─── Sanity: still rejects missing user_id (regression cover for the Slice
+//     9b validator behaviour) ───────────────────────────────────────────────
+Deno.test("validateRequest_invalid_user_id_returns_400", () => {
+  const result = validateRequest({
+    user_id: "not-a-uuid",
+    session_id: VALID_SESSION_ID,
+    session_payload: {},
+  });
+  if (!("error" in result)) {
+    throw new Error("expected error response");
+  }
+  assertEquals(result.error, "user_id must be a UUID string");
+});
+
+// ─── Edge case: intent set to null (vs missing) — 400 ───────────────────────
+Deno.test("validateRequest_set_log_intent_null_returns_400", () => {
+  const setLogs = [
+    { set_number: 1, weight_kg: 80, reps_completed: 8, intent: null },
+  ];
+  const result = validateRequest(baseRequest({ set_logs: setLogs }));
+  if (!("error" in result)) {
+    throw new Error("expected error response");
+  }
+  assertEquals(
+    result.error.includes("set_logs[0]") &&
+      result.error.includes("missing required field 'intent'"),
+    true,
+    `unexpected error text: ${result.error}`,
+  );
+});
+
+// ─── Edge case: intent set to non-string (number) — 400 ─────────────────────
+Deno.test("validateRequest_set_log_intent_non_string_returns_400", () => {
+  const setLogs = [
+    { set_number: 1, weight_kg: 80, reps_completed: 8, intent: 42 },
+  ];
+  const result = validateRequest(baseRequest({ set_logs: setLogs }));
+  if (!("error" in result)) {
+    throw new Error("expected error response");
+  }
+  assertEquals(
+    result.error.includes("set_logs[0].intent") &&
+      result.error.includes("warmup/top/backoff/technique/amrap"),
+    true,
+    `unexpected error text: ${result.error}`,
+  );
+});
+
+// ─── Edge case: set_logs entry that is null — 400 ───────────────────────────
+Deno.test("validateRequest_set_log_entry_null_returns_400", () => {
+  const result = validateRequest(baseRequest({ set_logs: [null] }));
+  if (!("error" in result)) {
+    throw new Error("expected error response");
+  }
+  assertEquals(result.error, "session_payload.set_logs[0] must be a JSON object");
+});


### PR DESCRIPTION
## Pre-merge checklist (forcing function)

**Do not squash-merge until every box is ticked.**

- [ ] **Replace `#<TBD>` placeholders in the migration headers with this PR's actual number.** Two files reference `PR: #<TBD>`:
  - `migrations/0004_add_intent_to_set_logs_with_default_and_backfill.sql`
  - `migrations/0005_drop_intent_default_from_set_logs.sql`
- [ ] CI green; full Swift test suite passes (1 known pre-existing flake on `test_networkFailure_urlError_returnsFallbackLLMProviderError` — same class of issue as #39, distinct test).
- [ ] Edge Function Deno tests pass: `deno test supabase/functions/update-trainee-model/index_test.ts` → 9/9.
- [ ] Visual picker review (HITL) signed off in this PR's review comments.
- [ ] PR description references match the actual migration filenames (sanity check).

---

## Summary

Three-phase set-intent migration (ADR-0005, issue #10) shipped as one coordinated unit. **Phase 0 code is in this PR; Phases 1 and 2 are migration files that DO NOT auto-run on merge** — they're applied manually by the operator on the gated schedule below.

**Critical correctness invariant**: the Phase-0-ships-before-Phase-1 ordering is load-bearing. If Phase 1 ran first, old (pre-Phase-0) clients writing `set_logs` without intent would receive the DB DEFAULT `'top'` silently — exactly the silent-default bug the migration is designed to prevent. The manual rollout-confirmation gate at Phase 0 / step 4 enforces this; replacing the manual gate with proper `app_build` telemetry is tracked as #41.

**Behaviour change beyond just intent** (separate from the migration but in the same PR): `AIInferenceService.prescribe` and `prescribeAdaptation` now fail fast on ALL validation errors per ADR-0007 §1, not just missing-intent. Pre-Slice-6 these retried up to `maxRetries+1` times with a "CORRECTION REQUIRED" addendum; they now return `.fallback(.malformedResponse)` after exactly one provider call, surfacing `InferenceRetrySheet` instead of burning the 8-second product timeout. Two pre-Slice-6 retry-then-success tests were replaced with prominent banners documenting the change. Audit of other foreground LLM call sites (`SessionPlanService.callAndDecodeSession`, `ExerciseSwapService.sendMessage`) tracked as #42; greppable hook is `emitPermanentFailureFallback` in `ProjectApex/Services/FallbackLogRecord.swift`.

**Picker UX redesign mid-slice.** The original picker required an explicit chip tap before Save enabled — the wrong model. The AI's prescription IS the explicit intent; asking the user to confirm what the AI already explicitly told them is redundant data entry, not no-silent-defaults enforcement. Redesigned to capture **deviation, not confirmation**: AI-prescribed sets default to the prescribed intent (zero friction, Save Set always enabled); a subtle "Did something different?" link reveals the chip row for users who actually deviated; "Never mind" dismiss collapses + resets. Freestyle sets (no AI prescription) still show the picker by default. The redesign also added pain / form-breakdown completion-flag toggles for high-signal in-session AI adaptation, and an AI-generated `set_framing` mental-set framing shown on the prescription card pre-completion. Iteration history visible in the commit list.

**Deliberate asymmetries documented in code:**
- Chip ordering (warmup → top → backoff in row 1; technique → amrap in row 2) mirrors typical session progression with Top centered for thumb path.
- Active set view uses chip row; ManualSessionLogView uses compact dropdown menu — driven by horizontal-space pressure in the dense table layout. Documented at the call site so future maintainers see the rationale.

**iPhone 16 Pro substitution note**: Xcode 26.4's bundled simulators don't include iPhone 16 series. iPhone 17 Pro was used for build/install verification — same screen-size class. SwiftUI previews for HITL review live at the bottom of `ActiveSetView.swift` and render in canvas without an app launch.

---

## Deploy sequence — three phases, gated

> **Note on closure**: the squash-merge message intentionally omits any auto-close keyword for issue #10. The slice operationally isn't done until step 10 of this sequence completes (potentially days after merge). Issue #10 stays open as the most honest signal that work remains. Manual close at step 10 should reference: this PR's merge commit SHA, the 0004 apply timestamp, the 0005 apply timestamp, and the `MigrationDates.v2SetIntentBackfill` follow-up commit SHA — that's the audit trail.

### Phase 0 — code release (this PR's merge)

1. **Squash-merge this PR to main.** Phase 0 code is now on main, ready to ship.
2. **Cut a TestFlight build** containing the merged code.
3. **Distribute to alpha cohort.**
4. **GATE — manual rollout confirmation.** DM each alpha user the EXACT question:
   > Have you logged at least one set in the new build (Slice 6 / Phase 0)?

   "Have you updated" is NOT sufficient — the build can be installed but never exercised. Capture each confirmation in this PR thread (or a follow-up issue if the PR is already closed) before proceeding to Phase 1. At alpha scale (n ≤ 5) this manual gate is the workaround for the absence of `app_build` telemetry; see #41 for the beta-scale replacement.

### Phase 1 — DB migration (manual, gated)

5. **GATE — race-window mitigation.** DM the alpha cohort to pause logging for the apply window, BEFORE running the SQL. Pre-written text (copy verbatim, fill in the two `[HH:MM]` times — give yourself a 30-minute buffer):
   > Apex maintenance: I'm running the set-intent DB migration in ~10 min and need ~30 min of clear writes — please don't log any sets between [HH:MM] and [HH:MM] [TZ] (about 30 min). Reason: any sets logged during the apply window may receive default 'top' labels instead of the heuristic-derived label. I'll DM you when it's done. Thanks!

   Wait for ALL alpha users to acknowledge before proceeding to step 6.

6. **Apply `migrations/0004_add_intent_to_set_logs_with_default_and_backfill.sql`** via Supabase SQL editor or psql against the production project URL. (Top-level `migrations/` is not picked up by `supabase db push` — see project memory note. Path-drift fix is a separate slice.)

7. **GATE — backfill verification (BEFORE unpausing logging).** Run the verification queries against production:
   ```sql
   SELECT intent, COUNT(*)
   FROM public.set_logs
   GROUP BY intent
   ORDER BY 2 DESC;

   SELECT session_id, exercise_id, set_number, weight_kg, reps_completed, intent
   FROM public.set_logs
   ORDER BY session_id, exercise_id, set_number
   LIMIT 50;
   ```
   Eyeball: top set in each `(session, exercise)` group is the heaviest? Backoff/warmup distribution looks plausible? AMRAP and technique counts are 0 for pre-cutoff rows (heuristic cannot recover them — known limitation, documented in column comment)? Sample 50 rows pass the eye test? **Verify BEFORE unpausing** — the unhappy path (verification fails, writes are flowing again, recovery requires re-pausing) is operationally messier than a 2-3 minute extension of the original window.

8. **DM the alpha cohort** that the maintenance window is over and logging can resume.

### Phase 2 — drop default (manual, gated)

9. **Apply `migrations/0005_drop_intent_default_from_set_logs.sql`** via SQL editor or psql.

10. **Update `MigrationDates.v2SetIntentBackfill`** in Swift to the 0004-apply timestamp (the timestamp from step 6, not step 9). Follow-up commit on main per the Slice 5 precedent — see [Models/MigrationDates.swift](ProjectApex/Models/MigrationDates.swift). Pre-cutoff analytics consumers branch on this date.

11. **Manually close issue #10** with the audit-trail comment (PR merge SHA + 0004 apply timestamp + 0005 apply timestamp + MigrationDates follow-up commit SHA).

---

## What's in this PR

**Six commits** showing iteration history (per CLAUDE.md "branch + commit per logical unit"):

- `7221cd0` Slice 6: deviation picker dismiss affordance — toggle link + reset
- `a86e6fa` Slice 6: redesign picker — deviation affordance + pain/form flag (supersedes 7bac17b + 7b60302)
- `7b60302` Slice 6: extract picker into RepRPEIntentConfirmationSheet + previews
- `390ce49` Slice 6 / Phases 1+2: set_logs.intent migration files
- `7bac17b` Slice 6 / Phase 0: visual picker + intent plumbing through SetLog
- `963c6f3` Slice 6 / Phase 0: set-intent validation + fail-fast retry semantics

**Test status**: 280 tests, 0 Slice 6 regressions. 1 pre-existing flake on `test_networkFailure_urlError_returnsFallbackLLMProviderError` (same class as #39, passes 1/1 in isolation).

**Edge Function Deno tests**: 9/9 passing.

**Spinoff issues filed during the slice**: #41 (telemetry), #42 (ADR-0007 audit), #43 (completion_flags column), #44 (session arc), #45 (manual log redesign), #46 (intent taxonomy review).

**Incidental fix included**: `ProjectApex.xcodeproj/project.pbxproj` had a doubled-path bug introduced by Slice 7 (b7ae033) registering `EquipmentCatalogSeedTests.swift` with `path = ProjectApexTests/EquipmentCatalogSeedTests.swift` inside the `ProjectApexTests` group, which resolved to a non-existent doubled path. Verified by stashing Slice 6 and running `xcodebuild test` on plain main HEAD: hard build failure on the doubled path. No commit since b7ae033 had run the test target and caught it. Fixed via `scripts/slice6_register_files.rb` so Slice 6's tests could run; now clean.

## Test plan

- [x] `xcodebuild test` runs 280 tests with 0 Slice 6 regressions.
- [x] `deno test supabase/functions/update-trainee-model/index_test.ts` runs 9 tests with 0 failures.
- [x] HITL visual review of all 8 SwiftUI previews in `ActiveSetView.swift` (default state, deviation expanded, deviation recorded, deviation picked then dismissed, freestyle empty, freestyle picked, pain flag, both flags).
- [x] HITL visual review of intent label + framing on the prescription card.
- [ ] **Operator** confirms each alpha user has logged at least one set on the Phase-0 build (deploy step 4) before applying 0004.
- [ ] **Operator** runs the verification queries between 0004 and 0005 (deploy step 7).
- [ ] **Operator** updates `MigrationDates.v2SetIntentBackfill` after 0004 applies (deploy step 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
