### PR TITLE
chore(ci): slim CoreSimulator-warmup comment to 2 lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,8 @@ jobs:
         run: xcodebuild -version
 
       - name: Initialise CoreSimulator under selected Xcode
-        # Load-bearing: xcode-select to a non-default Xcode leaves xcodebuild's
-        # destination resolver blind to pre-baked simulators until simctl is
-        # invoked under the new selection. Without this ping, the Build & Test
-        # step below fails at destination matching ("Unable to find a device
-        # matching ..." with only placeholder destinations enumerated).
-        # Verified empirically on PR #57.
+        # Initialises CoreSimulator under non-default Xcode — required before xcodebuild
+        # can resolve simulator destinations (see PR #57). Do not remove.
         run: xcrun simctl list devices "com.apple.CoreSimulator.SimRuntime.iOS-26-2" available
 
       - name: Resolve Swift packages


### PR DESCRIPTION
## Summary

Slims the in-workflow comment on the `Initialise CoreSimulator under selected Xcode` step from 6 lines to 2, following the discovery in PR #57.

## What changed

Just the comment. The step itself (`xcrun simctl list devices "com.apple.CoreSimulator.SimRuntime.iOS-26-2" available`) is unchanged and still load-bearing.

Before:
\`\`\`yaml
# Load-bearing: xcode-select to a non-default Xcode leaves xcodebuild's
# destination resolver blind to pre-baked simulators until simctl is
# invoked under the new selection. Without this ping, the Build & Test
# step below fails at destination matching ("Unable to find a device
# matching ..." with only placeholder destinations enumerated).
# Verified empirically on PR #57.
\`\`\`

After:
\`\`\`yaml
# Initialises CoreSimulator under non-default Xcode — required before xcodebuild
# can resolve simulator destinations (see PR #57). Do not remove.
\`\`\`

## Why

The original 6-line comment was useful context during development; once merged, the load-bearing nature is the only thing future maintainers need to know to avoid deleting the step as "unused." PR #57's body holds the durable reference for the full *why* (iteration trail, three-commit verification, hosted-runner wrinkle explanation).

The phrase "Do not remove." is the operationally important bit — without that anchor, an aggressive cleanup pass could plausibly delete a step that just calls `simctl list` without an obvious purpose, and CI would silently re-break.

## Verification

CI on this PR is the verification — same workflow content as PR #57's final commit (`aef237f`) modulo the comment, so should pass cleanly.