### PR TITLE
fix(migrations): drop Pass 1 from 0004 (column never existed)

### DIFF
--- a/migrations/0004_add_intent_to_set_logs_with_default_and_backfill.sql
+++ b/migrations/0004_add_intent_to_set_logs_with_default_and_backfill.sql
@@ -22,9 +22,11 @@
 --
 -- STEP 3. Race-window mitigation — DM the alpha cohort to pause logging for
 --   the apply window, BEFORE running the SQL below. A Phase-0 write that
---   lands AFTER Pass 1 evaluates but BEFORE Pass 2 evaluates would receive
---   the column DEFAULT 'top' and miss the heuristic re-labelling. Cheap to
---   prevent at n ≤ 5; expensive to detect after the fact.
+--   lands during the apply receives the column DEFAULT 'top' as it inserts.
+--   The heuristic backfill below is a one-shot pass at apply time — it does
+--   not revisit rows on subsequent inserts, so any DEFAULT-tagged row that
+--   slips in during the window stays mislabelled. Cheap to prevent at
+--   n ≤ 5; expensive to detect after the fact.
 --
 --   Pre-written DM text — copy verbatim, fill in the two [HH:MM] times
 --   (give yourself a 30-minute buffer; the actual SQL runs in seconds but
@@ -83,9 +85,9 @@
 --   rows from per-intent breakdowns.
 --
 -- Idempotency: ADD COLUMN IF NOT EXISTS makes the schema change
--- re-runnable. Both UPDATE passes filter `intent = 'top'` so they only
--- touch rows still at the column DEFAULT — Pass-1-written real values
--- and Pass-2 heuristic labels are never overwritten on re-run.
+-- re-runnable. The UPDATE pass filters `intent = 'top'` so it only
+-- touches rows still at the column DEFAULT — heuristic labels written
+-- by a prior apply are never overwritten on re-run.
 
 -- ─── 1. Schema change ───────────────────────────────────────────────────────
 ALTER TABLE public.set_logs
@@ -104,32 +106,29 @@ COMMENT ON COLUMN public.set_logs.intent IS
   'break out per-intent must filter pre-cutoff via '
   'MigrationDates.v2SetIntentBackfill.';
 
--- ─── 2. Pass 1 — pull intent from ai_prescribed JSONB where Phase 0 stashed it.
+-- Pass 1 removed.
 --
---   AI-prescribed sets carry intent inside the `ai_prescribed` JSONB blob
---   from the moment Phase 0 ships, because SetPrescription.intent is a
---   field on the SetPrescription Codable shape and gets serialised into
---   ai_prescribed without a schema change.
+-- Original intent: pull intent values from set_logs.ai_prescribed JSONB
+-- where Phase 0 Swift had stashed them.
 --
---   (Freestyle / manual sets do NOT stash intent here per Slice 6 design
---   choice γ — the picker captures intent client-side as enforcement
---   theatre during the rollout window; pre-cutoff freestyle rows fall
---   through to the heuristic in Pass 2. See Slice 6 PR for the rationale.)
+-- Why removed: the assumption was wrong. set_logs.ai_prescribed never
+-- existed on the production schema, and Phase 0's SetLogPayload encoder
+-- did not serialize the field even when the in-memory SetLog carried it.
+-- Pass 1 was therefore either a no-op (column-exists case) or a hard
+-- error (column-doesn't-exist case, which is what production is).
 --
---   Idempotent: only touches rows still at the column DEFAULT.
-UPDATE public.set_logs
-SET intent = ai_prescribed->>'intent'
-WHERE intent = 'top'
-  AND ai_prescribed IS NOT NULL
-  AND ai_prescribed ? 'intent'
-  AND ai_prescribed->>'intent' IN ('warmup','top','backoff','technique','amrap');
+-- The heuristic backfill below (window function over weight/session/
+-- exercise) does all the actual work and operates only on columns that
+-- demonstrably exist on production.
+--
+-- See PR #47 (the original Slice 6 PR) and this fix-up PR's body for
+-- the failed deploy attempt context (2026-05-06) and audit findings.
 
--- ─── 3. Pass 2 — heuristic for the remainder ────────────────────────────────
+-- ─── 2. Heuristic backfill ──────────────────────────────────────────────────
 --
 --   Window over (session_id, exercise_id), pick the highest weight as 'top',
 --   and partition the rest by 50%-of-top into 'backoff' / 'warmup'.
---   Only touches rows still at the column DEFAULT so Pass-1-written real
---   values are preserved.
+--   Only touches rows still at the column DEFAULT.
 WITH ranked AS (
     SELECT
         id,


### PR DESCRIPTION
## Summary

Drops Pass 1 from `migrations/0004_add_intent_to_set_logs_with_default_and_backfill.sql`. Pass 1 read intent from a JSONB column (`set_logs.ai_prescribed`) that never existed on production, and Phase 0's `SetLogPayload` encoder never wrote it either. The deploy attempt on 2026-05-06 hit `ERROR 42703: column "ai_prescribed" does not exist` at exactly this point.

The remaining heuristic backfill (window function over weight/session/exercise) does all the actual work and operates only on columns that demonstrably exist on production.

## Context

This is a fix-up PR for the original Slice 6 / issue #10 work in #47. PR #47 merged correctly but its DB-side deploy paused mid-step when 0004 errored. A read-only audit followed (see "Audit findings" below); this PR is the first of several follow-ups and the gating one for resuming the Slice 6 deploy.

## Audit findings (relevant subset)

The deploy failure prompted a read-only audit of production schema vs the `migrations/` directory. Headlines:

- **Migrations not applied:** 0002 (`set_logs.local_date`), 0003 (equipment_catalog seed), 0004 (this file), 0005 (drop-default) all unapplied as of 2026-05-06. 0002 and 0003 were applied earlier this session under separate authorization; 0004 (this PR's target) and 0005 are still pending.
- **Finding F3 (this PR's territory):** `set_logs` is missing `local_date`, `ai_prescribed`, `intent`. The encoder side (`SetLogPayload`) does not serialize any of those fields, so Pass 1's premise — that `ai_prescribed` carries the intent value — was wrong from the start. There is nothing to read from there.
- **Other findings (out of scope for this PR, in scope for separate follow-ups):** F1 — `session_notes` table doesn't exist; F2 — `users` missing 4 columns; F4 — `workout_sessions` has `manually_logged` + `status` not in any migration file; F5 — other tables verified clean.

The migrations directory has not been the authoritative record of production schema. The fix-it sequence (this PR + follow-ups for F1/F2/F4 + a migration-tracking mechanism) is being walked through under explicit human authorization at every SQL apply.

## What this PR changes

Single-file change to `migrations/0004_add_intent_to_set_logs_with_default_and_backfill.sql`:

1. **Pass 1 removed.** The `UPDATE public.set_logs SET intent = ai_prescribed->>'intent' ...` block and its preceding section comment are replaced by a tombstone comment block explaining what was there and why it was removed.
2. **Heuristic backfill renumbered.** Section header `─── 3. Pass 2 — heuristic for the remainder` → `─── 2. Heuristic backfill`. No code change to the `WITH ranked AS (...) UPDATE ...` block.
3. **Deploy gate STEP 3 rewritten.** Drops the "AFTER Pass 1 / BEFORE Pass 2" race-window framing. The race window itself is still real — a Phase-0 write landing during the apply receives the column DEFAULT `'top'`, and the heuristic backfill is a one-shot pass that won't revisit it — so the maintenance-window directive stands; only the rationale text changed.
4. **Idempotency note rewritten.** "Both UPDATE passes" → "The UPDATE pass." Drops `Pass-1-written real values` reference.
5. **Heuristic-backfill inline comment trimmed.** Drops the `so Pass-1-written real values are preserved` clause; keeps `Only touches rows still at the column DEFAULT` (the still-valid idempotency property).

Cross-cutting grep across `migrations/`, `docs/`, `CONTEXT.md` — zero hits for `Pass 1` / `Pass-1` / `ai_prescribed` outside this file. Inside the file: four hits, all inside the new tombstone block where they reference Pass 1 by its historical name to explain the removal.

## What this PR does NOT do

- **Does not apply 0004 to production.** The migration runs as step 5 of the recovery deploy plan, after this PR merges and the diff is back on `main`.
- **Does not touch the schema-change `ALTER TABLE ... ADD COLUMN ... DEFAULT 'top'` block.** Phase 1's safety-net default is unchanged.
- **Does not touch 0005.** Phase 2's drop-default migration runs after 0004 as step 7.
- **Does not address F1 / F2 / F4 / migration-tracking.** Those are separate follow-up PRs in the recovery sequence.

## Test plan

- [x] Cross-cutting grep across `migrations/`, `docs/`, `CONTEXT.md` for `Pass 1` / `Pass-1` / `ai_prescribed` returned only the four intentional in-tombstone references.
- [ ] Reviewer eyeball: tombstone block reads coherently as a standalone explanation; deploy-gate STEP 3 still conveys the maintenance-window requirement; section numbering flows 1 → 2 with no gap.
- [ ] After merge, 0004 applies against production without error (verified at recovery deploy step 5; expected effect is the schema change + Pass 2's heuristic UPDATE; verification queries from 0005's header will be eyeballed for distribution sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)