### PR TITLE
fix(slice-6/#60): persist intent and local_date in set_logs payloads

### DIFF
--- a/ProjectApex/Features/Program/ProgramDayDetailView.swift
+++ b/ProjectApex/Features/Program/ProgramDayDetailView.swift
@@ -236,7 +236,11 @@ struct ProgramDayDetailView: View {
                                         setLogs: historicalSetLogs[exercise.exerciseId] ?? [],
                                         editedIds: editedSetLogIds,
                                         onTapSet: { log in editingSetLog = log },
-                                        onAddSet: { newLog in Task { await addNewSetLog(newLog) } }
+                                        // Slice 6 / #60: intent defaults to .backoff for retroactively-added
+                                        // sets. AddSet sheet doesn't yet expose an intent picker — UI
+                                        // follow-up tracked separately. .backoff is the sensible default
+                                        // (typical for extra working sets added after the fact).
+                                        onAddSet: { newLog in Task { await addNewSetLog(newLog, intent: .backoff) } }
                                     )
                                 }
                             }
@@ -1060,8 +1064,10 @@ struct ProgramDayDetailView: View {
 
     /// Inserts a new set_log row for an exercise on this completed session,
     /// then refreshes local state so the new row appears immediately.
+    /// Slice 6 / #60 fix: intent is required by the schema; passed explicitly
+    /// by the caller (no silent defaults at the encoder layer per ADR-0005).
     @MainActor
-    private func addNewSetLog(_ newLog: SetLog) async {
+    private func addNewSetLog(_ newLog: SetLog, intent: SetIntent) async {
         guard let sessionId = completedSessionId else { return }
         let supabase = deps.supabaseClient
 
@@ -1078,12 +1084,15 @@ struct ProgramDayDetailView: View {
             let weightKg: Double
             let rpeFelt, rirEstimated: Int?
             let primaryMuscle: String?
+            let localDate: String
+            let intent: String
             enum CodingKeys: String, CodingKey {
                 case id; case sessionId = "session_id"; case exerciseId = "exercise_id"
                 case setNumber = "set_number"; case weightKg = "weight_kg"
                 case repsCompleted = "reps_completed"; case rpeFelt = "rpe_felt"
                 case rirEstimated = "rir_estimated"; case loggedAt = "logged_at"
                 case primaryMuscle = "primary_muscle"
+                case localDate = "local_date"; case intent
             }
         }
         let exerciseForLog = currentDay.exercises.first(where: { $0.exerciseId == newLog.exerciseId })
@@ -1097,7 +1106,9 @@ struct ProgramDayDetailView: View {
             weightKg: newLog.weightKg,
             rpeFelt: newLog.rpeFelt,
             rirEstimated: newLog.rpeFelt.map { max(0, 10 - $0) },
-            primaryMuscle: ExerciseLibrary.primaryMuscle(for: newLog.exerciseId)?.rawValue ?? exerciseForLog?.primaryMuscle
+            primaryMuscle: ExerciseLibrary.primaryMuscle(for: newLog.exerciseId)?.rawValue ?? exerciseForLog?.primaryMuscle,
+            localDate: SetLog.formatLocalDate(newLog.loggedAt),
+            intent: intent.rawValue
         )
 
         do {
@@ -1107,7 +1118,8 @@ struct ProgramDayDetailView: View {
             return
         }
 
-        // Update local state immediately
+        // Update local state immediately. intent mirrors the value just persisted
+        // to set_logs so the in-memory model is consistent with the row on the server.
         let inserted = SetLog(
             id: newLog.id,
             sessionId: sessionId,
@@ -1119,7 +1131,8 @@ struct ProgramDayDetailView: View {
             rirEstimated: newLog.rpeFelt.map { max(0, 10 - $0) },
             aiPrescribed: nil,
             loggedAt: newLog.loggedAt,
-            primaryMuscle: ExerciseLibrary.primaryMuscle(for: newLog.exerciseId)?.rawValue ?? exerciseForLog?.primaryMuscle
+            primaryMuscle: ExerciseLibrary.primaryMuscle(for: newLog.exerciseId)?.rawValue ?? exerciseForLog?.primaryMuscle,
+            intent: intent
         )
         var newGroups = historicalSetLogs
         newGroups[newLog.exerciseId, default: []].append(inserted)

--- a/ProjectApex/Features/Workout/ManualSessionLogView.swift
+++ b/ProjectApex/Features/Workout/ManualSessionLogView.swift
@@ -362,7 +362,7 @@ struct ManualSessionLogView: View {
         }
 
         // Build and write set logs
-        var allSetLogs: [(SetLog, PlannedExercise)] = []
+        var allSetLogs: [(SetLog, PlannedExercise, SetIntent)] = []
         for entry in entries {
             for (setIndex, setEntry) in entry.sets.enumerated() {
                 // Skip empty sets (weight 0 and reps 0) unless user explicitly entered something
@@ -371,6 +371,14 @@ struct ManualSessionLogView: View {
                 guard reps > 0 || weight > 0 else { continue }
 
                 let rpe = parseRPE(setEntry.rpeString) ?? setEntry.rpe
+                // Slice 6 / #60: intent must be non-nil when writing to set_logs
+                // (NOT NULL schema constraint). Manual-entry picker is optional, so
+                // fall back to .top — the most likely intent for a manually logged
+                // set the user actually did. Documented at-the-call-site default per
+                // ADR-0005 "no silent defaults at any layer" — if the user didn't
+                // pick, the choice is visible in this code, not silently resolved
+                // inside the encoder.
+                let resolvedIntent: SetIntent = setEntry.intent ?? .top
 
                 let setLog = SetLog(
                     id: UUID(),
@@ -384,21 +392,15 @@ struct ManualSessionLogView: View {
                     aiPrescribed: nil,
                     loggedAt: sessionDate,
                     primaryMuscle: ExerciseLibrary.primaryMuscle(for: entry.exercise.exerciseId)?.rawValue ?? entry.exercise.primaryMuscle,
-                    // Slice 6 (#10): picker-captured intent threaded into
-                    // the SetLog client-side. ManualSetLogPayload encoder
-                    // does NOT serialise this in Phase 0 (γ — top-level
-                    // column doesn't exist; user-truthful intent for
-                    // pre-cutoff freestyle rows is the documented
-                    // trade-off). Phase 1+ Swift release will promote.
-                    intent: setEntry.intent
+                    intent: resolvedIntent
                 )
-                allSetLogs.append((setLog, entry.exercise))
+                allSetLogs.append((setLog, entry.exercise, resolvedIntent))
             }
         }
 
         // Write set logs to Supabase
-        for (setLog, _) in allSetLogs {
-            let payload = ManualSetLogPayload(from: setLog)
+        for (setLog, _, intent) in allSetLogs {
+            let payload = ManualSetLogPayload(from: setLog, intent: intent)
             do {
                 try await deps.supabaseClient.insert(payload, table: "set_logs")
             } catch {
@@ -412,7 +414,7 @@ struct ManualSessionLogView: View {
         let userIdStr = userId.uuidString
         let sessionIdStr = sessionId.uuidString
 
-        for (setLog, exercise) in allSetLogs {
+        for (setLog, exercise, _) in allSetLogs {
             let weight = setLog.weightKg
             let reps = setLog.repsCompleted
             let rpeStr = setLog.rpeFelt.map { ", RPE \($0)" } ?? ""
@@ -783,6 +785,8 @@ private struct ManualSetLogPayload: Encodable {
     let rirEstimated: Int?
     let loggedAt: String
     let primaryMuscle: String?
+    let localDate: String
+    let intent: String
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -795,9 +799,14 @@ private struct ManualSetLogPayload: Encodable {
         case rirEstimated  = "rir_estimated"
         case loggedAt      = "logged_at"
         case primaryMuscle = "primary_muscle"
+        case localDate     = "local_date"
+        case intent
     }
 
-    init(from log: SetLog) {
+    /// Slice 6 / #60 fix: intent and local_date are required by the schema.
+    /// intent is a required init parameter (compiler-enforced) per ADR-0005
+    /// "no silent defaults at any layer."
+    init(from log: SetLog, intent: SetIntent) {
         let formatter = ISO8601DateFormatter()
         self.id            = log.id.uuidString
         self.sessionId     = log.sessionId.uuidString
@@ -809,6 +818,8 @@ private struct ManualSetLogPayload: Encodable {
         self.rirEstimated  = log.rirEstimated
         self.loggedAt      = formatter.string(from: log.loggedAt)
         self.primaryMuscle = log.primaryMuscle
+        self.localDate     = SetLog.formatLocalDate(log.loggedAt)
+        self.intent        = intent.rawValue
     }
 }
 

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -334,7 +334,9 @@ actor WorkoutSessionManager {
         // 1. Write to local queue then immediately flush to Supabase (P3-T06).
         //    Immediate flush ensures each set_log lands in Supabase synchronously,
         //    so killing the app between sets never loses data.
-        let setPayload = SetLogPayload(from: setLog)
+        //    intent is the function's required parameter — threaded explicitly per
+        //    Slice 6 / #60 fix so the encoder cannot silently fall back to nil.
+        let setPayload = SetLogPayload(from: setLog, intent: intent)
         try? await writeAheadQueue.enqueue(setPayload, table: "set_logs")
         print("[WAQ] Enqueued set_log — session_id: \(session.id), set: \(setNumber), exercise: \(exercise.name), weight: \(currentPrescription?.weightKg ?? 0)kg, reps: \(actualReps)")
 
@@ -1773,6 +1775,8 @@ nonisolated private struct SetLogPayload: Encodable {
     let rirEstimated: Int?
     let loggedAt: String
     let primaryMuscle: String?
+    let localDate: String
+    let intent: String
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -1785,9 +1789,17 @@ nonisolated private struct SetLogPayload: Encodable {
         case rirEstimated  = "rir_estimated"
         case loggedAt      = "logged_at"
         case primaryMuscle = "primary_muscle"
+        case localDate     = "local_date"
+        case intent
     }
 
-    init(from log: SetLog) {
+    /// Slice 6 / #60 fix: intent is required by the schema (NOT NULL, no
+    /// default). local_date is required by the schema (NOT NULL with a
+    /// backfill-only sentinel default that this writer must not rely on,
+    /// per #63). Intent is a required parameter (compiler-enforced) rather
+    /// than read off the SetLog optional, so callers cannot silently fall
+    /// back to nil — ADR-0005 "no silent defaults at any layer."
+    init(from log: SetLog, intent: SetIntent) {
         let formatter = ISO8601DateFormatter()
         self.id = log.id.uuidString
         self.sessionId = log.sessionId.uuidString
@@ -1799,6 +1811,8 @@ nonisolated private struct SetLogPayload: Encodable {
         self.rirEstimated = log.rirEstimated
         self.loggedAt = formatter.string(from: log.loggedAt)
         self.primaryMuscle = log.primaryMuscle
+        self.localDate = SetLog.formatLocalDate(log.loggedAt)
+        self.intent = intent.rawValue
     }
 }
 

--- a/ProjectApex/Models/WorkoutSession.swift
+++ b/ProjectApex/Models/WorkoutSession.swift
@@ -200,6 +200,21 @@ nonisolated struct SetLog: Codable, Identifiable, Sendable {
     }
 }
 
+extension SetLog {
+    /// Pre-bucketed local-date string (yyyy-MM-dd) for set_logs.local_date.
+    /// Same formatter shape as TopSetSnapshot.make per ADR-0005's
+    /// timezone-immune day-boundary policy (Slice 5 / #4). Pinned to
+    /// en_US_POSIX so the format is interpreted as ISO-8601 calendar fields
+    /// regardless of host locale; timezone is explicit (default .current).
+    static func formatLocalDate(_ date: Date, in tz: TimeZone = .current) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = tz
+        return formatter.string(from: date)
+    }
+}
+
 // MARK: - SessionNote
 
 /// A voice or text note logged during a session. Mirrors the `session_notes` table.


### PR DESCRIPTION
## Summary

Fixes [#60](https://github.com/thearnavmenon/ProjectApex/issues/60) (P0 data loss — set_logs WAQ enqueue dropping rows on null `intent` NOT NULL violation) and [#63](https://github.com/thearnavmenon/ProjectApex/issues/63) (silent data corruption — set_logs.local_date sentinel default).

Both bugs share a single root cause: the Slice 6 schema migration shipped but the corresponding Swift change to promote `intent` and `local_date` into the three set_logs payload encoders never landed. The smoking-gun comment is at `Models/WorkoutSession.swift:118` — *"Phase-1+ Swift release will promote."* This is that promotion.

## What changed

Three encoders updated, one helper added, two callers updated to thread intent through, one `intent` parameter added to `addNewSetLog`.

| File | What |
|---|---|
| `Models/WorkoutSession.swift` | New `SetLog.formatLocalDate(_:in:)` helper — mirrors `TopSetSnapshot.make`'s formatter shape (en_US_POSIX, yyyy-MM-dd, explicit timezone) per ADR-0005's day-boundary policy |
| `Features/Workout/WorkoutSessionManager.swift` | `SetLogPayload` adds `intent`/`local_date` fields + `CodingKeys`; `init(from:intent:)` now requires intent. Caller at `completeSet` passes the function's existing `intent: SetIntent` parameter |
| `Features/Workout/ManualSessionLogView.swift` | `ManualSetLogPayload` same shape change. Inner loop resolves `setEntry.intent ?? .top` at the call site (visible default, ADR-0005 compliant) and threads through a 3-tuple to the write loop |
| `Features/Program/ProgramDayDetailView.swift` | Inline `NewSetLogPayload` same shape change. `addNewSetLog` now takes `intent: SetIntent` as a required parameter; caller at line 243 passes `.backoff` explicitly with a comment (typical default for retroactively-added sets) |

## Why intent is a required parameter (compiler-enforced)

Reading `setLog.intent` (which is `SetIntent?`) and falling back inside the encoder would silently encode `nil` if any caller forgot to set it — exactly the failure mode that produced #60. Making `intent: SetIntent` a required init parameter means a missed call site fails to build. ADR-0005's "no silent defaults at any layer" — at the encoder layer.

Where the call site can't avoid a default (manual-entry picker is optional; AddSet sheet doesn't yet have an intent picker), the default lives at the call site with a comment, not inside the encoder.

## What this fixes

- **#60 — data loss going forward**: `set_logs` inserts succeed (no 23502 NOT NULL violation on intent), WAQ does not drop new items, no permanent loss for sets logged after this lands.
- **#63 — silent local_date corruption going forward**: new rows have `local_date` matching the user's current local date, not the `'1970-01-01'` sentinel.

## What this does NOT fix (out of scope, follow-ups will be filed)

- **Backfill of the 278 existing set_logs rows** whose `local_date` is currently the sentinel. Per #63's recommendation: defer to (c) — alpha-cohort scale doesn't justify backfill complexity.
- **Removing the `local_date DEFAULT '1970-01-01'`** from the schema as defence-in-depth. Once all writers have shipped explicit population (this PR), the default can be removed so the next "encoder forgot a field" bug surfaces as a 23502 immediately rather than corrupting silently for weeks.
- **AddSet sheet intent picker UI**. Currently `addNewSetLog` is called with `.backoff` hardcoded. UX work to expose intent selection to the user is a separate slice.
- **Regression tests on the payload encoding shape**. Adding direct unit tests requires either (a) module-visibility refactor of the three private payload structs, or (b) integration tests via WAQ + mock URLProtocol. Both are scope expansions; tracking as a separate follow-up.

## Verification path

Re-run the on-device E2E smoke that surfaced #60 on 2026-05-07. Expected behaviour after this fix lands:

- ✅ Set logs persist to Supabase with no `WriteAheadQueue` drop logs
- ✅ New `set_logs` rows have `local_date = '2026-05-07'` (or whatever the user's local date is at write time), not `'1970-01-01'`
- ✅ The session-detail view bug ([#62](https://github.com/thearnavmenon/ProjectApex/issues/62)) is **independent** — even after this PR, real `set_logs` data still won't render in the UI; that's a separate fix

## Cross-cutting grep

Per CLAUDE.md "grep before declaring done":

- `SetLogPayload(from:` — only call site is `WorkoutSessionManager.swift:340`, updated to pass intent
- `ManualSetLogPayload(from:` — only call site is `ManualSessionLogView.swift:404`, updated to pass intent
- `NewSetLogPayload(` — only call site is in `addNewSetLog` itself; updated
- `addNewSetLog` callers — only `ProgramDayDetailView.swift:243`, updated to pass `intent: .backoff`
- `onAddSet` callers — only `ProgramDayDetailView.swift:1644` (inside SetLogAddSheet); calls the closure at 243 which now hardcodes `.backoff` — chain end, no further changes needed
- No test files reference `SetLogPayload(from:`, `ManualSetLogPayload(from:`, or `addNewSetLog` directly — no test breakage from API signature changes

## Discovered via

On-device E2E smoke for Slice 11 / PR #56 on 2026-05-07. Triage trail: #60 → #62 (view bug) → #63 (sentinel corruption) → this fix.

Closes #60
Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)