### PR TITLE
chore: append Karpathy coding-discipline guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,69 @@ git -C /Users/arnav/Desktop/ProjectApex/.claude/worktrees/<name> push ...
 ```
 
 Same rule for `git status`, `git log`, `git diff` when you need them to reflect the worktree's state. Read tools (`Read`, `grep` on absolute paths) are unaffected — they don't depend on cwd.
+
+## Coding Discipline (Karpathy Guidelines)
+
+_Adapted from forrestchang/andrej-karpathy-skills, derived from Andrej Karpathy's observations on LLM coding pitfalls._
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.


### PR DESCRIPTION
## Summary

Appends a four-principle "Coding Discipline (Karpathy Guidelines)" section to the bottom of CLAUDE.md, capturing observations on LLM coding pitfalls:

1. **Think Before Coding** — surface assumptions, present alternatives, don't pick silently.
2. **Simplicity First** — minimum code that solves the problem, nothing speculative.
3. **Surgical Changes** — touch only what you must; clean up only your own mess.
4. **Goal-Driven Execution** — define verifiable success criteria for each task.

Adapted from `forrestchang/andrej-karpathy-skills`. Complements the existing Mattpocock workflow skills (`to-prd`, `to-issues`, `tdd`) which handle workflow shape; these guidelines handle coding behaviour.

## Provenance

This commit (`79ed4d6` originally) was authored locally on 2026-05-07 against `chore/phase-1-retrospective` after PR #59 merged, but never pushed. Recovered during branch cleanup post-PR #92, cherry-picked onto a fresh branch off current `main`. Auto-merged cleanly with the new "Migrations workflow" section added in PR #92 (no manual conflict resolution).

## Test plan

- [ ] Read through the four principles and trim or expand any items that don't match how you actually want to work
- [ ] Confirm the section's tone fits alongside the existing Process commitment / Cross-cutting fixes prose
- [ ] Optional: cross-link from the `tdd` / `to-prd` / `to-issues` skill descriptions if that improves discoverability
- [ ] Merge when satisfied; future Claude sessions will pick up the guidelines automatically (CLAUDE.md is loaded into every session's context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)