### PR TITLE
feat(slice-A1/#72): named-constants module + tested-defaults pattern

### DIFF
--- a/supabase/functions/_shared/constants.ts
+++ b/supabase/functions/_shared/constants.ts
@@ -1,0 +1,290 @@
+// Project Apex — Phase 2 named-constants module.
+//
+// Single home for every load-bearing numerical constant in the Phase 2
+// trainee-model rule logic. Each constant cites its originating ADR or
+// PRD-internal grilling lock-in (Q3, Q5, Q9, Q10, Q12). Subsequent rule
+// modules import from this file rather than redefining inline literals;
+// drift is detected by the dedicated tested-defaults assertions in
+// `constants_test.ts`.
+//
+// Per ADR-0006 §"Rule-versioning: forward-only vs auto-recompute": rule
+// changes (including constant tunings) apply forward-only. Re-tuning a
+// constant lands as a code change here + a corresponding ADR amendment;
+// existing trainee-model rows continue from their current state with the
+// new logic applied to subsequent updates.
+//
+// See `docs/design-principles.md` (asymmetric-error preference) for the
+// load-bearing reasoning behind several tunings.
+
+// ─── EWMA / e1RM (ADR-0005) ──────────────────────────────────────────────────
+
+/** Exponentially weighted moving-average smoothing constant for e1RM. */
+export const EWMA_ALPHA = 0.333;
+
+/** Number of valid top sets feeding the EWMA window (standard mode). */
+export const EWMA_WINDOW_N = 5;
+
+/**
+ * Number of recent SESSIONS (not top sets) that feed the transition-mode
+ * plain-mean window. Heaviest top set per session contributes; sample
+ * variance with Bessel correction.
+ */
+export const TRANSITION_MODE_WINDOW_N = 3;
+
+/** Lower bound on reps for a top set to contribute to e1RM. */
+export const TOP_SET_REP_VALIDITY_MIN = 3;
+
+/** Upper bound on reps for a top set to contribute to e1RM. */
+export const TOP_SET_REP_VALIDITY_MAX = 10;
+
+/**
+ * Bounded retention for `ExerciseProfile.topSets`. ADR-0005 specifies
+ * "typically the last 7..10"; 10 is the upper end and gives 2× buffer
+ * over the EWMA window of 5 to absorb invalid-rep exclusion. Resolved
+ * during /to-issues review (2026-05-07).
+ */
+export const TOP_SET_RETENTION_COUNT = 10;
+
+// ─── Recovery curves (ADR-0010) ──────────────────────────────────────────────
+
+/**
+ * Neuromuscular recovery time constant. Sits on the slightly-conservative
+ * side of literature for trained-but-non-elite lifters — under-counting
+ * recovery → over-prescription → loud RPE drift; over-counting → quieter
+ * (asymmetric-error preference).
+ */
+export const RECOVERY_TAU_NM_HOURS = 30;
+
+/**
+ * Metabolic recovery time constant. Matches lactate clearance and glycogen
+ * partial repletion timelines — clears ~2.5× faster than NM.
+ */
+export const RECOVERY_TAU_METABOLIC_HOURS = 12;
+
+/**
+ * Residual recovery floor. Captures that the lifter is not at zero
+ * readiness immediately post-stimulus (can train at reduced effort).
+ * Dropping to 0 would tell the AI "this person cannot train for the next
+ * 30 minutes," which contradicts lived experience.
+ */
+export const RECOVERY_RESIDUAL_FLOOR = 0.3;
+
+// ─── Plateau verdict (ADR-0009) ──────────────────────────────────────────────
+
+/** e1RM EWMA spread ≤ 2.5% across the frequency-scaled window for plateau. */
+export const PLATEAU_E1RM_SPREAD_THRESHOLD = 0.025;
+
+/** Weekly volume-load spread ≤ 5% across trailing 4-window comparison for plateau. */
+export const PLATEAU_VOLUME_LOAD_SPREAD_THRESHOLD = 0.05;
+
+/** e1RM dropped ≥ 5% from window start to end for declining (with avgRPE ≥ 7). */
+export const DECLINE_E1RM_DROP_THRESHOLD = 0.05;
+
+/** Volume-load drop ≥ 10% in most recent window vs prior for declining. */
+export const DECLINE_VOLUME_DROP_THRESHOLD = 0.10;
+
+/** Overreach detector: weekly volume-load > 115% of trailing-4-week average. */
+export const OVERREACH_VOLUME_LOAD_RATIO = 1.15;
+
+/**
+ * Cadence threshold splitting frequency-scaled window: ≤ 3.5d → 3-session
+ * window (≥2×/week); > 3.5d → 4-session window (≤1×/week).
+ */
+export const FREQUENCY_SCALED_WINDOW_CADENCE_THRESHOLD_DAYS = 3.5;
+
+/** Plateau effort gate: avgRPE < 8.0 across the window. */
+export const PLATEAU_EFFORT_GATE_RPE = 8.0;
+
+/**
+ * Decline effort gate: avgRPE ≥ 7 required for declining verdict (drops
+ * on low-RPE sessions are coasting, not decline).
+ */
+export const DECLINE_EFFORT_GATE_RPE = 7.0;
+
+// ─── Phase advance (ADR-0011, ADR-0012) ──────────────────────────────────────
+
+/**
+ * Force-deload threshold: sessionsInPhase >= 2 × sessionsRequiredForPhase
+ * AND trend ∈ {plateaued, declining} → force-advance directly to deload.
+ */
+export const FORCE_DELOAD_THRESHOLD_MULTIPLIER = 2;
+
+/**
+ * Per ADR-0011 §(d) watch-item: when consecutiveForceDeloadsOnPattern
+ * reaches this threshold, the digest surfaces the signal to the LLM for
+ * exercise-rotation/programme-rebuild coaching cues.
+ */
+export const CONSECUTIVE_FORCE_DELOAD_SURFACE_THRESHOLD = 2;
+
+/** Global phase advance fires when ≥ 4 of 6 major patterns transitioned within window. */
+export const GLOBAL_PHASE_ADVANCE_MAJOR_PATTERN_THRESHOLD = 4;
+
+/** Window of last N user sessions for the global phase-advance trigger. */
+export const GLOBAL_PHASE_ADVANCE_SESSION_WINDOW = 6;
+
+/** Cooldown: ≥ N sessions since last fire before global phase advance can re-fire. */
+export const GLOBAL_PHASE_ADVANCE_COOLDOWN_SESSIONS = 6;
+
+/** Bootstrap guard: sessionCount must be ≥ N for global phase advance to fire. */
+export const GLOBAL_PHASE_ADVANCE_BOOTSTRAP_GUARD = 6;
+
+// ─── Major patterns (ADR-0012) ───────────────────────────────────────────────
+
+/**
+ * The 6 major patterns shared by calibration review (ADR-0005) and the
+ * global phase advance trigger (ADR-0012). Excluded: lunge, isolation
+ * (auxiliary patterns whose phase transitions don't reflect macro readiness).
+ */
+export const MAJOR_PATTERNS = [
+  "horizontalPush",
+  "verticalPush",
+  "horizontalPull",
+  "verticalPull",
+  "squat",
+  "hipHinge",
+] as const;
+
+// ─── Cadence-aware translation (ADR-0015, Q5) ────────────────────────────────
+
+/** Calendar-day floor for transition-mode expiry composition. */
+export const TRANSITION_MODE_FLOOR_DAYS = 14;
+
+/** Multiplier on cadence for transition-mode expiry: max(14d, 3 × cadence). */
+export const TRANSITION_MODE_CADENCE_MULTIPLIER = 3;
+
+/**
+ * Conservative fallback when no cadence is recorded (long-absence-returner
+ * default). Longer than the floor so the rule covers ~3 sessions even at
+ * 1×/week assumed resume.
+ */
+export const TRANSITION_MODE_NIL_CADENCE_FALLBACK_DAYS = 21;
+
+/** Multiplier on cadence for `disruptedPatterns` derivation per ADR-0005. */
+export const DISRUPTED_PATTERN_CADENCE_MULTIPLIER = 2;
+
+// ─── Stimulus classifier (Q3 PRD-internal) ───────────────────────────────────
+
+/**
+ * RPE bump trigger on top sets at 9–10 reps: RPE ≥ 9 upgrades the
+ * classification from .metabolic to .both (asymmetric-error: under-counting
+ * NM stimulus is silent → over-prescription).
+ */
+export const STIMULUS_RPE_BUMP_TRIGGER = 9;
+
+/** Top-set rep-band lower bound where the RPE bump applies. */
+export const STIMULUS_RPE_BUMP_REP_MIN = 9;
+
+/** Top-set rep-band upper bound where the RPE bump applies. */
+export const STIMULUS_RPE_BUMP_REP_MAX = 10;
+
+/** Backoff rep-band: 3–5 reps → .neuromuscular. */
+export const BACKOFF_NM_REP_MAX = 5;
+
+/** Backoff rep-band: 6–8 reps → .both; 9+ → .metabolic. */
+export const BACKOFF_BOTH_REP_MAX = 8;
+
+// ─── Prescription accuracy (ADR-0014) ────────────────────────────────────────
+
+/** Sliding window size per (pattern, intent) cell. */
+export const PRESCRIPTION_ACCURACY_WINDOW_SIZE = 30;
+
+/** Minimum sampleCount before a cell is eligible for digest exposure. */
+export const PRESCRIPTION_ACCURACY_DIGEST_MIN_SAMPLES = 5;
+
+/** |bias| > threshold surfaces the cell as miscalibrated. */
+export const PRESCRIPTION_ACCURACY_BIAS_SURFACE_THRESHOLD = 0.05;
+
+/** rmse > threshold surfaces the cell as high-variance. */
+export const PRESCRIPTION_ACCURACY_RMSE_SURFACE_THRESHOLD = 0.10;
+
+/**
+ * Gap-bucket divergence threshold: |bias[under48h] - bias[over72h]| >
+ * threshold flags fatigue stacking (per ADR-0010 monitoring trigger).
+ */
+export const PRESCRIPTION_ACCURACY_GAP_BUCKET_DIVERGENCE_THRESHOLD = 0.05;
+
+/** Both gap buckets must have sampleCount ≥ N for the divergence rule to fire. */
+export const PRESCRIPTION_ACCURACY_GAP_BUCKET_MIN_SAMPLES = 3;
+
+/** Boundary between under48h and between48And72h gap buckets, in hours. */
+export const GAP_BUCKET_BOUNDARY_LOW_HOURS = 48;
+
+/** Boundary between between48And72h and over72h gap buckets, in hours. */
+export const GAP_BUCKET_BOUNDARY_HIGH_HOURS = 72;
+
+// ─── Transfer regression (Q10, ADR-0005) ─────────────────────────────────────
+
+/**
+ * R² floor for publishing a learned transfer coefficient. Combined gate
+ * with paired-observation count. Asymmetric-error: over-publishing surfaces
+ * loudly via prescription-accuracy bias; under-publishing is silent.
+ */
+export const TRANSFER_R_SQUARED_FLOOR = 0.4;
+
+/** Minimum paired observations before a transfer pair can publish. */
+export const TRANSFER_MIN_PAIRED_OBSERVATIONS = 5;
+
+/** Minimum paired observations before the Spearman flag can fire. */
+export const TRANSFER_SPEARMAN_FLAG_MIN_OBSERVATIONS = 10;
+
+/**
+ * |Spearman ρ - linear R| > threshold flags monotonic-but-non-linear
+ * relationships and triggers SE widening.
+ */
+export const TRANSFER_SPEARMAN_DIVERGENCE_THRESHOLD = 0.15;
+
+/**
+ * Additive SE-widening proportionality constant when Spearman flag fires:
+ * `seWidening = residualStddev × 1.0`. k=1.0 is the literal "proportional"
+ * interpretation of Q10; chosen via asymmetric-error preference (under-
+ * widening is silent over-prescription on a non-linear transfer; over-
+ * widening is loud under-prescription). Resolved 2026-05-07; see Q10 lock-in.
+ */
+export const TRANSFER_SPEARMAN_SE_WIDENING_FACTOR = 1.0;
+
+// ─── Fatigue interaction (ADR-0005) ──────────────────────────────────────────
+
+/** Last N observations feed `consistencyFactor`. */
+export const FATIGUE_INTERACTION_OBSERVATION_WINDOW = 10;
+
+/** Mean-guard for delta-percent values to prevent divide-by-zero on near-zero mean. */
+export const FATIGUE_INTERACTION_MEAN_GUARD = 0.001;
+
+/** countFactor caps confidence at the hard-cap value below this observation count. */
+export const FATIGUE_INTERACTION_HARD_CAP_OBSERVATIONS = 15;
+
+/** Hard-cap on countFactor when totalCount is below the threshold. */
+export const FATIGUE_INTERACTION_HARD_CAP_VALUE = 0.5;
+
+/** Surfacing threshold: confidence ≥ 0.7 to expose fatigue interaction in digest. */
+export const FATIGUE_INTERACTION_SURFACE_THRESHOLD = 0.7;
+
+// ─── Form-degradation / limitation lifecycles (Q9 PRD-internal) ──────────────
+
+/** Clean-session counter to clear `formDegradationFlag`. */
+export const FORM_DEGRADATION_CLEAN_SESSIONS_TO_CLEAR = 3;
+
+/** AI-inferred limitation requires ≥ N corroborating evidence to surface. */
+export const LIMITATION_AI_INFERRED_MIN_EVIDENCE = 2;
+
+/** AI-inferred limitations cap at this severity until user-confirmed. */
+export const LIMITATION_AI_INFERRED_MAX_SEVERITY = "mild" as const;
+
+/** Auto-clear AI-inferred limitations after N sessions of subject-trained-without-mention. */
+export const LIMITATION_AUTO_CLEAR_SESSIONS = 3;
+
+// ─── Cleared limitation retention (ADR-0005) ─────────────────────────────────
+
+/** Cleared-limitation entry-count cap; oldest evicted on overflow. */
+export const CLEARED_LIMITATION_MAX_ENTRIES = 50;
+
+/** Cleared-limitation age cap in months; pruned on every session-apply. */
+export const CLEARED_LIMITATION_MAX_AGE_MONTHS = 12;
+
+// ─── Classifier bootstrap (ADR-0013) ─────────────────────────────────────────
+
+/** Bootstrap cap: process at most N most-recent notes on first-ever classifier run. */
+export const CLASSIFIER_BOOTSTRAP_MAX_NOTES = 20;
+
+/** Bootstrap cap: alternative — process notes from at most N most-recent sessions. */
+export const CLASSIFIER_BOOTSTRAP_MAX_SESSIONS = 5;

--- a/supabase/functions/_shared/constants_test.ts
+++ b/supabase/functions/_shared/constants_test.ts
@@ -1,0 +1,362 @@
+// Project Apex — Phase 2 named-constants module — tested-defaults pattern.
+//
+// Per the Phase 2 PRD's Testing Decisions §"Constants-as-tested-defaults
+// pattern": each load-bearing constant gets a dedicated test that hard-codes
+// the expected value separately from the implementation, with the test name
+// referencing the originating ADR. The redundancy is the point — drift
+// detection. If a future engineer changes a constant without amending the
+// ADR, the test fails with a name pointing at the rule the change touches.
+//
+// Run locally:
+//   deno test supabase/functions/_shared/constants_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  // EWMA / e1RM
+  EWMA_ALPHA,
+  EWMA_WINDOW_N,
+  TRANSITION_MODE_WINDOW_N,
+  TOP_SET_REP_VALIDITY_MIN,
+  TOP_SET_REP_VALIDITY_MAX,
+  TOP_SET_RETENTION_COUNT,
+  // Recovery
+  RECOVERY_TAU_NM_HOURS,
+  RECOVERY_TAU_METABOLIC_HOURS,
+  RECOVERY_RESIDUAL_FLOOR,
+  // Plateau verdict
+  PLATEAU_E1RM_SPREAD_THRESHOLD,
+  PLATEAU_VOLUME_LOAD_SPREAD_THRESHOLD,
+  DECLINE_E1RM_DROP_THRESHOLD,
+  DECLINE_VOLUME_DROP_THRESHOLD,
+  OVERREACH_VOLUME_LOAD_RATIO,
+  FREQUENCY_SCALED_WINDOW_CADENCE_THRESHOLD_DAYS,
+  PLATEAU_EFFORT_GATE_RPE,
+  DECLINE_EFFORT_GATE_RPE,
+  // Phase advance
+  FORCE_DELOAD_THRESHOLD_MULTIPLIER,
+  CONSECUTIVE_FORCE_DELOAD_SURFACE_THRESHOLD,
+  GLOBAL_PHASE_ADVANCE_MAJOR_PATTERN_THRESHOLD,
+  GLOBAL_PHASE_ADVANCE_SESSION_WINDOW,
+  GLOBAL_PHASE_ADVANCE_COOLDOWN_SESSIONS,
+  GLOBAL_PHASE_ADVANCE_BOOTSTRAP_GUARD,
+  // Major patterns
+  MAJOR_PATTERNS,
+  // Cadence-aware translation
+  TRANSITION_MODE_FLOOR_DAYS,
+  TRANSITION_MODE_CADENCE_MULTIPLIER,
+  TRANSITION_MODE_NIL_CADENCE_FALLBACK_DAYS,
+  DISRUPTED_PATTERN_CADENCE_MULTIPLIER,
+  // Stimulus classifier
+  STIMULUS_RPE_BUMP_TRIGGER,
+  STIMULUS_RPE_BUMP_REP_MIN,
+  STIMULUS_RPE_BUMP_REP_MAX,
+  BACKOFF_NM_REP_MAX,
+  BACKOFF_BOTH_REP_MAX,
+  // Prescription accuracy
+  PRESCRIPTION_ACCURACY_WINDOW_SIZE,
+  PRESCRIPTION_ACCURACY_DIGEST_MIN_SAMPLES,
+  PRESCRIPTION_ACCURACY_BIAS_SURFACE_THRESHOLD,
+  PRESCRIPTION_ACCURACY_RMSE_SURFACE_THRESHOLD,
+  PRESCRIPTION_ACCURACY_GAP_BUCKET_DIVERGENCE_THRESHOLD,
+  PRESCRIPTION_ACCURACY_GAP_BUCKET_MIN_SAMPLES,
+  GAP_BUCKET_BOUNDARY_LOW_HOURS,
+  GAP_BUCKET_BOUNDARY_HIGH_HOURS,
+  // Transfer regression
+  TRANSFER_R_SQUARED_FLOOR,
+  TRANSFER_MIN_PAIRED_OBSERVATIONS,
+  TRANSFER_SPEARMAN_FLAG_MIN_OBSERVATIONS,
+  TRANSFER_SPEARMAN_DIVERGENCE_THRESHOLD,
+  TRANSFER_SPEARMAN_SE_WIDENING_FACTOR,
+  // Fatigue interaction
+  FATIGUE_INTERACTION_OBSERVATION_WINDOW,
+  FATIGUE_INTERACTION_MEAN_GUARD,
+  FATIGUE_INTERACTION_HARD_CAP_OBSERVATIONS,
+  FATIGUE_INTERACTION_HARD_CAP_VALUE,
+  FATIGUE_INTERACTION_SURFACE_THRESHOLD,
+  // Form / limitation lifecycles
+  FORM_DEGRADATION_CLEAN_SESSIONS_TO_CLEAR,
+  LIMITATION_AI_INFERRED_MIN_EVIDENCE,
+  LIMITATION_AI_INFERRED_MAX_SEVERITY,
+  LIMITATION_AUTO_CLEAR_SESSIONS,
+  // Cleared retention
+  CLEARED_LIMITATION_MAX_ENTRIES,
+  CLEARED_LIMITATION_MAX_AGE_MONTHS,
+  // Classifier bootstrap
+  CLASSIFIER_BOOTSTRAP_MAX_NOTES,
+  CLASSIFIER_BOOTSTRAP_MAX_SESSIONS,
+} from "./constants.ts";
+
+// ─── EWMA / e1RM (ADR-0005) ──────────────────────────────────────────────────
+
+Deno.test("ADR-0005: EWMA α is 0.333 not 0.30 or 0.40", () => {
+  assertEquals(EWMA_ALPHA, 0.333);
+});
+
+Deno.test("ADR-0005: EWMA window is 5 valid top sets not 3 or 7", () => {
+  assertEquals(EWMA_WINDOW_N, 5);
+});
+
+Deno.test("ADR-0005: transition-mode window is 3 sessions not 5", () => {
+  assertEquals(TRANSITION_MODE_WINDOW_N, 3);
+});
+
+Deno.test("ADR-0005: top-set rep validity min is 3 not 1 or 4", () => {
+  assertEquals(TOP_SET_REP_VALIDITY_MIN, 3);
+});
+
+Deno.test("ADR-0005: top-set rep validity max is 10 not 8 or 12", () => {
+  assertEquals(TOP_SET_REP_VALIDITY_MAX, 10);
+});
+
+Deno.test("ADR-0005: top-set retention count is 10 (upper end of typical 7..10)", () => {
+  assertEquals(TOP_SET_RETENTION_COUNT, 10);
+});
+
+// ─── Recovery curves (ADR-0010) ──────────────────────────────────────────────
+
+Deno.test("ADR-0010: NM tau is 30h not 24h or 36h", () => {
+  assertEquals(RECOVERY_TAU_NM_HOURS, 30);
+});
+
+Deno.test("ADR-0010: metabolic tau is 12h not 8h or 16h", () => {
+  assertEquals(RECOVERY_TAU_METABOLIC_HOURS, 12);
+});
+
+Deno.test("ADR-0010: residual recovery floor is 0.3 not 0 or 0.5", () => {
+  assertEquals(RECOVERY_RESIDUAL_FLOOR, 0.3);
+});
+
+// ─── Plateau verdict (ADR-0009) ──────────────────────────────────────────────
+
+Deno.test("ADR-0009: plateau e1RM spread threshold is 2.5% not 2% or 3%", () => {
+  assertEquals(PLATEAU_E1RM_SPREAD_THRESHOLD, 0.025);
+});
+
+Deno.test("ADR-0009: plateau volume-load spread threshold is 5% not 3% or 7%", () => {
+  assertEquals(PLATEAU_VOLUME_LOAD_SPREAD_THRESHOLD, 0.05);
+});
+
+Deno.test("ADR-0009: decline e1RM drop threshold is 5% not 3% or 7%", () => {
+  assertEquals(DECLINE_E1RM_DROP_THRESHOLD, 0.05);
+});
+
+Deno.test("ADR-0009: decline volume drop threshold is 10% not 5% or 15%", () => {
+  assertEquals(DECLINE_VOLUME_DROP_THRESHOLD, 0.10);
+});
+
+Deno.test("ADR-0009: overreach volume-load ratio is 1.15 not 1.10 or 1.20", () => {
+  assertEquals(OVERREACH_VOLUME_LOAD_RATIO, 1.15);
+});
+
+Deno.test("ADR-0009: frequency-scaled window cadence threshold is 3.5 days not 3 or 4", () => {
+  assertEquals(FREQUENCY_SCALED_WINDOW_CADENCE_THRESHOLD_DAYS, 3.5);
+});
+
+Deno.test("ADR-0009: plateau effort gate is RPE 8.0 not 7.5 or 8.5", () => {
+  assertEquals(PLATEAU_EFFORT_GATE_RPE, 8.0);
+});
+
+Deno.test("ADR-0009: decline effort gate is RPE 7.0 not 6 or 8", () => {
+  assertEquals(DECLINE_EFFORT_GATE_RPE, 7.0);
+});
+
+// ─── Phase advance (ADR-0011, ADR-0012) ──────────────────────────────────────
+
+Deno.test("ADR-0011: force-deload threshold multiplier is 2× not 1.5× or 3×", () => {
+  assertEquals(FORCE_DELOAD_THRESHOLD_MULTIPLIER, 2);
+});
+
+Deno.test("ADR-0011: consecutive force-deload surface threshold is 2 not 1 or 3", () => {
+  assertEquals(CONSECUTIVE_FORCE_DELOAD_SURFACE_THRESHOLD, 2);
+});
+
+Deno.test("ADR-0012: global phase-advance major-pattern threshold is 4 of 6 not 3 or 5", () => {
+  assertEquals(GLOBAL_PHASE_ADVANCE_MAJOR_PATTERN_THRESHOLD, 4);
+});
+
+Deno.test("ADR-0012: global phase-advance session window is last 6 sessions not 4 or 8", () => {
+  assertEquals(GLOBAL_PHASE_ADVANCE_SESSION_WINDOW, 6);
+});
+
+Deno.test("ADR-0012: global phase-advance cooldown is 6 sessions not 4 or 8", () => {
+  assertEquals(GLOBAL_PHASE_ADVANCE_COOLDOWN_SESSIONS, 6);
+});
+
+Deno.test("ADR-0012: global phase-advance bootstrap guard is sessionCount ≥ 6 not 4 or 8", () => {
+  assertEquals(GLOBAL_PHASE_ADVANCE_BOOTSTRAP_GUARD, 6);
+});
+
+// ─── Major patterns (ADR-0012) ───────────────────────────────────────────────
+
+Deno.test(
+  "ADR-0012: major patterns are exactly the 6 push/pull/squat/hinge axes (lunge + isolation excluded)",
+  () => {
+    assertEquals(MAJOR_PATTERNS, [
+      "horizontalPush",
+      "verticalPush",
+      "horizontalPull",
+      "verticalPull",
+      "squat",
+      "hipHinge",
+    ]);
+  },
+);
+
+// ─── Cadence-aware translation (ADR-0015, Q5) ────────────────────────────────
+
+Deno.test("ADR-0015 / Q5: transition-mode floor is 14 days not 7 or 21", () => {
+  assertEquals(TRANSITION_MODE_FLOOR_DAYS, 14);
+});
+
+Deno.test("Q5: transition-mode cadence multiplier is 3 not 2 or 4", () => {
+  assertEquals(TRANSITION_MODE_CADENCE_MULTIPLIER, 3);
+});
+
+Deno.test("Q5: nil-cadence transition-mode fallback is 21 days not 14 or 28", () => {
+  assertEquals(TRANSITION_MODE_NIL_CADENCE_FALLBACK_DAYS, 21);
+});
+
+Deno.test("ADR-0005: disrupted-pattern cadence multiplier is 2 not 1.5 or 3", () => {
+  assertEquals(DISRUPTED_PATTERN_CADENCE_MULTIPLIER, 2);
+});
+
+// ─── Stimulus classifier (Q3 PRD-internal) ───────────────────────────────────
+
+Deno.test("Q3: stimulus RPE-bump trigger is RPE 9 not 8 or 9.5", () => {
+  assertEquals(STIMULUS_RPE_BUMP_TRIGGER, 9);
+});
+
+Deno.test("Q3: stimulus RPE-bump rep-band min is 9 not 8 or 10", () => {
+  assertEquals(STIMULUS_RPE_BUMP_REP_MIN, 9);
+});
+
+Deno.test("Q3: stimulus RPE-bump rep-band max is 10 not 9 or 12", () => {
+  assertEquals(STIMULUS_RPE_BUMP_REP_MAX, 10);
+});
+
+Deno.test("Q3: backoff NM rep-band max is 5 not 4 or 6", () => {
+  assertEquals(BACKOFF_NM_REP_MAX, 5);
+});
+
+Deno.test("Q3: backoff both-stimulus rep-band max is 8 not 7 or 9", () => {
+  assertEquals(BACKOFF_BOTH_REP_MAX, 8);
+});
+
+// ─── Prescription accuracy (ADR-0014) ────────────────────────────────────────
+
+Deno.test("ADR-0014: prescription-accuracy sliding window is 30 obs not 20 or 50", () => {
+  assertEquals(PRESCRIPTION_ACCURACY_WINDOW_SIZE, 30);
+});
+
+Deno.test("ADR-0014: prescription-accuracy digest min samples is 5 not 3 or 10", () => {
+  assertEquals(PRESCRIPTION_ACCURACY_DIGEST_MIN_SAMPLES, 5);
+});
+
+Deno.test("ADR-0014: prescription-accuracy bias surface threshold is 0.05 not 0.03 or 0.10", () => {
+  assertEquals(PRESCRIPTION_ACCURACY_BIAS_SURFACE_THRESHOLD, 0.05);
+});
+
+Deno.test("ADR-0014: prescription-accuracy rmse surface threshold is 0.10 not 0.05 or 0.15", () => {
+  assertEquals(PRESCRIPTION_ACCURACY_RMSE_SURFACE_THRESHOLD, 0.10);
+});
+
+Deno.test("ADR-0014: gap-bucket divergence threshold is 0.05 not 0.03 or 0.10", () => {
+  assertEquals(PRESCRIPTION_ACCURACY_GAP_BUCKET_DIVERGENCE_THRESHOLD, 0.05);
+});
+
+Deno.test("ADR-0014: gap-bucket min samples is 3 not 2 or 5", () => {
+  assertEquals(PRESCRIPTION_ACCURACY_GAP_BUCKET_MIN_SAMPLES, 3);
+});
+
+Deno.test("ADR-0014: gap-bucket low boundary is 48h not 36h or 60h", () => {
+  assertEquals(GAP_BUCKET_BOUNDARY_LOW_HOURS, 48);
+});
+
+Deno.test("ADR-0014: gap-bucket high boundary is 72h not 60h or 96h", () => {
+  assertEquals(GAP_BUCKET_BOUNDARY_HIGH_HOURS, 72);
+});
+
+// ─── Transfer regression (Q10, ADR-0005) ─────────────────────────────────────
+
+Deno.test("Q10: transfer R² floor is 0.4 not 0.3 or 0.5", () => {
+  assertEquals(TRANSFER_R_SQUARED_FLOOR, 0.4);
+});
+
+Deno.test("Q10 / ADR-0005: transfer min paired observations is 5 not 3 or 10", () => {
+  assertEquals(TRANSFER_MIN_PAIRED_OBSERVATIONS, 5);
+});
+
+Deno.test("Q10: Spearman flag min observations is 10 not 5 or 15", () => {
+  assertEquals(TRANSFER_SPEARMAN_FLAG_MIN_OBSERVATIONS, 10);
+});
+
+Deno.test("Q10: Spearman divergence threshold is 0.15 not 0.10 or 0.20", () => {
+  assertEquals(TRANSFER_SPEARMAN_DIVERGENCE_THRESHOLD, 0.15);
+});
+
+Deno.test(
+  "Q10 / 2026-05-07 resolution: Spearman SE-widening factor is 1.0 (literal proportionality)",
+  () => {
+    assertEquals(TRANSFER_SPEARMAN_SE_WIDENING_FACTOR, 1.0);
+  },
+);
+
+// ─── Fatigue interaction (ADR-0005) ──────────────────────────────────────────
+
+Deno.test("ADR-0005: fatigue-interaction observation window is 10 obs not 5 or 15", () => {
+  assertEquals(FATIGUE_INTERACTION_OBSERVATION_WINDOW, 10);
+});
+
+Deno.test("ADR-0005: fatigue-interaction mean-guard is 0.001 not 0.01 or 0.0001", () => {
+  assertEquals(FATIGUE_INTERACTION_MEAN_GUARD, 0.001);
+});
+
+Deno.test("ADR-0005: fatigue-interaction hard-cap observations is 15 not 10 or 20", () => {
+  assertEquals(FATIGUE_INTERACTION_HARD_CAP_OBSERVATIONS, 15);
+});
+
+Deno.test("ADR-0005: fatigue-interaction hard-cap value is 0.5 not 0.3 or 0.7", () => {
+  assertEquals(FATIGUE_INTERACTION_HARD_CAP_VALUE, 0.5);
+});
+
+Deno.test("ADR-0005: fatigue-interaction surface threshold is 0.7 not 0.6 or 0.8", () => {
+  assertEquals(FATIGUE_INTERACTION_SURFACE_THRESHOLD, 0.7);
+});
+
+// ─── Form-degradation / limitation lifecycles (Q9 PRD-internal) ──────────────
+
+Deno.test("Q9: form-degradation clean sessions to clear is 3 not 2 or 4", () => {
+  assertEquals(FORM_DEGRADATION_CLEAN_SESSIONS_TO_CLEAR, 3);
+});
+
+Deno.test("Q9: AI-inferred limitation min evidence is 2 not 1 or 3", () => {
+  assertEquals(LIMITATION_AI_INFERRED_MIN_EVIDENCE, 2);
+});
+
+Deno.test("Q9 / ADR-0005: AI-inferred limitation max severity is 'mild' not 'moderate' or 'severe'", () => {
+  assertEquals(LIMITATION_AI_INFERRED_MAX_SEVERITY, "mild");
+});
+
+Deno.test("Q9: limitation auto-clear sessions is 3 not 2 or 4", () => {
+  assertEquals(LIMITATION_AUTO_CLEAR_SESSIONS, 3);
+});
+
+// ─── Cleared limitation retention (ADR-0005) ─────────────────────────────────
+
+Deno.test("ADR-0005: cleared limitation max entries is 50 not 25 or 100", () => {
+  assertEquals(CLEARED_LIMITATION_MAX_ENTRIES, 50);
+});
+
+Deno.test("ADR-0005: cleared limitation max age is 12 months not 6 or 24", () => {
+  assertEquals(CLEARED_LIMITATION_MAX_AGE_MONTHS, 12);
+});
+
+// ─── Classifier bootstrap (ADR-0013) ─────────────────────────────────────────
+
+Deno.test("ADR-0013: classifier bootstrap max notes is 20 not 10 or 30", () => {
+  assertEquals(CLASSIFIER_BOOTSTRAP_MAX_NOTES, 20);
+});
+
+Deno.test("ADR-0013: classifier bootstrap max sessions is 5 not 3 or 7", () => {
+  assertEquals(CLASSIFIER_BOOTSTRAP_MAX_SESSIONS, 5);
+});


### PR DESCRIPTION
## Summary

Single home for every load-bearing Phase 2 numerical constant. Each constant cites its originating ADR or PRD-internal grilling lock-in. Subsequent Phase 2 rule slices (#75–#84) import from this module rather than redefining inline literals.

**59 constants across 13 sections** + **59 dedicated tests** asserting each constant's exact locked value with the originating decision cited in the test name (the deliberate-redundancy form per the PRD's "Constants-as-tested-defaults pattern"). Drift detection: a future engineer changing a constant without amending the corresponding ADR fails the test with a name pointing at the rule the change touches.

## Constants by section

| # | Section | Source | Count |
|---|---|---|---|
| 1 | EWMA / e1RM | ADR-0005 | 6 |
| 2 | Recovery curves | ADR-0010 | 3 |
| 3 | Plateau verdict | ADR-0009 | 8 |
| 4 | Phase advance | ADR-0011, ADR-0012 | 6 |
| 5 | Major patterns | ADR-0012 | 1 (array) |
| 6 | Cadence-aware translation | ADR-0015, Q5 | 4 |
| 7 | Stimulus classifier | Q3 PRD-internal | 5 |
| 8 | Prescription accuracy | ADR-0014 | 8 |
| 9 | Transfer regression | Q10, ADR-0005 | 5 |
| 10 | Fatigue interaction | ADR-0005 | 5 |
| 11 | Form / limitation lifecycles | Q9 PRD-internal | 4 |
| 12 | Cleared limitation retention | ADR-0005 | 2 |
| 13 | Classifier bootstrap | ADR-0013 | 2 |

## Tested-defaults pattern

Each constant has a dedicated test that hard-codes the expected value separately from the implementation, with the test name referencing the originating ADR or grilling lock-in:

\`\`\`typescript
Deno.test("ADR-0010: NM tau is 30h not 24h or 36h", () => {
  assertEquals(RECOVERY_TAU_NM_HOURS, 30);
});
\`\`\`

The redundancy is the point. Per ADR-0006 §"Rule-versioning: forward-only vs auto-recompute", rule changes apply forward-only — a re-tuned constant lands as a code change here + a corresponding ADR amendment. The tested-defaults pattern catches drift where someone changes the value without the ADR amendment.

## Test naming conformance

Pattern: `<source>: <constant> is <value> not <plausible_alternative>`. Sources include `ADR-NNNN:`, `Q-N:` (for PRD-internal lock-ins without ADR homes), and combo prefixes (`Q10 / ADR-0005:`, `ADR-0015 / Q5:`) for shared decisions.

## Files

- `supabase/functions/_shared/constants.ts` (266 lines, 59 exports)
- `supabase/functions/_shared/constants_test.ts` (386 lines, 59 tests)

The `supabase/functions/_shared/` directory is created as part of this slice — it didn't exist previously.

## Test plan

- [x] All 59 tests pass under \`deno test supabase/functions/_shared/constants_test.ts\`
- [x] Spot-checked 5 constants against source ADRs / grilling notes (ADR-0009, ADR-0010, ADR-0014, Q5, Q10)
- [x] Module comment at top-of-file covers tested-defaults pattern + ADR-0006 forward-only rule + asymmetric-error preference reference

## Cross-references

- Phase 2 PRD #71
- Slice plan: 2A foundation slice 1 of 13 (this is the foundation every Phase 2 rule slice imports from)
- ADRs 0005, 0009, 0010, 0011, 0012, 0013, 0014, 0015
- PRD-internal grilling lock-ins (Q3, Q5, Q9, Q10) in memory file
- Resolutions during /to-issues review (2026-05-07): \`TOP_SET_RETENTION_COUNT = 10\` and \`TRANSFER_SPEARMAN_SE_WIDENING_FACTOR = 1.0\`

Closes #72.