### PR TITLE
Slice 10 — TraineeModelService actor + TraineeModelDigest (closes #11)

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		47E356DC2F61D07B00C69CD6 /* GymFactStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356DB2F61D07B00C69CD6 /* GymFactStoreTests.swift */; };
 		51F067120CE1EA4A3EA813A6 /* MuscleTaxonomyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */; };
 		5DE94F8F1D136C65C96FCAD1 /* WeekFatigueSignalsHelperAgreementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4422DE7829C0C124138BB4B0 /* WeekFatigueSignalsHelperAgreementTests.swift */; };
+		6587F62EDC961A3C558A6226 /* TraineeModelServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6437BED8DCD7F98C80FF4377 /* TraineeModelServiceTests.swift */; };
 		6ECE420C1031E80360FF1EFE /* TraineeModelProfilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */; };
 		6ED5B7636B15C7C513C11C2E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC23D0A3EB460CF97B18574 /* Foundation.framework */; };
 		729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */; };
@@ -48,6 +49,7 @@
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */; };
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
+		C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */; };
 		E50E3B4CBD53ED7ABE725DB8 /* EquipmentCatalogSeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -94,8 +96,10 @@
 		47E356CE2F61BFCF00C69CD6 /* EquipmentMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquipmentMergerTests.swift; sourceTree = "<group>"; };
 		47E356D92F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultWeightIncrementsTests.swift; sourceTree = "<group>"; };
 		47E356DB2F61D07B00C69CD6 /* GymFactStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymFactStoreTests.swift; sourceTree = "<group>"; };
+		6437BED8DCD7F98C80FF4377 /* TraineeModelServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelServiceTests.swift; sourceTree = "<group>"; };
 		6DC23D0A3EB460CF97B18574 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		70E3BA94C76430CACFD657B5 /* EquipmentRounderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EquipmentRounderTests.swift; sourceTree = "<group>"; };
+		7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelDigestTests.swift; sourceTree = "<group>"; };
 		85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelInteractionsTests.swift; sourceTree = "<group>"; };
 		878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelProfilesTests.swift; sourceTree = "<group>"; };
 		993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelSnapshotsTests.swift; sourceTree = "<group>"; };
@@ -114,6 +118,8 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		47D91BC22F60266A007B3B34 /* ProjectApex */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = ProjectApex;
 			sourceTree = "<group>";
 		};
@@ -236,6 +242,8 @@
 				ED1E4BCA9CBB3EDBB8068E06 /* SetCompletionFormStateTests.swift */,
 				DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */,
 				ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */,
+				7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */,
+				6437BED8DCD7F98C80FF4377 /* TraineeModelServiceTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -379,6 +387,8 @@
 				0CFD5EC802FC7842DCAC24AE /* SetCompletionFormStateTests.swift in Sources */,
 				8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */,
 				7D8C4E6ADC8DEDCA31B72B1D /* ManualLogIntentGateTests.swift in Sources */,
+				C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */,
+				6587F62EDC961A3C558A6226 /* TraineeModelServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/Models/TraineeModelDigest.swift
+++ b/ProjectApex/Models/TraineeModelDigest.swift
@@ -36,6 +36,9 @@ struct TraineeModelDigest: Codable, Sendable, Hashable {
     var perMuscleSummary: [MuscleSummary]
     var activeFatigueInteractions: [FatigueInteraction]
     var activeLimitations: [ActiveLimitation]
+    /// Unfiltered — every entry from the source model's nested map, flattened.
+    /// Callers consuming this for prompt assembly must filter by request context
+    /// before passing to the model; do not forward the full list verbatim.
     var prescriptionAccuracy: [PrescriptionAccuracy]
     var disruptedPatterns: [MovementPattern]
 

--- a/ProjectApex/Models/TraineeModelDigest.swift
+++ b/ProjectApex/Models/TraineeModelDigest.swift
@@ -1,0 +1,136 @@
+// TraineeModelDigest.swift
+// ProjectApex — Models
+//
+// Request-time projection of the trainee model for inference and
+// session-generation prompts (Phase 1 / Slice 10, issue #11).
+//
+// Per ADR-0005: "WorkoutContext payload becomes a TraineeModelDigest — a
+// request-time projection of relevant trainee-model fields, narrower than
+// the full model (token economics)."
+//
+// Phase 1 ships the shape and the assembly fn. Phase 2 wires the digest
+// into prompt construction; the per-context filter on prescription
+// accuracy lands at that point — the slice 10 issue's "(relevant patterns
+// only)" qualifier is intentionally deferred because the request-context
+// type does not yet exist. The digest emitted here carries every entry
+// from the source model's prescriptionAccuracy map, flattened into a list.
+//
+// Filtering rules implemented now (per ADR-0005 / issue #11):
+//   • activeFatigueInteractions: only entries with confidence ≥ 0.7
+//     (FatigueInteraction.confidence — derived from consistencyFactor ×
+//     countFactor; the 15-paired-observation gate is enforced inside the
+//     same confidence value via countFactor).
+//
+// PatternSummary / MuscleSummary carry only the prompt-relevant fields —
+// recoveryProfile, recentSessionDates, and other detail fields are
+// dropped. Phase 2 may extend either summary if the prompt warrants it.
+
+import Foundation
+
+// MARK: - TraineeModelDigest
+
+struct TraineeModelDigest: Codable, Sendable, Hashable {
+    var goal: GoalState
+    var projections: ProjectionState?
+    var perPatternSummary: [PatternSummary]
+    var perMuscleSummary: [MuscleSummary]
+    var activeFatigueInteractions: [FatigueInteraction]
+    var activeLimitations: [ActiveLimitation]
+    var prescriptionAccuracy: [PrescriptionAccuracy]
+    var disruptedPatterns: [MovementPattern]
+
+    /// Threshold below which a fatigue interaction is excluded from
+    /// coaching prompts per ADR-0005.
+    static let fatigueInteractionConfidenceThreshold: Double = 0.7
+}
+
+// MARK: - Assembly
+
+extension TraineeModelDigest {
+    init(from model: TraineeModel, asOf reference: Date = Date()) {
+        let perPatternSummary = model.patterns
+            .sorted { $0.key.rawValue < $1.key.rawValue }
+            .map { PatternSummary(profile: $0.value, asOf: reference) }
+
+        let perMuscleSummary = model.muscles
+            .sorted { $0.key.rawValue < $1.key.rawValue }
+            .map { MuscleSummary(profile: $0.value) }
+
+        let activeFatigueInteractions = model.fatigueInteractions.filter {
+            $0.confidence >= Self.fatigueInteractionConfidenceThreshold
+        }
+
+        let prescriptionAccuracy = model.prescriptionAccuracy
+            .sorted { $0.key.rawValue < $1.key.rawValue }
+            .flatMap { (_, byIntent) in
+                byIntent
+                    .sorted { $0.key.rawValue < $1.key.rawValue }
+                    .map { $0.value }
+            }
+
+        let disruptedPatterns = model.disruptedPatterns(asOf: reference)
+            .sorted { $0.rawValue < $1.rawValue }
+
+        self.init(
+            goal: model.goal,
+            projections: model.projections,
+            perPatternSummary: perPatternSummary,
+            perMuscleSummary: perMuscleSummary,
+            activeFatigueInteractions: activeFatigueInteractions,
+            activeLimitations: model.activeLimitations,
+            prescriptionAccuracy: prescriptionAccuracy,
+            disruptedPatterns: disruptedPatterns
+        )
+    }
+}
+
+// MARK: - PatternSummary
+
+/// Narrow projection of PatternProfile carrying the fields a coaching
+/// prompt actually needs. Recovery, RPE-offset history, and the recent-
+/// session-date list are dropped; cadence and disruption are pre-derived
+/// at the digest level.
+struct PatternSummary: Codable, Sendable, Hashable {
+    var pattern: MovementPattern
+    var currentPhase: MesocyclePhase
+    var confidence: AxisConfidence
+    var rpeOffset: Double
+    var trend: ProgressionTrend
+    /// Pre-evaluated against the digest's reference date so the consumer
+    /// doesn't need to re-derive transition-mode state at prompt-assembly
+    /// time.
+    var inTransitionMode: Bool
+
+    init(profile: PatternProfile, asOf reference: Date = Date()) {
+        self.pattern         = profile.pattern
+        self.currentPhase    = profile.currentPhase
+        self.confidence      = profile.confidence
+        self.rpeOffset       = profile.rpeOffset
+        self.trend           = profile.trend
+        self.inTransitionMode = profile.inTransitionMode(asOf: reference)
+    }
+}
+
+// MARK: - MuscleSummary
+
+/// Narrow projection of MuscleProfile. observedSweetSpot is dropped
+/// because it varies with phase (per ADR-0005) and is not stable enough
+/// to surface in coaching prompts in Phase 1; it can be added in Phase 2
+/// if the prompt strategy benefits.
+struct MuscleSummary: Codable, Sendable, Hashable {
+    var muscleGroup: MuscleGroup
+    var volumeTolerance: Double
+    var volumeDeficit: Int
+    var focusWeight: Double
+    var stagnationStatus: ProgressionTrend
+    var confidence: AxisConfidence
+
+    init(profile: MuscleProfile) {
+        self.muscleGroup       = profile.muscleGroup
+        self.volumeTolerance   = profile.volumeTolerance
+        self.volumeDeficit     = profile.volumeDeficit
+        self.focusWeight       = profile.focusWeight
+        self.stagnationStatus  = profile.stagnationStatus
+        self.confidence        = profile.confidence
+    }
+}

--- a/ProjectApex/Services/TraineeModelService.swift
+++ b/ProjectApex/Services/TraineeModelService.swift
@@ -76,8 +76,18 @@ actor TraineeModelService {
     }
 
     /// Returns the request-time digest projection of the cached model,
-    /// or nil if the local store is empty. See file header for the
-    /// rationale for the Optional return.
+    /// or nil if the local store is empty (cold-start / pre-onboarding,
+    /// before the first server update hydrates the cache).
+    ///
+    /// Callers must handle the nil case — do not assume a digest is
+    /// always present. Typical guard pattern:
+    ///
+    ///     guard let digest = await service.digest() else {
+    ///         // trainee model not yet available; skip prompt section
+    ///         return
+    ///     }
+    ///
+    /// See file header for the rationale for the Optional return.
     func digest() async -> TraineeModelDigest? {
         guard let model = await store.load() else { return nil }
         return TraineeModelDigest(from: model, asOf: now())

--- a/ProjectApex/Services/TraineeModelService.swift
+++ b/ProjectApex/Services/TraineeModelService.swift
@@ -1,0 +1,133 @@
+// Services/TraineeModelService.swift
+// ProjectApex
+//
+// Read-side actor exposing the canonical interface to the trainee model
+// for the rest of the app. Phase 1 / Slice 10, issue #11. ADR-0005 / ADR-0006.
+//
+// Three async public methods:
+//   • read()                    -> TraineeModel?         — cached snapshot or nil
+//   • digest()                  -> TraineeModelDigest?   — narrow prompt projection
+//   • enqueueUpdate(forSession:)                         — WAQ enqueue (Phase 1 storage path)
+//
+// Returning Optional from digest() rather than the issue-specified
+// `TraineeModelDigest` is a deliberate Phase-1 choice: the digest carries a
+// non-optional GoalState, and synthesising a placeholder goal at cold-start
+// would lie about onboarding state. The cold-start path is defined as
+// "no digest available yet" — call sites decide whether to skip the
+// trainee-model section of the prompt or to wait until the first server
+// update lands.
+//
+// State is held privately (the store and queue references are immutable
+// `let`s; there is no per-instance mutable state). Public methods only —
+// no reach-into-internals from callers.
+//
+// The store is @MainActor-isolated (see TraineeModelLocalStore.swift —
+// SwiftData ModelContainer requires main-actor executor); calls into it
+// hop the actor boundary via `await`. The WriteAheadQueue is its own
+// actor; same.
+//
+// Out of scope (Phase 2 / later slices):
+//   • Update-rule logic — runs server-side via Edge Function (ADR-0006).
+//   • TraineeModelUpdateJob WAQ flush handler that routes
+//     "trainee_model_updates" items to update-trainee-model rather than
+//     to a Postgres insert (Slice 11 / #12). Until that lands, items
+//     enqueued here will be retried by the existing flush against
+//     Supabase REST and dropped after maxRetries — an accepted gap for
+//     the slice boundary.
+//   • Per-context filtering of prescription accuracy — needs a
+//     request-context type that does not yet exist.
+
+import Foundation
+
+actor TraineeModelService {
+
+    // MARK: - Dependencies
+
+    private let store: TraineeModelLocalStore
+    private let writeAheadQueue: WriteAheadQueue
+    private let now: @Sendable () -> Date
+
+    // MARK: - WAQ table key
+    //
+    // Sentinel table name for trainee-model-update items. Slice 11 will
+    // teach the WAQ flush handler to route this table to the
+    // update-trainee-model Edge Function rather than a Postgres insert.
+    // Plural form follows the existing WAQ convention (set_logs,
+    // workout_sessions, session_notes).
+    static let waqTable = "trainee_model_updates"
+
+    // MARK: - Init
+
+    init(store: TraineeModelLocalStore,
+         writeAheadQueue: WriteAheadQueue,
+         now: @Sendable @escaping () -> Date = Date.init) {
+        self.store = store
+        self.writeAheadQueue = writeAheadQueue
+        self.now = now
+    }
+
+    // MARK: - Read
+
+    /// Returns the cached TraineeModel snapshot, or nil if the local
+    /// store is empty (cold-start path, before the first server update
+    /// hydrates the cache).
+    func read() async -> TraineeModel? {
+        await store.load()
+    }
+
+    /// Returns the request-time digest projection of the cached model,
+    /// or nil if the local store is empty. See file header for the
+    /// rationale for the Optional return.
+    func digest() async -> TraineeModelDigest? {
+        guard let model = await store.load() else { return nil }
+        return TraineeModelDigest(from: model, asOf: now())
+    }
+
+    // MARK: - Write — enqueue path only (Phase 1)
+
+    /// Enqueues a `trainee_model_update` item carrying the session-
+    /// completion shape expected by the update-trainee-model Edge
+    /// Function:
+    ///
+    ///     { "user_id": <uuid>, "session_id": <uuid>, "session_payload": { … } }
+    ///
+    /// Phase 1 sends an empty `session_payload` object — the
+    /// shape is the contract; the contents are filled in by Phase 2
+    /// when rule logic ships and the Edge Function actually consumes
+    /// session data.
+    func enqueueUpdate(forSession session: WorkoutSession) async throws {
+        let payload = TraineeModelUpdatePayload(
+            userId: session.userId,
+            sessionId: session.id,
+            sessionPayload: SessionUpdatePayload()
+        )
+        try await writeAheadQueue.enqueue(payload, table: Self.waqTable)
+    }
+}
+
+// MARK: - Edge Function payload shape
+//
+// Mirrors the contract enforced by supabase/functions/update-trainee-model
+// /index.ts (see ADR-0006 §3): top-level keys must be exactly user_id,
+// session_id, session_payload — snake_case, with both IDs as UUID strings
+// and session_payload as a JSON object.
+
+nonisolated struct TraineeModelUpdatePayload: Codable, Sendable {
+    let userId: UUID
+    let sessionId: UUID
+    let sessionPayload: SessionUpdatePayload
+
+    enum CodingKeys: String, CodingKey {
+        case userId         = "user_id"
+        case sessionId      = "session_id"
+        case sessionPayload = "session_payload"
+    }
+}
+
+/// Phase 1 placeholder — encodes as an empty JSON object `{}`. Phase 2
+/// extends this struct with set_logs, session notes, and any other fields
+/// the Edge Function rule logic needs. Keeping it as a dedicated type
+/// (rather than `[String: String]()`) means Phase 2 changes are additive
+/// — the empty object remains valid against any future fields-all-optional
+/// shape.
+nonisolated struct SessionUpdatePayload: Codable, Sendable {}

--- a/ProjectApexTests/TraineeModelDigestTests.swift
+++ b/ProjectApexTests/TraineeModelDigestTests.swift
@@ -1,0 +1,320 @@
+// TraineeModelDigestTests.swift
+// ProjectApexTests
+//
+// Unit tests for TraineeModelDigest assembly (Phase 1 / Slice 10, issue #11).
+//
+// Behaviours covered:
+//   • Goal + projections passed through verbatim from the source model.
+//   • per-pattern summary projects each PatternProfile across all four
+//     AxisConfidence states (bootstrapping, calibrating, established, seasoned).
+//   • per-muscle summary projects each MuscleProfile across all four
+//     AxisConfidence states.
+//   • Active fatigue interactions filter by confidence ≥ 0.7
+//     (FatigueInteraction.confidence — derived from consistencyFactor ×
+//     countFactor per ADR-0005).
+//   • Active limitations are passed through.
+//   • Prescription accuracy entries are flattened from the [pattern: [intent: …]]
+//     map into a list (Phase 1 — no per-context filtering, see PR notes).
+//   • Disrupted patterns are computed from the per-pattern recent-session
+//     dates against the supplied reference date.
+//   • Cold-start is handled by the actor (digest returning nil); this file
+//     only exercises the assembly fn given a present model.
+//
+// The summary types (PatternSummary, MuscleSummary) carry only the prompt-
+// relevant fields — the digest is narrower than the full model for token
+// economics per ADR-0005.
+
+import XCTest
+@testable import ProjectApex
+
+final class TraineeModelDigestTests: XCTestCase {
+
+    // MARK: ─── Helpers ────────────────────────────────────────────────────────
+
+    private let ref = Date(timeIntervalSinceReferenceDate: 800_000_000) // mid-2026
+
+    private func makeGoal() -> GoalState {
+        GoalState(statement: "Hypertrophy", focusAreas: [.legs], updatedAt: ref)
+    }
+
+    private func makeBaselineModel() -> TraineeModel {
+        TraineeModel(goal: makeGoal())
+    }
+
+    /// Returns a PatternProfile with the given confidence and a 7-day cadence
+    /// (two recorded sessions one week apart). Used to verify digest assembly
+    /// projects each per-axis confidence state through unchanged.
+    private func makePattern(_ pattern: MovementPattern, confidence: AxisConfidence) -> PatternProfile {
+        PatternProfile(
+            pattern: pattern,
+            currentPhase: .accumulation,
+            sessionsInPhase: 4,
+            rpeOffset: -0.25,
+            confidence: confidence,
+            trend: .progressing,
+            recentSessionDates: [ref.addingTimeInterval(-14 * 86400),
+                                 ref.addingTimeInterval(-7 * 86400)]
+        )
+    }
+
+    private func makeMuscle(_ group: MuscleGroup, confidence: AxisConfidence) -> MuscleProfile {
+        MuscleProfile(
+            muscleGroup: group,
+            volumeTolerance: 12,
+            observedSweetSpot: 10,
+            volumeDeficit: 2,
+            focusWeight: 0.5,
+            stagnationStatus: .progressing,
+            confidence: confidence
+        )
+    }
+
+    // MARK: ─── Cycle 1: goal + projections pass through ──────────────────────
+
+    func test_digest_passesThroughGoalAndProjections() {
+        var model = makeBaselineModel()
+        let projection = PatternProjection(
+            pattern: .squat, floor: 100, stretch: 120, progress: .onTrack
+        )
+        model.projections = ProjectionState(
+            patternProjections: [projection],
+            calibrationReviewFiredAt: ref,
+            goalLastRenegotiatedAt: nil
+        )
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+
+        XCTAssertEqual(digest.goal, model.goal)
+        XCTAssertEqual(digest.projections, model.projections)
+    }
+
+    // MARK: ─── Cycle 2: per-pattern summary across confidence states ──────────
+
+    func test_digest_perPatternSummary_includesAllConfidenceStates() {
+        var model = makeBaselineModel()
+        model.patterns = [
+            .squat:          makePattern(.squat,          confidence: .bootstrapping),
+            .horizontalPush: makePattern(.horizontalPush, confidence: .calibrating),
+            .horizontalPull: makePattern(.horizontalPull, confidence: .established),
+            .verticalPush:   makePattern(.verticalPush,   confidence: .seasoned),
+        ]
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+
+        XCTAssertEqual(digest.perPatternSummary.count, 4)
+        let byPattern = Dictionary(uniqueKeysWithValues:
+            digest.perPatternSummary.map { ($0.pattern, $0.confidence) })
+        XCTAssertEqual(byPattern[.squat],          .bootstrapping)
+        XCTAssertEqual(byPattern[.horizontalPush], .calibrating)
+        XCTAssertEqual(byPattern[.horizontalPull], .established)
+        XCTAssertEqual(byPattern[.verticalPush],   .seasoned)
+    }
+
+    func test_digest_perPatternSummary_carriesPromptRelevantFields() {
+        var model = makeBaselineModel()
+        var profile = makePattern(.squat, confidence: .calibrating)
+        profile.currentPhase = .intensification
+        profile.rpeOffset = -0.5
+        profile.trend = .plateaued
+        profile.transitionModeUntil = ref.addingTimeInterval(7 * 86400) // active
+        model.patterns[.squat] = profile
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+
+        let summary = try! XCTUnwrap(digest.perPatternSummary.first { $0.pattern == .squat })
+        XCTAssertEqual(summary.currentPhase,   .intensification)
+        XCTAssertEqual(summary.confidence,     .calibrating)
+        XCTAssertEqual(summary.rpeOffset,      -0.5)
+        XCTAssertEqual(summary.trend,          .plateaued)
+        XCTAssertTrue(summary.inTransitionMode)
+    }
+
+    func test_digest_perPatternSummary_inTransitionMode_falseWhenExpired() {
+        var model = makeBaselineModel()
+        var profile = makePattern(.squat, confidence: .established)
+        profile.transitionModeUntil = ref.addingTimeInterval(-86400) // expired
+        model.patterns[.squat] = profile
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+        let summary = try! XCTUnwrap(digest.perPatternSummary.first { $0.pattern == .squat })
+
+        XCTAssertFalse(summary.inTransitionMode)
+    }
+
+    // MARK: ─── Cycle 3: per-muscle summary across confidence states ───────────
+
+    func test_digest_perMuscleSummary_includesAllConfidenceStates() {
+        var model = makeBaselineModel()
+        model.muscles = [
+            .legs:      makeMuscle(.legs,      confidence: .bootstrapping),
+            .back:      makeMuscle(.back,      confidence: .calibrating),
+            .chest:     makeMuscle(.chest,     confidence: .established),
+            .shoulders: makeMuscle(.shoulders, confidence: .seasoned),
+        ]
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+
+        XCTAssertEqual(digest.perMuscleSummary.count, 4)
+        let byGroup = Dictionary(uniqueKeysWithValues:
+            digest.perMuscleSummary.map { ($0.muscleGroup, $0.confidence) })
+        XCTAssertEqual(byGroup[.legs],      .bootstrapping)
+        XCTAssertEqual(byGroup[.back],      .calibrating)
+        XCTAssertEqual(byGroup[.chest],     .established)
+        XCTAssertEqual(byGroup[.shoulders], .seasoned)
+    }
+
+    func test_digest_perMuscleSummary_carriesPromptRelevantFields() {
+        var model = makeBaselineModel()
+        model.muscles[.legs] = MuscleProfile(
+            muscleGroup: .legs,
+            volumeTolerance: 14.0,
+            observedSweetSpot: 11,
+            volumeDeficit: 3,
+            focusWeight: 0.7,
+            stagnationStatus: .declining,
+            confidence: .calibrating
+        )
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+        let summary = try! XCTUnwrap(digest.perMuscleSummary.first { $0.muscleGroup == .legs })
+
+        XCTAssertEqual(summary.volumeTolerance,   14.0)
+        XCTAssertEqual(summary.volumeDeficit,     3)
+        XCTAssertEqual(summary.focusWeight,       0.7)
+        XCTAssertEqual(summary.stagnationStatus,  .declining)
+        XCTAssertEqual(summary.confidence,        .calibrating)
+    }
+
+    // MARK: ─── Cycle 4: fatigue-interaction filtering by confidence ≥ 0.7 ─────
+
+    func test_digest_filtersFatigueInteractions_belowThreshold() {
+        // 14 paired observations → countFactor = 0.5 (cap below 15).
+        // Even with perfect consistency, confidence = 0.5 × 1.0 = 0.5 < 0.7.
+        var model = makeBaselineModel()
+        model.fatigueInteractions = [
+            FatigueInteraction(
+                fromPattern: .squat,
+                toPattern:   .hipHinge,
+                observations: Array(repeating: -0.05, count: 10), // perfect consistency
+                totalCount:   14
+            )
+        ]
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+
+        XCTAssertTrue(
+            digest.activeFatigueInteractions.isEmpty,
+            "Below-threshold fatigue interactions must be excluded from the digest"
+        )
+    }
+
+    func test_digest_includesFatigueInteractions_atOrAboveThreshold() {
+        // 15 observations → countFactor = 1.0; all-equal observations →
+        // consistencyFactor = 1.0; confidence = 1.0 ≥ 0.7.
+        var model = makeBaselineModel()
+        let included = FatigueInteraction(
+            fromPattern: .horizontalPush,
+            toPattern:   .verticalPush,
+            observations: Array(repeating: -0.05, count: 10),
+            totalCount:   15
+        )
+        // 14 observations → confidence = 0.5 (excluded).
+        let excluded = FatigueInteraction(
+            fromPattern: .squat,
+            toPattern:   .hipHinge,
+            observations: Array(repeating: -0.05, count: 10),
+            totalCount:   14
+        )
+        model.fatigueInteractions = [included, excluded]
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+
+        XCTAssertEqual(digest.activeFatigueInteractions.count, 1)
+        XCTAssertEqual(digest.activeFatigueInteractions.first?.fromPattern, .horizontalPush)
+        XCTAssertEqual(digest.activeFatigueInteractions.first?.toPattern,   .verticalPush)
+    }
+
+    // MARK: ─── Cycle 5: active limitations passed through ────────────────────
+
+    func test_digest_passesThroughActiveLimitations() {
+        var model = makeBaselineModel()
+        let limitation = ActiveLimitation(
+            subject: .joint(.shoulder),
+            severity: .mild,
+            onsetDate: ref.addingTimeInterval(-30 * 86400),
+            evidenceCount: 3,
+            userConfirmed: false,
+            notes: "AI-inferred — left shoulder mentioned 3× in 6 sessions"
+        )
+        model.activeLimitations = [limitation]
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+
+        XCTAssertEqual(digest.activeLimitations, [limitation])
+    }
+
+    // MARK: ─── Cycle 6: prescription accuracy flattened from nested map ───────
+
+    func test_digest_prescriptionAccuracy_flattensNestedMap() {
+        var model = makeBaselineModel()
+        let squatTop = PrescriptionAccuracy(
+            pattern: .squat, intent: .top, bias: -0.05, rmse: 0.08, sampleCount: 12
+        )
+        let squatBackoff = PrescriptionAccuracy(
+            pattern: .squat, intent: .backoff, bias: 0.02, rmse: 0.06, sampleCount: 18
+        )
+        let pushTop = PrescriptionAccuracy(
+            pattern: .horizontalPush, intent: .top, bias: 0.0, rmse: 0.04, sampleCount: 9
+        )
+        model.prescriptionAccuracy = [
+            .squat:          [.top: squatTop, .backoff: squatBackoff],
+            .horizontalPush: [.top: pushTop],
+        ]
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+
+        XCTAssertEqual(digest.prescriptionAccuracy.count, 3)
+        let entries = Set(digest.prescriptionAccuracy.map { "\($0.pattern.rawValue):\($0.intent.rawValue)" })
+        XCTAssertEqual(entries, ["squat:top", "squat:backoff", "horizontal_push:top"])
+    }
+
+    // MARK: ─── Cycle 7: disrupted patterns derived from cadence ──────────────
+
+    func test_digest_disruptedPatterns_derivedFromCadence() {
+        var model = makeBaselineModel()
+        // Cadence: two sessions 7 days apart; last 30 days ago → 4.3× cadence
+        var disrupted = PatternProfile(pattern: .squat, confidence: .calibrating)
+        disrupted.recentSessionDates = [
+            ref.addingTimeInterval(-37 * 86400),
+            ref.addingTimeInterval(-30 * 86400),
+        ]
+        // Cadence: two sessions 7 days apart; last 5 days ago → not disrupted
+        var fresh = PatternProfile(pattern: .horizontalPush, confidence: .calibrating)
+        fresh.recentSessionDates = [
+            ref.addingTimeInterval(-12 * 86400),
+            ref.addingTimeInterval(-5 * 86400),
+        ]
+        model.patterns = [.squat: disrupted, .horizontalPush: fresh]
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+
+        XCTAssertEqual(digest.disruptedPatterns, [.squat])
+    }
+
+    // MARK: ─── Cycle 8: empty-input edge cases ───────────────────────────────
+
+    func test_digest_emptyModel_yieldsEmptyCollections() {
+        let model = makeBaselineModel()
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+
+        XCTAssertEqual(digest.goal, model.goal)
+        XCTAssertNil(digest.projections)
+        XCTAssertTrue(digest.perPatternSummary.isEmpty)
+        XCTAssertTrue(digest.perMuscleSummary.isEmpty)
+        XCTAssertTrue(digest.activeFatigueInteractions.isEmpty)
+        XCTAssertTrue(digest.activeLimitations.isEmpty)
+        XCTAssertTrue(digest.prescriptionAccuracy.isEmpty)
+        XCTAssertTrue(digest.disruptedPatterns.isEmpty)
+    }
+}

--- a/ProjectApexTests/TraineeModelServiceTests.swift
+++ b/ProjectApexTests/TraineeModelServiceTests.swift
@@ -1,0 +1,232 @@
+// TraineeModelServiceTests.swift
+// ProjectApexTests
+//
+// Unit tests for TraineeModelService actor (Phase 1 / Slice 10, issue #11).
+//
+// The actor is the read-side interface to the trainee model — wraps the
+// SwiftData local cache (@MainActor TraineeModelLocalStore) and the
+// WriteAheadQueue. Phase 1 ships read(), digest(), enqueueUpdate(forSession:);
+// the WAQ flush handler that routes trainee_model_update items to the
+// Edge Function lands in Slice 11 (#12). Update-rule logic is Phase 2.
+//
+// The class is @MainActor because TraineeModelLocalStore must be created
+// and torn down inside an active Swift Concurrency Task — same constraint
+// as TraineeModelLocalStoreTests.
+//
+// Behaviours covered:
+//   • read() returns nil when the local cache is empty (cold-start path)
+//   • read() returns the cached snapshot after the store is hydrated
+//   • digest() returns nil when the local cache is empty (cold-start path)
+//   • digest() returns a TraineeModelDigest assembled from the cached model
+//   • enqueueUpdate(forSession:) appends one item to the WAQ
+//   • enqueueUpdate(forSession:) targets the trainee_model_updates table
+//   • enqueueUpdate(forSession:) emits a payload whose decoded JSON shape
+//     matches the Edge Function contract { user_id, session_id, session_payload }
+
+import XCTest
+@testable import ProjectApex
+
+// MARK: - URLProtocol that fails every request
+//
+// Used so the WAQ's automatic flush attempt does not silently drop the
+// enqueued item before the test inspects the queue. A 500 response keeps
+// the item in queue (with retryCount incremented) — perfect for the
+// shape-only assertions this file makes.
+
+private final class TMSAlwaysFailURLProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 500,
+            httpVersion: nil, headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data())
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+private func makeFailingSupabase() -> SupabaseClient {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [TMSAlwaysFailURLProtocol.self]
+    return SupabaseClient(
+        supabaseURL: URL(string: "https://test.supabase.co")!,
+        anonKey: "test-key",
+        urlSession: URLSession(configuration: config)
+    )
+}
+
+// MARK: - TraineeModelServiceTests
+
+@MainActor
+final class TraineeModelServiceTests: XCTestCase {
+
+    // MARK: ─── Lifecycle ─────────────────────────────────────────────────────
+
+    private var store: TraineeModelLocalStore!
+    private var waq: WriteAheadQueue!
+    private var service: TraineeModelService!
+
+    private let userId    = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    private let programId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+    private let sessionId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+    private let ref = Date(timeIntervalSinceReferenceDate: 800_000_000)
+
+    override func setUp() async throws {
+        UserDefaults.standard.removeObject(forKey: "com.projectapex.writeAheadQueue")
+        store   = try TraineeModelLocalStore.makeInMemory()
+        waq     = WriteAheadQueue(supabase: makeFailingSupabase())
+        service = TraineeModelService(store: store, writeAheadQueue: waq, now: { [ref] in ref })
+    }
+
+    override func tearDown() async throws {
+        // Do NOT call `await waq.clearAll()` here. WAQ.flush() retries failed
+        // writes via `queue[0] = item` after each backoff; if clearAll() runs
+        // during that suspension window, the index-set crashes with
+        // "Index out of range". The fix is to leave any in-flight flush
+        // tasks alone — they will exhaust retries against the failing mock
+        // and exit on their own — and rely on setUp's UserDefaults clear
+        // to ensure no persisted state leaks into the next test.
+        service = nil
+        waq = nil
+        store = nil
+        UserDefaults.standard.removeObject(forKey: "com.projectapex.writeAheadQueue")
+    }
+
+    // MARK: ─── Helpers ────────────────────────────────────────────────────────
+
+    private func makeRichModel() -> TraineeModel {
+        TraineeModel(
+            goal: GoalState(statement: "Strength + size",
+                            focusAreas: [.legs, .back],
+                            updatedAt: ref),
+            patterns: [
+                .squat: PatternProfile(
+                    pattern: .squat,
+                    currentPhase: .accumulation,
+                    sessionsInPhase: 4,
+                    rpeOffset: -0.5,
+                    confidence: .calibrating,
+                    recentSessionDates: [ref.addingTimeInterval(-14 * 86400),
+                                         ref.addingTimeInterval(-7 * 86400)]
+                ),
+                .horizontalPush: PatternProfile(
+                    pattern: .horizontalPush,
+                    currentPhase: .intensification,
+                    sessionsInPhase: 6,
+                    rpeOffset: 0,
+                    confidence: .established,
+                    recentSessionDates: [ref.addingTimeInterval(-10 * 86400),
+                                         ref.addingTimeInterval(-3 * 86400)]
+                ),
+            ],
+            muscles: [
+                .legs: MuscleProfile(muscleGroup: .legs,
+                                     volumeTolerance: 14,
+                                     volumeDeficit: 2,
+                                     focusWeight: 0.6,
+                                     confidence: .calibrating)
+            ],
+            totalSessionCount: 8
+        )
+    }
+
+    private func makeSession() -> WorkoutSession {
+        WorkoutSession(
+            id: sessionId,
+            userId: userId,
+            programId: programId,
+            sessionDate: ref,
+            weekNumber: 2,
+            dayType: "Push A",
+            completed: true,
+            status: "completed"
+        )
+    }
+
+    // MARK: ─── read() — cold start vs hydrated ───────────────────────────────
+
+    func test_read_returnsNil_whenStoreEmpty() async {
+        let result = await service.read()
+        XCTAssertNil(result)
+    }
+
+    func test_read_returnsCachedSnapshot_afterSave() async throws {
+        let model = makeRichModel()
+        try store.save(model)
+
+        let result = await service.read()
+
+        XCTAssertEqual(result, model)
+    }
+
+    // MARK: ─── digest() — cold start vs hydrated ─────────────────────────────
+
+    func test_digest_returnsNil_whenStoreEmpty() async {
+        let result = await service.digest()
+        XCTAssertNil(result)
+    }
+
+    func test_digest_returnsAssembledProjection_afterSave() async throws {
+        let model = makeRichModel()
+        try store.save(model)
+
+        let maybe = await service.digest()
+        let digest = try XCTUnwrap(maybe)
+
+        XCTAssertEqual(digest.goal, model.goal)
+        XCTAssertEqual(digest.perPatternSummary.count, 2)
+        XCTAssertEqual(digest.perMuscleSummary.count, 1)
+        // Confidence states surface verbatim — covers the per-axis
+        // assembly path the issue calls out specifically.
+        let patternConfidences = Set(digest.perPatternSummary.map { $0.confidence })
+        XCTAssertEqual(patternConfidences, [.calibrating, .established])
+    }
+
+    // MARK: ─── enqueueUpdate(forSession:) — WAQ shape ────────────────────────
+
+    func test_enqueueUpdate_appendsOneItemToQueue() async throws {
+        let session = makeSession()
+
+        try await service.enqueueUpdate(forSession: session)
+
+        let pending = await waq.queue
+        XCTAssertEqual(pending.count, 1, "Expected exactly one queued write")
+    }
+
+    func test_enqueueUpdate_targetsTraineeModelUpdatesTable() async throws {
+        let session = makeSession()
+
+        try await service.enqueueUpdate(forSession: session)
+
+        let pending = await waq.queue
+        let item = try XCTUnwrap(pending.first)
+        XCTAssertEqual(item.table, "trainee_model_updates")
+    }
+
+    func test_enqueueUpdate_payloadShape_matchesEdgeFunctionContract() async throws {
+        let session = makeSession()
+
+        try await service.enqueueUpdate(forSession: session)
+
+        let pending = await waq.queue
+        let item = try XCTUnwrap(pending.first)
+
+        // Edge Function (supabase/functions/update-trainee-model/index.ts)
+        // expects exactly { user_id, session_id, session_payload } with
+        // user_id and session_id as UUID strings and session_payload as a
+        // JSON object. Phase 1 sends an empty session_payload object;
+        // Phase 2 fills in set_logs / notes when rule logic ships.
+        let json = try JSONSerialization.jsonObject(with: item.payload) as? [String: Any]
+        let body = try XCTUnwrap(json)
+
+        XCTAssertEqual((body["user_id"]    as? String)?.lowercased(), userId.uuidString.lowercased())
+        XCTAssertEqual((body["session_id"] as? String)?.lowercased(), sessionId.uuidString.lowercased())
+        XCTAssertNotNil(body["session_payload"] as? [String: Any],
+                        "session_payload must be a JSON object per Edge Function contract")
+        XCTAssertEqual(Set(body.keys), ["user_id", "session_id", "session_payload"],
+                       "Payload must carry exactly the Edge Function contract keys")
+    }
+}

--- a/scripts/slice10_register_files.rb
+++ b/scripts/slice10_register_files.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# scripts/slice10_register_files.rb
+#
+# Registers Slice 10 (#11) test files with the Xcode project:
+#   - ProjectApexTests/TraineeModelDigestTests.swift  → ProjectApexTests target
+#   - ProjectApexTests/TraineeModelServiceTests.swift → ProjectApexTests target
+#
+# Production files (TraineeModelDigest.swift, TraineeModelService.swift) live
+# inside the ProjectApex/ folder, which is a PBXFileSystemSynchronizedRootGroup
+# (Xcode's synchronized-folder mode), so they're included without explicit
+# registration. The test target is not synchronized — explicit registration
+# is required.
+#
+# Idempotent — safe to re-run.
+
+require 'xcodeproj'
+
+PROJECT_PATH = 'ProjectApex.xcodeproj'
+project = Xcodeproj::Project.open(PROJECT_PATH)
+
+test_target = project.targets.find { |t| t.name == 'ProjectApexTests' }
+raise 'ProjectApexTests target not found' unless test_target
+
+tests_group = project.main_group['ProjectApexTests']
+raise 'ProjectApexTests group not found' unless tests_group
+
+%w[
+  TraineeModelDigestTests.swift
+  TraineeModelServiceTests.swift
+].each do |basename|
+  if tests_group.files.any? { |f| f.path == basename }
+    puts "Already registered: #{basename}"
+    next
+  end
+  ref = tests_group.new_file(basename)
+  test_target.source_build_phase.add_file_reference(ref)
+  puts "Registered: #{basename} → #{test_target.name}"
+end
+
+project.save
+puts 'Saved ProjectApex.xcodeproj'


### PR DESCRIPTION
Closes #11.

## Summary

- **`TraineeModelService` actor** ([ProjectApex/Services/TraineeModelService.swift](ProjectApex/Services/TraineeModelService.swift)) — Phase 1 read-side interface to the trainee model. Three async public methods, state held privately, callers consume via the actor only. Wraps the `@MainActor` `TraineeModelLocalStore` and the `WriteAheadQueue` actor; calls hop boundaries via `await`.
- **`TraineeModelDigest` + summary types** ([ProjectApex/Models/TraineeModelDigest.swift](ProjectApex/Models/TraineeModelDigest.swift)) — narrow request-time projection per ADR-0005 ("WorkoutContext payload becomes a TraineeModelDigest — narrower than the full model for token economics"). `PatternSummary` and `MuscleSummary` carry only prompt-relevant fields; recovery profile, recent-session-date list, and observed sweet spot are dropped (cadence/disruption are pre-derived at digest-assembly time).
- **TDD coverage** ([ProjectApexTests/TraineeModelDigestTests.swift](ProjectApexTests/TraineeModelDigestTests.swift), [ProjectApexTests/TraineeModelServiceTests.swift](ProjectApexTests/TraineeModelServiceTests.swift)) — 19 new tests exercising both layers; all green alongside the rest of the suite (299 tests, 7 skipped — the integration tests gated on `APEX_INTEGRATION_TESTS=1`).

## Acceptance criteria status (issue #11)

| AC | Status |
|---|---|
| #1 `TraineeModelService` actor with `read`, `digest`, `enqueueUpdate` | done |
| #2 `read()` returns cached snapshot when present, `nil` when empty | done — `test_read_*` |
| #3 `digest()` projects across `bootstrapping`, `calibrating`, `established` (and `seasoned`) | done — `test_digest_perPatternSummary_includesAllConfidenceStates`, `test_digest_perMuscleSummary_includesAllConfidenceStates` |
| #4 `digest()` filters fatigue interactions to confidence ≥ 0.7 | done — `test_digest_filtersFatigueInteractions_belowThreshold`, `test_digest_includesFatigueInteractions_atOrAboveThreshold` (the 15-paired-obs gate is enforced inside `FatigueInteraction.confidence` via `countFactor`) |
| #5 `digest()` filters prescription accuracy to relevant patterns | **deferred — see notes below** |
| #6 `enqueueUpdate(forSession:)` emits the Edge Function shape | done — `test_enqueueUpdate_payloadShape_matchesEdgeFunctionContract` asserts exactly `{ user_id, session_id, session_payload }` and targets the `trainee_model_updates` WAQ table |
| #7–8 Unit tests cover all three methods + cold-start | done — `read()`/`digest()` cold-start tests assert `nil` |
| #9 No rule logic implemented | done — Phase 2 concern; the actor only reads the cache and enqueues |

## Notes that warrant review

Two judgment calls I want explicit eyes on. Both surfaced as ambiguities under Process commitment rule 3 ("surface ambiguity, don't fill it silently"); the AFK invocation forced a unilateral choice this round.

**(1) `digest()` returns `Optional`, not the literal issue signature.** Issue #11 specifies `digest() -> TraineeModelDigest`. I returned `TraineeModelDigest?` because `TraineeModelDigest.goal` is a non-optional `GoalState`, and synthesising a placeholder goal at cold-start would lie about onboarding state. Cold-start is defined as "no digest available yet" — call sites in Phase 2 will decide whether to skip the trainee-model section of the prompt or wait for the first server hydration. If you'd prefer the literal signature with a synthetic goal, say the word and I'll switch it.

**(2) Prescription accuracy is unfiltered (no per-context filter yet).** Issue #11 says "prescription accuracy (relevant patterns only)". `digest() -> TraineeModelDigest` has no context parameter, so "relevant" can't be evaluated here. I flattened the entire `[MovementPattern: [SetIntent: PrescriptionAccuracy]]` map into a list. The natural place for the filter is the Phase 2 prompt-assembly entry point (when a request-context type lands); a context-aware overload like `digest(forContext:)` can be added without breaking this baseline. Flagging it explicitly so the deferral isn't a silent cut.

## WAQ wiring (out-of-scope reminder)

`enqueueUpdate(forSession:)` writes to a new WAQ table key `"trainee_model_updates"`. The current `WriteAheadQueue.flush()` flushes everything via `supabase.insertRawJSON`, so until Slice 11 (#12) lands the routing logic that posts these items to the `update-trainee-model` Edge Function instead, items enqueued here will retry against a non-existent table and drop after `maxRetries`. That's the natural slice boundary called out in the issue ("the WAQ flush handler is implemented in Slice 11"); this PR doesn't touch it.

## Pre-existing rough edge surfaced

While writing the WAQ-touching tests, the `TraineeModelServiceTests` tearDown initially called `await waq.clearAll()`. This races with `WriteAheadQueue.flush()`'s retry path: flush suspends on `await sendToSupabase`, `clearAll()` empties the queue, flush resumes and crashes on `queue[0] = item` (Index out of range). The fix in this PR is test-side only (don't call `clearAll()`; rely on `setUp`'s UserDefaults reset). The underlying WAQ assumes its queue isn't mutated externally during a flush — worth filing as a spinoff fix, but I haven't done so without authorization per Process commitment rule 2.

## Test plan

- [x] All 19 new tests pass on iPhone 17 simulator (iOS 26.4).
- [x] Full test suite green: 299 tests executed, 0 failures, 7 skipped (integration gate).
- [x] No production code paths in the existing suite touched — additive only.
- [ ] (Reviewer) Confirm the two judgment calls in §Notes are acceptable, or push back so I can revise before merge.
- [ ] (Reviewer) Confirm the `trainee_model_updates` WAQ table key is the right name for Slice 11 to dispatch on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)