### PR TITLE
fix(slice-11/#62): scope session-detail query to week_number

### DIFF
--- a/ProjectApex/Features/Program/ProgramDayDetailView.swift
+++ b/ProjectApex/Features/Program/ProgramDayDetailView.swift
@@ -906,6 +906,17 @@ struct ProgramDayDetailView: View {
 
     /// Fetches set logs for this completed day by finding the matching workout_session
     /// then querying set_logs where session_id matches.
+    ///
+    /// Slice 11 / #62 fix: query is keyed on (user_id, day_type, **week_number**) — the
+    /// missing week_number filter caused every "Pull A" / "Push A" / etc. detail page
+    /// across every week to render the same session's data, since the prior query
+    /// matched all sessions of a given day_type and `sessions.last` returned a
+    /// non-deterministic single row. Also drops the `completed = true` filter so a
+    /// session that was started and ended early (e.g. one logged set) still renders
+    /// its own real data on its own week's detail page rather than falling through
+    /// to a different week's session. Order by session_date desc + limit 1 picks
+    /// the most recent attempt deterministically when the user has re-run a
+    /// (week, day) pair.
     @MainActor
     private func loadHistoricalSetLogs() async {
         guard currentDay.status == .completed else { return }
@@ -915,26 +926,30 @@ struct ProgramDayDetailView: View {
         let supabase = deps.supabaseClient
         let userId = deps.resolvedUserId
 
-        // Find the workout session for this day (match on day_type + user_id + completed)
-        print("[ProgramDayDetailView] Querying sessions — userId: \(userId), dayLabel: '\(currentDay.dayLabel)', status: \(currentDay.status)")
+        // Find the workout session for this day. Filters: user + day_type + week_number.
+        // No `completed` filter — incomplete sessions still render their real logged
+        // sets on their own week's page (rather than mismatching to a different week).
+        print("[ProgramDayDetailView] Querying sessions — userId: \(userId), dayLabel: '\(currentDay.dayLabel)', weekNumber: \(week.weekNumber), status: \(currentDay.status)")
         let sessions: [WorkoutSessionRow]
         do {
             sessions = try await supabase.fetch(
                 WorkoutSessionRow.self,
                 table: "workout_sessions",
                 filters: [
-                    Filter(column: "user_id",  op: .eq, value: userId.uuidString),
-                    Filter(column: "day_type", op: .eq, value: currentDay.dayLabel),
-                    Filter(column: "completed", op: .eq, value: "true")
-                ]
+                    Filter(column: "user_id",     op: .eq, value: userId.uuidString),
+                    Filter(column: "day_type",    op: .eq, value: currentDay.dayLabel),
+                    Filter(column: "week_number", op: .eq, value: "\(week.weekNumber)")
+                ],
+                order: "session_date.desc",
+                limit: 1
             )
         } catch {
             print("[ProgramDayDetailView] Failed to fetch sessions: \(error.localizedDescription)")
             return
         }
 
-        print("[ProgramDayDetailView] Found \(sessions.count) session(s) for day '\(currentDay.dayLabel)'")
-        guard let sessionRow = sessions.last else {
+        print("[ProgramDayDetailView] Found \(sessions.count) session(s) for day '\(currentDay.dayLabel)' week \(week.weekNumber)")
+        guard let sessionRow = sessions.first else {
             print("[ProgramDayDetailView] No matching session — completedSessionId stays nil, prompt will not show")
             return
         }
@@ -1526,12 +1541,16 @@ private extension String {
 private struct WorkoutSessionRow: Decodable, Identifiable {
     let id: UUID
     let dayType: String
+    let weekNumber: Int
     let completed: Bool
+    let sessionDate: Date?
 
     enum CodingKeys: String, CodingKey {
         case id
-        case dayType  = "day_type"
+        case dayType     = "day_type"
+        case weekNumber  = "week_number"
         case completed
+        case sessionDate = "session_date"
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes [#62](https://github.com/thearnavmenon/ProjectApex/issues/62). The session-detail view was rendering the same session's data on every (day_type) page across every week — hiding 43 real logged sets across 4 Pull_A sessions in the user's history.

## Root cause

`ProgramDayDetailView.loadHistoricalSetLogs` queried `workout_sessions` keyed only on `user_id` + `day_type`, then picked `sessions.last` non-deterministically. The query returned ALL sessions of a given day_type across ALL weeks, and one was picked arbitrarily — that single session's data rendered for every page in the (day_type) family.

Compounding: the `completed = true` filter excluded incomplete sessions entirely. The on-device trial (Week 4 Pull_A, ended early after one set, `completed=false`) didn't match the query at all, fell through to whichever Week 1/2/3 completed Pull_A session the broken `.last` returned, and rendered that as Week 4's "history."

## Fix

Three changes in `loadHistoricalSetLogs`:

1. **Add `week_number` filter** — each `(day_type, week_number)` page now resolves to its own session.
2. **Drop the `completed = true` filter** — incomplete sessions render their real `set_logs` on their own week's page (not a sibling week's). Empty exercises correctly show "No sets logged" rather than fabricating a different session's data.
3. **`order: session_date.desc, limit: 1`** — deterministic selection when a user has re-run a `(week, day)` pair.

`WorkoutSessionRow` decoder updated to include `week_number` and `session_date` for diagnostics; the existing log line now includes `weekNumber` for traceability.

## Cross-cutting grep (per CLAUDE.md "grep before declaring done")

Audited every workout_sessions query in product code:

| Site | Filter shape | Verdict |
|---|---|---|
| `WorkoutView.fetchLastCompletedSessionDate:118` | user-wide most-recent, no day_type | ✅ Different intent |
| `ProgramViewModel.refreshRecentSessionMeta:374` | date-windowed (7d), no day_type | ✅ Different intent |
| `ProgramViewModel.deepLiftHistory:428` | day_type, last 10, intentionally cross-week | ✅ Different intent |
| `WorkoutSessionManager.fetchCompletedSessionCount:1296` | user-wide count, no day_type | ✅ Different intent |
| `WorkoutSessionManager.stagnationRefresh:1488` | user-wide last 50, no day_type | ✅ Different intent |
| `ProgramDayDetailView.loadHistoricalSetLogs:920` | day_type, no week, .last | ✗ **Bug — fixed in this PR** |

Only `loadHistoricalSetLogs` had the `(day_type × no week)` shape. No further sites need editing.

## Verification path

Re-run the on-device click-through across Pull_A weeks 1–4 (after also merging #64 for #60 + #63):

- Each Pull_A page should show **its own week's data** — Week 1 → 11 sets; Week 2 → 16; Week 3 → 7 or 9 (whichever attempt is most recent); Week 4 → today's trial's real data (1 set after #60 fix lands)
- Week 4's page should show real data with "No sets logged" placeholders for the 4 exercises that weren't logged before the user ended early
- Continue Session / Restart Session buttons should appear correctly only on weeks where the session was incomplete (`isCompletedIncomplete` evaluates against that week's own session's logs)

## Out of scope

- The "Continue Session + Restart Session + Session Completed banner" simultaneous display — already documented in #62. After this fix, the buttons gate correctly on the *correct* session's incompleteness, which removes the worst case (showing them when no session exists for the week). The deeper "is this UI affordance combination ever correct?" UX question is separate.
- Week-mismatch in the screen header (user reported "Week 5" but header showed Week 4) — that turned out to be the user misremembering, not a bug.
- Backfill of existing data — none needed; this is a read-side fix.

Closes #62