### PR TITLE
feat(slice-A6/#77): EWMA engine + transition-mode expiry (ADR-0005 + Q5)

### DIFF
--- a/supabase/functions/_shared/ewma-engine.ts
+++ b/supabase/functions/_shared/ewma-engine.ts
@@ -1,0 +1,136 @@
+// Project Apex — Phase 2 EWMA engine.
+//
+// Per ADR-0005 §"e1RM update: EWMA": exponentially weighted moving
+// average over the last 5 valid top sets (validity 3..10 reps,
+// α = 0.333), with a transition-mode collapse to N=3 plain mean over
+// recent SESSIONS — heaviest top set per session, sample variance with
+// Bessel correction — when a per-axis confidence has just transitioned
+// to `.established` or another ADR-0005 trigger fires.
+//
+// Pure: no I/O, no clock reads.
+
+import {
+  EWMA_ALPHA,
+  EWMA_WINDOW_N,
+  TOP_SET_REP_VALIDITY_MAX,
+  TOP_SET_REP_VALIDITY_MIN,
+  TRANSITION_MODE_WINDOW_N,
+} from "./constants.ts";
+
+export interface TopSet {
+  weight: number; // kg
+  reps: number;
+  loggedAt: Date;
+  sessionId: string;
+}
+
+/**
+ * Epley estimated 1RM: `weight × (1 + reps / 30)`. Returns null when
+ * reps fall outside the ADR-0005 validity range (3..10) — the formula
+ * is unreliable below 3 (too rep-spotty) and above 10 (cardiovascular
+ * limit dominates).
+ */
+export function e1rm(weight: number, reps: number): number | null {
+  if (reps < TOP_SET_REP_VALIDITY_MIN || reps > TOP_SET_REP_VALIDITY_MAX) {
+    return null;
+  }
+  return weight * (1 + reps / 30);
+}
+
+/**
+ * EWMA over last 5 valid top sets (α = 0.333) per ADR-0005.
+ *
+ * Filtering precedes windowing: the validity gate (3..10 reps) is
+ * applied first, then the suffix-of-5 is taken from the filtered list.
+ * This means the EWMA is over 5 valid observations, not over 5 raw
+ * inputs of which some may be invalid.
+ *
+ * @param topSets - chronologically ordered (oldest first); filtered by
+ *                 rep validity, then suffix-of-5 contributes.
+ * @returns null when no valid top sets exist.
+ */
+export function ewmaE1RM(topSets: TopSet[]): number | null {
+  const valid = topSets.filter(
+    (s) => s.reps >= TOP_SET_REP_VALIDITY_MIN &&
+      s.reps <= TOP_SET_REP_VALIDITY_MAX,
+  );
+  if (valid.length === 0) return null;
+  const window = valid.slice(-EWMA_WINDOW_N);
+  // Initialize at oldest in window; iterate forward, weighting α toward newer.
+  let ema = e1rm(window[0].weight, window[0].reps)!;
+  for (let i = 1; i < window.length; i++) {
+    ema = EWMA_ALPHA * e1rm(window[i].weight, window[i].reps)! +
+      (1 - EWMA_ALPHA) * ema;
+  }
+  return ema;
+}
+
+/**
+ * Result of the transition-mode plain-mean computation per ADR-0005.
+ *
+ * `variance` is sample variance with Bessel correction (n−1 denominator)
+ * across the heaviest e1RM per session. For `sessionCount === 1` the
+ * Bessel formula is undefined (0/0); the convention returns 0 in that
+ * case (the test naming this convention pins the special-case behavior).
+ */
+export interface TransitionModeResult {
+  mean: number;
+  variance: number;
+  sessionCount: number;
+}
+
+/**
+ * Transition-mode mean per ADR-0005: plain mean of the heaviest e1RM per
+ * session across the 3 most recent SESSIONS (not top sets), with sample
+ * variance using Bessel correction.
+ *
+ * @returns null when no valid top sets exist.
+ */
+export function transitionModeMean(
+  topSets: TopSet[],
+): TransitionModeResult | null {
+  const valid = topSets.filter(
+    (s) => s.reps >= TOP_SET_REP_VALIDITY_MIN &&
+      s.reps <= TOP_SET_REP_VALIDITY_MAX,
+  );
+  if (valid.length === 0) return null;
+  // Group by sessionId in chronological insertion order, retaining the
+  // heaviest e1RM per session (per ADR-0005: multi-set sessions in 5×5
+  // programmes contribute their hardest top set, not their first).
+  const sessionValues = new Map<string, number>();
+  for (const s of valid) {
+    const e = e1rm(s.weight, s.reps)!;
+    const existing = sessionValues.get(s.sessionId);
+    if (existing === undefined || e > existing) {
+      sessionValues.set(s.sessionId, e);
+    }
+  }
+  const values = Array.from(sessionValues.values()).slice(
+    -TRANSITION_MODE_WINDOW_N,
+  );
+  const n = values.length;
+  const mean = values.reduce((a, b) => a + b, 0) / n;
+  // Bessel-corrected sample variance; n=1 returns 0 by convention
+  // (formula yields 0/0 — see TransitionModeResult docstring).
+  const variance = n === 1
+    ? 0
+    : values.reduce((acc, v) => acc + (v - mean) ** 2, 0) / (n - 1);
+  return { mean, variance, sessionCount: n };
+}
+
+/**
+ * Single entry point used by the orchestrator. Branches on
+ * `inTransitionMode`: true → transition-mode mean (collapsed N=3 plain
+ * mean over sessions); false → standard EWMA over the N=5 valid-top-set
+ * window. Returns just the central-tendency number — callers needing
+ * the variance/sessionCount must call `transitionModeMean` directly.
+ */
+export function computeE1RM(
+  topSets: TopSet[],
+  inTransitionMode: boolean,
+): number | null {
+  if (inTransitionMode) {
+    return transitionModeMean(topSets)?.mean ?? null;
+  }
+  return ewmaE1RM(topSets);
+}

--- a/supabase/functions/_shared/ewma-engine_test.ts
+++ b/supabase/functions/_shared/ewma-engine_test.ts
@@ -1,0 +1,223 @@
+// Project Apex — Phase 2 EWMA engine tests.
+//
+// Per ADR-0005 §"e1RM update: EWMA": EWMA over last 5 valid top sets
+// (validity 3..10 reps, α = 0.333), with transition-mode collapse to
+// N=3 plain mean over recent SESSIONS (heaviest top set per session,
+// sample variance with Bessel correction).
+//
+// Each test name pins the originating ADR so a failure surfaces the
+// rule the change touches. Test ordering matches the per-behavior TDD
+// cycle list approved on the slice plan.
+//
+// Run locally:
+//   deno test supabase/functions/_shared/ewma-engine_test.ts
+
+import {
+  assertAlmostEquals,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  computeE1RM,
+  e1rm,
+  ewmaE1RM,
+  type TopSet,
+  transitionModeMean,
+} from "./ewma-engine.ts";
+import { EWMA_ALPHA } from "./constants.ts";
+
+// Test fixture builder. `daysAgo` is just a sortable day offset; sessionId
+// defaults to one-per-day so tests that don't care about session boundaries
+// (ewmaE1RM cases) get distinct sessions for free, and tests that DO care
+// (transitionModeMean cases) override it to group sets into a session.
+const mk = (
+  weight: number,
+  reps: number,
+  daysAgo: number,
+  sessionId: string = `s${daysAgo}`,
+): TopSet => ({
+  weight,
+  reps,
+  loggedAt: new Date(2026, 0, 1 + daysAgo),
+  sessionId,
+});
+
+Deno.test("ADR-0005: ewmaE1RM([]) returns null (no top sets to weight)", () => {
+  assertEquals(ewmaE1RM([]), null);
+});
+
+Deno.test("ADR-0005: all reps out of 3..10 validity → null", () => {
+  // reps=2 below TOP_SET_REP_VALIDITY_MIN, reps=11 above
+  // TOP_SET_REP_VALIDITY_MAX → both filtered, no observations remain.
+  assertEquals(ewmaE1RM([mk(100, 2, 0), mk(100, 11, 1)]), null);
+});
+
+Deno.test("ADR-0005: single valid top set → that set's Epley e1RM (EWMA degenerates to single value)", () => {
+  // Epley: weight × (1 + reps / 30) = 100 × (1 + 5/30) = 116.666…
+  const result = ewmaE1RM([mk(100, 5, 0)]);
+  assertAlmostEquals(result!, 100 * (1 + 5 / 30), 1e-9);
+});
+
+Deno.test("ADR-0005: EWMA α is 0.333 (single-step formula on 2 sets, oldest-first input)", () => {
+  // Input ordered oldest → newest. Single-step EWMA collapses to:
+  //   ema = α × newer + (1 − α) × older
+  // (Initialize at older; one update step weighted at α toward newer.)
+  const older = mk(100, 5, 0);
+  const newer = mk(110, 5, 1);
+  const expected = EWMA_ALPHA * e1rm(110, 5)! +
+    (1 - EWMA_ALPHA) * e1rm(100, 5)!;
+  assertAlmostEquals(ewmaE1RM([older, newer])!, expected, 1e-9);
+});
+
+Deno.test("ADR-0005: filter-first then suffix — invalid sets do not shrink the EWMA window", () => {
+  // 7 raw sets with one invalid (reps=11) interleaved at index 4.
+  // Filter-first (CORRECT, locked here): filtered=[v1..v6] (6 valid),
+  //   suffix-5 = [v2..v6] → 5 valid contribute, EWMA initialized at v2.
+  // Suffix-then-filter (INCORRECT divergent interpretation): raw suffix-5
+  //   = [v3, INVALID, v4, v5, v6]; filtering drops INVALID, leaving 4
+  //   valid; EWMA initialized at v3. v2 never contributes.
+  // The two interpretations only diverge when ≥6 raw sets exist with at
+  // least one invalid interleaved such that filtered.length > 5; this
+  // case satisfies that condition by construction (110kg distinctive at v2).
+  const raw: TopSet[] = [
+    mk(1000, 5, 0), // v1 — beyond suffix under both interpretations
+    mk(110, 5, 1), // v2 — only contributes under filter-first
+    mk(100, 5, 2), // v3
+    mk(100, 5, 3), // v4
+    mk(100, 11, 4), // INVALID
+    mk(100, 5, 5), // v5
+    mk(100, 5, 6), // v6
+  ];
+  // Closed-form filter-first expectation: window = [v2..v6] e1RMs.
+  const w = [110, 100, 100, 100, 100].map((kg) => e1rm(kg, 5)!);
+  const a = EWMA_ALPHA;
+  const expected = Math.pow(1 - a, 4) * w[0] +
+    a * Math.pow(1 - a, 3) * w[1] +
+    a * Math.pow(1 - a, 2) * w[2] +
+    a * (1 - a) * w[3] +
+    a * w[4];
+  assertAlmostEquals(ewmaE1RM(raw)!, expected, 1e-9);
+});
+
+Deno.test("ADR-0005: EWMA window is suffix-of-5 — older sets beyond the window do not contribute", () => {
+  // Oldest set is 1000kg×5 (a wildly high outlier). The remaining 5 are
+  // 100×5. If the window were 6 (or no window), the outlier would pull
+  // the EWMA up via the (1−α)⁵ tail weight. With suffix-of-5 the outlier
+  // is dropped and the EWMA over 5 identical 100×5 sets equals e1rm(100,5).
+  const sets = [
+    mk(1000, 5, 0),
+    mk(100, 5, 1),
+    mk(100, 5, 2),
+    mk(100, 5, 3),
+    mk(100, 5, 4),
+    mk(100, 5, 5),
+  ];
+  assertAlmostEquals(ewmaE1RM(sets)!, e1rm(100, 5)!, 1e-9);
+});
+
+Deno.test("ADR-0005: transition-mode mean over 3 sessions — plain mean + Bessel-corrected sample variance (n−1 denominator)", () => {
+  // Three sessions, one valid top set each, chronologically ordered.
+  const sets = [
+    mk(100, 5, 0, "session-A"),
+    mk(110, 5, 1, "session-B"),
+    mk(120, 5, 2, "session-C"),
+  ];
+  const e = sets.map((s) => e1rm(s.weight, s.reps)!);
+  const expectedMean = (e[0] + e[1] + e[2]) / 3;
+  const expectedVariance =
+    ((e[0] - expectedMean) ** 2 + (e[1] - expectedMean) ** 2 +
+      (e[2] - expectedMean) ** 2) / (3 - 1);
+
+  const result = transitionModeMean(sets);
+  assertEquals(result?.sessionCount, 3);
+  assertAlmostEquals(result!.mean, expectedMean, 1e-9);
+  assertAlmostEquals(result!.variance, expectedVariance, 1e-9);
+});
+
+Deno.test("ADR-0005: transition-mode 4 sessions → suffix-3 (only the 3 most recent contribute)", () => {
+  // Oldest session is a 1000kg outlier; if not dropped from the window
+  // the mean would skew an order of magnitude high. Suffix-3 → mean is
+  // computed over sessions B, C, D only.
+  const sets = [
+    mk(1000, 5, 0, "session-A"), // dropped under suffix-3
+    mk(100, 5, 1, "session-B"),
+    mk(110, 5, 2, "session-C"),
+    mk(120, 5, 3, "session-D"),
+  ];
+  const e = [e1rm(100, 5)!, e1rm(110, 5)!, e1rm(120, 5)!];
+  const expectedMean = (e[0] + e[1] + e[2]) / 3;
+  const expectedVariance =
+    ((e[0] - expectedMean) ** 2 + (e[1] - expectedMean) ** 2 +
+      (e[2] - expectedMean) ** 2) / (3 - 1);
+
+  const result = transitionModeMean(sets);
+  assertEquals(result?.sessionCount, 3);
+  assertAlmostEquals(result!.mean, expectedMean, 1e-9);
+  assertAlmostEquals(result!.variance, expectedVariance, 1e-9);
+});
+
+Deno.test("ADR-0005: computeE1RM(inTransitionMode=false) delegates to ewmaE1RM (standard 5-set window)", () => {
+  const sets = [
+    mk(100, 5, 0),
+    mk(102, 5, 1),
+    mk(104, 5, 2),
+    mk(106, 5, 3),
+    mk(108, 5, 4),
+  ];
+  assertAlmostEquals(computeE1RM(sets, false)!, ewmaE1RM(sets)!, 1e-9);
+});
+
+Deno.test("ADR-0005: computeE1RM(inTransitionMode=true) returns transitionModeMean.mean (drops variance/sessionCount — orchestrator only needs central tendency here)", () => {
+  const sets = [
+    mk(100, 5, 0, "session-A"),
+    mk(110, 5, 1, "session-B"),
+    mk(120, 5, 2, "session-C"),
+  ];
+  const tm = transitionModeMean(sets);
+  assertAlmostEquals(computeE1RM(sets, true)!, tm!.mean, 1e-9);
+});
+
+Deno.test("ADR-0005: transition-mode multi-set session → heaviest e1RM per session is used (not first-logged)", () => {
+  // Two sets in the same session: 80×5 (logged first) and 120×5 (logged
+  // later, heavier). Heaviest-e1RM-per-session selects the 120×5.
+  // First-encounter selection would pick 80×5 and fail this test.
+  const sets = [
+    mk(80, 5, 0, "session-A"),
+    mk(120, 5, 0, "session-A"),
+  ];
+  const result = transitionModeMean(sets);
+  assertEquals(result?.sessionCount, 1);
+  assertAlmostEquals(result!.mean, e1rm(120, 5)!, 1e-9);
+  assertEquals(result?.variance, 0);
+});
+
+Deno.test("ADR-0005: transition-mode mean over 1 session — variance=0 is a convention (n=1 special case, not derived from Bessel-corrected formula which would be 0/0)", () => {
+  // With one session the sample-variance numerator is 0 (the single
+  // observation IS the mean) and the n−1 denominator is 0, so the
+  // formula yields 0/0. Implementations must special-case n=1 to
+  // return variance = 0; this test pins that convention.
+  const result = transitionModeMean([mk(100, 5, 0, "session-A")]);
+  assertEquals(result?.sessionCount, 1);
+  assertAlmostEquals(result!.mean, e1rm(100, 5)!, 1e-9);
+  assertEquals(result?.variance, 0);
+});
+
+Deno.test("ADR-0005: EWMA over 5-set window applies α weighting across full window (oldest → newest)", () => {
+  // Closed-form check (independent of the iterative implementation):
+  //   ema = (1−α)⁴ x₀ + α(1−α)³ x₁ + α(1−α)² x₂ + α(1−α) x₃ + α x₄
+  // Weights of expanding the recurrence ema_n = α x_n + (1−α) ema_{n-1}.
+  const sets = [
+    mk(100, 5, 0),
+    mk(102, 5, 1),
+    mk(104, 5, 2),
+    mk(106, 5, 3),
+    mk(108, 5, 4),
+  ];
+  const e = sets.map((s) => e1rm(s.weight, s.reps)!);
+  const a = EWMA_ALPHA;
+  const expected = Math.pow(1 - a, 4) * e[0] +
+    a * Math.pow(1 - a, 3) * e[1] +
+    a * Math.pow(1 - a, 2) * e[2] +
+    a * (1 - a) * e[3] +
+    a * e[4];
+  assertAlmostEquals(ewmaE1RM(sets)!, expected, 1e-9);
+});

--- a/supabase/functions/_shared/transition-mode-expiry.ts
+++ b/supabase/functions/_shared/transition-mode-expiry.ts
@@ -1,0 +1,62 @@
+// Project Apex — Phase 2 transition-mode expiry composer.
+//
+// Per Q5 PRD-internal lock-in: when an ADR-0005 trigger fires
+// (calibration recency, deload-end, phase transition, long-absence
+// return), the trainee model's `transitionModeUntil` is set to:
+//
+//   transitionModeUntil = now + cadenceAwareDuration(cadence, 3, 14d, 21d)
+//
+// composed via the ADR-0015 cadence-aware-duration primitive
+// (`./cadence-translation.ts`). Composition with an existing
+// `currentUntil` is max-of-untils on overlap (extend, don't reset),
+// fresh-from-now after expiry.
+//
+// The 14-day floor rationale is independent-session-equivalents at high
+// cadence (statistical noise reduction needs more sessions when sessions
+// are less independent), NOT fatigue accumulation. The 21-day nil
+// fallback covers ~3 sessions at an assumed 1×/week resume cadence for
+// the long-absence-returner case.
+//
+// Pure: no I/O, no clock reads. `now` is injected by the caller.
+
+import { cadenceAwareDuration } from "./cadence-translation.ts";
+import {
+  TRANSITION_MODE_CADENCE_MULTIPLIER,
+  TRANSITION_MODE_FLOOR_DAYS,
+  TRANSITION_MODE_NIL_CADENCE_FALLBACK_DAYS,
+} from "./constants.ts";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const addDays = (base: Date, days: number): Date =>
+  new Date(base.getTime() + days * MS_PER_DAY);
+
+/**
+ * Compose transition-mode expiry per Q5 PRD-internal + ADR-0015.
+ *
+ * @param now - injected wall-clock (caller-supplied; this module reads no clock).
+ * @param cadenceDays - mean delta between recent sessions, or null when fewer
+ *                     than 2 sessions are recorded (long-absence-returner case).
+ * @param currentUntil - the existing `transitionModeUntil`, or null on first
+ *                      transition-mode entry.
+ */
+export function computeTransitionModeUntil(
+  now: Date,
+  cadenceDays: number | null,
+  currentUntil: Date | null,
+): Date {
+  const days = cadenceAwareDuration(
+    cadenceDays,
+    TRANSITION_MODE_CADENCE_MULTIPLIER,
+    TRANSITION_MODE_FLOOR_DAYS,
+    TRANSITION_MODE_NIL_CADENCE_FALLBACK_DAYS,
+  );
+  const computed = addDays(now, days);
+  // Max-of-untils on overlap (extend, don't shrink). currentUntil only
+  // participates when it's still in the future; an expired currentUntil
+  // is treated as fresh-from-now (no carry-over).
+  if (currentUntil !== null && currentUntil.getTime() > now.getTime()) {
+    return currentUntil.getTime() > computed.getTime() ? currentUntil : computed;
+  }
+  return computed;
+}

--- a/supabase/functions/_shared/transition-mode-expiry_test.ts
+++ b/supabase/functions/_shared/transition-mode-expiry_test.ts
@@ -1,0 +1,70 @@
+// Project Apex — Phase 2 transition-mode expiry composer tests.
+//
+// Per Q5 PRD-internal lock-in (memory: project_phase_2_grilling_prd_internal_lockins.md)
+// and ADR-0015 (cadence-aware translation pattern):
+//
+//   transitionModeUntil = now + cadenceAwareDuration(cadence, 3, 14d, 21d)
+//
+//   - On overlap (currentUntil non-null and in the future):
+//       new transitionModeUntil = max(currentUntil, computedUntil)
+//   - After expiry (currentUntil non-null and in the past, or null):
+//       new transitionModeUntil = computedUntil (fresh from now)
+//
+// Run locally:
+//   deno test supabase/functions/_shared/transition-mode-expiry_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { computeTransitionModeUntil } from "./transition-mode-expiry.ts";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const NOW = new Date("2026-05-08T12:00:00Z");
+const daysAfter = (base: Date, days: number) =>
+  new Date(base.getTime() + days * MS_PER_DAY);
+
+Deno.test("Q5 / ADR-0015: no prior expiry + cadence 4d → now + 14d (floor wins over 3 × 4 = 12d)", () => {
+  const result = computeTransitionModeUntil(NOW, 4, null);
+  assertEquals(result.getTime(), daysAfter(NOW, 14).getTime());
+});
+
+Deno.test("Q5 / ADR-0015: no prior expiry + cadence 7d → now + 21d (cadence × 3 = 21d wins over 14d floor)", () => {
+  const result = computeTransitionModeUntil(NOW, 7, null);
+  assertEquals(result.getTime(), daysAfter(NOW, 21).getTime());
+});
+
+Deno.test("Q5 / ADR-0015: no prior expiry + nil cadence → now + 21d (long-absence-returner nil fallback)", () => {
+  const result = computeTransitionModeUntil(NOW, null, null);
+  assertEquals(result.getTime(), daysAfter(NOW, 21).getTime());
+});
+
+Deno.test("Q5: overlap with currentUntil 5d in future and computed 14d → computed wins (max-of-untils)", () => {
+  // Both candidates are in the future; max(now+5d, now+14d) = now+14d.
+  const currentUntil = daysAfter(NOW, 5);
+  const result = computeTransitionModeUntil(NOW, 4, currentUntil);
+  assertEquals(result.getTime(), daysAfter(NOW, 14).getTime());
+});
+
+Deno.test("Q5: overlap with currentUntil 20d in future and computed 14d → currentUntil preserved (max-of-untils, extend-don't-shrink)", () => {
+  // currentUntil > computed → max-of-untils preserves currentUntil so a
+  // re-trigger inside an existing window cannot shrink the deadline.
+  const currentUntil = daysAfter(NOW, 20);
+  const result = computeTransitionModeUntil(NOW, 4, currentUntil);
+  assertEquals(result.getTime(), currentUntil.getTime());
+});
+
+Deno.test("Q5 / ADR-0015: high-cadence pathology guard — cadence 1d → now + 14d (3 × 1d = 3d, floor wins)", () => {
+  // Mirrors the cadence-translator's pathology test: at very high
+  // cadence the session-derived candidate would shrink the window
+  // implausibly small; the 14d calendar floor is the guard.
+  const result = computeTransitionModeUntil(NOW, 1, null);
+  assertEquals(result.getTime(), daysAfter(NOW, 14).getTime());
+});
+
+Deno.test("Q5: expired currentUntil (1d past) + cadence 7d → fresh-from-now (now + 21d) — past currentUntil is ignored, no carry-over", () => {
+  // Pins two semantics in one assertion: an expired currentUntil never
+  // participates in max-of-untils (it would otherwise drag the new until
+  // backwards into the past), and the cadence × 3 = 21d formula is used
+  // (since 21d > 14d floor).
+  const currentUntil = daysAfter(NOW, -1);
+  const result = computeTransitionModeUntil(NOW, 7, currentUntil);
+  assertEquals(result.getTime(), daysAfter(NOW, 21).getTime());
+});


### PR DESCRIPTION
## Summary

Two paired pure modules per #77 — they ship together because EWMA window-mode and transition-mode expiry are inseparable (flipping the `inTransitionMode` flag IS what changes the EWMA window; Q5 expiry governs when the flag turns off).

- **`supabase/functions/_shared/ewma-engine.ts`** — exports `e1rm`, `ewmaE1RM`, `transitionModeMean`, `computeE1RM`. Standard mode: EWMA (α = 0.333) over the last 5 valid top sets. Transition mode: plain mean over the heaviest e1RM per session across the 3 most recent sessions, with Bessel-corrected sample variance.
- **`supabase/functions/_shared/transition-mode-expiry.ts`** — exports `computeTransitionModeUntil`, the Q5 PRD-internal composer. Composes with A4's cadence-aware-duration primitive (#75) per ADR-0015: `transitionModeUntil = now + cadenceAwareDuration(cadence, 3, 14d, 21d)`. Max-of-untils on overlap (extend, don't shrink); fresh-from-now after expiry.

Pure functions throughout — no I/O, no clock reads (`now: Date` is caller-injected). All load-bearing numbers come from the A1 named-constants module (#72); no new constants.

## TDD cycles (20/20)

Per-behavior, RED → GREEN, no horizontal batching. Test names cite the originating ADR / PRD-internal lock-in so a failure surfaces the rule it pins.

**EWMA engine — 13 cycles**

1. `ewmaE1RM([])` → null (no observations)
2. All reps out of 3..10 validity → null
3. Single valid top set → that set's Epley e1RM
4. Two valid sets, oldest-first input → `α × newer + (1−α) × older` single-step formula
5. Five valid sets → full window EWMA recursion (closed-form weighted-sum check, independent of the iterative impl)
6. Six valid sets → suffix-of-5; oldest 1000 kg outlier dropped
7. **Filter-first divergent case** — 7 raw with one invalid interleaved (see Sharpenings below)
8. `transitionModeMean` 1 session → variance = 0 by **convention** (n=1 special-case)
9. `transitionModeMean` 3 sessions → plain mean + Bessel-corrected sample variance (n−1 denominator)
10. `transitionModeMean` 4 sessions → only the 3 most recent contribute
11. `transitionModeMean` multi-set sessions → heaviest e1RM per session is used (not first-logged)
12. `computeE1RM(_, true)` delegates to `transitionModeMean.mean`
13. `computeE1RM(_, false)` delegates to `ewmaE1RM`

**Transition-mode expiry — 7 cycles**

14. `currentUntil = null` + cadence 4d → now + 14d (floor wins over 12d)
15. `currentUntil = null` + cadence 7d → now + 21d (cadence × 3 wins over floor)
16. `currentUntil = null` + nil cadence → now + 21d (long-absence-returner fallback)
17. Overlap, currentUntil 5d future + computed 14d → computed wins (max-of-untils)
18. Overlap, currentUntil 20d future + computed 14d → currentUntil preserved (extend, don't shrink)
19. **Expired currentUntil 1d past + cadence 7d → fresh-from-now at now + 21d** (see Sharpenings)
20. High-cadence pathology guard — cadence 1d → now + 14d (floor wins)

Several cycles passed without code change (2, 5, 7, 15, 16, 17, 19) — they pin the spec for cases the prior minimal implementation already covered correctly. Each still locks the behavior so a future refactor cannot regress silently.

## Discipline

- Validity gate (`TOP_SET_REP_VALIDITY_MIN..MAX`) is applied **filter-first** inside `ewmaE1RM` and `transitionModeMean`. Invalid sets do not shrink the suffix-of-5 (or suffix-of-3) windows — the spec is "5 valid observations," not "5 raw inputs of which some may be valid."
- Pure functions: no I/O, no `Date.now()`. Caller injects `now: Date` for the expiry composer. EWMA functions read no clock at all.
- Code comments cite ADR-0005 (EWMA + transition mode), Q5 PRD-internal (expiry composition), ADR-0015 (cadence-aware translation). Test names follow the `ADR-NNNN: …` / `Q5: …` form established by A4 / A5.
- Module-local `addDays` helper in expiry — no premature shared-helper extraction for one consumer.
- Cross-cutting grep performed: no inline `EWMA_ALPHA`, `transitionModeUntil`, Epley `weight × (1 + reps/30)`, or transition-floor literals exist elsewhere in `supabase/`. These modules are the canonical homes.

## Pre-approved sharpenings

The planning step surfaced three interpretive ambiguities; each was sharpened before any RED was written.

- **Cycle 7 — filter-first divergent case.** A short `[valid, invalid, valid]` test would pass under both filter-first and suffix-then-filter (no divergence). The cycle uses 7 raw sets with one invalid interleaved at index 4 such that filter-first yields 5 valid contributors and suffix-then-filter would yield 4. Closed-form weighted sum used so the assertion is independent of the iterative implementation. *Pre-approved during planning.*
- **Cycle 8 — n=1 → variance=0 as convention.** Bessel's n−1 denominator yields 0/0 for a single-session input. The cycle 8 test name and the source `TransitionModeResult` docstring both name this as a convention rather than a derived value, so a future reader does not assume it falls out of the formula. *Pre-approved during planning.*
- **Cycle 19 — couple ignore-past + cadence formula in one assertion.** Cadence chosen as 7d → fresh value = now + 21d, locking both the "expired currentUntil is ignored" semantic and the cadence formula in a single test. *Pre-approved during planning.*

## Out of scope (per #77)

- Triggering transition mode (calibration recency / deload-end / phase transition / long-absence return) — orchestrator A12.
- Top-set retention with bounded list — orchestrator decides retention against `TOP_SET_RETENTION_COUNT`.
- e1RM SE widening from form-degradation flag — A13.
- Form-degradation flag itself — A13 classifier slice.

## Corrections / trade-offs

None. No fresh decision points surfaced during implementation; the planning review pre-approved every interpretive choice that came up.

## Test results

`deno test supabase/functions/_shared/` — 118 passed, 0 failed (20 new + 98 pre-existing across the existing `_shared` modules).

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)