### PR TITLE
test: broaden warmup/technique assertion breadth (post-A5 follow-up)

### DIFF
--- a/supabase/functions/_shared/stimulus-classifier_test.ts
+++ b/supabase/functions/_shared/stimulus-classifier_test.ts
@@ -14,10 +14,17 @@ import { classifyStimulus } from "./stimulus-classifier.ts";
 
 Deno.test("Q3 / ADR-0005: warmup intent honoured even with high-load rep shape → null", () => {
   assertEquals(classifyStimulus("warmup", 5, 8), null);
+  // Spans rep/RPE space so the "regardless of reps/RPE" claim has breadth:
+  // a different rep band + the null-RPE path. Implementation is intent-first,
+  // so any one point is sufficient evidence; broader assertions guard against
+  // a future refactor that reorders rep/RPE checks ahead of intent on some path.
+  assertEquals(classifyStimulus("warmup", 12, null), null);
 });
 
 Deno.test("Q3 / ADR-0005: technique intent → null regardless of reps/RPE", () => {
   assertEquals(classifyStimulus("technique", 5, 8), null);
+  // Different rep band + a high-RPE point — same breadth rationale as above.
+  assertEquals(classifyStimulus("technique", 3, 10), null);
 });
 
 Deno.test("Q3: top set in 3–5 rep band → neuromuscular", () => {


### PR DESCRIPTION
## Summary

Post-A5 follow-up. Broadens assertion breadth on the warmup/technique intent-honoring tests in `stimulus-classifier_test.ts` so the test names ("regardless of reps/RPE") match what the assertions verify.

Tests previously asserted a single `(reps, rpeFelt)` point each. Behavior was correct — implementation is intent-first, so any single point is sufficient evidence — but the test name overclaimed relative to what the assertion verified.

Supplement adds:
- `(warmup, 12, null)` — different rep band + null-RPE path
- `(technique, 3, 10)` — different rep band + high-RPE point

These span enough of the rep/RPE space that the "regardless" claim has verification breadth. No implementation changes; pre-existing assertions already passed for the right reason. Guards against a future refactor that reorders rep/RPE checks ahead of intent on some path — single-point assertions could pass by coincidence and break elsewhere.

## Origin

This commit was originally part of PR #97, which turned out to duplicate the already-merged PR #96 (same head branch, same content, opened by parallel sessions). #97 is being closed as a duplicate; this PR re-opens just the genuinely-new portion (breadth supplement) on a clean branch off main.

## Test plan

- [x] `deno test supabase/functions/_shared/stimulus-classifier_test.ts` — 16/16 passing on top of main

🤖 Generated with [Claude Code](https://claude.com/claude-code)