### PR TITLE
fix(ci): pin Xcode 26.3 + iPhone 17 Pro / iOS 26.2 (closes #28)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,15 @@
 # Builds the project and executes the full unit-test suite (mock-only tests).
 # Real-API integration tests are excluded via the absence of APEX_INTEGRATION_TESTS=1.
 #
-# TDD Section 14.6 compliance:
-#   • macOS 15 runner
-#   • Xcode 16
-#   • iPhone 16 Pro simulator
+# Toolchain pin (closes #28):
+#   • macOS 15 runner (hosted macos-15 image)
+#   • Xcode 26.3 — newest Xcode on the runner image. Xcode 16.x ships iOS 18 SDK
+#     and cannot build the project (IPHONEOS_DEPLOYMENT_TARGET=26.2 needs iOS 26 SDK).
+#   • iPhone 17 Pro / iOS 26.2 simulator — iOS 26.2 is the only simulator runtime
+#     on the macos-15 image that meets the deployment target (iOS 26.0 and 26.1
+#     are below it; iOS 26.3 is not yet shipped on the runner).
+#   • OS pinned explicitly (no OS=latest) so the runner image's catalog rotation
+#     can't silently break this workflow again.
 #   • Test results uploaded as artifact on failure
 
 name: CI
@@ -28,8 +33,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.app/Contents/Developer
+      - name: Select Xcode 26.3
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
 
       - name: Show Xcode version
         run: xcodebuild -version
@@ -47,7 +52,7 @@ jobs:
             -project ProjectApex.xcodeproj \
             -scheme ProjectApex \
             -testPlan ProjectApex \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' \
             -resultBundlePath TestResults.xcresult \
             | xcpretty --color --report junit --output test-results.xml \
             ; exit ${PIPESTATUS[0]}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,20 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
+      - name: Diagnostic — simulator devices and devicetypes (for #28, will be removed)
+        # Build & Test below will still fail this run; this step exists to surface
+        # the runner's simulator inventory under Xcode 26.3 so the next commit
+        # can pin the exact iPhone device-type identifier present at iOS 26.2.
+        run: |
+          echo "===== xcrun simctl list runtimes (under selected Xcode) ====="
+          xcrun simctl list runtimes
+          echo
+          echo "===== xcrun simctl list devicetypes | grep -i 'iPhone 1[6-7]' ====="
+          xcrun simctl list devicetypes | grep -i 'iPhone 1[6-7]' || echo "(no matches)"
+          echo
+          echo "===== xcrun simctl list devices available ====="
+          xcrun simctl list devices available
+
       - name: Resolve Swift packages
         run: |
           xcodebuild -resolvePackageDependencies \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,19 +39,14 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
-      - name: Diagnostic — simulator devices and devicetypes (for #28, will be removed)
-        # Build & Test below will still fail this run; this step exists to surface
-        # the runner's simulator inventory under Xcode 26.3 so the next commit
-        # can pin the exact iPhone device-type identifier present at iOS 26.2.
-        run: |
-          echo "===== xcrun simctl list runtimes (under selected Xcode) ====="
-          xcrun simctl list runtimes
-          echo
-          echo "===== xcrun simctl list devicetypes | grep -i 'iPhone 1[6-7]' ====="
-          xcrun simctl list devicetypes | grep -i 'iPhone 1[6-7]' || echo "(no matches)"
-          echo
-          echo "===== xcrun simctl list devices available ====="
-          xcrun simctl list devices available
+      - name: Initialise CoreSimulator under selected Xcode
+        # Load-bearing: xcode-select to a non-default Xcode leaves xcodebuild's
+        # destination resolver blind to pre-baked simulators until simctl is
+        # invoked under the new selection. Without this ping, the Build & Test
+        # step below fails at destination matching ("Unable to find a device
+        # matching ..." with only placeholder destinations enumerated).
+        # Verified empirically on PR #57.
+        run: xcrun simctl list devices "com.apple.CoreSimulator.SimRuntime.iOS-26-2" available
 
       - name: Resolve Swift packages
         run: |


### PR DESCRIPTION
## Summary

Replaces the broken `Xcode_16.app` + `OS=latest` pin in `.github/workflows/ci.yml` with concrete versions that the macos-15 runner image actually has installed and that satisfy the project's `IPHONEOS_DEPLOYMENT_TARGET=26.2`.

CI infrastructure only — no feature, test, scheme, test-plan, or deployment-target changes.

## Why the existing pin was broken

`Xcode_16.app` resolves to Xcode 16.0 on `macos-15`, which ships the iOS 18 SDK. The project's deployment target is iOS 26.2, so Xcode 16.x cannot build it at all — destination resolution fails before compilation even starts. CI has been red on every push and PR since #19 because of this.

## Runner image inventory (evidence)

Verified two independent ways. (1) The [`actions/runner-images` macos-15 manifest](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md) (re-fetched 2026-05-07). (2) The diagnostic CI run on PR #31's branch ([run 25348530120](https://github.com/thearnavmenon/ProjectApex/actions/runs/25348530120), 2026-05-04). Both agree:

**Installed Xcodes**

| Version | Path |
|---|---|
| 26.3 | `/Applications/Xcode_26.3.app` |
| 26.2 | `/Applications/Xcode_26.2.app` |
| 26.1.1 | `/Applications/Xcode_26.1.1.app` |
| 26.0.1 | `/Applications/Xcode_26.0.1.app` |
| 16.4 (default) | `/Applications/Xcode_16.4.app` |
| 16.3, 16.2, 16.1, 16.0 | `/Applications/Xcode_<v>.app` |

Xcode 26.4 is **not** on the runner image.

**Installed iOS Simulator runtimes**

`18.5`, `18.6`, `26.0`, `26.1`, `26.2`. iOS 26.3 / 26.3.1 / 26.4 are **not** on the runner image.

## Chosen pin

| Setting | Value | Rationale |
|---|---|---|
| Xcode | **26.3** | Newest Xcode on the runner. Xcode 16.x ships iOS 18 SDK, can't build a 26.2-target project. |
| Simulator OS | **26.2** | Only installed runtime that meets `IPHONEOS_DEPLOYMENT_TARGET=26.2`. iOS 26.0/26.1 are below it; 26.3+ aren't on the runner. |
| Simulator device | **iPhone 17 Pro** | Available in the iOS 26.2 simulator device profile set. Aligns with the project's local-dev iPhone 17 family. |
| `OS=` form | Explicit version | No more `OS=latest` — runner-image catalog rotation can't silently break this again. |

`runs-on: macos-15` unchanged. Other workflow steps unchanged.

## Risk note — coupling with #33

[PR #32](https://github.com/thearnavmenon/ProjectApex/pull/32) previously pinned `Xcode 16.4 + iOS 26.2`. Destination resolved cleanly but the test target failed to compile under Xcode 16.4's stricter Swift 6 concurrency mode (filed as [#33](https://github.com/thearnavmenon/ProjectApex/issues/33), still open). #32 was closed without merge to keep CI-pin scope separate from real Swift fixes.

This PR's hypothesis: **Xcode 26.3 will compile the test target** because the local dev toolchain is in the same Xcode 26.x family and tests pass there. The verification is this PR's CI run.

If CI surfaces #33-class actor-isolation / concurrency errors, this PR closes the same way #32 did, and the path forward is fixing #33 first.

## Verification

CI on this PR is the verification. Expected outcome: green `Build & Test`. Failure modes to watch for:

- ✅ **Destination resolution succeeds** — confirms the pin is viable on the runner.
- ⚠ **Test target compile errors** — would mean #33 is gating after all, and this PR closes without merge.
- ⚠ **Real test failures** — would be the first real test-failure signal in weeks. Triage on its own.

## Branch name caveat

The branch is named `fix/28-ci-xcode-26-2-and-ios-26-2-pin` — created before the Xcode pin was bumped from 26.2 to 26.3 mid-discussion. The pin in the actual diff is Xcode **26.3**. Branch name not worth renaming; flagging here so reviewers don't get confused.

Closes #28

---

## Post-merge addendum — CoreSimulator warmup discovery

The version pin alone was **not** enough to make CI green. The actual fix shipped here is **version pin + a load-bearing CoreSimulator warmup step**. Three commits trace the discovery:

| Commit | Step shape | Outcome |
|---|---|---|
| `6e926a9` | version pin only | **Failed** — destination resolver returned only placeholder destinations (`Any iOS Simulator Device`), no concrete devices |
| `6736b7a` | + verbose `simctl list runtimes/devicetypes/devices` diagnostic | **Passed** — destination resolved, tests ran (11m18s) |
| `aef237f` | + minimal targeted `simctl list devices ... iOS-26-2 available` warmup | **Passed** — confirmed the slim form is sufficient |

### Why the warmup is needed

When `xcode-select` switches to a non-default Xcode (default `Xcode_16.4.app` → `Xcode_26.3.app`), CoreSimulatorService leaves xcodebuild's destination resolver blind to pre-baked simulator devices. xcodebuild enumerates only `Any iOS Simulator Device` placeholders and fails destination matching with `"Unable to find a device matching ..."`. Calling `xcrun simctl list ...` under the new Xcode selection initialises the device catalog, after which xcodebuild sees the pre-baked devices (e.g. iPhone 17 Pro at iOS 26.2, UDID `3AC7382D-C1C1-42B7-A219-AA9F9CD59202`).

This is a hosted-runner wrinkle — pre-baked simulator devices on `macos-15` are registered against the default Xcode (16.4), and switching Xcodes requires a simctl ping to re-initialise the daemon under the new selection.

### Load-bearing — do not delete

The `Initialise CoreSimulator under selected Xcode` step in the workflow is **load-bearing**, not diagnostic. Future maintainers should not delete it as "unused" or "dead code" — without it, CI immediately fails at destination resolution. The in-workflow comment was slimmed to two lines in a follow-up PR; this PR is the durable reference for the *why*.
