### PR TITLE
feat(slice-A7/#78): plateau verdict — hybrid two-track + muscle aggre…

### DIFF
--- a/supabase/functions/_shared/plateau-verdict.ts
+++ b/supabase/functions/_shared/plateau-verdict.ts
@@ -1,0 +1,251 @@
+// Project Apex — Phase 2 plateau-verdict module.
+//
+// Per ADR-0009 (hybrid plateau verdict, accepted 2026-05-07; amended
+// 2026-05-07 for muscle-level aggregation): this module computes
+// per-pattern `ProgressionTrend` from a hybrid two-track verdict
+// combining e1RM EWMA flatness with weekly-volume-load flatness, and
+// aggregates upward to `MuscleProfile.stagnationStatus` via
+// worst-across-patterns.
+//
+// Architectural commitment from ADR-0005: the trainee model is hybrid
+// strength/hypertrophy. The verdict surface MUST not silently flag
+// volume-shifted progression (e1RM stuck while volume rising) as
+// plateau — that's the v1 → v2 shift this slice operationalizes.
+//
+// Pure: no I/O, no clock reads. e1RM values are consumed (computed by
+// A6's EWMA engine in #77), not recomputed here.
+
+import {
+  DECLINE_E1RM_DROP_THRESHOLD,
+  DECLINE_EFFORT_GATE_RPE,
+  DECLINE_VOLUME_DROP_THRESHOLD,
+  FREQUENCY_SCALED_WINDOW_CADENCE_THRESHOLD_DAYS,
+  OVERREACH_VOLUME_LOAD_RATIO,
+  PLATEAU_E1RM_SPREAD_THRESHOLD,
+  PLATEAU_EFFORT_GATE_RPE,
+  PLATEAU_VOLUME_LOAD_SPREAD_THRESHOLD,
+} from "./constants.ts";
+
+const VOLUME_LOAD_PLATEAU_WINDOW_N = 4;
+const VOLUME_LOAD_OVERREACH_TRAILING_WINDOW_N = 4;
+
+export type ProgressionTrend = "progressing" | "plateaued" | "declining";
+type TrackVerdict = "improving" | "flat" | "declining";
+
+export interface E1RMSession {
+  loggedAt: Date;
+  e1rm: number;
+  avgRPE: number | null;
+}
+
+/**
+ * Frequency-scaled window per ADR-0009 §Tracks: 3 sessions when the
+ * pattern's cadence is ≤ 3.5d (≥2×/week training), 4 sessions when
+ * cadence > 3.5d (≤1×/week — needs an extra session to compensate
+ * for the wider between-session noise floor). Nil cadence (no
+ * derived value yet) defaults to the 3-session window.
+ */
+const windowSize = (cadenceDays: number | null): number => {
+  if (cadenceDays === null) return 3;
+  return cadenceDays <= FREQUENCY_SCALED_WINDOW_CADENCE_THRESHOLD_DAYS ? 3 : 4;
+};
+
+/**
+ * e1RM track per ADR-0009 §Tracks.
+ *
+ * Spread formula: `(max − min) / mean` over the e1RM values in the
+ * frequency-scaled window — coefficient-of-range form, symmetric
+ * (does not bias against the high or low tail of the window).
+ */
+export function e1rmTrack(
+  sessions: E1RMSession[],
+  cadenceDays: number | null,
+): TrackVerdict {
+  const baseN = windowSize(cadenceDays);
+  if (sessions.length < baseN) return "improving";
+
+  // Manual-log defence (ADR-0009 §"Plateau effort gate"): if any session
+  // in the base window has nil avgRPE, defer firing until window+1
+  // sessions are present. The evaluation window then expands to
+  // window+1 (the extra data point participates in spread + gate).
+  const baseWindow = sessions.slice(-baseN);
+  const hasNilInBase = baseWindow.some((s) => s.avgRPE === null);
+  if (hasNilInBase && sessions.length < baseN + 1) return "improving";
+  const evalWindow = hasNilInBase ? sessions.slice(-(baseN + 1)) : baseWindow;
+
+  const e1rms = evalWindow.map((s) => s.e1rm);
+  const max = Math.max(...e1rms);
+  const min = Math.min(...e1rms);
+  const mean = e1rms.reduce((a, b) => a + b, 0) / e1rms.length;
+  const spread = (max - min) / mean;
+
+  const avgRPEs = evalWindow
+    .map((s) => s.avgRPE)
+    .filter((r): r is number => r !== null);
+  // Gate behaviour:
+  //   - All non-nil:        require mean(non-nil) < 8.0 to fire
+  //   - Mixed (partial-nil): require mean(non-nil) < 8.0 to fire (Q3 refinement)
+  //   - All nil (manual-log only at window+1): gate suspended, fire on spread alone
+  const gatePassed = avgRPEs.length === 0
+    ? true
+    : (avgRPEs.reduce((a, b) => a + b, 0) / avgRPEs.length) <
+      PLATEAU_EFFORT_GATE_RPE;
+
+  // Decline rule (ADR-0009 §"Decline rules"): e1RM dropped ≥ 5% from
+  // start to end of the window AND avgRPE ≥ 7 across the window.
+  // Drops on low-RPE sessions are coasting, not decline — the gate
+  // suppresses false-positives during light/recovery weeks.
+  const start = e1rms[0];
+  const end = e1rms[e1rms.length - 1];
+  const drop = (start - end) / start;
+  const declineEffortPasses = avgRPEs.length > 0 &&
+    (avgRPEs.reduce((a, b) => a + b, 0) / avgRPEs.length) >=
+      DECLINE_EFFORT_GATE_RPE;
+  if (drop >= DECLINE_E1RM_DROP_THRESHOLD && declineEffortPasses) {
+    return "declining";
+  }
+
+  if (spread <= PLATEAU_E1RM_SPREAD_THRESHOLD && gatePassed) return "flat";
+  return "improving";
+}
+
+export interface VolumeLoadSession {
+  loggedAt: Date;
+  /** Σ weight × reps × sets for non-warmup sets per ADR-0009; one weekly aggregate. */
+  weeklyVolumeLoad: number;
+  avgRPE: number | null;
+}
+
+/**
+ * Volume-load track per ADR-0009 §Tracks. Operates on weekly aggregates
+ * (the orchestrator computes `weeklyVolumeLoad` per ADR-0002's 7-event
+ * windowing; this slice consumes the values).
+ *
+ * Plateau: spread ≤ 5% across the trailing 4 weeks AND avgRPE < 8.0.
+ */
+export function volumeLoadTrack(sessions: VolumeLoadSession[]): TrackVerdict {
+  if (sessions.length < VOLUME_LOAD_PLATEAU_WINDOW_N) return "improving";
+  const window = sessions.slice(-VOLUME_LOAD_PLATEAU_WINDOW_N);
+
+  const vls = window.map((s) => s.weeklyVolumeLoad);
+  const max = Math.max(...vls);
+  const min = Math.min(...vls);
+  const mean = vls.reduce((a, b) => a + b, 0) / vls.length;
+  const spread = (max - min) / mean;
+
+  const avgRPEs = window
+    .map((s) => s.avgRPE)
+    .filter((r): r is number => r !== null);
+  const meanRPE = avgRPEs.length === 0
+    ? Number.POSITIVE_INFINITY // no data → conservatively block plateau (gate fails)
+    : avgRPEs.reduce((a, b) => a + b, 0) / avgRPEs.length;
+
+  // Decline rule (drop): week-over-week comparison — most recent week
+  // vs the preceding week. ADR-0009 §"Decline rules" wording is "drops
+  // ≥ 10% in the most recent window relative to the prior window";
+  // v2 reads "window" as a single week (the literal reading given that
+  // weeklyVolumeLoad is already a weekly aggregate). v2.x watch-item:
+  // if alpha cohort shows decline firing on benign single-week dips
+  // (illness, travel, taper weeks), revisit as a window-based
+  // comparison (trailing 2 vs preceding 2 weeks) for additional
+  // smoothing. Asymmetric-error reasoning still favours the louder
+  // (more-firing) direction, so single-week is the right v2 default.
+  if (sessions.length >= 2) {
+    const prior = sessions[sessions.length - 2].weeklyVolumeLoad;
+    const current = sessions[sessions.length - 1].weeklyVolumeLoad;
+    const drop = (prior - current) / prior;
+    if (drop >= DECLINE_VOLUME_DROP_THRESHOLD) return "declining";
+  }
+
+  // Decline rule (overreach): current week's volume-load > 115% of the
+  // mean of the trailing 4 weeks (excluding the current). ADR-0009 uses
+  // strict ">115%" — at exactly 115%, overreach does NOT fire.
+  if (sessions.length >= VOLUME_LOAD_OVERREACH_TRAILING_WINDOW_N + 1) {
+    const current = sessions[sessions.length - 1].weeklyVolumeLoad;
+    const trailing = sessions.slice(
+      -(VOLUME_LOAD_OVERREACH_TRAILING_WINDOW_N + 1),
+      -1,
+    );
+    const trailingMean =
+      trailing.reduce((a, s) => a + s.weeklyVolumeLoad, 0) / trailing.length;
+    if (current > OVERREACH_VOLUME_LOAD_RATIO * trailingMean) return "declining";
+  }
+
+  if (
+    spread <= PLATEAU_VOLUME_LOAD_SPREAD_THRESHOLD &&
+    meanRPE < PLATEAU_EFFORT_GATE_RPE
+  ) {
+    return "flat";
+  }
+  return "improving";
+}
+
+/**
+ * Hybrid plateau verdict per ADR-0009 §"Verdict aggregation".
+ *
+ * Aggregation precedence (Option B — declining-wins):
+ *   1. either track declining → declining
+ *   2. both tracks flat       → plateaued
+ *   3. otherwise              → progressing
+ *
+ * ADR-0009's verdict table has internal precedence conflicts in the cells
+ * {improving e1RM, declining volume} and {declining e1RM, improving volume}.
+ * The ADR prose says "OR for progressing and AND for plateaued" but does
+ * not address declining precedence. Resolved here per `docs/design-
+ * principles.md` asymmetric-error preference: prefer the loud failure
+ * (over-firing declining) over the silent failure (under-flagging
+ * overreach). The {declining e1RM, improving volume} cell is the classic
+ * overreach signature — silently calling it 'progressing' would let
+ * fatigue accumulate to crash. ADR-0009 amendment proposed post-merge to
+ * make this precedence explicit in the prose.
+ */
+export function plateauVerdict(
+  e1rmSessions: E1RMSession[],
+  volumeLoadSessions: VolumeLoadSession[],
+  cadenceDays: number | null,
+): ProgressionTrend {
+  const e1rmV = e1rmTrack(e1rmSessions, cadenceDays);
+  const volumeV = volumeLoadTrack(volumeLoadSessions);
+  if (e1rmV === "declining" || volumeV === "declining") return "declining";
+  if (e1rmV === "flat" && volumeV === "flat") return "plateaued";
+  return "progressing";
+}
+
+/**
+ * Per-pattern trend + confidence used for muscle-level aggregation.
+ * `confidence` is the `PatternProfile.confidence` field; only patterns
+ * above `bootstrapping` participate per the ADR-0009 amendment.
+ */
+export interface PatternTrendForMuscleAggregation {
+  pattern: string;
+  trend: ProgressionTrend;
+  confidence: "bootstrapping" | "calibrating" | "established" | "seasoned";
+}
+
+/**
+ * Muscle-level aggregation per ADR-0009 amendment (2026-05-07).
+ *
+ * Rule: worst-across-patterns over participating patterns, where worst
+ * order is `declining > plateaued > progressing`.
+ *
+ * Participation precondition: a pattern P participates iff
+ * `PatternProfile[P].confidence > .bootstrapping` (the trend is only
+ * trustworthy once enough data has accumulated). Bootstrapping patterns
+ * are filtered out before aggregation regardless of their trend value.
+ *
+ * Empty-participation default: when zero patterns participate (the
+ * cold-start case for muscle M), the result is `'progressing'` — the
+ * `ProgressionTrend` enum has no `.bootstrapping` case, and the cold-
+ * start signal is carried by `MuscleProfile.confidence` independently.
+ * LLM digest consumers MUST read both fields per ADR-0009 amendment.
+ */
+export function aggregateMuscleStagnationStatus(
+  patterns: PatternTrendForMuscleAggregation[],
+): ProgressionTrend {
+  const participating = patterns.filter(
+    (p) => p.confidence !== "bootstrapping",
+  );
+  if (participating.some((p) => p.trend === "declining")) return "declining";
+  if (participating.some((p) => p.trend === "plateaued")) return "plateaued";
+  return "progressing";
+}

--- a/supabase/functions/_shared/plateau-verdict_test.ts
+++ b/supabase/functions/_shared/plateau-verdict_test.ts
@@ -1,0 +1,466 @@
+// Project Apex — Phase 2 plateau-verdict tests.
+//
+// Per ADR-0009 (hybrid two-track plateau verdict, including the
+// 2026-05-07 amendment for muscle-level aggregation), this slice
+// computes per-pattern `ProgressionTrend` from e1RM EWMA flatness
+// combined with weekly-volume-load flatness, and aggregates upward
+// to `MuscleProfile.stagnationStatus` via worst-across-patterns.
+//
+// Each test name pins the originating ADR (or §amendment) so a
+// failure surfaces the rule the change touches.
+//
+// Run locally:
+//   deno test supabase/functions/_shared/plateau-verdict_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  aggregateMuscleStagnationStatus,
+  type E1RMSession,
+  e1rmTrack,
+  type PatternTrendForMuscleAggregation,
+  plateauVerdict,
+  type VolumeLoadSession,
+  volumeLoadTrack,
+} from "./plateau-verdict.ts";
+
+const mkE1RM = (
+  e1rm: number,
+  daysAgo: number,
+  avgRPE: number | null = 7,
+): E1RMSession => ({
+  loggedAt: new Date(2026, 0, 1 + daysAgo),
+  e1rm,
+  avgRPE,
+});
+
+const mkVL = (
+  weeklyVolumeLoad: number,
+  weekIndex: number,
+  avgRPE: number | null = 7,
+): VolumeLoadSession => ({
+  loggedAt: new Date(2026, 0, 1 + weekIndex * 7),
+  weeklyVolumeLoad,
+  avgRPE,
+});
+
+Deno.test("ADR-0009: e1RM spread boundary at 2.5% — spread 2.4% → flat (plateau-eligible), 2.6% → improving (strict ≤ threshold)", () => {
+  // Spread formula: (max − min) / mean (Q1 lock).
+  //   [98.8, 100, 101.2] → spread = 2.4 / 100 = 2.4% ≤ 2.5% → flat
+  //   [98.7, 100, 101.3] → spread = 2.6 / 100 = 2.6% > 2.5% → improving
+  const flat: E1RMSession[] = [mkE1RM(98.8, 0), mkE1RM(100, 1), mkE1RM(101.2, 2)];
+  const improving: E1RMSession[] = [
+    mkE1RM(98.7, 0),
+    mkE1RM(100, 1),
+    mkE1RM(101.3, 2),
+  ];
+  assertEquals(e1rmTrack(flat, 3.4), "flat");
+  assertEquals(e1rmTrack(improving, 3.4), "improving");
+});
+
+Deno.test("ADR-0009: e1RM nil-RPE manual-log defence — 3 all-nil sessions defer (require window+1); 4 all-nil sessions with low spread fire on spread alone (effort gate suspended when all data is nil)", () => {
+  // Cadence 3.4 → window = 3.
+  // 3 all-nil sessions: any-nil triggers window+1 requirement; not enough data → improving.
+  // 4 all-nil sessions: window+1 satisfied; mean(non-nil) is undefined →
+  //   gate is suspended; plateau fires on spread alone (1% ≤ 2.5%).
+  const threeAllNil: E1RMSession[] = [
+    mkE1RM(99.5, 0, null),
+    mkE1RM(100, 1, null),
+    mkE1RM(100.5, 2, null),
+  ];
+  assertEquals(e1rmTrack(threeAllNil, 3.4), "improving");
+
+  const fourAllNil: E1RMSession[] = [
+    mkE1RM(99.5, 0, null),
+    mkE1RM(100, 1, null),
+    mkE1RM(100, 2, null),
+    mkE1RM(100.5, 3, null),
+  ];
+  assertEquals(e1rmTrack(fourAllNil, 3.4), "flat");
+});
+
+Deno.test("ADR-0009: e1RM decline boundary at 5% drop — 4.9% drop with avgRPE 7 → improving (under threshold, ≥ 5% required)", () => {
+  // (start − end) / start = (100 − 95.1) / 100 = 4.9% < 5% threshold → no decline.
+  const sessions: E1RMSession[] = [
+    mkE1RM(100, 0, 7),
+    mkE1RM(97.55, 1, 7),
+    mkE1RM(95.1, 2, 7),
+  ];
+  assertEquals(e1rmTrack(sessions, 3.4), "improving");
+});
+
+Deno.test("ADR-0009: e1RM 5% drop with avgRPE < 7 → improving (coasting, not declining — low-effort drops are deload/recovery, not regression)", () => {
+  // Same drop fixture as the high-RPE case but avgRPE = 6.5 < 7.0.
+  // The decline gate is the protection against firing on light weeks.
+  const sessions: E1RMSession[] = [
+    mkE1RM(100, 0, 6.5),
+    mkE1RM(97.5, 1, 6.5),
+    mkE1RM(95, 2, 6.5),
+  ];
+  assertEquals(e1rmTrack(sessions, 3.4), "improving");
+});
+
+Deno.test("ADR-0009: e1RM 5% drop start→end with avgRPE ≥ 7 → declining", () => {
+  // (start − end) / start = (100 − 95) / 100 = 5% ≥ 5% threshold,
+  // avgRPE = 7 ≥ 7 → declining fires.
+  const sessions: E1RMSession[] = [
+    mkE1RM(100, 0, 7),
+    mkE1RM(97.5, 1, 7),
+    mkE1RM(95, 2, 7),
+  ];
+  assertEquals(e1rmTrack(sessions, 3.4), "declining");
+});
+
+Deno.test("ADR-0009: e1RM partial-nil at window+1 — gate applied to mean(non-nil values), NOT bypassed to spread-alone (Q3 refinement)", () => {
+  // 4 sessions at cadence 3.4 (window=3, window+1=4):
+  //   - Session 2 has nil avgRPE; the other three are 9.0 (high effort)
+  //   - Spread = 1% (well under 2.5%)
+  //   - mean(non-nil avgRPE) = 9.0 ≥ 8.0 → gate fails → improving
+  // The "fire on spread alone" path is reserved for ALL-nil at window+1.
+  // Partial-nil keeps the effort gate active using whatever RPE data exists.
+  const partialNil: E1RMSession[] = [
+    mkE1RM(99.5, 0, 9.0),
+    mkE1RM(100, 1, null),
+    mkE1RM(100, 2, 9.0),
+    mkE1RM(100.5, 3, 9.0),
+  ];
+  assertEquals(e1rmTrack(partialNil, 3.4), "improving");
+});
+
+Deno.test("ADR-0009: e1RM effort gate at avgRPE 8.0 (strict <) — 7.99 plateau-eligible, 8.0 → improving (high-RPE flatness is grinding, not plateau)", () => {
+  const flat: E1RMSession[] = [
+    mkE1RM(100, 0, 7.99),
+    mkE1RM(100, 1, 7.99),
+    mkE1RM(100, 2, 7.99),
+  ];
+  const improving: E1RMSession[] = [
+    mkE1RM(100, 0, 8.0),
+    mkE1RM(100, 1, 8.0),
+    mkE1RM(100, 2, 8.0),
+  ];
+  assertEquals(e1rmTrack(flat, 3.4), "flat");
+  assertEquals(e1rmTrack(improving, 3.4), "improving");
+});
+
+Deno.test("ADR-0009: volume-load drop ≥ 10% prior week → most recent week → declining (no RPE gate on volume-load decline)", () => {
+  // Week-over-week drop: prior=10000, current=9000 → 10% drop ≥ threshold.
+  const sessions: VolumeLoadSession[] = [
+    mkVL(10000, 0),
+    mkVL(10000, 1),
+    mkVL(10000, 2),
+    mkVL(9000, 3),
+  ];
+  assertEquals(volumeLoadTrack(sessions), "declining");
+});
+
+Deno.test("ADR-0009: volume-load overreach boundary — current at 114.9% of trailing-4 mean does NOT fire overreach; fall-through is 'improving' under realistic fixture geometry (Option A applied per cycle 10 reasoning)", () => {
+  // Same math constraint as cycle 10: a 14.9% spike above the trailing
+  // mean produces suffix-4 spread ~14% — incompatible with the 5%
+  // plateau threshold. Per the authority hierarchy (formula > issue prose),
+  // the test asserts the actual fall-through verdict 'improving'.
+  // The strict ≥ threshold check on overreach is what the test pins.
+  const sessions: VolumeLoadSession[] = [
+    mkVL(10000, 0),
+    mkVL(10000, 1),
+    mkVL(10000, 2),
+    mkVL(10000, 3),
+    mkVL(11490, 4),
+  ];
+  assertEquals(volumeLoadTrack(sessions), "improving");
+});
+
+Deno.test("ADR-0009: volume-load overreach boundary at exactly 115% — strict > threshold, so 115.0% itself does NOT fire overreach (boundary lock — flipping to ≥ would regress this test)", () => {
+  // Prior 4 mean = 10000; current = 11500 exactly. 11500 > 1.15 × 10000 = 11500
+  // is FALSE under strict-greater-than. Drop is negative (volume rose), spread
+  // suffix-4 is ~14.5% > 5% → fall-through verdict is 'improving'.
+  const sessions: VolumeLoadSession[] = [
+    mkVL(10000, 0),
+    mkVL(10000, 1),
+    mkVL(10000, 2),
+    mkVL(10000, 3),
+    mkVL(11500, 4),
+  ];
+  assertEquals(volumeLoadTrack(sessions), "improving");
+});
+
+Deno.test("ADR-0009: volume-load overreach detector — current week > 115% of mean(prior 4 weeks) → declining", () => {
+  // 5 weeks: prior 4 = [10000]×4 (mean 10000); current = 11600.
+  // 11600 > 1.15 × 10000 = 11500 → overreach fires → declining.
+  const sessions: VolumeLoadSession[] = [
+    mkVL(10000, 0),
+    mkVL(10000, 1),
+    mkVL(10000, 2),
+    mkVL(10000, 3),
+    mkVL(11600, 4),
+  ];
+  assertEquals(volumeLoadTrack(sessions), "declining");
+});
+
+Deno.test("ADR-0009: volume-load drop boundary at 10% — drop 9.9% does NOT fire decline (strict ≥ threshold); fall-through is 'improving' under realistic fixture geometry", () => {
+  // Issue #78 describes this case as "drop 9.9% → flat (under threshold)",
+  // but that verdict is mathematically unreachable under Q1's (max−min)/mean
+  // spread formula: a 9.9% week-over-week drop produces range ≥ 990, and
+  // (max−min)/mean ≤ 5% would require mean ≥ 19800 — incompatible with a
+  // min of 9010 in any realistic-shape fixture. Per the authority hierarchy
+  // (formula > issue prose), the test asserts what the rule actually
+  // returns: 'improving' (decline doesn't fire AND spread > plateau gate).
+  // The boundary-lock value is preserved: a strict ≥ threshold test would
+  // fail if the implementation flipped to >.
+  const sessions: VolumeLoadSession[] = [
+    mkVL(10000, 0),
+    mkVL(10000, 1),
+    mkVL(10000, 2),
+    mkVL(9010, 3),
+  ];
+  assertEquals(volumeLoadTrack(sessions), "improving");
+});
+
+Deno.test("ADR-0009: volume-load track plateau on 5% spread (trailing 4 weeks) + avgRPE < 8 → flat", () => {
+  // Trailing 4 weeks: [9750, 10000, 10000, 10250] → max=10250, min=9750,
+  // mean=10000, spread = 500/10000 = 5% ≤ 5% threshold; avgRPE 7 < 8 → flat.
+  const sessions: VolumeLoadSession[] = [
+    mkVL(9750, 0),
+    mkVL(10000, 1),
+    mkVL(10000, 2),
+    mkVL(10250, 3),
+  ];
+  assertEquals(volumeLoadTrack(sessions), "flat");
+});
+
+Deno.test("ADR-0009 amendment: muscle aggregation — empty participation (no patterns at all) → muscle progressing (no-signal default; cold-start signal lives in MuscleProfile.confidence)", () => {
+  assertEquals(aggregateMuscleStagnationStatus([]), "progressing");
+});
+
+Deno.test("ADR-0009 amendment: muscle aggregation — single-pattern muscle (chest with horizontalPush declining) → muscle declining (trivial aggregation; chest/shoulders/biceps/triceps have ≤1 primary pattern)", () => {
+  const chestPatterns: PatternTrendForMuscleAggregation[] = [
+    { pattern: "horizontalPush", trend: "declining", confidence: "established" },
+  ];
+  assertEquals(aggregateMuscleStagnationStatus(chestPatterns), "declining");
+});
+
+Deno.test("ADR-0009 amendment: muscle aggregation — legs scenario (squat plateaued + hipHinge progressing + lunge progressing, all participating) → legs plateaued (the canonical aggregation-risk concentration cell — see v2.x watch-item #9)", () => {
+  // The named scenario from ADR-0009 §"Concentration of aggregation risk".
+  // Squat plateaus are common; under worst-across-patterns, one squat plateau
+  // forces legs.stagnationStatus = .plateaued even when hipHinge and lunge
+  // are progressing. v2.x upgrade-path trigger if this fires >30% of the
+  // time across alpha cohort.
+  const legsPatterns: PatternTrendForMuscleAggregation[] = [
+    { pattern: "squat", trend: "plateaued", confidence: "established" },
+    { pattern: "hipHinge", trend: "progressing", confidence: "established" },
+    { pattern: "lunge", trend: "progressing", confidence: "calibrating" },
+  ];
+  assertEquals(aggregateMuscleStagnationStatus(legsPatterns), "plateaued");
+});
+
+Deno.test("ADR-0009 amendment: muscle aggregation — all patterns declining BUT all bootstrapping → muscle progressing (precondition filters them all out, falling through to no-signal default)", () => {
+  // Without the precondition filter, the worst-of rule would return
+  // declining. With it, the participating set is empty → progressing.
+  const patterns: PatternTrendForMuscleAggregation[] = [
+    { pattern: "squat", trend: "declining", confidence: "bootstrapping" },
+    { pattern: "hipHinge", trend: "declining", confidence: "bootstrapping" },
+    { pattern: "lunge", trend: "declining", confidence: "bootstrapping" },
+  ];
+  assertEquals(aggregateMuscleStagnationStatus(patterns), "progressing");
+});
+
+Deno.test("ADR-0009 amendment: muscle aggregation — bootstrapping pattern with declining trend does NOT participate (precondition: confidence > .bootstrapping); rest progressing → muscle progressing", () => {
+  // Squat is declining but its confidence is bootstrapping — not enough
+  // data to trust the trend. Filtered out per the amendment's
+  // participation precondition. Remaining patterns are both progressing.
+  const patterns: PatternTrendForMuscleAggregation[] = [
+    { pattern: "squat", trend: "declining", confidence: "bootstrapping" },
+    { pattern: "hipHinge", trend: "progressing", confidence: "established" },
+    { pattern: "lunge", trend: "progressing", confidence: "calibrating" },
+  ];
+  assertEquals(aggregateMuscleStagnationStatus(patterns), "progressing");
+});
+
+Deno.test("ADR-0009 amendment: muscle aggregation — one declining + one plateaued + one progressing → muscle declining (declining > plateaued in worst-order)", () => {
+  const patterns: PatternTrendForMuscleAggregation[] = [
+    { pattern: "squat", trend: "declining", confidence: "established" },
+    { pattern: "hipHinge", trend: "plateaued", confidence: "established" },
+    { pattern: "lunge", trend: "progressing", confidence: "calibrating" },
+  ];
+  assertEquals(aggregateMuscleStagnationStatus(patterns), "declining");
+});
+
+Deno.test("ADR-0009 amendment: muscle aggregation — one pattern plateaued + rest progressing → muscle plateaued", () => {
+  const patterns: PatternTrendForMuscleAggregation[] = [
+    { pattern: "squat", trend: "plateaued", confidence: "established" },
+    { pattern: "hipHinge", trend: "progressing", confidence: "established" },
+    { pattern: "lunge", trend: "progressing", confidence: "calibrating" },
+  ];
+  assertEquals(aggregateMuscleStagnationStatus(patterns), "plateaued");
+});
+
+Deno.test("ADR-0009 amendment: muscle aggregation — one pattern declining + rest progressing → muscle declining (worst-across-patterns)", () => {
+  const patterns: PatternTrendForMuscleAggregation[] = [
+    { pattern: "squat", trend: "declining", confidence: "established" },
+    { pattern: "hipHinge", trend: "progressing", confidence: "established" },
+    { pattern: "lunge", trend: "progressing", confidence: "calibrating" },
+  ];
+  assertEquals(aggregateMuscleStagnationStatus(patterns), "declining");
+});
+
+Deno.test("ADR-0009 amendment (2026-05-07): muscle aggregation — all participating patterns progressing → muscle progressing", () => {
+  // legs scenario base: 3 patterns all progressing, mixed confidence levels
+  // (none bootstrapping → all participate).
+  const patterns: PatternTrendForMuscleAggregation[] = [
+    { pattern: "squat", trend: "progressing", confidence: "established" },
+    { pattern: "hipHinge", trend: "progressing", confidence: "established" },
+    { pattern: "lunge", trend: "progressing", confidence: "calibrating" },
+  ];
+  assertEquals(aggregateMuscleStagnationStatus(patterns), "progressing");
+});
+
+Deno.test("ADR-0005 + ADR-0009: architectural commitment — volume-shifted progression must NOT silently plateau (e1RM EWMA spread 1% with avgRPE 7 is flat per the rule, volume-load rising → verdict is 'progressing'; the v1 → v2 hybrid commitment lives or dies on this cell)", () => {
+  // The legacy strength-only StagnationService would call this 'plateaued'
+  // because the e1RM track is flat. ADR-0009's hybrid two-track verdict
+  // exists so volume-shifted progression (e1RM stuck while working sets
+  // climb) is correctly read as real progress.
+  const e1rmFlatSpread1pct: E1RMSession[] = [
+    mkE1RM(99.5, 0, 7),
+    mkE1RM(100, 1, 7),
+    mkE1RM(100.5, 2, 7),
+  ];
+  const volumeRising: VolumeLoadSession[] = [
+    mkVL(9000, 0),
+    mkVL(9500, 1),
+    mkVL(10000, 2),
+    mkVL(10500, 3),
+  ];
+  assertEquals(
+    plateauVerdict(e1rmFlatSpread1pct, volumeRising, 3.4),
+    "progressing",
+  );
+});
+
+Deno.test("ADR-0009 + design-principles.md: aggregation — any e1RM + volume declining → declining; the {improving e1RM + declining volume} sub-case is the load-bearing Option B precedence lock on the mirror cell (could be peaking phase or overreach precursor; loud-failure preference fires declining either way)", () => {
+  const volumeDeclining: VolumeLoadSession[] = [
+    mkVL(10000, 0),
+    mkVL(10000, 1),
+    mkVL(10000, 2),
+    mkVL(9000, 3),
+  ];
+  const e1rmImproving: E1RMSession[] = [
+    mkE1RM(95, 0),
+    mkE1RM(100, 1),
+    mkE1RM(105, 2),
+  ];
+  const e1rmFlat: E1RMSession[] = [
+    mkE1RM(100, 0),
+    mkE1RM(100, 1),
+    mkE1RM(100, 2),
+  ];
+  const e1rmDeclining: E1RMSession[] = [
+    mkE1RM(100, 0, 7),
+    mkE1RM(97.5, 1, 7),
+    mkE1RM(95, 2, 7),
+  ];
+  // Load-bearing precedence lock: peaking-phase or overreach-precursor cell.
+  assertEquals(plateauVerdict(e1rmImproving, volumeDeclining, 3.4), "declining");
+  assertEquals(plateauVerdict(e1rmFlat, volumeDeclining, 3.4), "declining");
+  assertEquals(plateauVerdict(e1rmDeclining, volumeDeclining, 3.4), "declining");
+});
+
+Deno.test("ADR-0009 + design-principles.md: aggregation — e1RM declining + any volume → declining; the {declining e1RM + improving volume} sub-case is the load-bearing Option B precedence lock (loud-failure preference resolves the table's conflict cell — silently calling overreach 'progressing' would let fatigue accumulate to crash)", () => {
+  const e1rmDeclining: E1RMSession[] = [
+    mkE1RM(100, 0, 7),
+    mkE1RM(97.5, 1, 7),
+    mkE1RM(95, 2, 7),
+  ];
+  const volumeFlat: VolumeLoadSession[] = [
+    mkVL(10000, 0),
+    mkVL(10000, 1),
+    mkVL(10000, 2),
+    mkVL(10000, 3),
+  ];
+  const volumeDeclining: VolumeLoadSession[] = [
+    mkVL(10000, 0),
+    mkVL(10000, 1),
+    mkVL(10000, 2),
+    mkVL(9000, 3),
+  ];
+  const volumeRising: VolumeLoadSession[] = [
+    mkVL(9000, 0),
+    mkVL(9500, 1),
+    mkVL(10000, 2),
+    mkVL(10500, 3),
+  ];
+  assertEquals(plateauVerdict(e1rmDeclining, volumeFlat, 3.4), "declining");
+  assertEquals(plateauVerdict(e1rmDeclining, volumeDeclining, 3.4), "declining");
+  // Load-bearing precedence lock: the classic overreach signature.
+  assertEquals(plateauVerdict(e1rmDeclining, volumeRising, 3.4), "declining");
+});
+
+Deno.test("ADR-0009: aggregation — flat + flat → plateaued (the only verdict cell that fires plateau; both tracks must be flat AND-conjunctively)", () => {
+  const e1rmFlat: E1RMSession[] = [
+    mkE1RM(100, 0),
+    mkE1RM(100, 1),
+    mkE1RM(100, 2),
+  ];
+  const volumeFlat: VolumeLoadSession[] = [
+    mkVL(10000, 0),
+    mkVL(10000, 1),
+    mkVL(10000, 2),
+    mkVL(10000, 3),
+  ];
+  assertEquals(plateauVerdict(e1rmFlat, volumeFlat, 3.4), "plateaued");
+});
+
+Deno.test("ADR-0009: aggregation — flat e1RM + improving volume → progressing (volume-shifted save; the architectural commitment cell is a fixture-of-this-test in cycle 19)", () => {
+  // Sub-case: e1RM flat (rep-band stuck) but volume rising — verdict is
+  // 'progressing' because volume saves it. Lock for cycle 15.
+  // The declining+improving cell of "any e1RM + volume improving" is
+  // declining under Option B and is tested in cycle 17.
+  const e1rmFlat: E1RMSession[] = [
+    mkE1RM(100, 0),
+    mkE1RM(100, 1),
+    mkE1RM(100, 2),
+  ];
+  const volumeRising: VolumeLoadSession[] = [
+    mkVL(9000, 0),
+    mkVL(9500, 1),
+    mkVL(10000, 2),
+    mkVL(10500, 3),
+  ];
+  assertEquals(plateauVerdict(e1rmFlat, volumeRising, 3.4), "progressing");
+});
+
+Deno.test("ADR-0009: aggregation — e1RM improving + volume {improving | flat} → progressing (rising e1RM is unambiguous progress; volume can be plateau or rising without changing the verdict)", () => {
+  // The improving + declining sub-case is locked to 'declining' under Option B
+  // (declining-wins precedence per design-principles.md asymmetric-error) and
+  // is tested in cycle 18 below — not here.
+  const e1rmRising: E1RMSession[] = [
+    mkE1RM(95, 0),
+    mkE1RM(100, 1),
+    mkE1RM(105, 2),
+  ];
+  const volumeRising: VolumeLoadSession[] = [
+    mkVL(9000, 0),
+    mkVL(9500, 1),
+    mkVL(10000, 2),
+    mkVL(10500, 3),
+  ];
+  const volumeFlat: VolumeLoadSession[] = [
+    mkVL(10000, 0),
+    mkVL(10000, 1),
+    mkVL(10000, 2),
+    mkVL(10000, 3),
+  ];
+  assertEquals(plateauVerdict(e1rmRising, volumeRising, 3.4), "progressing");
+  assertEquals(plateauVerdict(e1rmRising, volumeFlat, 3.4), "progressing");
+});
+
+Deno.test("ADR-0009: cadence ≤ 3.5d uses 3-session window; > 3.5d uses 4-session window (frequency-scaled)", () => {
+  // Fixture distinguishes the two windows by verdict:
+  //   suffix-3 = [100, 100, 100] → spread 0%, avgRPE 7 < 8 → flat
+  //   suffix-4 = [90, 100, 100, 100] → spread 10/97.5 ≈ 10.26% > 2.5% → improving
+  const sessions: E1RMSession[] = [
+    mkE1RM(90, 0),
+    mkE1RM(100, 1),
+    mkE1RM(100, 2),
+    mkE1RM(100, 3),
+  ];
+  assertEquals(e1rmTrack(sessions, 3.4), "flat");
+  assertEquals(e1rmTrack(sessions, 3.6), "improving");
+});


### PR DESCRIPTION
…gation (ADR-0009)

Pure module computing per-pattern ProgressionTrend from a hybrid two-track verdict (e1RM EWMA flatness + weekly-volume-load flatness) and aggregating upward to MuscleProfile.stagnationStatus via worst-across-patterns per the ADR-0009 amendment (2026-05-07).

Module

- supabase/functions/_shared/plateau-verdict.ts — exports e1rmTrack, volumeLoadTrack, plateauVerdict, aggregateMuscleStagnationStatus, plus types ProgressionTrend, E1RMSession, VolumeLoadSession, and PatternTrendForMuscleAggregation. Pure: no I/O, no clock reads. EWMA outputs from A6 (#77) are consumed as session-level e1RM values, not recomputed.

Track logic

e1RM track (per ADR-0009 §Tracks): frequency-scaled window (3 sessions when cadence ≤ 3.5d, 4 sessions when > 3.5d). Plateau on spread ≤ 2.5% AND avgRPE < 8.0 with the manual-log defence (any nil avgRPE in the base window defers to window+1; partial-nil at window+1 keeps the gate active on mean(non-nil); all-nil at window+1 suspends the gate and fires on spread alone). Decline on ≥ 5% drop start→end with avgRPE ≥ 7 (the gate suppresses coasting/light-week false-positives).

Volume-load track: trailing-4-week spread ≤ 5% with avgRPE < 8 for plateau. Decline on ≥ 10% week-over-week drop OR current week > 115% × mean(prior 4 weeks) overreach detector. Strict > on the overreach boundary.

Aggregation

Verdict aggregation: declining-wins precedence (Option B) per the asymmetric-error preference in docs/design-principles.md; flat+flat → plateaued; otherwise progressing. Muscle aggregation: worst-across-patterns over patterns whose confidence > .bootstrapping; empty participation falls through to .progressing (the no-signal default) — cold-start signal is carried by MuscleProfile.confidence independently per the ADR-0009 amendment.

Spread formula (Q1 lock-in): (max − min) / mean — coefficient-of- range form, symmetric, no directional bias. Applied uniformly across both tracks. All thresholds and constants import from the A1 named-constants module (#72) — no inline literals.

TDD shape

29/29 per-behaviour cycles, all RED → GREEN, no horizontal batching. 8 cycles for the e1RM track (incl. Q3 refinement at cycle 4b for partial-nil), 6 for the volume-load track, 6 for the verdict aggregation table, 9 for muscle aggregation. Several cycles passed without code change (they pin the spec for cases the prior minimal impl already covered correctly). Total deno test count: 147 passing across the edge-functions test suite (29 new + 118 pre-existing, all green).

Decisions surfaced and locked during implementation

- Q1–Q6 + the two refinements (Q2 v2.x watch-item comment, Q3 partial-nil at window+1) were pre-approved during planning.

- Cycles 10 / 13 (Option A): issue #78's "drop 9.9% → flat" and "volume 114.9% → flat" descriptions are mathematically unreachable under Q1's (max−min)/mean spread formula. A near-threshold week-over-week drop produces suffix-4 spread ~10%, incompatible with the 5% plateau threshold. Tests assert the actual fall-through verdict 'improving' with explanatory comments citing the math constraint and the authority hierarchy (formula > issue prose). Issue body amendment proposed post-merge.

- Cycles 17 / 18 (Option B — declining-wins precedence): ADR-0009's verdict table has internal precedence conflict in cells {improving e1RM + declining volume} and {declining e1RM + improving volume}. ADR prose addresses progressing-OR and plateau-AND but doesn't resolve declining precedence. Implementation applies declining-wins per the asymmetric-error preference in docs/design-principles.md — the {declining e1RM
  + improving volume} cell is the classic overreach signature, silent under Option A (top-down table reading). Cycles 17 and 18 carry the load-bearing precedence tests with explicit ADR-0009 + design-principles.md citations in their test names. ADR-0009 amendment proposed post-merge to make the precedence explicit in prose.