### PR TITLE
feat(slice-A5/#76): stimulus-classifier + recovery-curve (ADR-0010)

### DIFF
--- a/supabase/functions/_shared/recovery-curve.ts
+++ b/supabase/functions/_shared/recovery-curve.ts
@@ -1,0 +1,71 @@
+// Project Apex — Phase 2 recovery-curve.
+//
+// Per ADR-0010 (recovery readiness curves and time constants), per-axis
+// readiness is a pure function of hours since the last stimulus event:
+//
+//   readiness(t) = clamp(0, 1, RESIDUAL_FLOOR + (1 - RESIDUAL_FLOOR) × (1 - exp(-t / tau)))
+//
+// The residual floor (0.3) captures that the lifter is not at zero
+// readiness immediately post-stimulus (ADR-0010 §"residual floor").
+// NM tau is 30h; metabolic tau is 12h — metabolic clears ~2.5× faster
+// (ADR-0010 §"time constants", asymmetric-error preference under-counts
+// recovery → loud RPE drift; over-counts → quieter, easier to correct).
+//
+// Pure: `readinessCurve` has no side effects. The `readiness` wrapper
+// invokes #74's `emitClockSkew` helper when given future-dated
+// `lastStimulusAt` — clock skew at non-trivial rates is a data-integrity
+// signal worth surfacing.
+
+import {
+  RECOVERY_RESIDUAL_FLOOR,
+  RECOVERY_TAU_METABOLIC_HOURS,
+  RECOVERY_TAU_NM_HOURS,
+} from "./constants.ts";
+import { emitClockSkew } from "./observability.ts";
+
+export type RecoveryAxis = "neuromuscular" | "metabolic";
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+const TAU_BY_AXIS: Record<RecoveryAxis, number> = {
+  neuromuscular: RECOVERY_TAU_NM_HOURS,
+  metabolic: RECOVERY_TAU_METABOLIC_HOURS,
+};
+
+/**
+ * Pure readiness curve per ADR-0010. No clock-skew detection or logging
+ * — see `readiness` for the wrapper that handles those.
+ */
+export function readinessCurve(tHours: number, tauHours: number): number {
+  const t = Math.max(0, tHours);
+  const value = RECOVERY_RESIDUAL_FLOOR +
+    (1 - RECOVERY_RESIDUAL_FLOOR) * (1 - Math.exp(-t / tauHours));
+  return Math.max(0, Math.min(1, value));
+}
+
+/**
+ * Per-axis recovery readiness. Edge cases (ADR-0010 §"edge cases"):
+ *   - lastStimulusAt === null → 1.0 (brand-new user, fully recovered).
+ *   - Future-dated lastStimulusAt → t clamps to 0 (readiness = residual
+ *     floor) and `recovery.clock_skew` is emitted via #74's helper.
+ *     Clock skew at non-trivial rates is a data-integrity signal.
+ */
+export function readiness(
+  axis: RecoveryAxis,
+  lastStimulusAt: Date | null,
+  now: Date,
+  context: { userId: string },
+): number {
+  if (lastStimulusAt === null) return 1.0;
+  const deltaMs = now.getTime() - lastStimulusAt.getTime();
+  if (deltaMs < 0) {
+    emitClockSkew({
+      user_id: context.userId,
+      last_stimulus_at: lastStimulusAt.toISOString(),
+      now: now.toISOString(),
+      delta_seconds: -deltaMs / 1000,
+    });
+  }
+  const tHours = Math.max(0, deltaMs) / MS_PER_HOUR;
+  return readinessCurve(tHours, TAU_BY_AXIS[axis]);
+}

--- a/supabase/functions/_shared/recovery-curve_test.ts
+++ b/supabase/functions/_shared/recovery-curve_test.ts
@@ -1,0 +1,125 @@
+// Project Apex — Phase 2 recovery-curve tests.
+//
+// Per ADR-0010 (recovery readiness curves and time constants), this
+// module exposes (a) `readinessCurve(tHours, tauHours)` — the pure
+// formula, used directly in numerical-tolerance tests against the
+// ADR-0010 Table; and (b) `readiness(axis, lastStimulusAt, now,
+// context)` — the public wrapper that handles brand-new users, clamps
+// future-dated timestamps, and emits `recovery.clock_skew` (via #74's
+// helper) when clock skew is detected.
+//
+// Numerical tolerance: 2 decimal places per issue #76 (the ADR-0010
+// Table values are rounded; the underlying floats differ slightly).
+//
+// Run locally:
+//   deno test supabase/functions/_shared/recovery-curve_test.ts
+
+import {
+  assertAlmostEquals,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { readiness, readinessCurve } from "./recovery-curve.ts";
+import {
+  RECOVERY_RESIDUAL_FLOOR,
+  RECOVERY_TAU_METABOLIC_HOURS,
+  RECOVERY_TAU_NM_HOURS,
+} from "./constants.ts";
+
+// 2-decimal tolerance per issue #76 (ADR-0010 Table values are rounded).
+const TOLERANCE = 0.005;
+
+Deno.test("ADR-0010: brand-new user (lastStimulusAt === null) → readiness 1.0", () => {
+  const now = new Date("2026-05-08T12:00:00Z");
+  assertEquals(readiness("neuromuscular", null, now, { userId: "u1" }), 1.0);
+});
+
+Deno.test("ADR-0010: t = 0 → exactly residual floor (0.3)", () => {
+  assertEquals(readinessCurve(0, RECOVERY_TAU_NM_HOURS), RECOVERY_RESIDUAL_FLOOR);
+  assertEquals(readinessCurve(0, RECOVERY_TAU_METABOLIC_HOURS), RECOVERY_RESIDUAL_FLOOR);
+});
+
+Deno.test("ADR-0010 formula at t=24h, NM tau=30h → 0.6855 (matches Table 0.69)", () => {
+  assertAlmostEquals(readinessCurve(24, RECOVERY_TAU_NM_HOURS), 0.6855, TOLERANCE);
+});
+
+Deno.test("ADR-0010 formula at t=48h, NM tau=30h → 0.8587 (formula-derived; ADR Table cell 0.84 needs amendment)", () => {
+  // Spec divergence flagged in PR description: ADR-0010 Table reads 0.84
+  // at NM@48h, but the formula 0.3 + 0.7 × (1 - exp(-48/30)) yields
+  // 0.8587 ≈ 0.86. The formula and tau are correct; the Table cell is a
+  // hand-computation typo. Test pins the formula output; ADR amendment
+  // is a follow-up.
+  assertAlmostEquals(readinessCurve(48, RECOVERY_TAU_NM_HOURS), 0.8587, TOLERANCE);
+});
+
+Deno.test("ADR-0010 formula at t=72h, NM tau=30h → 0.9365 (matches Table 0.94)", () => {
+  assertAlmostEquals(readinessCurve(72, RECOVERY_TAU_NM_HOURS), 0.9365, TOLERANCE);
+});
+
+Deno.test("ADR-0010 formula at t=24h, metabolic tau=12h → 0.9053 (Table reads 0.90; rounding-convention discrepancy)", () => {
+  // Standard rounding of 0.9053 is 0.91; ADR Table says 0.90 (truncation).
+  // Difference is within rounding-convention noise; flagged in PR but
+  // lower priority than NM@48h.
+  assertAlmostEquals(readinessCurve(24, RECOVERY_TAU_METABOLIC_HOURS), 0.9053, TOLERANCE);
+});
+
+Deno.test("ADR-0010 formula at t=48h, metabolic tau=12h → 0.9872 (matches Table 0.99)", () => {
+  assertAlmostEquals(readinessCurve(48, RECOVERY_TAU_METABOLIC_HOURS), 0.9872, TOLERANCE);
+});
+
+Deno.test("ADR-0010 formula at t=72h, metabolic tau=12h → 0.9983 (matches Table 1.00 asymptote)", () => {
+  assertAlmostEquals(readinessCurve(72, RECOVERY_TAU_METABOLIC_HOURS), 0.9983, TOLERANCE);
+});
+
+Deno.test("ADR-0010: at t=24h, NM readiness < metabolic readiness (asymmetry — metabolic clears ~2.5× faster)", () => {
+  // ADR-0010 §"time constants": "The asymmetry (metabolic clears ~2.5×
+  // faster than NM under these constants) is consistent with the design
+  // rationale for two-dimensional recovery in ADR-0005."
+  const nm24 = readinessCurve(24, RECOVERY_TAU_NM_HOURS);
+  const metabolic24 = readinessCurve(24, RECOVERY_TAU_METABOLIC_HOURS);
+  if (!(nm24 < metabolic24)) {
+    throw new Error(
+      `Expected NM readiness < metabolic readiness at t=24h, got NM=${nm24}, metabolic=${metabolic24}`,
+    );
+  }
+});
+
+// ─── readiness wrapper: future-dated clock-skew handling ────────────────────
+
+/**
+ * Calls `fn` with `console.log` replaced by a capture sink. Mirrors the
+ * helper in `observability_test.ts`. Returns the captured strings (one
+ * per call). Restores the original `console.log` unconditionally — even
+ * on thrown exceptions — so test failures don't pollute later tests.
+ */
+function captureConsoleLog(fn: () => void): string[] {
+  const captured: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    captured.push(args.map((a) => typeof a === "string" ? a : JSON.stringify(a)).join(" "));
+  };
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return captured;
+}
+
+Deno.test("ADR-0010: future-dated lastStimulusAt clamps readiness to residual floor (0.3) and emits recovery.clock_skew with positive delta_seconds", () => {
+  const now = new Date("2026-05-08T12:00:00Z");
+  const future = new Date("2026-05-08T13:00:00Z"); // 3600 seconds in the future
+
+  let result = Number.NaN;
+  const lines = captureConsoleLog(() => {
+    result = readiness("neuromuscular", future, now, { userId: "u1" });
+  });
+
+  assertEquals(result, RECOVERY_RESIDUAL_FLOOR);
+  assertEquals(lines.length, 1, "expected exactly one console.log envelope");
+  const envelope = JSON.parse(lines[0]);
+  assertEquals(envelope.channel, "recovery.clock_skew");
+  assertEquals(envelope.event.user_id, "u1");
+  assertEquals(envelope.event.last_stimulus_at, future.toISOString());
+  assertEquals(envelope.event.now, now.toISOString());
+  assertEquals(envelope.event.delta_seconds, 3600);
+});

--- a/supabase/functions/_shared/stimulus-classifier.ts
+++ b/supabase/functions/_shared/stimulus-classifier.ts
@@ -1,0 +1,64 @@
+// Project Apex — Phase 2 stimulus-classifier.
+//
+// Per Q3 PRD-internal (lock-in 2026-05-07) and ADR-0005 §"two-dimensional
+// recovery", a pure classifier mapping (intent, reps, rpeFelt) to the
+// stimulus dimension(s) a set drives. Non-stimulus sets (warmup,
+// technique) return null so the orchestrator (#A12) skips updating
+// recovery timestamps (ADR-0005 §"low-stimulus exclusion via Optional
+// return").
+//
+// AMRAP returns 'both' (not 'metabolic') per Q3 lock-in: AMRAP is by
+// definition a max-effort final-set, the asymmetric-error logic of the
+// top-9–10 RPE-bump applies — under-counting NM stimulus is silent →
+// over-prescription. Issue #76 body's 'metabolic' cell is a transcription
+// error against the grilling lock-in; flagged in PR description.
+//
+// Pure: no I/O, no clock reads.
+
+import {
+  BACKOFF_BOTH_REP_MAX,
+  BACKOFF_NM_REP_MAX,
+  STIMULUS_RPE_BUMP_REP_MAX,
+  STIMULUS_RPE_BUMP_REP_MIN,
+  STIMULUS_RPE_BUMP_TRIGGER,
+} from "./constants.ts";
+
+export type SetIntent = "warmup" | "top" | "backoff" | "technique" | "amrap";
+
+export type StimulusDimension = "neuromuscular" | "metabolic" | "both";
+
+export function classifyStimulus(
+  intent: SetIntent,
+  reps: number,
+  rpeFelt: number | null,
+): StimulusDimension | null {
+  switch (intent) {
+    case "warmup":
+    case "technique":
+      return null;
+    case "amrap":
+      return "both";
+    case "top":
+      if (reps <= BACKOFF_NM_REP_MAX) return "neuromuscular";
+      if (reps <= BACKOFF_BOTH_REP_MAX) return "both";
+      if (
+        reps >= STIMULUS_RPE_BUMP_REP_MIN &&
+        reps <= STIMULUS_RPE_BUMP_REP_MAX
+      ) {
+        // RPE-bump: RPE ≥ 9 upgrades metabolic → both (Q3 asymmetric-error
+        // preference — under-counting NM stimulus is silent).
+        if (rpeFelt !== null && rpeFelt >= STIMULUS_RPE_BUMP_TRIGGER) {
+          return "both";
+        }
+        return "metabolic";
+      }
+      // reps > 10: outside ADR-0005's e1RM validity (3..10), but stimulus
+      // classification still applies. Per Q3 / #76 item-11: metabolic;
+      // PR description flags for reviewer.
+      return "metabolic";
+    case "backoff":
+      if (reps <= BACKOFF_NM_REP_MAX) return "neuromuscular";
+      if (reps <= BACKOFF_BOTH_REP_MAX) return "both";
+      return "metabolic";
+  }
+}

--- a/supabase/functions/_shared/stimulus-classifier_test.ts
+++ b/supabase/functions/_shared/stimulus-classifier_test.ts
@@ -1,0 +1,108 @@
+// Project Apex — Phase 2 stimulus-classifier tests.
+//
+// Per Q3 PRD-internal (lock-in 2026-05-07) and ADR-0005 (two-dimensional
+// recovery via Optional return for low-stimulus sets), this module
+// classifies (intent, reps, rpeFelt) → StimulusDimension | null. Each
+// test name pins the originating decision (Q3 row or ADR clause) so a
+// failure surfaces the rule the change touches.
+//
+// Run locally:
+//   deno test supabase/functions/_shared/stimulus-classifier_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { classifyStimulus } from "./stimulus-classifier.ts";
+
+Deno.test("Q3 / ADR-0005: warmup intent honoured even with high-load rep shape → null", () => {
+  assertEquals(classifyStimulus("warmup", 5, 8), null);
+});
+
+Deno.test("Q3 / ADR-0005: technique intent → null regardless of reps/RPE", () => {
+  assertEquals(classifyStimulus("technique", 5, 8), null);
+});
+
+Deno.test("Q3: top set in 3–5 rep band → neuromuscular", () => {
+  assertEquals(classifyStimulus("top", 3, 7), "neuromuscular");
+  assertEquals(classifyStimulus("top", 5, 7), "neuromuscular");
+});
+
+Deno.test("Q3: top set in 6–8 rep band → both", () => {
+  assertEquals(classifyStimulus("top", 6, 7), "both");
+  assertEquals(classifyStimulus("top", 8, 7), "both");
+});
+
+Deno.test("Q3: top set in 9–10 rep band with RPE < 9 → metabolic", () => {
+  assertEquals(classifyStimulus("top", 9, 7), "metabolic");
+  assertEquals(classifyStimulus("top", 10, 8.5), "metabolic");
+});
+
+Deno.test("Q3: top set in 9–10 rep band with RPE ≥ 9 → both (RPE bump)", () => {
+  assertEquals(classifyStimulus("top", 9, 9), "both");
+  assertEquals(classifyStimulus("top", 10, 10), "both");
+});
+
+Deno.test("Q3: RPE-bump boundary is strict — RPE = 8.99 → metabolic (not both)", () => {
+  // RPE bump fires at rpeFelt >= 9 (STIMULUS_RPE_BUMP_TRIGGER); strict-less-than at boundary.
+  assertEquals(classifyStimulus("top", 9, 8.99), "metabolic");
+  assertEquals(classifyStimulus("top", 10, 8.99), "metabolic");
+});
+
+Deno.test("Q3: top 9–10 with nil RPE → metabolic (bump requires RPE ≥ 9; null is not ≥)", () => {
+  assertEquals(classifyStimulus("top", 9, null), "metabolic");
+  assertEquals(classifyStimulus("top", 10, null), "metabolic");
+});
+
+Deno.test("Q3: top rep-band boundaries — 5→NM, 6→both, 8→both, 9→metabolic", () => {
+  assertEquals(classifyStimulus("top", 5, 7), "neuromuscular");
+  assertEquals(classifyStimulus("top", 6, 7), "both");
+  assertEquals(classifyStimulus("top", 8, 7), "both");
+  assertEquals(classifyStimulus("top", 9, 7), "metabolic");
+});
+
+Deno.test("Q3: backoff in 3–5 rep band → neuromuscular", () => {
+  assertEquals(classifyStimulus("backoff", 3, 8), "neuromuscular");
+  assertEquals(classifyStimulus("backoff", 5, 8), "neuromuscular");
+});
+
+Deno.test("Q3: backoff in 6–8 rep band → both", () => {
+  assertEquals(classifyStimulus("backoff", 6, 8), "both");
+  assertEquals(classifyStimulus("backoff", 8, 8), "both");
+});
+
+Deno.test("Q3: backoff at 9+ reps → metabolic (no upper bound, no RPE bump)", () => {
+  assertEquals(classifyStimulus("backoff", 9, 8), "metabolic");
+  assertEquals(classifyStimulus("backoff", 12, 8), "metabolic");
+  assertEquals(classifyStimulus("backoff", 20, 10), "metabolic");
+});
+
+Deno.test("Q3: backoff rep-band boundaries — 5→NM, 6→both, 8→both, 9→metabolic", () => {
+  assertEquals(classifyStimulus("backoff", 5, 8), "neuromuscular");
+  assertEquals(classifyStimulus("backoff", 6, 8), "both");
+  assertEquals(classifyStimulus("backoff", 8, 8), "both");
+  assertEquals(classifyStimulus("backoff", 9, 8), "metabolic");
+});
+
+Deno.test("Q3: amrap → both regardless of reps/RPE (max-effort final-set; intent dominates)", () => {
+  // Q3 PRD-internal lock-in (2026-05-07): AMRAP is a max-effort final set;
+  // the asymmetric-error logic of the top 9–10 RPE-bump applies — AMRAP-to-
+  // failure crosses NM-driving territory in addition to metabolic. Issue
+  // #76 body's "metabolic" cell is a transcription error against the
+  // grilling lock-in; flagged in PR description.
+  assertEquals(classifyStimulus("amrap", 12, 10), "both");
+  assertEquals(classifyStimulus("amrap", 8, 9), "both");
+});
+
+Deno.test("Q3: amrap at low reps still → both (intent dominates over rep shape)", () => {
+  assertEquals(classifyStimulus("amrap", 5, 9), "both");
+  assertEquals(classifyStimulus("amrap", 3, 8), "both");
+});
+
+Deno.test("Q3 / #76 item-11: top reps > 10 (outside e1RM validity) → metabolic", () => {
+  // Issue #76 edge case: "Top set at 11+ reps — outside the 3-10 validity
+  // range; classify as if 9-10 row applies (most permissive metabolic-
+  // shaped result). The 3..10 validity gate is for e1RM contribution,
+  // not stimulus classification." Flagged in PR description for reviewer
+  // confirmation; if reviewer disagrees, the row is amendable in a
+  // follow-up patch.
+  assertEquals(classifyStimulus("top", 11, 7), "metabolic");
+  assertEquals(classifyStimulus("top", 15, 8), "metabolic");
+});

--- a/supabase/functions/_shared/stimulus-classifier_test.ts
+++ b/supabase/functions/_shared/stimulus-classifier_test.ts
@@ -14,10 +14,17 @@ import { classifyStimulus } from "./stimulus-classifier.ts";
 
 Deno.test("Q3 / ADR-0005: warmup intent honoured even with high-load rep shape → null", () => {
   assertEquals(classifyStimulus("warmup", 5, 8), null);
+  // Spans rep/RPE space so the "regardless of reps/RPE" claim has breadth:
+  // a different rep band + the null-RPE path. Implementation is intent-first,
+  // so any one point is sufficient evidence; broader assertions guard against
+  // a future refactor that reorders rep/RPE checks ahead of intent on some path.
+  assertEquals(classifyStimulus("warmup", 12, null), null);
 });
 
 Deno.test("Q3 / ADR-0005: technique intent → null regardless of reps/RPE", () => {
   assertEquals(classifyStimulus("technique", 5, 8), null);
+  // Different rep band + a high-RPE point — same breadth rationale as above.
+  assertEquals(classifyStimulus("technique", 3, 10), null);
 });
 
 Deno.test("Q3: top set in 3–5 rep band → neuromuscular", () => {


### PR DESCRIPTION
## Summary

- Two pure TypeScript modules in `supabase/functions/_shared/` composing as a producer/consumer pair: stimulus classifier (Q3 PRD-internal 9-row table + ADR-0005 two-dimensional recovery) and recovery curve (ADR-0010 exponential approach with residual floor, NM tau=30h, metabolic tau=12h)
- 26 module tests (16 classifier + 10 recovery) plus the wider `_shared` suite at 98 passing
- Future-dated `lastStimulusAt` clamps t=0 (yielding 0.3 residual floor) AND emits `recovery.clock_skew` via #74's helper with positive `delta_seconds`

## Audit nature

This PR ships a slice whose implementation pre-existed in the working tree at session start; the work in this conversation was an audit walkthrough against the 26 planned behaviors from issue #76, not per-behavior TDD authorship.

- **Phase 1 — Coverage mapping (read-only):** Walked all 26 planned behaviors against the existing 16+10 test names. 26/26 mapped to existing tests with named ADR/Q citations matching the planned-behavior list.
- **Phase 2 — Implementation verification (read-only):** Ten correctness checks against the implementation (AMRAP→both for all rep ranges, top reps>10→metabolic regardless of RPE, formula matches `0.3 + 0.7 × (1 - exp(-tHours/tauHours))`, future-dated `lastStimulusAt` both clamps t=0 and emits ClockSkew with positive `delta_seconds`, `now` parameter honored with no internal `Date.now()` reads, etc.). 10/10 pass.
- **Phase 3 — Gap supplements (RED→GREEN cycles):** Empty. No correctness bugs surfaced. The only test-file change in this PR (commit `d4a78d2`) broadens assertion breadth on the warmup/technique intent-honoring tests so the test names ("regardless of reps/RPE") match what the assertions verify — pre-existing single-point assertions passed for the right reason but didn't span enough rep/RPE space to back the test-name claim.

## Decisions / corrections (reviewer ratification)

Three spec divergences were resolved unilaterally by the pre-existing implementation; surfacing here for explicit reviewer ruling. None silently amended pre-merge.

1. **AMRAP classification — implementation returns `'both'`, diverging from issue #76 body's `metabolic`.** Issue #76 body's 9-row table (and the "Amrap with low reps (rare)" edge-case example) reads `metabolic` for AMRAP. The Q3 PRD-internal grilling lock-in (2026-05-07) reads `.both`. Implementation aligns with the lock-in. **Proposed follow-up:** issue #76 body amendment to correct the 9-row table cell, OR reviewer pushes back and implementation flips to `metabolic`.

2. **ADR-0010 Table NM@48h cell reads 0.84; formula yields 0.8587 ≈ 0.86.** Formula `0.3 + 0.7 × (1 - exp(-48/30))` and the Table cell are mathematically inconsistent under tau=30h. Tests pin formula output (0.8587 ± 0.005). **Proposed follow-up:** ADR-0010 Table amendment from 0.84 → 0.86 to match the formula it cites.

3. **ADR-0010 Table Metabolic@24h cell reads 0.90; formula yields 0.9053 (rounding-convention dependent — standard rounding gives 0.91, truncation gives 0.90).** Lower-priority sibling of (2). Tests pin formula output. **Proposed follow-up:** Table amendment alongside (2).

## Trade-off worth reviewer eyeballing

**Top reps > 10 classifies as `metabolic` with no RPE-bump path** ([stimulus-classifier.ts:55-58](supabase/functions/_shared/stimulus-classifier.ts#L55-L58)), per issue #76's edge-case decision (item 11). By the same recruitment-near-failure logic that takes top 9–10 RPE≥9 to `'both'`, a top set at 11+ reps near failure is also recruiting high-threshold motor units — so `top, 15, 9` classifies as `metabolic` even though arguably it's both. Implementation honors issue #76 as written; reviewer can decide whether a follow-up issue should extend the RPE-bump path beyond 10 reps.

## Out of scope (per #76)

- Applying classifier output to update `last*StimulusAt` (orchestrator A12)
- Volume-modulated tau (v2.x watch-item #2 — uniform tau in v2; volume-blindness acknowledged limitation in ADR-0010)
- Stacking detection (v2.x watch-item #1 — gap-bucket aggregation in #A9 is the monitoring trigger)
- Recovery decay during a session (per ADR-0010 §"Recompute cadence")

## Test plan

- [x] `deno test supabase/functions/_shared/stimulus-classifier_test.ts supabase/functions/_shared/recovery-curve_test.ts` — 26/26 passing
- [x] `deno test supabase/functions/_shared/` (full suite) — 98/98 passing
- [ ] Reviewer confirms or pushes back on AMRAP→both decision (item 1 above)
- [ ] Reviewer confirms or pushes back on top reps>10 trade-off (no RPE-bump path beyond 10 reps)
- [ ] Reviewer ratifies proposed ADR-0010 Table amendments (items 2 and 3)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)