### PR TITLE
fix(slice-11/#62): hotfix WorkoutSessionRow decoding — drop sessionDate

### DIFF
--- a/ProjectApex/Features/Program/ProgramDayDetailView.swift
+++ b/ProjectApex/Features/Program/ProgramDayDetailView.swift
@@ -1538,19 +1538,22 @@ private extension String {
 // MARK: - WorkoutSessionRow (lightweight Decodable for session query)
 
 /// Lightweight read-only row decoded from `workout_sessions` for historical set log lookup.
+/// Hotfix: `session_date` (Postgres `date` type, format "yyyy-MM-dd") is intentionally NOT
+/// decoded — the row was breaking the entire fetch when the field was typed `Date?` because
+/// the default decoder couldn't parse the bare-date format. Ordering / limit happens
+/// server-side via the `order: "session_date.desc"` query parameter, so the column never
+/// has to round-trip through Swift's decoder for this read path.
 private struct WorkoutSessionRow: Decodable, Identifiable {
     let id: UUID
     let dayType: String
     let weekNumber: Int
     let completed: Bool
-    let sessionDate: Date?
 
     enum CodingKeys: String, CodingKey {
         case id
         case dayType     = "day_type"
         case weekNumber  = "week_number"
         case completed
-        case sessionDate = "session_date"
     }
 }
 


### PR DESCRIPTION
## Hotfix on top of #68

PR #68 added `sessionDate: Date?` to `WorkoutSessionRow` as a diagnostic field. The `workout_sessions.session_date` column is Postgres `date` type (\"yyyy-MM-dd\"), not a timestamp. Swift's default JSONDecoder can't parse the bare-date format as `Date`, so every fetch threw a (flattened) DecodingError, every (week, day_type) page returned 0 rows, and every detail page rendered as if the user had no logged history.

## Confirmed live

User reported \"all the previous set logs are empty\" after merging #68. Console log:

```
[ProgramDayDetailView] Querying sessions — userId: ..., dayLabel: 'Pull_A', weekNumber: 4, status: completed
[ProgramDayDetailView] Failed to fetch sessions: Decoding error: The data couldn't be read because it isn't in the correct format.
[ProgramDayDetailView] Querying sessions — userId: ..., dayLabel: 'Pull_A', weekNumber: 3, status: completed
[ProgramDayDetailView] Failed to fetch sessions: Decoding error: The data couldn't be read because it isn't in the correct format.
[... same for every (week, day_type) combination]
```

## Fix

Drop `sessionDate` from `WorkoutSessionRow` entirely. It was diagnostic-only and not used downstream — the ordering already happens server-side via `order: \"session_date.desc\"` in the query string, so the column never has to round-trip through Swift's decoder for this read path.

Code comment added explaining why the field is intentionally absent, so a future maintainer doesn't \"helpfully\" re-add it.

## Verification

Re-run the on-device click-through across Pull_A weeks 1–4. Expected per the disambiguator query data:

- Week 1 → 11 sets visible
- Week 2 → 16 sets visible
- Week 3 → 7 sets visible (most recent of the two Week 3 attempts)
- Week 4 → empty (the trial e7e32e81 had set_count=0 due to #60; after #60 fix lands subsequent trials will show real data)

## Sibling concern flagged

[#61](https://github.com/thearnavmenon/ProjectApex/issues/61) (stagnation computation decoding error) reports the **same flattened error message** — \"The data couldn't be read because it isn't in the correct format.\" Same shape suggests the same class of bug: a Decodable type with a format-sensitive field (Date, custom enum, etc.) breaking the entire decode. Worth a separate audit of every Decodable hitting Supabase to surface latent breakage proactively.

Closes #62 (the original symptom — view never showed real data — is now actually fixed end-to-end after this lands)