### PR TITLE
feat(slice-A4/#75): cadence-aware-duration translator (ADR-0015)

### DIFF
--- a/supabase/functions/_shared/cadence-translation.ts
+++ b/supabase/functions/_shared/cadence-translation.ts
@@ -1,0 +1,38 @@
+// Project Apex — Phase 2 cadence-aware-duration translator.
+//
+// Per ADR-0015 (Cadence-aware session-to-time translation pattern), this
+// is the canonical primitive for translating "N sessions of training"
+// into a wall-clock duration. Future rules adopting the shape MUST cite
+// this ADR in their code comments (per ADR-0015 §Decision).
+//
+// Formula (verbatim from ADR-0015 §Decision):
+//   durationDays = (cadence === null)
+//       ? nilFallbackDays                        // conservative, calendar-day floor
+//       : max(floorDays, N × cadenceDays);      // session-derived, with calendar floor
+//
+// Pure: no I/O, no clock reads. Caller composes with `Date` arithmetic.
+
+/**
+ * Cadence-aware translation per ADR-0015.
+ *
+ * @param cadenceDays - mean delta in days between consecutive recent
+ *                     sessions (`PatternProfile.sessionsCadenceDays`);
+ *                     null when fewer than 2 sessions are recorded.
+ * @param n - the session-count semantic the rule is expressing.
+ * @param floorDays - calendar-day minimum that prevents pathological
+ *                   values at very high cadences.
+ * @param nilFallbackDays - conservative fallback when no cadence is
+ *                         available (long-absence-returner default).
+ * @returns duration in days (Number, may be fractional).
+ */
+export function cadenceAwareDuration(
+  cadenceDays: number | null,
+  n: number,
+  floorDays: number,
+  nilFallbackDays: number,
+): number {
+  if (cadenceDays === null) {
+    return nilFallbackDays;
+  }
+  return Math.max(floorDays, n * cadenceDays);
+}

--- a/supabase/functions/_shared/cadence-translation_test.ts
+++ b/supabase/functions/_shared/cadence-translation_test.ts
@@ -1,0 +1,80 @@
+// Project Apex — Phase 2 cadence-aware-duration translator tests.
+//
+// Per ADR-0015 (canonical translation pattern), each test name pins the
+// originating ADR (and Q5 PRD-internal where applicable) so a failure
+// surfaces the rule the change touches.
+//
+// Run locally:
+//   deno test supabase/functions/_shared/cadence-translation_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { cadenceAwareDuration } from "./cadence-translation.ts";
+import {
+  DISRUPTED_PATTERN_CADENCE_MULTIPLIER,
+  TRANSITION_MODE_CADENCE_MULTIPLIER,
+  TRANSITION_MODE_FLOOR_DAYS,
+  TRANSITION_MODE_NIL_CADENCE_FALLBACK_DAYS,
+} from "./constants.ts";
+
+Deno.test("ADR-0015: nil cadence falls back to nilFallbackDays", () => {
+  assertEquals(cadenceAwareDuration(null, 3, 14, 21), 21);
+});
+
+Deno.test("ADR-0015: cadence × N exceeds floor → cadence × N", () => {
+  assertEquals(cadenceAwareDuration(7, 3, 14, 21), 21);
+});
+
+Deno.test("ADR-0015: cadence × N below floor → floor wins", () => {
+  assertEquals(cadenceAwareDuration(3, 3, 14, 21), 14);
+});
+
+Deno.test("ADR-0015: pathology guard at high cadence (1d × 3) → floor wins", () => {
+  assertEquals(cadenceAwareDuration(1, 3, 14, 21), 14);
+});
+
+Deno.test("ADR-0015: pathology guard at very high cadence (0.5d × 3) → floor wins", () => {
+  assertEquals(cadenceAwareDuration(0.5, 3, 14, 21), 14);
+});
+
+Deno.test("ADR-0015: cadence × N equals floor (boundary) → floor", () => {
+  // (14/3) × 3 === 14.0 exactly in IEEE-754 (no rounding error on this
+  // division-multiplication round-trip), so Math.max(14, 14) === 14.
+  assertEquals(cadenceAwareDuration(14 / 3, 3, 14, 21), 14);
+});
+
+Deno.test("ADR-0015: cadence = 0 (degenerate, not nil) → floor applies, not nil fallback", () => {
+  assertEquals(cadenceAwareDuration(0, 3, 14, 21), 14);
+});
+
+Deno.test("ADR-0015: N = 0 returns floor (degenerate)", () => {
+  assertEquals(cadenceAwareDuration(7, 0, 14, 21), 14);
+});
+
+Deno.test("Q5 / ADR-0015: 1×/week cadence with 3-session window → 21d (max of 14d floor and 21d)", () => {
+  assertEquals(
+    cadenceAwareDuration(
+      7,
+      TRANSITION_MODE_CADENCE_MULTIPLIER,
+      TRANSITION_MODE_FLOOR_DAYS,
+      TRANSITION_MODE_NIL_CADENCE_FALLBACK_DAYS,
+    ),
+    21,
+  );
+});
+
+Deno.test("ADR-0005 / ADR-0015: disruptedPatterns derivation (2 × cadence, no floor) expressible via primitive", () => {
+  // ADR-0005's pre-existing `disruptedPatterns` derivation is
+  // `daysSinceLastSession > 2 × sessionsCadenceDays`. Set floor=0 to
+  // disable the floor; nilFallbackDays is irrelevant when cadence is
+  // non-null (sentinel value chosen for clarity).
+  const irrelevantNilFallback = 999;
+  assertEquals(
+    cadenceAwareDuration(
+      4,
+      DISRUPTED_PATTERN_CADENCE_MULTIPLIER,
+      0,
+      irrelevantNilFallback,
+    ),
+    8,
+  );
+});


### PR DESCRIPTION
## Summary

- Pure TypeScript primitive `cadenceAwareDuration(cadenceDays, n, floorDays, nilFallbackDays)` in [supabase/functions/_shared/cadence-translation.ts](supabase/functions/_shared/cadence-translation.ts), implementing ADR-0015's canonical formula: `max(floorDays, N × cadenceDays)` when cadence is non-nil, `nilFallbackDays` when nil. No I/O, no clock reads.
- 10 edge-case tests in [supabase/functions/_shared/cadence-translation_test.ts](supabase/functions/_shared/cadence-translation_test.ts) covering every required case from #75: nil fallback, above/below/at-floor, pathology guards at 1d and 0.5d cadence, null-vs-0 distinction, N=0 degenerate, plus Q5 and ADR-0005 instantiations exercised via the constants module from #72.
- Code comment cites ADR-0015 verbatim per the ADR's instruction ("Future rules adopting the shape MUST cite this ADR").

## Scope notes

- ADR-0005 `disruptedPatterns` derivation in `TraineeModel.swift:108` is the pre-existing instantiation of this same pattern. Per #75 it is **explicitly out of scope** — not refactored to call the new primitive in this slice. Cross-cutting grep confirmed it's the only other instantiation; no other TS sites exist.
- Q5 transition-mode expiry composition (max-of-untils on overlap, fresh-from-now after expiry) is #A6 — this slice ships the primitive only.
- Date-arithmetic wrappers also out of scope; primitive returns days as `number`.

## TDD progression

- Cycle 1 (RED→GREEN): nil-cadence fallback drove `return nilFallbackDays`.
- Cycle 2: passed coincidentally on the Cycle-1 stub (cadence×N=21 collided with nilFallbackDays=21) — kept as a property pin, surfaced before continuing.
- Cycle 3 (RED→GREEN): below-floor case drove the full `Math.max(floorDays, n × cadenceDays)` form.
- Cycles 4–10: regression-pin tests for orthogonal axes (high-cadence pathology, fractional cadence, IEEE-754 boundary, null-vs-0, N=0, Q5 via constants, ADR-0005 via constants with floor=0).

Two ambiguities surfaced and resolved with the user before RED-1: boundary value uses `14/3` for an exact `=== 14` assertion (no `assertAlmostEquals` needed); ADR-0005-instantiation test uses `999` as a clearly-marked nilFallback sentinel.

## Test plan

- [x] `deno test supabase/functions/_shared/cadence-translation_test.ts` — 10 passed
- [x] `deno test supabase/functions/_shared/` — 72 passed (no regressions in A1 / A3 suites)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)