### PR TITLE
chore(models): pin v2 migration cutoff dates to actual apply timestamps

### DIFF
--- a/ProjectApex/Models/MigrationDates.swift
+++ b/ProjectApex/Models/MigrationDates.swift
@@ -6,8 +6,10 @@
 // field rollout) so query-time logic can branch on "before" vs "after"
 // without scattering literal dates through services.
 //
-// Placeholder values point to the v2 release horizon and must be updated
-// to actual deploy timestamps before v2 ships.
+// Anchors below are the actual production apply timestamps captured during
+// the 2026-05-06 deploy. Sub-second precision is recorded in the audit trail
+// (PRs #48 / #52 commit messages, #10 close comment); second-level precision
+// is sufficient for the consumer branching logic.
 
 import Foundation
 
@@ -16,12 +18,22 @@ enum MigrationDates {
     /// migration with code validation shipping before DB migration).
     /// Reads of pre-cutoff sets must tolerate missing intent; reads of
     /// post-cutoff sets must require it.
-    static let v2SetIntentBackfill: Date = Date(timeIntervalSince1970: 0)
+    /// Apply timestamp: migration 0004, 2026-05-06 08:10:17.147758 UTC.
+    static let v2SetIntentBackfill: Date = iso8601Utc("2026-05-06T08:10:17Z")
 
     /// Cutoff for the localDate-field rollout (per ADR-0005 — pre-bucketed
     /// localDate string at write time, immune to subsequent timezone
     /// changes). Reads of pre-cutoff sessions derive localDate from
     /// timestamp + active timezone; reads of post-cutoff sessions trust
     /// the stored field.
-    static let v2LocalDateField: Date = Date(timeIntervalSince1970: 0)
+    /// Apply timestamp: migration 0002, 2026-05-06 07:25:14.561933 UTC.
+    static let v2LocalDateField: Date = iso8601Utc("2026-05-06T07:25:14Z")
+
+    private static func iso8601Utc(_ literal: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        guard let date = formatter.date(from: literal) else {
+            preconditionFailure("MigrationDates: invalid ISO8601 literal: \(literal)")
+        }
+        return date
+    }
 }


### PR DESCRIPTION
## Summary

Replaces the `Date(timeIntervalSince1970: 0)` placeholders in `MigrationDates` with the actual production apply timestamps from the 2026-05-06 deploy.

| Constant | Old | New | Migration | Captured at apply time |
|---|---|---|---|---|
| `v2LocalDateField` | epoch 0 | `2026-05-06T07:25:14Z` | 0002 (`set_logs.local_date`) | `2026-05-06 07:25:14.561933 UTC` |
| `v2SetIntentBackfill` | epoch 0 | `2026-05-06T08:10:17Z` | 0004 (`set_logs.intent` + heuristic) | `2026-05-06 08:10:17.147758 UTC` |

Both timestamps were captured via `SELECT NOW() AT TIME ZONE 'UTC'` immediately after the respective migration applied; values are recorded in the audit trail.

## Decisions

- **Second-level precision in the constants.** Sub-second precision was captured in the audit (microsecond resolution from `NOW()`) but the constants get rounded to seconds for readability. Justification: zero current consumers (verified via grep across `ProjectApex/`); the constants are forward-declared for analytics that will branch on pre-vs-post-cutoff. Sub-second precision would be over-engineering for that use case, and the exact sub-second values are preserved in PR #48's commit message, PR #52's baseline migration, and the upcoming #10 close comment.
- **Switched the literal expression** from `Date(timeIntervalSince1970:)` to a small `iso8601Utc(_:)` helper. Reads as a date instead of an opaque epoch number; one-line preconditionFailure on parse error so a typo crashes loudly on app launch rather than silently degrading to "no cutoff."

## What this PR does NOT do

- Does **not** add any consumer code — the analytics paths that will branch on these constants are out of scope.
- Does **not** address the rounding-direction question (round down vs round up). With zero consumers and the maintenance-window discipline that prevented concurrent writes during the apply, second-level precision is operationally indistinguishable from microsecond-precision. If a future consumer needs strict ordering against actual write timestamps, the helper is easy to extend with `.withFractionalSeconds`.

## Test plan

- [x] `grep "v2SetIntentBackfill\\|v2LocalDateField"` shows zero non-declaration consumers — replacing the placeholders cannot affect any current code path.
- [x] Helper preconditionFailure path tested mentally against the two literals (`2026-05-06T07:25:14Z`, `2026-05-06T08:10:17Z`); both are valid `.withInternetDateTime` ISO8601 strings.
- [ ] Reviewer eyeball: timestamps match the audit trail in PR #48's commit message; helper signature is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)