### PR TITLE
feat(slice-A3/#74): observability channels — 3 typed log helpers + WAQ late-arrival routing

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
 		C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */; };
 		C88AB47564E9AD1E0A3C2197 /* TraineeModelUpdateJobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */; };
+		A3741A0001CAFE0001CAFE01 /* LateArrivalNotificationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */; };
 		E50E3B4CBD53ED7ABE725DB8 /* EquipmentCatalogSeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -103,6 +104,7 @@
 		7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelDigestTests.swift; sourceTree = "<group>"; };
 		85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelInteractionsTests.swift; sourceTree = "<group>"; };
 		862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelUpdateJobTests.swift; sourceTree = "<group>"; };
+		A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LateArrivalNotificationQueueTests.swift; sourceTree = "<group>"; };
 		878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelProfilesTests.swift; sourceTree = "<group>"; };
 		993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelSnapshotsTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 				7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */,
 				6437BED8DCD7F98C80FF4377 /* TraineeModelServiceTests.swift */,
 				862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */,
+				A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -393,6 +396,7 @@
 				C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */,
 				6587F62EDC961A3C558A6226 /* TraineeModelServiceTests.swift in Sources */,
 				C88AB47564E9AD1E0A3C2197 /* TraineeModelUpdateJobTests.swift in Sources */,
+				A3741A0001CAFE0001CAFE01 /* LateArrivalNotificationQueueTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -43,6 +43,8 @@ final class AppDependencies {
     let traineeModelLocalStore: TraineeModelLocalStore
     /// WAQ adapter: routes trainee_model_updates items to the Edge Function (Phase 1 / Slice 11).
     let traineeModelUpdateJob: TraineeModelUpdateJob
+    /// Pending late-arrival notifications surfaced on the post-session summary (Phase 2 / Slice A3, ADR-0008).
+    let lateArrivalNotificationQueue: LateArrivalNotificationQueue
     /// Orchestrates the full set-by-set AI coaching loop during active workout sessions.
     let workoutSessionManager: WorkoutSessionManager
 
@@ -147,7 +149,13 @@ final class AppDependencies {
         // makeShared() can fail only if SwiftData can't create the container — treat as fatal.
         let tmStore = (try? TraineeModelLocalStore.makeShared()) ?? (try! TraineeModelLocalStore.makeInMemory())
         self.traineeModelLocalStore = tmStore
-        let tmJob = TraineeModelUpdateJob(supabase: supabaseClient, store: tmStore)
+        let lateArrivalQueue = LateArrivalNotificationQueue.makeShared()
+        self.lateArrivalNotificationQueue = lateArrivalQueue
+        let tmJob = TraineeModelUpdateJob(
+            supabase: supabaseClient,
+            store: tmStore,
+            notificationQueue: lateArrivalQueue
+        )
         self.traineeModelUpdateJob = tmJob
         // Register the handler with the WAQ. Done via Task so the async WAQ actor hop
         // doesn't block the synchronous init. The Task is scheduled immediately and

--- a/ProjectApex/Features/Workout/PostWorkoutSummaryView.swift
+++ b/ProjectApex/Features/Workout/PostWorkoutSummaryView.swift
@@ -43,6 +43,15 @@ struct PostWorkoutSummaryView: View {
 
     @State private var insightsState: InsightsState = .loading
 
+    // MARK: - Late-Arrival Notifications (Slice A3 / ADR-0008)
+
+    /// Pending late-arrival notifications dequeued from
+    /// `AppDependencies.lateArrivalNotificationQueue` on appearance.
+    /// Renders a soft banner above the trophy header; dismiss-on-tap.
+    /// Preview-friendly: previews can seed this directly to verify the
+    /// banner stack without booting the WAQ.
+    @State var lateArrivalNotices: [LateArrivalNotification] = []
+
     // MARK: - Body
 
     var body: some View {
@@ -56,6 +65,13 @@ struct PostWorkoutSummaryView: View {
                     if summary.earlyExitReason != nil {
                         partialSessionBadge
                             .padding(.top, 20)
+                    }
+
+                    // Late-arrival notifications (Slice A3 / ADR-0008)
+                    if !lateArrivalNotices.isEmpty {
+                        lateArrivalNoticesSection
+                            .padding(.top, summary.earlyExitReason != nil ? 12 : 20)
+                            .padding(.horizontal, 24)
                     }
 
                     // Trophy header
@@ -123,7 +139,53 @@ struct PostWorkoutSummaryView: View {
             }
         }
         .task {
+            // Dequeue any late-arrival notifications enqueued by
+            // TraineeModelUpdateJob since this surface was last shown
+            // (per ADR-0008). Dequeue is atomic — second appearance
+            // shows nothing unless a fresh refusal happened in between.
+            lateArrivalNotices = deps.lateArrivalNotificationQueue.dequeueAll()
             await loadInsights()
+        }
+    }
+
+    // MARK: - Late-Arrival Notices
+
+    private var lateArrivalNoticesSection: some View {
+        VStack(spacing: 8) {
+            ForEach(lateArrivalNotices) { notice in
+                Button {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        lateArrivalNotices.removeAll { $0.id == notice.id }
+                    }
+                } label: {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "clock.badge.exclamationmark")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(Color(red: 1.0, green: 0.75, blue: 0.0))
+                            .padding(.top, 1)
+                        Text(notice.message)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.80))
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Spacer(minLength: 8)
+                        Image(systemName: "xmark")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.40))
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(red: 1.0, green: 0.75, blue: 0.0).opacity(0.10),
+                                in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(Color(red: 1.0, green: 0.75, blue: 0.0).opacity(0.30), lineWidth: 0.5)
+                    )
+                }
+                .buttonStyle(.plain)
+            }
         }
     }
 
@@ -727,4 +789,37 @@ struct PostWorkoutSummaryView: View {
     )
     .environment(AppDependencies())
     .preferredColorScheme(.dark)
+}
+
+#Preview("Late-Arrival Notice") {
+    // Slice A3 / ADR-0008: fixture exercises the soft notification banner
+    // without needing the WAQ flush path. Use this preview at PR-review
+    // time to eyeball the banner's copy + spacing before merge.
+    var view = PostWorkoutSummaryView(
+        summary: SessionSummary(
+            totalVolumeKg: 4520,
+            setsCompleted: 18,
+            setsPlanned: 20,
+            personalRecords: [],
+            aiAdjustmentCount: 14,
+            notableNotes: [],
+            earlyExitReason: nil,
+            durationSeconds: 3720
+        ),
+        streak: StreakResult.compute(currentStreakDays: 7, longestStreak: 10),
+        onDone: {}
+    )
+    view.lateArrivalNotices = [
+        LateArrivalNotification(
+            id: UUID(),
+            message: LateArrivalNotification.lockedMessage,
+            receiptDate: Date(),
+            sessionId: nil,
+            incomingLoggedAt: nil,
+            watermark: nil
+        )
+    ]
+    return view
+        .environment(AppDependencies())
+        .preferredColorScheme(.dark)
 }

--- a/ProjectApex/Models/LateArrivalNotification.swift
+++ b/ProjectApex/Models/LateArrivalNotification.swift
@@ -1,0 +1,59 @@
+// Models/LateArrivalNotification.swift
+// ProjectApex — Phase 2 / Slice A3 / issue #74
+//
+// Soft post-session notification surfaced to the user when the Edge
+// Function refuses a session-completion event because its `loggedAt`
+// is earlier than the trainee model's last-applied watermark
+// (ADR-0008 §"Late arrival"). The notification's existence on the
+// post-session summary is the alpha cohort's signal channel for
+// whether late-arrival is a real problem; the user's training history
+// is preserved either way.
+//
+// Lifecycle: enqueued by `TraineeModelUpdateJob` on `late_arrival:true`
+// HTTP responses, dequeued by `PostWorkoutSummaryView` on appearance,
+// dismissed-on-tap.
+//
+// Forward-compat: `sessionId`, `incomingLoggedAt`, and `watermark` are
+// optional. A3-shipped notifications populate only `id`, `message`, and
+// `receiptDate`; A12 will populate the optional fields when the richer
+// Edge Function response shape ships. Locking the struct schema now
+// avoids an awkward UserDefaults-data migration later.
+
+import Foundation
+
+// MARK: - LateArrivalNotification
+
+/// Codable record of a single late-arrival event for post-session UI.
+struct LateArrivalNotification: Codable, Equatable, Identifiable {
+    /// Per-notification identifier — distinct from `sessionId` so that the
+    /// UI can dismiss one without disturbing other queued notifications.
+    let id: UUID
+
+    /// User-facing copy. Locked verbatim to ADR-0008; see `lockedMessage`.
+    let message: String
+
+    /// Wall-clock receipt time on the client. Used so the UI can display
+    /// "Logged X minutes ago" detail if desired.
+    let receiptDate: Date
+
+    /// Refused session's identifier. Populated when A12's richer response
+    /// shape ships; nil for A3-built notifications.
+    let sessionId: UUID?
+
+    /// `loggedAt` of the refused session. Populated when A12's richer
+    /// response shape ships; nil for A3-built notifications.
+    let incomingLoggedAt: Date?
+
+    /// Watermark the refused session was compared against. Populated when
+    /// A12's richer response shape ships; nil for A3-built notifications.
+    let watermark: Date?
+}
+
+extension LateArrivalNotification {
+    /// User-facing copy locked verbatim by ADR-0008 §"Decision". Any change
+    /// to this string MUST come back through ADR-0008 — paraphrases are a
+    /// regression. The corresponding test in `TraineeModelUpdateJobTests`
+    /// hard-codes the same literal so drift is caught at CI time.
+    static let lockedMessage =
+        "This session was logged after later sessions and won't update your training profile, but the history is preserved."
+}

--- a/ProjectApex/Services/LateArrivalNotificationQueue.swift
+++ b/ProjectApex/Services/LateArrivalNotificationQueue.swift
@@ -1,0 +1,99 @@
+// Services/LateArrivalNotificationQueue.swift
+// ProjectApex — Phase 2 / Slice A3 / issue #74
+//
+// UserDefaults-backed FIFO queue of pending `LateArrivalNotification`s
+// awaiting display on the post-session summary. Producer:
+// `TraineeModelUpdateJob` on `late_arrival:true` Edge Function responses
+// (per ADR-0008). Consumer: `PostWorkoutSummaryView` on `.task { ... }`.
+//
+// Why UserDefaults: matches the WriteAheadQueue's persistence pattern
+// for transient operational state. Notification volume is tiny
+// (minutes-to-hours lifecycle, dismiss-on-tap, alpha cohort scale) and
+// SwiftData's value-add — schema migration, relationships, querying —
+// doesn't apply. Convention: UserDefaults for transient operational
+// state (queues, sentinels, flags); SwiftData for entity snapshots.
+//
+// Threading: `@MainActor` because UserDefaults reads/writes from
+// arbitrary threads can race; the actor isolation centralises that.
+// `TraineeModelUpdateJob.parseResponse` already runs in async context;
+// the enqueue call hops to MainActor naturally via `await`.
+
+import Foundation
+
+// MARK: - LateArrivalNotificationQueue
+
+@MainActor
+final class LateArrivalNotificationQueue {
+
+    // MARK: - Constants
+
+    /// UserDefaults key under which the encoded `[LateArrivalNotification]`
+    /// JSON is stored. Production callers use `makeShared()`; tests use
+    /// `makeInMemory()` which scopes to a fresh suite.
+    nonisolated static let storageKey = "com.projectapex.lateArrivalNotificationQueue"
+
+    // MARK: - Dependencies
+
+    private let defaults: UserDefaults
+    private let key: String
+
+    // MARK: - Init
+
+    init(defaults: UserDefaults, key: String = LateArrivalNotificationQueue.storageKey) {
+        self.defaults = defaults
+        self.key      = key
+    }
+
+    // MARK: - Factories
+
+    /// Production queue persisted to `UserDefaults.standard`.
+    static func makeShared() -> LateArrivalNotificationQueue {
+        LateArrivalNotificationQueue(defaults: .standard)
+    }
+
+    /// In-memory queue scoped to a fresh ephemeral `UserDefaults` suite —
+    /// no cross-test leakage even when several queues exist concurrently.
+    static func makeInMemory() -> LateArrivalNotificationQueue {
+        let suiteName = "com.projectapex.tests.\(UUID().uuidString)"
+        // UserDefaults(suiteName:) returning nil means the suite name was
+        // reserved (e.g. `Globals`) — UUID-based suite names cannot collide.
+        let suite = UserDefaults(suiteName: suiteName) ?? .standard
+        return LateArrivalNotificationQueue(defaults: suite, key: storageKey)
+    }
+
+    // MARK: - Public API
+
+    /// Number of pending notifications without dequeuing.
+    var pendingCount: Int { load().count }
+
+    /// Appends `notification` to the persisted FIFO list.
+    func enqueue(_ notification: LateArrivalNotification) {
+        var pending = load()
+        pending.append(notification)
+        save(pending)
+    }
+
+    /// Returns every pending notification and clears the persisted list
+    /// atomically. Callers render the returned notifications and treat
+    /// them as consumed — there is no separate `markAsRead` step.
+    func dequeueAll() -> [LateArrivalNotification] {
+        let pending = load()
+        defaults.removeObject(forKey: key)
+        return pending
+    }
+
+    // MARK: - Persistence
+
+    private func load() -> [LateArrivalNotification] {
+        guard let data = defaults.data(forKey: key) else { return [] }
+        // Default Date strategy (.deferredToDate / TimeInterval-since-reference)
+        // round-trips Date exactly. ISO-8601 would truncate to seconds and
+        // break Equatable round-trip on sub-second receiptDates.
+        return (try? JSONDecoder().decode([LateArrivalNotification].self, from: data)) ?? []
+    }
+
+    private func save(_ notifications: [LateArrivalNotification]) {
+        guard let data = try? JSONEncoder().encode(notifications) else { return }
+        defaults.set(data, forKey: key)
+    }
+}

--- a/ProjectApex/Services/TraineeModelUpdateJob.swift
+++ b/ProjectApex/Services/TraineeModelUpdateJob.swift
@@ -59,12 +59,18 @@ final class TraineeModelUpdateJob {
 
     private let supabase: SupabaseClient
     private let store: TraineeModelLocalStore
+    private let notificationQueue: LateArrivalNotificationQueue
 
     // MARK: - Init
 
-    init(supabase: SupabaseClient, store: TraineeModelLocalStore) {
-        self.supabase = supabase
-        self.store    = store
+    init(
+        supabase: SupabaseClient,
+        store: TraineeModelLocalStore,
+        notificationQueue: LateArrivalNotificationQueue
+    ) {
+        self.supabase          = supabase
+        self.store             = store
+        self.notificationQueue = notificationQueue
     }
 
     // MARK: - Registration
@@ -82,10 +88,16 @@ final class TraineeModelUpdateJob {
     /// Returns the `@Sendable` closure that the WAQ calls for every
     /// `trainee_model_updates` item during flush.
     func makeHandler() -> @Sendable (QueuedWrite) async -> WAQFlushOutcome {
-        let supabase = self.supabase
-        let store    = self.store
+        let supabase          = self.supabase
+        let store             = self.store
+        let notificationQueue = self.notificationQueue
         return { item in
-            await TraineeModelUpdateJob.flush(item, supabase: supabase, store: store)
+            await TraineeModelUpdateJob.flush(
+                item,
+                supabase: supabase,
+                store: store,
+                notificationQueue: notificationQueue
+            )
         }
     }
 
@@ -94,7 +106,8 @@ final class TraineeModelUpdateJob {
     private static func flush(
         _ item: QueuedWrite,
         supabase: SupabaseClient,
-        store: TraineeModelLocalStore
+        store: TraineeModelLocalStore,
+        notificationQueue: LateArrivalNotificationQueue
     ) async -> WAQFlushOutcome {
         // POST item.payload (already-encoded TraineeModelUpdatePayload JSON) to Edge Function.
         let responseData: Data
@@ -107,7 +120,7 @@ final class TraineeModelUpdateJob {
             return .transientFailure
         }
 
-        return await parseResponse(responseData, item: item, store: store)
+        return await parseResponse(responseData, item: item, store: store, notificationQueue: notificationQueue)
     }
 
     // MARK: - Response Parsing
@@ -115,7 +128,8 @@ final class TraineeModelUpdateJob {
     private static func parseResponse(
         _ data: Data,
         item: QueuedWrite,
-        store: TraineeModelLocalStore
+        store: TraineeModelLocalStore,
+        notificationQueue: LateArrivalNotificationQueue
     ) async -> WAQFlushOutcome {
         // Response must be a JSON object containing a "trainee_model" key.
         guard
@@ -126,6 +140,28 @@ final class TraineeModelUpdateJob {
             logger.error("[\(callSite)] \(msg, privacy: .public) for item \(item.id, privacy: .public)")
             FallbackLogRecord(callSite: callSite, reason: msg).emit()
             return .permanentFailure(msg)
+        }
+
+        // ADR-0008 §"Late arrival": when the Edge Function returns
+        // `late_arrival: true`, the trainee_model field is the *cached*
+        // snapshot — applying it would clobber any in-flight local edit
+        // in the (unlikely) race. Dequeue identically (return .success),
+        // skip the local snapshot update, and enqueue a soft notification
+        // for the post-session summary surface.
+        if json["late_arrival"] as? Bool == true {
+            let notification = LateArrivalNotification(
+                id: UUID(),
+                message: LateArrivalNotification.lockedMessage,
+                receiptDate: Date(),
+                // sessionId / incomingLoggedAt / watermark are populated
+                // when A12 ships the richer Edge Function response shape.
+                // A3's bool-only response leaves them nil.
+                sessionId: nil,
+                incomingLoggedAt: nil,
+                watermark: nil
+            )
+            await notificationQueue.enqueue(notification)
+            return .success
         }
 
         // Try to decode the model value. Phase 1 stub returns {} — that won't

--- a/ProjectApexTests/LateArrivalNotificationQueueTests.swift
+++ b/ProjectApexTests/LateArrivalNotificationQueueTests.swift
@@ -38,7 +38,13 @@ final class LateArrivalNotificationQueueTests: XCTestCase {
     /// Single enqueue → dequeueAll yields the exact notification, queue
     /// becomes empty afterwards. The minimum contract the post-session
     /// summary surface depends on.
-    func test_enqueueThenDequeueAll_returnsTheNotification_andEmptiesQueue() {
+    ///
+    /// `async throws` is load-bearing: XCTest dispatches sync test methods
+    /// on a background thread by default, which trips the @MainActor
+    /// isolation on `LateArrivalNotificationQueue` (SIGABRT under Swift 6
+    /// strict concurrency on iOS 26.2 CI runner). Marking the method async
+    /// forces XCTest to run it on the main actor.
+    func test_enqueueThenDequeueAll_returnsTheNotification_andEmptiesQueue() async throws {
         let queue        = LateArrivalNotificationQueue.makeInMemory()
         let notification = makeFixture()
 
@@ -60,7 +66,7 @@ final class LateArrivalNotificationQueueTests: XCTestCase {
     /// Multiple enqueues are preserved in FIFO order, all returned in one
     /// dequeueAll call. This is the contract the UI relies on when
     /// rendering the banner stack.
-    func test_multipleEnqueues_dequeueAllReturnsAllInOrder() {
+    func test_multipleEnqueues_dequeueAllReturnsAllInOrder() async throws {
         let queue = LateArrivalNotificationQueue.makeInMemory()
         let n1    = makeFixture()
         let n2    = makeFixture()
@@ -78,7 +84,7 @@ final class LateArrivalNotificationQueueTests: XCTestCase {
     /// Two queues with different in-memory backing stores must NOT see
     /// each other's notifications — verifies makeInMemory()'s isolation
     /// guarantee so concurrent tests don't leak state.
-    func test_makeInMemory_isolatesQueuesAcrossInstances() {
+    func test_makeInMemory_isolatesQueuesAcrossInstances() async throws {
         let q1 = LateArrivalNotificationQueue.makeInMemory()
         let q2 = LateArrivalNotificationQueue.makeInMemory()
 

--- a/ProjectApexTests/LateArrivalNotificationQueueTests.swift
+++ b/ProjectApexTests/LateArrivalNotificationQueueTests.swift
@@ -1,0 +1,90 @@
+// LateArrivalNotificationQueueTests.swift
+// ProjectApexTests — Phase 2 / Slice A3 / issue #74
+//
+// Round-trip tests for the UserDefaults-backed LateArrivalNotificationQueue.
+// The queue is the producer↔consumer seam between TraineeModelUpdateJob
+// (enqueues on late_arrival:true) and PostWorkoutSummaryView (dequeues
+// on .task). This test class exercises the queue itself; the WAQ-side
+// contract is in TraineeModelUpdateJobTests.
+
+import XCTest
+@testable import ProjectApex
+
+@MainActor
+final class LateArrivalNotificationQueueTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Uses the production `lockedMessage` constant so this test class
+    /// does not double as a drift detector — that role is owned by
+    /// `TraineeModelUpdateJobTests.test_flushHandler_onLateArrivalTrue_enqueuesNotificationWithLockedCopy`,
+    /// which hardcodes the literal verbatim.
+    private func makeFixture(
+        id: UUID = UUID(),
+        receiptDate: Date = Date()
+    ) -> LateArrivalNotification {
+        LateArrivalNotification(
+            id: id,
+            message: LateArrivalNotification.lockedMessage,
+            receiptDate: receiptDate,
+            sessionId: nil,
+            incomingLoggedAt: nil,
+            watermark: nil
+        )
+    }
+
+    // MARK: - Round-trip
+
+    /// Single enqueue → dequeueAll yields the exact notification, queue
+    /// becomes empty afterwards. The minimum contract the post-session
+    /// summary surface depends on.
+    func test_enqueueThenDequeueAll_returnsTheNotification_andEmptiesQueue() {
+        let queue        = LateArrivalNotificationQueue.makeInMemory()
+        let notification = makeFixture()
+
+        XCTAssertEqual(queue.pendingCount, 0, "fresh queue must start empty")
+
+        queue.enqueue(notification)
+        XCTAssertEqual(queue.pendingCount, 1)
+
+        let dequeued = queue.dequeueAll()
+        XCTAssertEqual(dequeued, [notification],
+                       "dequeueAll must return the exact enqueued notification (Codable round-trip)")
+        XCTAssertEqual(queue.pendingCount, 0,
+                       "dequeueAll must atomically clear — second call returns nothing")
+
+        XCTAssertEqual(queue.dequeueAll(), [],
+                       "subsequent dequeue on an emptied queue must return []")
+    }
+
+    /// Multiple enqueues are preserved in FIFO order, all returned in one
+    /// dequeueAll call. This is the contract the UI relies on when
+    /// rendering the banner stack.
+    func test_multipleEnqueues_dequeueAllReturnsAllInOrder() {
+        let queue = LateArrivalNotificationQueue.makeInMemory()
+        let n1    = makeFixture()
+        let n2    = makeFixture()
+        let n3    = makeFixture()
+
+        queue.enqueue(n1)
+        queue.enqueue(n2)
+        queue.enqueue(n3)
+
+        let dequeued = queue.dequeueAll()
+        XCTAssertEqual(dequeued, [n1, n2, n3],
+                       "FIFO order must be preserved across enqueue/dequeue (Codable round-trip preserves field order)")
+    }
+
+    /// Two queues with different in-memory backing stores must NOT see
+    /// each other's notifications — verifies makeInMemory()'s isolation
+    /// guarantee so concurrent tests don't leak state.
+    func test_makeInMemory_isolatesQueuesAcrossInstances() {
+        let q1 = LateArrivalNotificationQueue.makeInMemory()
+        let q2 = LateArrivalNotificationQueue.makeInMemory()
+
+        q1.enqueue(makeFixture())
+        XCTAssertEqual(q1.pendingCount, 1)
+        XCTAssertEqual(q2.pendingCount, 0,
+                       "q2 must NOT see q1's enqueue — each makeInMemory() call gets its own UserDefaults suite")
+    }
+}

--- a/ProjectApexTests/TraineeModelUpdateJobTests.swift
+++ b/ProjectApexTests/TraineeModelUpdateJobTests.swift
@@ -111,6 +111,7 @@ final class TraineeModelUpdateJobTests: XCTestCase {
 
     private var store: TraineeModelLocalStore!
     private var supabase: SupabaseClient!
+    private var notificationQueue: LateArrivalNotificationQueue!
     private var job: TraineeModelUpdateJob!
 
     private let userId    = UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!
@@ -121,15 +122,21 @@ final class TraineeModelUpdateJobTests: XCTestCase {
         TMUJMockURLProtocol.capturedRequests = []
         TMUJMockURLProtocol.requestHandler   = nil
         UserDefaults.standard.removeObject(forKey: "com.projectapex.writeAheadQueue")
-        store    = try TraineeModelLocalStore.makeInMemory()
-        supabase = makeMockSupabase()
-        job      = TraineeModelUpdateJob(supabase: supabase, store: store)
+        store             = try TraineeModelLocalStore.makeInMemory()
+        supabase          = makeMockSupabase()
+        notificationQueue = LateArrivalNotificationQueue.makeInMemory()
+        job               = TraineeModelUpdateJob(
+            supabase: supabase,
+            store: store,
+            notificationQueue: notificationQueue
+        )
     }
 
     override func tearDown() async throws {
-        job      = nil
-        supabase = nil
-        store    = nil
+        job               = nil
+        notificationQueue = nil
+        supabase          = nil
+        store             = nil
         UserDefaults.standard.removeObject(forKey: "com.projectapex.writeAheadQueue")
     }
 
@@ -333,6 +340,85 @@ final class TraineeModelUpdateJobTests: XCTestCase {
                        "permanentFailure must remove the item from the WAQ immediately (no retry)")
     }
 
+    // MARK: ─── ADR-0008 late_arrival branch (slice A3 / #74) ────────────────
+
+    /// Builds a 200 response body with the late_arrival flag set. The
+    /// trainee_model field still carries the cached snapshot per ADR-0008
+    /// ("return the cached snapshot with a `late_arrival: true` flag in the
+    /// JSON body") — the WAQ adapter must NOT propagate it to the local store.
+    private func makeLateArrivalResponse(model: TraineeModel, late: Bool) throws -> Data {
+        struct Wrapper: Encodable {
+            let traineeModel: TraineeModel
+            let lateArrival: Bool
+            enum CodingKeys: String, CodingKey {
+                case traineeModel = "trainee_model"
+                case lateArrival  = "late_arrival"
+            }
+        }
+        let enc = JSONEncoder()
+        enc.dateEncodingStrategy = .iso8601
+        return try enc.encode(Wrapper(traineeModel: model, lateArrival: late))
+    }
+
+    /// ADR-0008 §"Late arrival": the Edge Function returns 200 with
+    /// `late_arrival: true` and the *cached* snapshot. The WAQ adapter must
+    /// dequeue identically (return .success) but skip the local snapshot
+    /// update — applying the cached snapshot would clobber any in-flight
+    /// local edit in the (unlikely) race.
+    func test_flushHandler_onLateArrivalTrue_returnsSuccess_withoutSavingStore() async throws {
+        let cachedModel = makeSimpleModel()
+        let body        = try makeLateArrivalResponse(model: cachedModel, late: true)
+        respond(status: 200, body: body)
+
+        let item    = try makeQueuedItem()
+        let handler = job.makeHandler()
+        let outcome = await handler(item)
+
+        XCTAssertEqual(outcome, .success,
+                       "late_arrival:true must dequeue identically (per ADR-0008)")
+        XCTAssertNil(store.load(),
+                     "late_arrival:true must NOT update the local snapshot — the trainee_model field is the *cached* snapshot, not a fresh write")
+    }
+
+    /// ADR-0008 locks the user-visible notification copy verbatim. A paraphrase
+    /// is a regression — the test asserts the exact string so any future edit
+    /// to the message must come back through ADR-0008.
+    func test_flushHandler_onLateArrivalTrue_enqueuesNotificationWithLockedCopy() async throws {
+        let body = try makeLateArrivalResponse(model: makeSimpleModel(), late: true)
+        respond(status: 200, body: body)
+
+        let outcome = await job.makeHandler()(try makeQueuedItem())
+
+        XCTAssertEqual(outcome, .success)
+
+        let pending = notificationQueue.dequeueAll()
+        XCTAssertEqual(pending.count, 1, "Exactly one notification per refused session")
+        XCTAssertEqual(
+            pending.first?.message,
+            "This session was logged after later sessions and won't update your training profile, but the history is preserved.",
+            "Notification copy is locked verbatim from ADR-0008 — any paraphrase is a regression"
+        )
+    }
+
+    /// ADR-0008 contract for the in-order branch: explicit `late_arrival:false`
+    /// (the shape A12 will return for accepted sessions) MUST behave identically
+    /// to the existing no-flag case — store updates, queue stays empty. Locks
+    /// in the gate so a downstream slice can't accidentally route an in-order
+    /// session through the late-arrival path by toggling the flag.
+    func test_flushHandler_onLateArrivalFalse_updatesSnapshot_andLeavesQueueEmpty() async throws {
+        let model        = makeSimpleModel()
+        let responseBody = try makeLateArrivalResponse(model: model, late: false)
+        respond(status: 200, body: responseBody)
+
+        let outcome = await job.makeHandler()(try makeQueuedItem())
+
+        XCTAssertEqual(outcome, .success)
+        XCTAssertEqual(store.load(), model,
+                       "late_arrival:false must take the normal path — store gets the fresh snapshot")
+        XCTAssertEqual(notificationQueue.pendingCount, 0,
+                       "late_arrival:false must NOT enqueue a notification — only true does")
+    }
+
     // MARK: ─── Test 14: Integration smoke (APEX_INTEGRATION_TESTS=1 only) ───
 
     func test_smoke_endToEnd_edgeFunctionReceivesCall() async throws {
@@ -343,7 +429,11 @@ final class TraineeModelUpdateJobTests: XCTestCase {
         // Verifies: WAQ enqueues → handler invoked → Edge Function called → item removed.
         // The Phase 1 stub returns { trainee_model: {} } — store won't update, but pipeline is confirmed.
         let liveSupabase = SupabaseClient(supabaseURL: Config.supabaseURL, anonKey: "")
-        let liveJob      = TraineeModelUpdateJob(supabase: liveSupabase, store: store)
+        let liveJob      = TraineeModelUpdateJob(
+            supabase: liveSupabase,
+            store: store,
+            notificationQueue: LateArrivalNotificationQueue.makeInMemory()
+        )
         let liveWAQ      = WriteAheadQueue(supabase: liveSupabase)
         await liveJob.register(with: liveWAQ)
 

--- a/supabase/functions/_shared/observability.ts
+++ b/supabase/functions/_shared/observability.ts
@@ -11,6 +11,16 @@
 // `trainee_model` (rule outcomes routed to the model update path) and
 // `recovery` (curve-evaluation edge cases per ADR-0010).
 
+/**
+ * Single emit primitive. Public typed wrappers below funnel through
+ * here so that the envelope shape and sink choice live in one place —
+ * future migrations (e.g., routing to a dedicated observability table
+ * per ADR-0006's "v2.x may add a table" note) change one function body.
+ */
+function emit(channel: string, event: unknown): void {
+  console.log(JSON.stringify({ channel, event }));
+}
+
 // ─── emitLateArrival (ADR-0008) ─────────────────────────────────────────────
 
 export interface LateArrivalEvent {
@@ -22,7 +32,7 @@ export interface LateArrivalEvent {
 }
 
 export function emitLateArrival(event: LateArrivalEvent): void {
-  console.log(JSON.stringify({ channel: "trainee_model.late_arrival", event }));
+  emit("trainee_model.late_arrival", event);
 }
 
 // ─── emitClassifierFailed (ADR-0013) ────────────────────────────────────────
@@ -36,7 +46,7 @@ export interface ClassifierFailedEvent {
 }
 
 export function emitClassifierFailed(event: ClassifierFailedEvent): void {
-  console.log(JSON.stringify({ channel: "trainee_model.classifier_failed", event }));
+  emit("trainee_model.classifier_failed", event);
 }
 
 // ─── emitClockSkew (ADR-0010) ───────────────────────────────────────────────
@@ -49,5 +59,5 @@ export interface ClockSkewEvent {
 }
 
 export function emitClockSkew(event: ClockSkewEvent): void {
-  console.log(JSON.stringify({ channel: "recovery.clock_skew", event }));
+  emit("recovery.clock_skew", event);
 }

--- a/supabase/functions/_shared/observability.ts
+++ b/supabase/functions/_shared/observability.ts
@@ -1,0 +1,53 @@
+// Project Apex — Phase 2 observability emit helpers.
+//
+// Typed wrappers around structured-log emission so that every rule
+// slice (A5/A12/A13) emits envelopes with the same shape. Per ADR-0006
+// §"Observability" and #74's implementation note: the alpha-scale sink
+// is Supabase Edge Function logs, which capture stdout — every helper
+// writes a single `{ channel, event }` JSON line via console.log.
+//
+// Channel-naming convention is set here (this is the first helper
+// module): `<domain>.<event_kind>` lower-snake. Domains in v2:
+// `trainee_model` (rule outcomes routed to the model update path) and
+// `recovery` (curve-evaluation edge cases per ADR-0010).
+
+// ─── emitLateArrival (ADR-0008) ─────────────────────────────────────────────
+
+export interface LateArrivalEvent {
+  user_id: string;
+  session_id: string;
+  incoming_logged_at: string; // ISO 8601
+  watermark: string;          // ISO 8601
+  delta_seconds: number;      // negative — incoming is `delta_seconds` before watermark
+}
+
+export function emitLateArrival(event: LateArrivalEvent): void {
+  console.log(JSON.stringify({ channel: "trainee_model.late_arrival", event }));
+}
+
+// ─── emitClassifierFailed (ADR-0013) ────────────────────────────────────────
+
+export interface ClassifierFailedEvent {
+  user_id: string;
+  session_id: string;
+  /** e.g., 'haiku_unreachable', 'malformed_response', 'rate_limit_exhausted'. */
+  error_class: string;
+  notes_attempted_count: number;
+}
+
+export function emitClassifierFailed(event: ClassifierFailedEvent): void {
+  console.log(JSON.stringify({ channel: "trainee_model.classifier_failed", event }));
+}
+
+// ─── emitClockSkew (ADR-0010) ───────────────────────────────────────────────
+
+export interface ClockSkewEvent {
+  user_id: string;
+  last_stimulus_at: string;   // ISO 8601 — the future-dated timestamp
+  now: string;                // ISO 8601 — server time at evaluation
+  delta_seconds: number;      // positive — how far in the future the timestamp was
+}
+
+export function emitClockSkew(event: ClockSkewEvent): void {
+  console.log(JSON.stringify({ channel: "recovery.clock_skew", event }));
+}

--- a/supabase/functions/_shared/observability_test.ts
+++ b/supabase/functions/_shared/observability_test.ts
@@ -1,0 +1,98 @@
+// Project Apex — Phase 2 observability emit-helpers tests.
+//
+// Per ADR-0006 §"Observability", structured events emit to "a Supabase
+// table or external log sink." For v2 alpha scale, the emit helpers
+// write a JSON envelope `{ channel, event }` to stdout via console.log
+// (Supabase Edge Function logs capture stdout). These tests exercise
+// each helper's payload shape so downstream rule slices (A5, A12, A13)
+// emit consistent envelopes.
+//
+// Testing approach: stub console.log per-test, capture the envelope,
+// assert channel string + every required field.
+//
+// Run locally:
+//   deno test supabase/functions/_shared/observability_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  emitClassifierFailed,
+  emitClockSkew,
+  emitLateArrival,
+} from "./observability.ts";
+
+// ─── stdout capture helper ──────────────────────────────────────────────────
+
+/**
+ * Calls `fn` with `console.log` replaced by a capture sink. Returns the
+ * captured strings (one per call). Restores the original `console.log`
+ * unconditionally — including on thrown exceptions — so test failures
+ * don't pollute subsequent tests.
+ */
+function captureConsoleLog(fn: () => void): string[] {
+  const captured: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    captured.push(args.map((a) => typeof a === "string" ? a : JSON.stringify(a)).join(" "));
+  };
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return captured;
+}
+
+// ─── emitLateArrival (ADR-0008) ─────────────────────────────────────────────
+
+Deno.test("ADR-0008: emitLateArrival emits JSON envelope on channel trainee_model.late_arrival with all 5 fields", () => {
+  const event = {
+    user_id: "11111111-1111-1111-1111-111111111111",
+    session_id: "22222222-2222-2222-2222-222222222222",
+    incoming_logged_at: "2026-05-07T12:00:00.000Z",
+    watermark: "2026-05-07T18:00:00.000Z",
+    delta_seconds: -21600,
+  };
+
+  const lines = captureConsoleLog(() => emitLateArrival(event));
+
+  assertEquals(lines.length, 1, "emitLateArrival must call console.log exactly once");
+  const envelope = JSON.parse(lines[0]);
+  assertEquals(envelope.channel, "trainee_model.late_arrival");
+  assertEquals(envelope.event, event);
+});
+
+// ─── emitClassifierFailed (ADR-0013) ────────────────────────────────────────
+
+Deno.test("ADR-0013: emitClassifierFailed emits JSON envelope on channel trainee_model.classifier_failed with all 4 fields", () => {
+  const event = {
+    user_id: "33333333-3333-3333-3333-333333333333",
+    session_id: "44444444-4444-4444-4444-444444444444",
+    error_class: "haiku_unreachable",
+    notes_attempted_count: 7,
+  };
+
+  const lines = captureConsoleLog(() => emitClassifierFailed(event));
+
+  assertEquals(lines.length, 1, "emitClassifierFailed must call console.log exactly once");
+  const envelope = JSON.parse(lines[0]);
+  assertEquals(envelope.channel, "trainee_model.classifier_failed");
+  assertEquals(envelope.event, event);
+});
+
+// ─── emitClockSkew (ADR-0010) ───────────────────────────────────────────────
+
+Deno.test("ADR-0010: emitClockSkew emits JSON envelope on channel recovery.clock_skew with all 4 fields", () => {
+  const event = {
+    user_id: "55555555-5555-5555-5555-555555555555",
+    last_stimulus_at: "2026-05-08T03:00:00.000Z",
+    now: "2026-05-07T18:00:00.000Z",
+    delta_seconds: 32400,
+  };
+
+  const lines = captureConsoleLog(() => emitClockSkew(event));
+
+  assertEquals(lines.length, 1, "emitClockSkew must call console.log exactly once");
+  const envelope = JSON.parse(lines[0]);
+  assertEquals(envelope.channel, "recovery.clock_skew");
+  assertEquals(envelope.event, event);
+});


### PR DESCRIPTION
## Summary
- Adds 3 typed structured-log emit helpers to the Edge Function shared module: `trainee_model.late_arrival` (ADR-0008), `trainee_model.classifier_failed` (ADR-0013), `recovery.clock_skew` (ADR-0010). Each writes a `{channel, event}` JSON envelope to stdout — Supabase logs capture stdout per ADR-0006 §"Observability".
- Wires the Swift WAQ adapter for the late-arrival branch: 200 + `late_arrival:true` returns `.success`, skips the local snapshot update (the `trainee_model` field is the *cached* snapshot per ADR-0008), and enqueues a soft notification for the post-session summary surface.
- Adds `LateArrivalNotificationQueue` (UserDefaults-backed FIFO) and surfaces notifications on `PostWorkoutSummaryView` with dismiss-on-tap.

## Forward-compat note (the part that will confuse future-me without this paragraph)
The `LateArrivalNotification` struct includes optional `sessionId`, `incomingLoggedAt`, and `watermark` fields for forward-compat. **These are nil in A3-shipped notifications and will be populated when A12 lands the richer Edge Function response shape.** A3's WAQ adapter reads only `late_arrival: bool` from the response — locking the struct schema now avoids an awkward UserDefaults-data migration when A12 ships.

## ADR-0008 copy is locked verbatim
The user-facing notification text is locked verbatim to ADR-0008. The dedicated test `test_flushHandler_onLateArrivalTrue_enqueuesNotificationWithLockedCopy` hardcodes the literal — any paraphrase fails CI with a name pointing at ADR-0008. Other call sites (queue tests, view preview) use the `LateArrivalNotification.lockedMessage` constant so the drift detector has a single owner.

## Persistence convention codified
UserDefaults for transient operational state (queues, sentinels, flags); SwiftData for entity snapshots. The queue's `com.projectapex.lateArrivalNotificationQueue` key matches the existing `com.projectapex.*` namespace (Keychain, Onboarding, GymProfile, Mesocycle, WorkoutSession persistence).

## Channel-naming convention set here
This is the first `console.log`-JSON-envelope helper module in the Edge Function tree, so the channel-naming convention `<domain>.<event_kind>` lower-snake is established here for downstream slices (A5/A12/A13) to match. The 3 helpers funnel through a shared private `emit` so that a future migration to a dedicated observability table (per ADR-0006's "v2.x may add a table" note) changes one function body instead of three.

## Files
- `supabase/functions/_shared/observability.ts` (new) + `observability_test.ts` (new) — 3 emit helpers, 3 envelope-shape tests
- `ProjectApex/Models/LateArrivalNotification.swift` (new)
- `ProjectApex/Services/LateArrivalNotificationQueue.swift` (new)
- `ProjectApexTests/LateArrivalNotificationQueueTests.swift` (new) — 3 round-trip / FIFO / isolation tests
- `ProjectApex/Services/TraineeModelUpdateJob.swift` — late-arrival branch in `parseResponse`
- `ProjectApexTests/TraineeModelUpdateJobTests.swift` — 3 new tests (true/copy/false branches)
- `ProjectApex/Features/Workout/PostWorkoutSummaryView.swift` — banner section + dequeue on `.task` + new `#Preview "Late-Arrival Notice"` for cheap visual verification at PR review
- `ProjectApex/App/AppDependencies.swift` — holds the shared queue, threads it into `TraineeModelUpdateJob`

## Test plan
- [x] `deno test supabase/functions/_shared/observability_test.ts` — 3 emit-helper envelope tests pass
- [x] `xcodebuild test` — full Swift suite passes (`TraineeModelUpdateJobTests`: 17 ✓, `LateArrivalNotificationQueueTests`: 3 ✓, no regressions elsewhere)
- [ ] Visual review: open `PostWorkoutSummaryView` "Late-Arrival Notice" preview in Xcode and eyeball banner copy + spacing before merge

## Out of scope (per #74)
Rule logic that emits these events lives in subsequent slices:
- A5 emits `recovery.clock_skew`
- A12 emits `trainee_model.late_arrival` (and ships the richer response shape that populates the optional notification fields)
- A13 emits `trainee_model.classifier_failed`

Sustained-failure user-facing surface for classifier failures is a v2.x consideration (watch-item #6).

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)