### PR TITLE
feat(migrations): add session_notes table (F1 recovery)

### DIFF
--- a/migrations/0006_create_session_notes_table.sql
+++ b/migrations/0006_create_session_notes_table.sql
@@ -1,0 +1,74 @@
+-- Migration: 0006_create_session_notes_table.sql
+-- F1 from 2026-05-06 migration recovery — create session_notes table
+--
+-- ████████████████████████████████████████████████████████████████████████
+-- WHY THIS MIGRATION EXISTS
+--
+-- A read-only audit of production schema on 2026-05-06 (triggered by
+-- the failed deploy attempt of migration 0004) found that
+-- public.session_notes did not exist on production. The Swift
+-- WorkoutSessionManager.addVoiceNote(...) path has been writing
+-- voice/text notes to the table since the feature shipped:
+--
+--   try? await writeAheadQueue.enqueue(notePayload, table: "session_notes")
+--
+-- The `try?` swallows the resulting REST-API "table does not exist"
+-- error, so every voice note logged in production has silently failed.
+-- No telemetry surfaced this — the only symptom was absence of rows in
+-- a table the client codebase referenced.
+--
+-- This migration creates the table with the schema that matches the
+-- Swift SessionNote / SessionNotePayload models exactly. There is no
+-- backfill — past notes were never persisted anywhere recoverable.
+-- New writes start populating after apply.
+--
+-- See:
+--   * ProjectApex/Models/WorkoutSession.swift:206  — SessionNote model
+--   * ProjectApex/Features/Workout/WorkoutSessionManager.swift:1805 —
+--     SessionNotePayload (the encoder shape)
+--   * ProjectApex/Features/Workout/WorkoutSessionManager.swift:485  —
+--     write site
+--   * PR #47 (the original Slice 6) and the 2026-05-06 deploy attempt
+--     that surfaced the audit
+--
+-- Out of scope (separate slices):
+--   * RLS policies — Phase 5 will land RLS for every table at once;
+--     matching the rest of the schema, this table is unprotected for now
+--   * Backfill of historical notes — impossible; they were never persisted
+--   * Surfacing the silent enqueue failures (#41 covers telemetry generally;
+--     a focused write-failure surface is its own slice)
+-- ████████████████████████████████████████████████████████████████████████
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS make
+-- every statement re-runnable.
+
+CREATE TABLE IF NOT EXISTS public.session_notes (
+    id              UUID        PRIMARY KEY,
+    session_id      UUID        NOT NULL REFERENCES public.workout_sessions(id) ON DELETE CASCADE,
+    exercise_id     TEXT        NULL,
+    raw_transcript  TEXT        NOT NULL,
+    tags            TEXT[]      NOT NULL DEFAULT '{}',
+    logged_at       TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_notes_session_id
+    ON public.session_notes(session_id);
+
+COMMENT ON TABLE public.session_notes IS
+    'Voice/text notes logged during a workout session. Mirrors the Swift '
+    'SessionNote / SessionNotePayload models exactly. Write-only from iOS — '
+    'the client never reads back from this table; the embedding pipeline '
+    '(memory_embeddings) consumes notes for RAG separately. Created in F1 '
+    'of the 2026-05-06 migration recovery; see migration header for context.';
+
+COMMENT ON COLUMN public.session_notes.exercise_id IS
+    'Nullable: the exercise the note relates to, if known. Some notes are '
+    'global to the session (no exercise context).';
+
+COMMENT ON COLUMN public.session_notes.tags IS
+    'Client-derived tags from detectNoteTags(transcript:) in '
+    'WorkoutSessionManager.swift. As of this migration, the bounded set of '
+    'emitted values is: ''injury_concern'', ''fatigue'', ''energy''. '
+    'Adding a new tag requires a Swift code change to detectNoteTags. '
+    'The column is typed as TEXT[] (not an enum) so future tag values '
+    'land without a schema migration.';


### PR DESCRIPTION
## Summary

Creates `public.session_notes` — F1 of the 2026-05-06 migration recovery. The Swift voice-note write path has targeted this table since the feature shipped; the production schema audit on 2026-05-06 found the table did not exist. Every voice note logged in production has been silently failing because `addVoiceNote` enqueues with `try?` and the resulting REST-API "table does not exist" error was swallowed.

## Schema

```sql
CREATE TABLE IF NOT EXISTS public.session_notes (
    id              UUID        PRIMARY KEY,
    session_id      UUID        NOT NULL REFERENCES public.workout_sessions(id) ON DELETE CASCADE,
    exercise_id     TEXT        NULL,
    raw_transcript  TEXT        NOT NULL,
    tags            TEXT[]      NOT NULL DEFAULT '{}',
    logged_at       TIMESTAMPTZ NOT NULL
);

CREATE INDEX IF NOT EXISTS idx_session_notes_session_id
    ON public.session_notes(session_id);
```

Mirrors `SessionNotePayload` ([WorkoutSessionManager.swift:1805](ProjectApex/Features/Workout/WorkoutSessionManager.swift#L1805)) and `SessionNote` ([WorkoutSession.swift:206](ProjectApex/Models/WorkoutSession.swift#L206)) exactly — six fields, no drift.

## Decisions and rationale

- **`ON DELETE CASCADE`** on `session_id` FK. Notes are semantically owned by the session; orphaned notes pointing at a deleted session would be dangling data. The "irrecoverable on accidental delete" risk is small at solo scale, and any future delete-session UI can warn about note-count there. RESTRICT would create friction on legitimate cleanup; skipping the FK loses referential integrity for marginal benefit.
- **No RLS.** Matches every other table in the schema — RLS is a Phase 5 concern across the board. Adding it to one table now would create churn.
- **No backfill.** Past notes were never persisted anywhere recoverable; this is a forward-only fix.
- **No `created_at` / `user_id` columns.** Swift only carries `logged_at`; user is reachable via `session_id → workout_sessions.user_id`. Not denormalized to avoid drift.
- **`tags` typed as `TEXT[]`** (not enum). The Swift `detectNoteTags(transcript:)` emits a bounded set today — `'injury_concern'`, `'fatigue'`, `'energy'` — but new tags should land via Swift code change, not schema migration. Column comment documents the current bounded set explicitly.
- **Single index on `session_id`.** The only foreseeable read pattern is "all notes for a session" (consumed by `memory_embeddings` pipeline). Premature additional indexes would just be cargo culting.

## Read sites

Grepped `ProjectApex/`, `supabase/` for SQL/HTTP read patterns of `session_notes` — **zero hits**. The iOS client only writes; the embedding pipeline (`memory_embeddings`, separate table) is the consumer for RAG.

## What this PR does NOT do

- Does **not** apply 0006 to production. The migration runs as a separate authorized SQL apply after this PR merges (per the recovery deploy cadence).
- Does **not** address F2 (`users` columns) or F4 (`workout_sessions` un-migrationed columns) — those are separate follow-ups.
- Does **not** add telemetry to surface silent enqueue failures. #41 covers telemetry generally; a focused write-failure surface is its own slice.

## Test plan

- [x] Schema mirrors `SessionNotePayload` field-for-field; verified by reading both Swift sources alongside the migration.
- [x] Cross-cutting grep confirms no read sites — write-only from iOS.
- [x] `detectNoteTags` source inspected to confirm the bounded tag set listed in the column comment is accurate.
- [ ] Reviewer eyeball: migration prologue conveys the F1 / audit-recovery context for a future archeologist; schema is reproducible; ON DELETE CASCADE choice is acceptable.
- [ ] Post-merge: 0006 applies against production without error (verified at next authorized apply step; verification: column shape via `information_schema.columns`, table exists, index exists).
- [ ] Post-apply: a real voice note from the iOS client lands a row in `session_notes` (functional verification — a useful smoke test of the F1 fix end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)