### PR TITLE
docs(adr-0009): amend with muscle-level aggregation rule

### DIFF
--- a/docs/adr/0009-hybrid-plateau-verdict-semantics.md
+++ b/docs/adr/0009-hybrid-plateau-verdict-semantics.md
@@ -1,6 +1,6 @@
 # Hybrid plateau verdict semantics on the trainee model
 
-**Status**: accepted, 2026-05-07
+**Status**: accepted, 2026-05-07; amended 2026-05-07 (muscle-level aggregation rule)
 
 ## Context
 
@@ -49,6 +49,49 @@ The trainee model populates `MuscleProfile.stagnationStatus` and `PatternProfile
 | any         | declining    | `declining`   |
 
 Where "improving" means neither plateau nor declining on that track. Plateau requires both tracks flat — not e1RM-only flat — because volume-shifted progression (e1RM stuck, working sets climbing) is real progress that the verdict must not bury.
+
+### Aggregation to `MuscleProfile.stagnationStatus` (amended 2026-05-07)
+
+The original ADR text described the e1RM track as "per-pattern, per-exercise — aggregates up to muscle" without pinning the aggregation rule. This amendment fills that hole.
+
+**Rule:** for each `MuscleGroup M`, `MuscleProfile.stagnationStatus` is the **worst** trend across the participating patterns, where worst order is `declining > plateaued > progressing`.
+
+**Participation precondition:** a pattern `P` participates in muscle `M`'s aggregation iff:
+- `∃` exercise `e` such that `ExerciseLibrary.primaryMuscle(e).muscleGroup == M` and `e.movementPattern == P`, AND
+- `PatternProfile[P].confidence > .bootstrapping` (the pattern has accumulated enough data for its trend to be evaluable).
+
+**Empty-participation case** (zero patterns above bootstrapping confidence map to `M`):
+- `stagnationStatus = .progressing` — `ProgressionTrend` has no `.bootstrapping` case; `.progressing` is the no-signal default.
+- The cold-start signal is carried by `MuscleProfile.confidence`, which stays at `.bootstrapping` independently. LLM digest consumers MUST read both fields — when `confidence == .bootstrapping`, the `stagnationStatus` value carries no actionable signal regardless of its trend value.
+
+**Why worst-across-patterns** (asymmetric-error preference per `docs/design-principles.md`):
+- Loud failure mode: muscle reads `.declining` because one pattern is declining → triggers exercise-rotation / programme-rebuild coaching cues; the user can override or RPE will quickly disconfirm if the muscle is actually fine.
+- Silent failure mode: muscle reads `.progressing` while one pattern is regressing → no coaching intervention; the regressing pattern accumulates damage.
+- Pick the loud one.
+
+**Considered alternatives:**
+- **Majority-vote with worst tiebreak** — smoother, more representative of average pattern state, but a 3-progressing/3-plateaued tie aggregates to plateaued (or progressing under a different tiebreak); the tiebreak rule is itself a decision and either direction has the asymmetric-error problem unsolved.
+- **Re-apply the hybrid verdict at muscle level** (compute muscle-level e1RM track aggregating exercises whose `primaryMuscle.muscleGroup == M`, plus the already-per-muscle volume-load track, then run the OR/AND aggregation table at muscle level) — architecturally cleaner; reuses verdict logic. Rejected for v2 because muscle-level e1RM aggregation requires a sub-decision (max-of-exercises vs mean vs primary-exercise dominance) that ducks the same grilling. Documented as the v2.x upgrade path below.
+
+**Concentration of aggregation risk on `legs` and `back`:**
+
+The "one bad pattern poisons the muscle signal" risk is concentrated on muscle groups with multiple participating patterns:
+- `legs`: 3 primary patterns (squat, hipHinge, lunge)
+- `back`: 2 primary patterns (horizontalPull, verticalPull)
+- `chest`, `shoulders`, `biceps`, `triceps`: 1 or 0 primary patterns (single-pattern muscles aggregate trivially)
+
+Squat plateaus are particularly common (squat is the most-trained lower-body lift in alpha-cohort training programmes); under worst-across-patterns, a single squat plateau forces `legs.stagnationStatus = .plateaued` even when hipHinge and lunge are progressing. **This is the right direction by asymmetric-error reasoning, but it's also the most likely place where alpha-cohort behaviour pushes toward the v2.x upgrade.**
+
+**Watch trigger** (catalogued in `docs/v2.x-watch-items.md`): if leg-muscle `stagnationStatus` reads `.plateaued` more than ~30% of the time across the alpha cohort's session-applies, that's the signal to re-apply ADR-0009's hybrid verdict at muscle level (the v2.x upgrade path) rather than aggregating from per-pattern verdicts. Until that trigger fires, worst-across-patterns is the right v2 rule.
+
+**v2.x upgrade path:**
+
+If alpha cohort surfaces the legs-aggregation problem, v2.x re-applies this ADR's verdict table at the muscle level. The required sub-decisions for that upgrade:
+1. Muscle-level e1RM aggregation rule (max-of-exercises vs mean vs primary-exercise dominance per muscle).
+2. Whether to keep per-pattern `PatternProfile.trend` as a separate signal alongside the muscle-level verdict, or derive it from the muscle-level result.
+3. Whether the volume-load track stays per-muscle (already its v2 shape) or stratifies further.
+
+The v2.x upgrade is forward-only per ADR-0006 — no auto-recompute of historical aggregations.
 
 ## Considered Options
 

--- a/docs/v2.x-watch-items.md
+++ b/docs/v2.x-watch-items.md
@@ -36,16 +36,22 @@ The current `MuscleGroup` enum is locked-six (back, chest, biceps, shoulders, tr
 ### 8. Consecutive force-deload automated remediation
 ADR-0011 introduces `consecutiveForceDeloadsOnPattern: Int` and surfaces it to the LLM digest at counter ≥ 2 for natural-language exercise-rotation/programme-rebuild coaching. v2 leaves the actual remediation (exercise rotation, programme rebuild) to the AI's natural-language coaching rather than automating it. Future versions may add deterministic rotation logic — e.g., automatic exercise substitution from a pool of equivalents — but v2 ships the signal only. **Source: ADR-0011 §(d) Watch-item: consecutive force-deloads.**
 
+## Muscle-level aggregation
+
+### 9. Muscle stagnationStatus aggregation under worst-across-patterns
+
+ADR-0009's amendment (2026-05-07) pins `MuscleProfile.stagnationStatus` aggregation as worst-across-patterns (`declining > plateaued > progressing`) over participating patterns whose confidence > `.bootstrapping`. The "one bad pattern poisons the muscle signal" risk concentrates on muscle groups with multiple participating patterns: `legs` (3: squat, hipHinge, lunge) and `back` (2: horizontalPull, verticalPull). Squat plateaus are particularly common; one squat plateau forces `legs.stagnationStatus = .plateaued` even when hipHinge and lunge are progressing. **Trigger:** if leg-muscle `stagnationStatus` reads `.plateaued` >30% of the time across the alpha cohort's session-applies, re-apply ADR-0009's hybrid verdict at muscle level (compute muscle-level e1RM track + already-per-muscle volume-load track, run the OR/AND aggregation table at muscle level). Sub-decision required at upgrade time: muscle-level e1RM aggregation rule (max-of-exercises vs mean vs primary-exercise dominance). **Source: ADR-0009 §"Aggregation to MuscleProfile.stagnationStatus", v2.x upgrade path.**
+
 ## Late-arrival sessions
 
-### 9. Backfill mode for refused late-arrival sessions
+### 10. Backfill mode for refused late-arrival sessions
 ADR-0008 refuses session-completion events with `loggedAt < watermark` and surfaces a soft notification to the user. The historical `set_logs` rows persist; the model state misses. v2.5 may add a backfill mode that re-derives the model from scratch when refused events accumulate above some threshold — the schema choice (`last_applied_logged_at` watermark + dedupe table) supports this without further migration. Revisit if alpha cohort reports cluster around late-arrival scenarios (e.g., extended connectivity outages). **Source: ADR-0008 §Consequences, v2.5 backfill hook.**
 
 ---
 
 ## How to use this list
 
-When v2.x design starts, walk these 9 items in order and ask for each:
+When v2.x design starts, walk these 10 items in order and ask for each:
 
 1. **Has alpha cohort surfaced this as a real problem?** Check the relevant observability channel (`trainee_model.classifier_failed`, prescription-accuracy gap-bucket divergence, etc.) and any user-reported incidents.
 2. **What's the v2.x-shaped fix?** Each item carries a likely-fix sketch in its source ADR; revisit it against current alpha learnings.


### PR DESCRIPTION
## Summary

Adds §"Aggregation to MuscleProfile.stagnationStatus" to ADR-0009, pinning the muscle-level aggregation rule that the original ADR text described as "per-pattern, per-exercise — aggregates up to muscle" without specifying.

**Rule:** worst-across-patterns (\`declining > plateaued > progressing\`) over participating patterns whose confidence > \`.bootstrapping\`. Empty-participation case returns \`.progressing\` (cold-start signal carried by \`MuscleProfile.confidence\` independently).

**Why amend rather than defer to PR-time:** the rule is non-obvious (future maintainer reading "5 of 6 patterns progressing, muscle declining" would reasonably ask why) and represents a genuine asymmetric-error tradeoff between worst-across-patterns and re-applying the hybrid verdict at muscle level. Letting the decision slip into the Stage 1 orchestrator slice's PR (#83) would have meant the architectural reasoning lived in a PR description rather than the ADR.

## Decision rationale (verbatim from ADR amendment)

Asymmetric-error preference per \`docs/design-principles.md\`:
- **Loud failure:** muscle reads \`.declining\` because one pattern is declining → triggers exercise-rotation/programme-rebuild coaching cues; user can override or RPE will quickly disconfirm if muscle is actually fine
- **Silent failure:** muscle reads \`.progressing\` while one pattern is regressing → no coaching intervention; regressing pattern accumulates damage
- Pick the loud one.

## Aggregation-risk concentration on \`legs\` and \`back\`

The "one bad pattern poisons the muscle signal" risk is concentrated on muscle groups with multiple participating patterns:
- \`legs\`: 3 primary patterns (squat, hipHinge, lunge)
- \`back\`: 2 primary patterns (horizontalPull, verticalPull)
- chest, shoulders, biceps, triceps: 1 or 0 (single-pattern muscles aggregate trivially)

Squat plateaus are common in alpha-cohort training programmes; under worst-across-patterns, a single squat plateau forces \`legs.stagnationStatus = .plateaued\` even when hipHinge and lunge are progressing. **This is the right direction by asymmetric-error reasoning, but it's also the most likely place where alpha-cohort behaviour pushes toward the v2.x upgrade.**

## v2.x upgrade path catalogued

New watch-item #9 in \`docs/v2.x-watch-items.md\`:

> If leg-muscle stagnationStatus reads \`.plateaued\` >30% of the time across alpha cohort, that's the trigger to re-apply ADR-0009's hybrid verdict at muscle level (compute muscle-level e1RM track + already-per-muscle volume-load track, run the OR/AND aggregation table at muscle level).

Existing item 9 (Backfill mode for refused late-arrival sessions) renumbered to 10. List header updated from "9 items" to "10 items".

## Files

- \`docs/adr/0009-hybrid-plateau-verdict-semantics.md\` — adds §"Aggregation to MuscleProfile.stagnationStatus" + rule + alternatives + asymmetric-error rationale + watch-item reference + v2.x upgrade path; status line updated to "amended 2026-05-07"
- \`docs/v2.x-watch-items.md\` — new watch-item #9 (muscle aggregation), renumbered late-arrival backfill to #10, updated "How to use" count

## Sequencing

This PR is independent of #90 (Slice A1 named-constants module) — A1 doesn't reference the amendment. Either order works. Worth landing now while the resolution is fresh; otherwise sits as state easy to lose track of.

The amendment is consumed by:
- Issue #78 (plateau-verdict slice) — issue body already updated to fold in the resolved aggregation rule with concrete test cases
- Issue #83 (Stage 1 orchestrator) — wires \`aggregateMuscleStagnationStatus\` from #78 into the Stage 1 transactional path

## Test plan

- [x] ADR amendment text reads cleanly alongside original ADR-0009 decision section
- [x] Watch-item #9 carries the trigger ("legs >30% plateau across alpha cohort") + v2.x upgrade sketch + sub-decision needed at upgrade time
- [x] No code changes — pure docs PR; no test runs needed

## Cross-references

- ADR-0009 (primary)
- \`docs/design-principles.md\` (asymmetric-error preference)
- Issue #78 (plateau-verdict slice — already references this amendment)
- Issue #83 (Stage 1 orchestrator — composes the amendment's rule)
- Resolved during /to-issues review 2026-05-07; see Phase 2 grilling lock-ins memory file for the alternatives weighed