### PR TITLE
feat(slice-A8/#79): phase-advance — per-pattern + global trigger (ADR-0011 + ADR-0012)

### DIFF
--- a/supabase/functions/_shared/global-phase-advance.ts
+++ b/supabase/functions/_shared/global-phase-advance.ts
@@ -1,0 +1,67 @@
+// Project Apex — Phase 2 global phase-advance trigger.
+//
+// Per ADR-0012 (global phase advance trigger and the major-pattern
+// enumeration, accepted 2026-05-07). Fires iff:
+//   - ≥4 of 6 major patterns transitioned phase within last 6 user
+//     sessions (currentSessionCount - lastPhaseTransitionAtSessionCount
+//     <= 6)
+//   - AND (lastGlobalPhaseAdvanceFiredAtSessionCount === null
+//          OR sessionCount - that >= 6)  // cooldown
+//   - AND sessionCount >= 6              // bootstrap guard
+//
+// Force-deload counts as a phase transition (per ADR-0011 §(b) — feature,
+// not bug; see ADR-0012 §Consequences "Force-deload-as-transition is a
+// feature").
+//
+// Pure: no I/O, no clock reads.
+
+import {
+  GLOBAL_PHASE_ADVANCE_BOOTSTRAP_GUARD,
+  GLOBAL_PHASE_ADVANCE_COOLDOWN_SESSIONS,
+  GLOBAL_PHASE_ADVANCE_MAJOR_PATTERN_THRESHOLD,
+  GLOBAL_PHASE_ADVANCE_SESSION_WINDOW,
+  MAJOR_PATTERNS,
+} from "./constants.ts";
+
+export interface PatternTransitionState {
+  pattern: string;
+  lastPhaseTransitionAtSessionCount: number;
+}
+
+/**
+ * Global phase-advance trigger per ADR-0012.
+ */
+export function shouldFireGlobalPhaseAdvance(
+  patternStates: PatternTransitionState[],
+  currentSessionCount: number,
+  lastGlobalPhaseAdvanceFiredAtSessionCount: number | null,
+): boolean {
+  // ADR-0012 §Cooldown: bootstrap guard. Prevents premature firing on a
+  // brand-new user whose 4th major's accumulation block fills up before
+  // they have 6 sessions of total training history.
+  if (currentSessionCount < GLOBAL_PHASE_ADVANCE_BOOTSTRAP_GUARD) return false;
+
+  // ADR-0012 §Cooldown: pure session-count, no cadence translation. Fires
+  // iff lastFired === null OR delta >= 6. Boundary-inclusive on the fires
+  // side: delta=6 fires (cooldown just expired), delta=5 blocks.
+  if (lastGlobalPhaseAdvanceFiredAtSessionCount !== null) {
+    const delta = currentSessionCount - lastGlobalPhaseAdvanceFiredAtSessionCount;
+    if (delta < GLOBAL_PHASE_ADVANCE_COOLDOWN_SESSIONS) return false;
+  }
+
+  // ADR-0012 §"6 major patterns": lunge and isolation transitions are
+  // accessory and do NOT count toward the ≥4-of-6 threshold. Filter to
+  // MAJOR_PATTERNS only before applying the window check.
+  const majorSet: Set<string> = new Set(MAJOR_PATTERNS);
+
+  // ADR-0012 §"Window semantics": for each major pattern, check
+  // currentSessionCount - lastPhaseTransitionAtSessionCount <= 6 (window).
+  // Count how many satisfy. Fires iff count >= 4.
+  const transitionedInWindow = patternStates.filter(
+    (p) =>
+      majorSet.has(p.pattern) &&
+      currentSessionCount - p.lastPhaseTransitionAtSessionCount <=
+        GLOBAL_PHASE_ADVANCE_SESSION_WINDOW,
+  ).length;
+  return transitionedInWindow >= GLOBAL_PHASE_ADVANCE_MAJOR_PATTERN_THRESHOLD;
+}

--- a/supabase/functions/_shared/global-phase-advance_test.ts
+++ b/supabase/functions/_shared/global-phase-advance_test.ts
@@ -1,0 +1,207 @@
+// Project Apex — Phase 2 global-phase-advance tests.
+//
+// Per ADR-0012 (global phase advance trigger and the major-pattern
+// enumeration, accepted 2026-05-07): the global trigger fires iff
+// ≥4 of 6 major patterns transitioned phase within the last 6 user
+// sessions, subject to cooldown and bootstrap guard.
+//
+// Each test name pins the originating ADR clause.
+//
+// Run locally:
+//   deno test supabase/functions/_shared/global-phase-advance_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  type PatternTransitionState,
+  shouldFireGlobalPhaseAdvance,
+} from "./global-phase-advance.ts";
+
+// All 6 major patterns per ADR-0012 / MAJOR_PATTERNS in constants.ts.
+const ALL_SIX_MAJORS = [
+  "horizontalPush",
+  "verticalPush",
+  "horizontalPull",
+  "verticalPull",
+  "squat",
+  "hipHinge",
+];
+
+// Build a state covering all 6 majors. Patterns with `lastAt=0` are treated
+// as never-transitioned (per ADR-0012 §Edge cases).
+const allMajorsWithLastAt = (
+  lastAtPerPattern: Partial<Record<string, number>>,
+): PatternTransitionState[] =>
+  ALL_SIX_MAJORS.map((pattern) => ({
+    pattern,
+    lastPhaseTransitionAtSessionCount: lastAtPerPattern[pattern] ?? 0,
+  }));
+
+Deno.test("ADR-0012: 3 of 6 majors transitioned in last 6 sessions → does NOT fire (under threshold)", () => {
+  // Threshold is 4 majors per ADR-0012; 3 is the under-threshold case.
+  const states = allMajorsWithLastAt({
+    horizontalPush: 13,
+    verticalPush: 14,
+    horizontalPull: 15,
+    // remaining 3 majors: lastAt=0 (never transitioned)
+  });
+  assertEquals(
+    shouldFireGlobalPhaseAdvance(states, /* sessionCount */ 18, /* lastFired */ null),
+    false,
+  );
+});
+
+Deno.test("ADR-0012 §Edge cases: ≥4 majors transitioned but sessionCount=5 (under bootstrap guard) → does NOT fire", () => {
+  // Bootstrap guard prevents premature firing on a brand-new user whose 4th
+  // major's accumulation block fills up before they have 6 sessions of total
+  // training history. Constants: GLOBAL_PHASE_ADVANCE_BOOTSTRAP_GUARD=6, so
+  // sessionCount<6 blocks. sessionCount=5 sits just under.
+  const states = allMajorsWithLastAt({
+    horizontalPush: 1,
+    verticalPush: 2,
+    horizontalPull: 3,
+    verticalPull: 4,
+    // squat, hipHinge: lastAt=0 (never)
+  });
+  assertEquals(
+    shouldFireGlobalPhaseAdvance(states, /* sessionCount */ 5, /* lastFired */ null),
+    false,
+  );
+});
+
+Deno.test("ADR-0012 §Cooldown: ≥4 majors but cooldown active (lastFired=4, sessionCount=9, delta=5 < 6) → does NOT fire", () => {
+  // Cooldown boundary: fires iff delta >= 6 (per ADR-0012 §Cooldown). At
+  // delta=5 the cooldown is still active and blocks even though the major-
+  // pattern threshold is met. Boundary-inclusive on the "fires" side: 6
+  // fires (C18 below), 5 blocks (this test).
+  const states = allMajorsWithLastAt({
+    horizontalPush: 5,
+    verticalPush: 6,
+    horizontalPull: 7,
+    verticalPull: 8,
+    // squat, hipHinge: lastAt=0
+  });
+  assertEquals(
+    shouldFireGlobalPhaseAdvance(states, /* sessionCount */ 9, /* lastFired */ 4),
+    false,
+  );
+});
+
+Deno.test("ADR-0012 §Cooldown: ≥4 majors with cooldown just expired (lastFired=4, sessionCount=10, delta=6) → fires (boundary-inclusive on fires side)", () => {
+  // Boundary partner to C17 (delta=5 blocks). At delta=6 the cooldown is
+  // exactly satisfied: per ADR-0012 §Cooldown the test is `delta >= 6`,
+  // so delta=6 fires. Boundary semantics consistent with the §"Window
+  // semantics" `delta <= 6` — both inclusive on the firing side.
+  const states = allMajorsWithLastAt({
+    horizontalPush: 5,
+    verticalPush: 6,
+    horizontalPull: 7,
+    verticalPull: 8,
+    // squat, hipHinge: lastAt=0
+  });
+  assertEquals(
+    shouldFireGlobalPhaseAdvance(states, /* sessionCount */ 10, /* lastFired */ 4),
+    true,
+  );
+});
+
+Deno.test("ADR-0012 §Edge cases: lastPhaseTransitionAtSessionCount=0 (never transitioned) is naturally excluded for users past session 6 (delta>window)", () => {
+  // 3 majors recently transitioned (in window) + 3 majors with lastAt=0
+  // (never transitioned). At sessionCount=7, the lastAt=0 patterns produce
+  // delta=7 > GLOBAL_PHASE_ADVANCE_SESSION_WINDOW=6, naturally excluded by
+  // the window check. The 3 transitioned majors fall short of the threshold
+  // of 4, so trigger does NOT fire.
+  //
+  // Load-bearing semantic: if lastAt=0 patterns were erroneously counted,
+  // total would be 6 ≥ 4 → fires. Pinning the natural-exclusion property.
+  //
+  // Boundary note: at sessionCount=6 the natural exclusion does NOT apply
+  // (delta=6 ≤ 6 would count erroneously). ADR-0012's "past session 6"
+  // wording matches this — the case is sidestepped by the assumption that
+  // all 6 majors have transitioned at least once by session 6. No defensive
+  // `lastAt > 0` guard added; the ADR's natural-exclusion claim is taken
+  // at face value.
+  const states = allMajorsWithLastAt({
+    horizontalPush: 2, // delta=5
+    verticalPush: 3, //   delta=4
+    horizontalPull: 4, // delta=3
+    // verticalPull, squat, hipHinge: lastAt=0 (delta=7 → excluded by window)
+  });
+  assertEquals(
+    shouldFireGlobalPhaseAdvance(states, /* sessionCount */ 7, /* lastFired */ null),
+    false,
+  );
+});
+
+Deno.test("ADR-0012 §Consequences: force-deload-as-transition is a feature — 4 force-deloads in last 6 sessions → fires (the 'programming is broken' emergent signal)", () => {
+  // The trigger reads `lastPhaseTransitionAtSessionCount` without
+  // distinguishing the transition kind (natural-advance / force-deload /
+  // deload-end-cycle). Per ADR-0012 §Consequences: force-deload-as-
+  // transition is the strongest "your programming is broken, you need a
+  // rebuild" signal the system can generate — exactly when heavy reassessment
+  // is most warranted. A user whose plumbing is leaking everywhere needs the
+  // heavy-reassessment UI to surface, not get suppressed by a "force-deloads
+  // don't count" exception.
+  //
+  // Fixture: 4 majors at lastAt = sessions 7,8,9,10 (each having force-
+  // deloaded; the rule is agnostic to the transition kind). 2 majors at
+  // lastAt=0 are excluded by the window check at sessionCount=12.
+  const states = allMajorsWithLastAt({
+    horizontalPush: 7, // delta=5 (recent force-deload)
+    verticalPush: 8, //   delta=4
+    horizontalPull: 9, // delta=3
+    verticalPull: 10, //  delta=2
+    // squat, hipHinge: lastAt=0 (delta=12 → excluded)
+  });
+  assertEquals(
+    shouldFireGlobalPhaseAdvance(states, /* sessionCount */ 12, /* lastFired */ null),
+    true,
+  );
+});
+
+Deno.test("ADR-0012 §Major patterns: lunge and isolation transitions do NOT count toward the ≥4-of-6 threshold (only major patterns counted)", () => {
+  // Per ADR-0012 §"6 major patterns": lunge is a unilateral accessory pattern
+  // and isolation is by definition accessory; counting their transitions
+  // toward macro readiness would dilute the signal. The trigger reads from
+  // patternStates filtered to MAJOR_PATTERNS only.
+  //
+  // Fixture: 3 majors transitioned recently (under threshold) + lunge AND
+  // isolation transitioned recently (would push count to 5 if not filtered).
+  // Correct behaviour: only 3 majors in window → does NOT fire.
+  // Buggy behaviour: 5 patterns in window ≥ 4 → would erroneously fire.
+  const states: PatternTransitionState[] = [
+    { pattern: "horizontalPush", lastPhaseTransitionAtSessionCount: 12 },
+    { pattern: "verticalPush", lastPhaseTransitionAtSessionCount: 13 },
+    { pattern: "horizontalPull", lastPhaseTransitionAtSessionCount: 14 },
+    { pattern: "verticalPull", lastPhaseTransitionAtSessionCount: 0 },
+    { pattern: "squat", lastPhaseTransitionAtSessionCount: 0 },
+    { pattern: "hipHinge", lastPhaseTransitionAtSessionCount: 0 },
+    { pattern: "lunge", lastPhaseTransitionAtSessionCount: 15 }, // accessory
+    { pattern: "isolation", lastPhaseTransitionAtSessionCount: 14 }, // accessory
+  ];
+  assertEquals(
+    shouldFireGlobalPhaseAdvance(states, /* sessionCount */ 17, /* lastFired */ null),
+    false,
+  );
+});
+
+Deno.test("ADR-0012: ≥4 of 6 majors transitioned in last 6 sessions, no prior fire, past bootstrap → fires", () => {
+  // 4 majors transitioned at sessions 12-15 (all within last 6 of currentSessionCount=18);
+  // 2 majors at lastAt=0 (never transitioned, naturally excluded from the count).
+  // No prior global fire → cooldown trivially satisfied.
+  // currentSessionCount=18 >= 6 → bootstrap guard satisfied.
+  const states = allMajorsWithLastAt({
+    horizontalPush: 12,
+    verticalPush: 13,
+    horizontalPull: 14,
+    verticalPull: 15,
+    // squat, hipHinge: lastAt=0 (never)
+  });
+  assertEquals(
+    shouldFireGlobalPhaseAdvance(
+      states,
+      /* currentSessionCount */ 18,
+      /* lastGlobalPhaseAdvanceFiredAtSessionCount */ null,
+    ),
+    true,
+  );
+});

--- a/supabase/functions/_shared/phase-advance.ts
+++ b/supabase/functions/_shared/phase-advance.ts
@@ -1,0 +1,199 @@
+// Project Apex — Phase 2 per-pattern phase-advance module.
+//
+// Per ADR-0011 (per-pattern phase advance — plateau-aware,
+// force-advance safety valve, cyclic mesocycle, accepted
+// 2026-05-07): advances `PatternProfile.currentPhase` on every
+// session-completion that increments `sessionsInPhase`.
+//
+// Composition (ADR-0011 §Decision):
+//   1. Caller increments `sessionsInPhase` before calling this
+//      function.
+//   2. If currentPhase == .deload AND sessionsInPhase >= threshold
+//      → cyclic advance to .accumulation; fires deload-end Q5
+//      transition-mode trigger; consecutiveForceDeloads NOT reset
+//      (only natural progressing-advance resets it).
+//   3. Else if sessionsInPhase >= 2× threshold AND trend ∈
+//      {plateaued, declining} → force-deload (skips intensification
+//      / peaking); consecutiveForceDeloads += 1.
+//   4. Else if sessionsInPhase >= threshold AND trend == .progressing
+//      → natural advance to nextPhase in cycle; counter reset.
+//   5. Else → blocked (threshold met but trend blocks) or no-op
+//      (under threshold). sessionsInPhase keeps accumulating per
+//      ADR-0011 §(a) "block is conditional, not destructive."
+//
+// Pure: no I/O, no clock reads. Caller injects `currentSessionCount`
+// for `lastPhaseTransitionAtSessionCount` updates.
+
+import { FORCE_DELOAD_THRESHOLD_MULTIPLIER } from "./constants.ts";
+import type { ProgressionTrend } from "./plateau-verdict.ts";
+
+export type MesocyclePhase =
+  | "accumulation"
+  | "intensification"
+  | "peaking"
+  | "deload";
+
+export interface PerPatternState {
+  currentPhase: MesocyclePhase;
+  sessionsInPhase: number;
+  sessionsRequiredForPhase: number;
+  trend: ProgressionTrend;
+  consecutiveForceDeloadsOnPattern: number;
+  lastPhaseTransitionAtSessionCount: number;
+}
+
+export interface PhaseAdvanceOutcome {
+  newPhase: MesocyclePhase;
+  newSessionsInPhase: number;
+  newConsecutiveForceDeloads: number;
+  newLastPhaseTransitionAtSessionCount: number;
+  fired: "natural-advance" | "force-deload" | "deload-end-cycle" | "blocked" | "no-op";
+  /** True if this transition fires the deload-end Q5 transition-mode trigger (ADR-0011 §(c)). */
+  firesDeloadEndTransitionMode: boolean;
+}
+
+/**
+ * Option-B threshold per ADR-0011 §Consequences — preserved verbatim
+ * from legacy `PatternPhaseService.swift:78`:
+ *
+ *   sessionsRequired = max(3, phaseWeeks × max(1, ⌊daysPerWeek / 2⌋))
+ *
+ * `Math.floor(daysPerWeek / 2)` mirrors Swift's integer-division semantics
+ * on the legacy `daysPerWeek / 2` expression. The floor of 3 catches the
+ * minimum-cadence edge case (daysPerWeek=1 → multiplier=1, deload=1 →
+ * 3 sessions, not 1).
+ */
+export function sessionsRequiredFor(
+  phase: MesocyclePhase,
+  daysPerWeek: number,
+): number {
+  let phaseWeeks: number;
+  switch (phase) {
+    case "accumulation":
+      phaseWeeks = 4;
+      break;
+    case "intensification":
+      phaseWeeks = 4;
+      break;
+    case "peaking":
+      phaseWeeks = 3;
+      break;
+    case "deload":
+      phaseWeeks = 1;
+      break;
+  }
+  const multiplier = Math.max(1, Math.floor(daysPerWeek / 2));
+  return Math.max(3, phaseWeeks * multiplier);
+}
+
+/**
+ * Phase order per ADR-0011 §(c). Cyclic: deload (index 3) → accumulation
+ * (index 0). Indexed-and-modulo on advance.
+ */
+const phaseOrder: readonly MesocyclePhase[] = [
+  "accumulation",
+  "intensification",
+  "peaking",
+  "deload",
+];
+
+const nextPhaseInCycle = (current: MesocyclePhase): MesocyclePhase => {
+  const idx = phaseOrder.indexOf(current);
+  return phaseOrder[(idx + 1) % phaseOrder.length];
+};
+
+/**
+ * Per-pattern phase advance per ADR-0011.
+ */
+export function advancePhase(
+  state: PerPatternState,
+  currentSessionCount: number,
+): PhaseAdvanceOutcome {
+  const passthrough = {
+    newPhase: state.currentPhase,
+    newSessionsInPhase: state.sessionsInPhase,
+    newConsecutiveForceDeloads: state.consecutiveForceDeloadsOnPattern,
+    newLastPhaseTransitionAtSessionCount: state.lastPhaseTransitionAtSessionCount,
+    firesDeloadEndTransitionMode: false,
+  };
+
+  const stuck = state.trend === "plateaued" || state.trend === "declining";
+  const forceDeloadThreshold = FORCE_DELOAD_THRESHOLD_MULTIPLIER *
+    state.sessionsRequiredForPhase;
+
+  // ADR-0011 §(c): cyclic deload→accumulation. At sessionsInPhase >= threshold
+  // in .deload, advance to .accumulation regardless of trend (coming out of
+  // deload the pattern is by definition refreshed; the §(a) trend block does
+  // not apply to the deload→accumulation transition). Fires the deload-end
+  // Q5 transition-mode trigger (3-session plain-mean window during resumption
+  // catches post-deload rebound and prevents stale pre-deload e1RM bleed).
+  // Per §(d): the counter is NOT reset by deload-end (only natural
+  // progressing-advance resets it) and NOT incremented (only force-deload
+  // increments it).
+  //
+  // Composition note: this branch must come BEFORE the §(b) force-deload
+  // branch. The ADR §(b) edge case "no-op while already in deload" describes
+  // a state unreachable under this composition — when currentPhase=.deload
+  // and sessionsInPhase >= threshold, this cyclic rule fires first, so §(b)
+  // never reaches an in-deload pattern. The user-visible invariant ("counter
+  // not double-incremented for in-deload patterns") is preserved by this
+  // branch's no-counter-touch property. See C8 test (§(b)+(c) composition).
+  if (
+    state.currentPhase === "deload" &&
+    state.sessionsInPhase >= state.sessionsRequiredForPhase
+  ) {
+    return {
+      newPhase: "accumulation",
+      newSessionsInPhase: 0,
+      newConsecutiveForceDeloads: state.consecutiveForceDeloadsOnPattern,
+      newLastPhaseTransitionAtSessionCount: currentSessionCount,
+      fired: "deload-end-cycle",
+      firesDeloadEndTransitionMode: true,
+    };
+  }
+
+  // ADR-0011 §(b): force-advance safety valve. Under stuck trend at ≥ 2×
+  // threshold, jump directly to .deload (skip intensification / peaking) to
+  // break the plateau. Counter increments here; the natural progressing-
+  // advance path (below) is the only path that resets it. Must come before
+  // the §(a) blocked check because at ≥ 2× threshold both predicates match.
+  if (state.sessionsInPhase >= forceDeloadThreshold && stuck) {
+    return {
+      newPhase: "deload",
+      newSessionsInPhase: 0,
+      newConsecutiveForceDeloads: state.consecutiveForceDeloadsOnPattern + 1,
+      newLastPhaseTransitionAtSessionCount: currentSessionCount,
+      fired: "force-deload",
+      firesDeloadEndTransitionMode: false,
+    };
+  }
+
+  // ADR-0011 §(a): plateau OR declining blocks natural advance. The block is
+  // conditional, not destructive — sessionsInPhase keeps accumulating toward
+  // the 2× force-deload threshold on subsequent calls. Declining is more
+  // urgent than plateau (lifter is regressing, not just stuck) so auto-
+  // advancing into a harder phase is the wrong intervention.
+  if (state.sessionsInPhase >= state.sessionsRequiredForPhase && stuck) {
+    return { ...passthrough, fired: "blocked" };
+  }
+
+  // ADR-0011 §(a): natural progressing-advance fires when sessionsInPhase has
+  // met the threshold and trend == progressing. Per ADR-0011 §(b), this path
+  // resets `consecutiveForceDeloadsOnPattern` to 0 — only this path resets
+  // the counter (deload-end-cycle does not).
+  if (
+    state.sessionsInPhase >= state.sessionsRequiredForPhase &&
+    state.trend === "progressing"
+  ) {
+    return {
+      newPhase: nextPhaseInCycle(state.currentPhase),
+      newSessionsInPhase: 0,
+      newConsecutiveForceDeloads: 0,
+      newLastPhaseTransitionAtSessionCount: currentSessionCount,
+      fired: "natural-advance",
+      firesDeloadEndTransitionMode: false,
+    };
+  }
+
+  return { ...passthrough, fired: "no-op" };
+}

--- a/supabase/functions/_shared/phase-advance_test.ts
+++ b/supabase/functions/_shared/phase-advance_test.ts
@@ -1,0 +1,353 @@
+// Project Apex — Phase 2 phase-advance tests.
+//
+// Per ADR-0011 (per-pattern phase advance — plateau-aware
+// composition, force-deload safety valve, cyclic mesocycle).
+//
+// Each test name pins the originating ADR clause so a failure
+// surfaces the rule the change touches.
+//
+// Run locally:
+//   deno test supabase/functions/_shared/phase-advance_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  advancePhase,
+  type PerPatternState,
+  sessionsRequiredFor,
+} from "./phase-advance.ts";
+
+// daysPerWeek=4 → sessionsRequiredFor('accumulation', 4) = max(3, 4 × max(1, 4/2)) = 8.
+// Tests use 8 as the canonical accumulation threshold; force-deload at 2× = 16.
+const baseState = (overrides: Partial<PerPatternState> = {}): PerPatternState => ({
+  currentPhase: "accumulation",
+  sessionsInPhase: 0,
+  sessionsRequiredForPhase: 8,
+  trend: "progressing",
+  consecutiveForceDeloadsOnPattern: 0,
+  lastPhaseTransitionAtSessionCount: 0,
+  ...overrides,
+});
+
+Deno.test("ADR-0011: first-time pattern (sessionsInPhase=1, under threshold) → no-op, no state change", () => {
+  // Caller incremented sessionsInPhase from 0 to 1 after the first session.
+  // Threshold is 8; sessionsInPhase=1 < threshold → no advance fires.
+  const state = baseState({ sessionsInPhase: 1 });
+  const outcome = advancePhase(state, /* currentSessionCount */ 1);
+
+  assertEquals(outcome.fired, "no-op");
+  assertEquals(outcome.newPhase, "accumulation");
+  assertEquals(outcome.newSessionsInPhase, 1);
+  assertEquals(outcome.newConsecutiveForceDeloads, 0);
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 0);
+  assertEquals(outcome.firesDeloadEndTransitionMode, false);
+});
+
+Deno.test("ADR-0011: sessionsRequiredFor matches legacy PatternPhaseService.swift:78 verbatim — max(3, phaseWeeks × max(1, ⌊daysPerWeek/2⌋))", () => {
+  // phaseWeeks: accumulation=4, intensification=4, peaking=3, deload=1
+  // multiplier: max(1, ⌊daysPerWeek/2⌋)
+  // result:     max(3, phaseWeeks × multiplier)
+
+  // daysPerWeek=4 → multiplier = ⌊4/2⌋ = 2
+  assertEquals(sessionsRequiredFor("accumulation", 4), 8); //    max(3, 4×2) = 8
+  assertEquals(sessionsRequiredFor("intensification", 4), 8); // max(3, 4×2) = 8
+  assertEquals(sessionsRequiredFor("peaking", 4), 6); //         max(3, 3×2) = 6
+  assertEquals(sessionsRequiredFor("deload", 4), 3); //          max(3, 1×2) = max(3, 2) = 3 (floor wins)
+
+  // daysPerWeek=1 → multiplier = max(1, ⌊1/2⌋) = max(1, 0) = 1
+  assertEquals(sessionsRequiredFor("accumulation", 1), 4); //    max(3, 4×1) = 4
+  assertEquals(sessionsRequiredFor("deload", 1), 3); //          max(3, 1×1) = 3 (floor wins)
+
+  // daysPerWeek=6 → multiplier = ⌊6/2⌋ = 3
+  assertEquals(sessionsRequiredFor("accumulation", 6), 12); //   max(3, 4×3) = 12
+  assertEquals(sessionsRequiredFor("peaking", 6), 9); //         max(3, 3×3) = 9
+});
+
+Deno.test("ADR-0011: natural progressing-advance — accumulation→intensification at threshold; sessionsInPhase resets, counter resets, lastTransitionAt updates", () => {
+  // Threshold met (sessionsInPhase = 8 = required), trend=progressing, no
+  // 2× force-deload pressure (sessionsInPhase < 16). Per ADR-0011 §(a):
+  //   advance to nextPhase (accumulation → intensification per phaseOrder)
+  //   sessionsInPhase = 0
+  //   lastPhaseTransitionAtSessionCount = currentSessionCount
+  // Per ADR-0011 §(b): natural progressing-advance resets the counter to 0.
+  // Counter pre-set to 2 to verify the reset is unconditional on this path.
+  const state = baseState({
+    sessionsInPhase: 8,
+    trend: "progressing",
+    consecutiveForceDeloadsOnPattern: 2,
+    lastPhaseTransitionAtSessionCount: 4,
+  });
+  const outcome = advancePhase(state, /* sessionCount */ 12);
+
+  assertEquals(outcome.fired, "natural-advance");
+  assertEquals(outcome.newPhase, "intensification");
+  assertEquals(outcome.newSessionsInPhase, 0);
+  assertEquals(outcome.newConsecutiveForceDeloads, 0); // reset
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 12);
+  assertEquals(outcome.firesDeloadEndTransitionMode, false);
+});
+
+Deno.test("ADR-0011 §(b): force-deload at 2× threshold (plateaued) — accumulation→deload (skips intensification/peaking); counter += 1", () => {
+  // Per ADR-0011 §(b): under prolonged stuck-trend pressure (≥ 2× threshold),
+  // the force-advance safety valve jumps the cycle directly to .deload to
+  // break the plateau. Skips intensification/peaking — those phases ask for
+  // heavier work, which is the wrong intervention for a stuck pattern.
+  // Counter increments on this path; lastTransitionAt updates.
+  const state = baseState({
+    sessionsInPhase: 16, // = 2 × sessionsRequiredForPhase
+    trend: "plateaued",
+    consecutiveForceDeloadsOnPattern: 0,
+    lastPhaseTransitionAtSessionCount: 4,
+  });
+  const outcome = advancePhase(state, /* sessionCount */ 20);
+
+  assertEquals(outcome.fired, "force-deload");
+  assertEquals(outcome.newPhase, "deload");
+  assertEquals(outcome.newSessionsInPhase, 0);
+  assertEquals(outcome.newConsecutiveForceDeloads, 1);
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 20);
+  assertEquals(outcome.firesDeloadEndTransitionMode, false);
+});
+
+Deno.test("ADR-0011 §(c): cyclic deload→accumulation at threshold fires deload-end Q5 transition-mode trigger (basic case, progressing trend)", () => {
+  // Basic case: currentPhase=deload, sessionsInPhase=threshold (not 2×, so
+  // §(b) trigger condition is NOT met and the C8 composition isn't in play).
+  // Per ADR-0011 §(c): cyclic rule fires regardless of trend; the deload-
+  // end transition fires the Q5 transition-mode trigger so the post-deload
+  // 3-session plain-mean window catches rebound and prevents stale pre-
+  // deload e1RM bleed into the new accumulation block.
+  const deloadThreshold = 3;
+  const state: PerPatternState = {
+    currentPhase: "deload",
+    sessionsInPhase: deloadThreshold,
+    sessionsRequiredForPhase: deloadThreshold,
+    trend: "progressing",
+    consecutiveForceDeloadsOnPattern: 0,
+    lastPhaseTransitionAtSessionCount: 5,
+  };
+  const outcome = advancePhase(state, /* sessionCount */ 8);
+
+  assertEquals(outcome.fired, "deload-end-cycle");
+  assertEquals(outcome.newPhase, "accumulation");
+  assertEquals(outcome.newSessionsInPhase, 0);
+  assertEquals(outcome.newConsecutiveForceDeloads, 0); // preserved (was 0)
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 8);
+  assertEquals(outcome.firesDeloadEndTransitionMode, true);
+});
+
+Deno.test("ADR-0011 §(c): cyclic deload→accumulation regardless of trend — plateaued in-deload still cycles (trend block does NOT apply to deload→accumulation)", () => {
+  // Distinct from C9's progressing-trend case: at sessionsInPhase=threshold
+  // in deload with trend=plateaued, the cyclic rule still fires. Per §(c),
+  // "the trend == .progressing block does not apply to the deload→accumulation
+  // transition" — coming out of deload the pattern is by definition refreshed.
+  // Counter preserved (was 1, stays 1) per the no-counter-touch property.
+  const deloadThreshold = 3;
+  const state: PerPatternState = {
+    currentPhase: "deload",
+    sessionsInPhase: deloadThreshold,
+    sessionsRequiredForPhase: deloadThreshold,
+    trend: "plateaued",
+    consecutiveForceDeloadsOnPattern: 1,
+    lastPhaseTransitionAtSessionCount: 5,
+  };
+  const outcome = advancePhase(state, /* sessionCount */ 8);
+
+  assertEquals(outcome.fired, "deload-end-cycle");
+  assertEquals(outcome.newPhase, "accumulation");
+  assertEquals(outcome.newSessionsInPhase, 0);
+  assertEquals(outcome.newConsecutiveForceDeloads, 1); // preserved
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 8);
+  assertEquals(outcome.firesDeloadEndTransitionMode, true);
+});
+
+Deno.test("ADR-0011 §(a): conditional-not-destructive trend flip — sessionsInPhase=threshold+3 plateaued, then trend=progressing → natural-advance fires immediately", () => {
+  // Per ADR-0011 §(a): the trend block is conditional, not destructive.
+  // sessionsInPhase keeps accumulating while blocked; if trend flips back to
+  // progressing while sessionsInPhase still meets/exceeds threshold, the
+  // deferred natural-advance fires on the very next session-completion call.
+  // This is the load-bearing semantic that distinguishes "blocked" from
+  // "reset" — a plateau that resolves doesn't lose the user's accumulated
+  // session-count toward advance.
+  //
+  // Fixture: 3 sessions of plateau-blocked accumulation past threshold (so
+  // sessionsInPhase=8+3=11), then trend flips to progressing on this call.
+  const state = baseState({
+    sessionsInPhase: 11, // = sessionsRequiredForPhase (8) + 3
+    trend: "progressing",
+    consecutiveForceDeloadsOnPattern: 0,
+  });
+  const outcome = advancePhase(state, /* sessionCount */ 14);
+
+  assertEquals(outcome.fired, "natural-advance");
+  assertEquals(outcome.newPhase, "intensification");
+  assertEquals(outcome.newSessionsInPhase, 0);
+  assertEquals(outcome.newConsecutiveForceDeloads, 0);
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 14);
+  assertEquals(outcome.firesDeloadEndTransitionMode, false);
+});
+
+Deno.test("ADR-0011 §Consequences migration: legacy v1 terminal-deload pattern decoded — ratchets normally; next deload-threshold met → cycles to accumulation (no migration code path)", () => {
+  // Legacy v1 PatternPhaseService.swift:126 ("Already at deload — no further
+  // transition") treated deload as terminal. v2's cyclic rule replaces that.
+  // Per ADR-0011 §Consequences: existing rows decode with currentPhase=
+  // .deload + additive defaults (counter=0, lastPhaseTransitionAt=0); the v2
+  // cyclic rule handles them transparently with NO migration code path.
+  //
+  // This test simulates a legacy decoded row across two consecutive session-
+  // completion calls:
+  //   1. sessionsInPhase=2 (under threshold) → no-op, ratchets normally
+  //   2. sessionsInPhase=3 (= deload threshold) → deload-end-cycle to
+  //      accumulation per §(c), regardless of trend
+  const deloadThreshold = 3;
+  const legacyDecodedBase: PerPatternState = {
+    currentPhase: "deload",
+    sessionsInPhase: 2, // ratcheting toward threshold
+    sessionsRequiredForPhase: deloadThreshold,
+    trend: "plateaued", // any trend; cyclic rule fires regardless
+    consecutiveForceDeloadsOnPattern: 0, // additive default on decode
+    lastPhaseTransitionAtSessionCount: 0, // legacy v1 didn't track this
+  };
+
+  // Step 1 — under threshold, ratchets normally (no-op).
+  const ratcheting = advancePhase(legacyDecodedBase, /* sessionCount */ 11);
+  assertEquals(ratcheting.fired, "no-op");
+  assertEquals(ratcheting.newPhase, "deload");
+  assertEquals(ratcheting.newSessionsInPhase, 2);
+  assertEquals(ratcheting.newLastPhaseTransitionAtSessionCount, 0);
+
+  // Step 2 — caller incremented sessionsInPhase to threshold, cycles per §(c).
+  const cycling = advancePhase(
+    { ...legacyDecodedBase, sessionsInPhase: deloadThreshold },
+    /* sessionCount */ 12,
+  );
+  assertEquals(cycling.fired, "deload-end-cycle");
+  assertEquals(cycling.newPhase, "accumulation");
+  assertEquals(cycling.newSessionsInPhase, 0);
+  assertEquals(cycling.newConsecutiveForceDeloads, 0);
+  assertEquals(cycling.newLastPhaseTransitionAtSessionCount, 12);
+  assertEquals(cycling.firesDeloadEndTransitionMode, true);
+});
+
+Deno.test("ADR-0011 §(d): deload-end-cycle does NOT reset consecutiveForceDeloads counter (only natural progressing-advance resets — negative case to C5)", () => {
+  // Negative-case companion to C5's positive assertion. Per ADR-0011 §(d):
+  //   "The counter increments only on force-deloads (not on natural deload-
+  //    end transitions), and resets to 0 on any natural progressing-advance."
+  // This test pins the no-reset semantic so a future maintainer who changes
+  // deload-end to also-reset (the symmetric-but-wrong intuition) breaks here.
+  // Without C11 as a separate cycle, a refactor that conflates the two
+  // counter-handling paths would not break C5 (which doesn't exercise
+  // deload-end), and the regression would slide through.
+  //
+  // Fixture: counter=3 (chronically force-deloaded pattern surfacing the
+  // §(d) digest threshold), going through deload-end. Counter must NOT
+  // drop to 0 — the LLM digest must keep seeing the chronic-stuck signal.
+  const deloadThreshold = 3;
+  const state: PerPatternState = {
+    currentPhase: "deload",
+    sessionsInPhase: deloadThreshold,
+    sessionsRequiredForPhase: deloadThreshold,
+    trend: "progressing",
+    consecutiveForceDeloadsOnPattern: 3,
+    lastPhaseTransitionAtSessionCount: 10,
+  };
+  const outcome = advancePhase(state, /* sessionCount */ 13);
+
+  assertEquals(outcome.fired, "deload-end-cycle");
+  assertEquals(outcome.newConsecutiveForceDeloads, 3); // NOT 0 (load-bearing)
+});
+
+Deno.test("ADR-0011 §(b)+(c): force-deload-trigger condition met while in deload — cyclic rule wins by composition; counter NOT incremented", () => {
+  // Issue #79's C8 edge-case wording ("force-deload while already in deload
+  // → no-op (NO counter increment)") describes a state UNREACHABLE under the
+  // composition rule. Step 2 (cyclic deload-end) always fires first when
+  // currentPhase=.deload AND sessionsInPhase >= threshold, so step 3 (§(b)
+  // force-deload) cannot reach a deload pattern. The "no-op" prose targets
+  // the user-visible invariant that the counter must not double-increment;
+  // the cyclic rule satisfies that invariant naturally because deload-end-
+  // cycle does not touch the counter (per §(d): "counter increments only on
+  // force-deloads, not on natural deload-end transitions").
+  //
+  // This test pins the actually-reachable composed outcome:
+  //   currentPhase=deload + sessionsInPhase=2×deload-threshold + plateaued
+  //   → cyclic deload-end-cycle (per step 2) → counter preserved.
+  //
+  // Issue amendment proposed post-merge to reword the C8 edge-case prose.
+  // See A7's cycle 10 / 13 / 17 / 18 for the same level-5-prose-vs-level-3-
+  // ADR pattern. Recurrence noted as a candidate for design-principles.md.
+  const deloadThreshold = 3; // = sessionsRequiredFor("deload", daysPerWeek=4)
+  const state: PerPatternState = {
+    currentPhase: "deload",
+    sessionsInPhase: 2 * deloadThreshold, // §(b) trigger condition met
+    sessionsRequiredForPhase: deloadThreshold,
+    trend: "plateaued",
+    consecutiveForceDeloadsOnPattern: 2, // pre-set non-zero to verify preservation
+    lastPhaseTransitionAtSessionCount: 8,
+  };
+  const outcome = advancePhase(state, /* sessionCount */ 14);
+
+  assertEquals(outcome.fired, "deload-end-cycle");
+  assertEquals(outcome.newPhase, "accumulation"); // cyclic per §(c)
+  assertEquals(outcome.newSessionsInPhase, 0);
+  assertEquals(outcome.newConsecutiveForceDeloads, 2); // preserved — the user-visible invariant
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 14);
+  assertEquals(outcome.firesDeloadEndTransitionMode, true);
+});
+
+Deno.test("ADR-0011 §(b): force-deload at 2× threshold (declining) — same path as plateaued; counter += 1", () => {
+  // Mirrors C6 with trend=declining. The §(b) safety valve fires on EITHER
+  // plateaued OR declining at ≥ 2× threshold — both are "stuck" trends from
+  // the advance-blocking perspective. Pinning this behaviour separately so
+  // a future refactor that narrows the §(b) trigger to plateaued-only does
+  // not silently leave declining patterns stuck forever (decline is the
+  // more-urgent of the two trends per ADR-0011 §(a)).
+  const state = baseState({
+    sessionsInPhase: 16,
+    trend: "declining",
+    consecutiveForceDeloadsOnPattern: 0,
+  });
+  const outcome = advancePhase(state, /* sessionCount */ 20);
+
+  assertEquals(outcome.fired, "force-deload");
+  assertEquals(outcome.newPhase, "deload");
+  assertEquals(outcome.newSessionsInPhase, 0);
+  assertEquals(outcome.newConsecutiveForceDeloads, 1);
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 20);
+  assertEquals(outcome.firesDeloadEndTransitionMode, false);
+});
+
+Deno.test("ADR-0011 §(a): declining blocks natural advance — block extension to declining (regressing lifter must not be auto-advanced into a harder phase)", () => {
+  // Threshold met but trend=declining blocks. Per ADR-0011 §(a) Considered
+  // Options: declining is more urgent than plateau, not less — auto-
+  // advancing a regressing lifter into intensification compounds the
+  // regression. Same conditional-not-destructive accumulation behaviour.
+  const state = baseState({
+    sessionsInPhase: 8,
+    trend: "declining",
+  });
+  const outcome = advancePhase(state, /* sessionCount */ 12);
+
+  assertEquals(outcome.fired, "blocked");
+  assertEquals(outcome.newPhase, "accumulation");
+  assertEquals(outcome.newSessionsInPhase, 8);
+  assertEquals(outcome.newConsecutiveForceDeloads, 0);
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 0);
+  assertEquals(outcome.firesDeloadEndTransitionMode, false);
+});
+
+Deno.test("ADR-0011: plateau blocks natural advance — sessionsInPhase keeps accumulating (conditional, not destructive)", () => {
+  // Threshold met (sessionsInPhase = 8 = required) but trend=plateaued blocks
+  // the natural-advance path. Per ADR-0011 §(a): block is conditional;
+  // sessionsInPhase passed through unchanged so the caller's accumulation
+  // continues toward the 2× force-deload threshold on subsequent sessions.
+  const state = baseState({
+    sessionsInPhase: 8, // = sessionsRequiredForPhase
+    trend: "plateaued",
+  });
+  const outcome = advancePhase(state, /* sessionCount */ 12);
+
+  assertEquals(outcome.fired, "blocked");
+  assertEquals(outcome.newPhase, "accumulation"); // unchanged
+  assertEquals(outcome.newSessionsInPhase, 8); // unchanged
+  assertEquals(outcome.newConsecutiveForceDeloads, 0);
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 0); // unchanged
+  assertEquals(outcome.firesDeloadEndTransitionMode, false);
+});


### PR DESCRIPTION
## Summary

Two paired pure modules per #79 — they ship together because ADR-0012's global rule explicitly composes with ADR-0011's force-deload-as-transition semantics; splitting requires a stub for transition events that defeats the cyclic-mesocycle test surface.

- **`supabase/functions/_shared/phase-advance.ts`** — exports `advancePhase`, `sessionsRequiredFor`, types `MesocyclePhase`, `PerPatternState`, `PhaseAdvanceOutcome`. Per-pattern composition: cyclic deload→accumulation (regardless of trend; fires the Q5 deload-end transition-mode trigger) → force-deload at 2× threshold under stuck trend (counter += 1) → blocked at threshold under stuck trend (sessionsInPhase keeps accumulating per ADR-0011 §(a) "conditional, not destructive") → natural progressing-advance at threshold (counter resets to 0) → no-op fall-through.
- **`supabase/functions/_shared/global-phase-advance.ts`** — exports `shouldFireGlobalPhaseAdvance`, type `PatternTransitionState`. Fires iff ≥4 of 6 major patterns transitioned within the last 6 sessions, past bootstrap (`sessionCount ≥ 6`), past cooldown (`delta ≥ 6` since last fire). Force-deload counts as a transition per ADR-0011 §(b) — the "your programming is broken" emergent signal documented in ADR-0012 §Consequences.

Pure throughout: no I/O, no clock reads. `ProgressionTrend` imported from A7's `plateau-verdict.ts` (#78). All thresholds and constants sourced from the A1 named-constants module (#72) — no inline literals. The Option-B threshold formula `max(3, phaseWeeks × max(1, ⌊daysPerWeek/2⌋))` preserved verbatim from legacy `PatternPhaseService.swift:78`.

## TDD cycles (21/21)

Per-behaviour, RED → GREEN, no horizontal batching. Test names cite the originating ADR clause so a failure surfaces the rule it pins.

**Per-pattern — 13 cycles**

1. Tracer: first-time pattern (`sessionsInPhase=1`, under threshold) → `no-op`, no state change
2. `sessionsRequiredFor` matches legacy `PatternPhaseService.swift:78` verbatim across 4 phases × 3 cadences
3. Plateau blocks natural advance — sessionsInPhase keeps accumulating
4. Declining blocks natural advance — block extension to declining (regressing lifter must not be auto-advanced)
5. Natural progressing-advance fires at threshold; sessionsInPhase / counter / lastTransitionAt all update
6. Force-deload at 2× threshold (plateaued) — accumulation→deload, counter += 1
7. Force-deload at 2× threshold (declining) — same path, counter += 1
8. **§(b)+(c) composition** — see Decisions below
9. Cyclic deload→accumulation at threshold fires deload-end trigger (basic case, progressing trend)
10. Cyclic deload→accumulation regardless of trend (plateaued in-deload still cycles)
11. **Counter NOT reset by deload-end** (negative-case to C5; pins ADR-0011 §(d))
12. Conditional-not-destructive trend flip — sessionsInPhase past threshold while plateaued, trend flips → natural-advance fires immediately
13. Migration: legacy v1 terminal-deload pattern decoded → ratchets normally, next deload-threshold met → cycles to accumulation

**Global trigger — 8 cycles**

14. Tracer: ≥4 of 6 majors in last 6 sessions, no prior fire, past bootstrap → fires
15. 3 of 6 majors → does NOT fire (under threshold)
16. ≥4 majors but `sessionCount=5` → does NOT fire (bootstrap guard)
17. ≥4 majors with cooldown active (`lastFired=4, sessionCount=9, delta=5 < 6`) → does NOT fire
18. ≥4 majors with cooldown just expired (`delta=6`, boundary) → fires
19. `lastPhaseTransitionAtSessionCount=0` naturally excluded for users past session 6 (window check)
20. Force-deload counts as a transition — 4 force-deloads in last 6 sessions → fires
21. Lunge / isolation transitions do NOT count toward the ≥4-of-6 threshold (filter to `MAJOR_PATTERNS` only)

C5 / C11 split kept (positive counter-reset in C5 vs negative no-reset-by-deload-end in C11) per the planning step. Folding would lose the load-bearing C11 invariant — a future maintainer who changes deload-end to also-reset (the symmetric-but-wrong intuition) would not break C5 (which doesn't exercise deload-end), and the regression would slide through.

Several cycles passed without code change (C7, C9–C13, C18–C20) — they pin the spec for cases the prior minimal impl already covered correctly. Each still locks the behaviour so a future refactor cannot regress silently.

## Decisions surfaced and locked during implementation

⚠️ **Two divergences for reviewer ratification:**

### Cycle C8 (Option B with B1+B2+B3 sub-options) — issue-prose-vs-composition

Issue #79's literal C8 edge-case wording — `currentPhase=.deload` ∧ `sessionsInPhase=2× threshold` ∧ `trend=plateaued` → `no-op (NO counter increment)` — describes a state UNREACHABLE under the composition rule. Step 2 (cyclic deload-end) always fires first when `currentPhase=.deload` and `sessionsInPhase ≥ threshold`, so step 3 (`§(b)` force-deload) cannot reach an in-deload pattern. The "Else if" guard makes step 3 unreachable for in-deload patterns at any `sessionsInPhase ≥ threshold` — `2×threshold > threshold` definitionally.

The "no-op" wording targets the user-visible invariant: *"the counter does not double-increment when the §(b) trigger conditions are met on a pattern that's already in deload."* The cyclic rule satisfies that invariant naturally because `deload-end-cycle` does not touch the counter (per ADR-0011 §(d): "counter increments only on force-deloads, not on natural deload-end transitions").

**Resolution (locked with user):**
- **B1**: Test name explicitly cites both rules — `ADR-0011 §(b)+(c): force-deload-trigger condition met while in deload — cyclic rule wins by composition; counter NOT incremented.` Future maintainer reading the test sees the precedence is intentional and which two rules compose.
- **B2**: Issue #79's C8 edge-case wording amended post-merge to language that matches reachable behaviour.
- **B3**: Source comment in `phase-advance.ts` documents the unreachable-guard reasoning to prevent dead-code addition. (See `phase-advance.ts:124-140`.)

This is the same shape as A7's cycles 10 / 13 (math constraint vs issue prose) and 17 / 18 (table conflict resolved by design principle). **Third instance of issue-prose-vs-composition divergence in two slices** — candidate for `docs/design-principles.md` if a pattern emerges. Tracking as a post-merge follow-up.

### Cycle C19 — `lastTransitionAt=0` boundary semantic

ADR-0012 §Edge cases: *"Pattern with `lastPhaseTransitionAtSessionCount=0` (never transitioned): doesn't satisfy `currentSessionCount - 0 <= 6` for users past session 6, naturally excluded from the count."*

Literal math: at `sessionCount=7`, `7−0=7 > 6` → excluded by the window check. At `sessionCount=6`, `6−0=6 ≤ 6` → would erroneously count. The ADR's "past session 6" wording matches `sessionCount > 6` exactly.

**Resolution:** No defensive `lastAt > 0` guard added. The ADR's natural-exclusion claim is taken at face value — at `sessionCount=6` the implicit assumption is that all 6 majors have transitioned at least once (so `lastAt=0` patterns don't exist in practice at the bootstrap boundary). C19 tests `sessionCount=7` to exercise the natural exclusion that the ADR documents.

Source-comment trail in the C19 test fixture documents this for future readers.

## Discipline

- Pure functions throughout: no I/O, no `Date.now()`, no clock reads. Caller injects `currentSessionCount` and `daysPerWeek`.
- All constants imported from A1 (#72) — `FORCE_DELOAD_THRESHOLD_MULTIPLIER`, `GLOBAL_PHASE_ADVANCE_BOOTSTRAP_GUARD`, `GLOBAL_PHASE_ADVANCE_COOLDOWN_SESSIONS`, `GLOBAL_PHASE_ADVANCE_MAJOR_PATTERN_THRESHOLD`, `GLOBAL_PHASE_ADVANCE_SESSION_WINDOW`, `MAJOR_PATTERNS`. No inline literals.
- `ProgressionTrend` type imported from `plateau-verdict.ts` (A7) — single source of truth, no duplication.
- Code comments cite ADR-0011 §(a)/(b)/(c)/(d) and ADR-0012 §"6 major patterns" / §"Window semantics" / §Cooldown / §Edge cases / §Consequences. Test names follow the `ADR-NNNN: …` form established by A4–A7.
- Cross-cutting grep performed: no inline `FORCE_DELOAD_THRESHOLD_*`, `GLOBAL_PHASE_ADVANCE_*`, `MAJOR_PATTERNS`, or Option-B-formula literals exist outside the canonical homes (`constants.ts` + `phase-advance.ts`). The legacy `PatternPhaseService.swift:78` Swift formula remains in the iOS app source unchanged (per ADR-0011 §Consequences: legacy preserved as the verbatim source-of-truth).

## Out of scope (per #79)

- Heavy reassessment UI screen — separate UI slice
- Goal renegotiation flow — separate UI slice
- Stretch projection re-derivation — orchestrator A12 wires it; mathematical derivation already in `ProjectionState`
- Mesocycle skeleton regeneration on user-accepted goal renegotiation — separate slice
- `consecutiveForceDeloadsOnPattern ≥ 2` digest surfacing rule for LLM coaching cue — B-slices
- Automated remediation (exercise rotation, programme rebuild) — v2.x watch-item #8

## Post-merge follow-ups

1. **Issue #79 amendment (B2)**: reword the C8 edge-case prose to match reachable behaviour.
2. **`docs/design-principles.md` candidate**: third instance of issue-prose-vs-composition divergence in two slices (A7 cycles 10/13/17/18 + A8 C8); worth naming as a pattern if a fourth occurrence lands.

## Test results

`deno test supabase/functions/_shared/` — **168 passed, 0 failed** (21 new + 147 pre-existing).

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)