### PR TITLE
feat(slice-A11/#82): fatigue-interaction aggregator (ADR-0005)

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */; };
 		7D8C4E6ADC8DEDCA31B72B1D /* ManualLogIntentGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */; };
 		81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */; };
+		A11FA719C0DE0001CAFE0001 /* FatigueInteractionCrossValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11FA719C0DE0002CAFE0002 /* FatigueInteractionCrossValidationTests.swift */; };
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
 		8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */; };
@@ -103,6 +104,7 @@
 		70E3BA94C76430CACFD657B5 /* EquipmentRounderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EquipmentRounderTests.swift; sourceTree = "<group>"; };
 		7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelDigestTests.swift; sourceTree = "<group>"; };
 		85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelInteractionsTests.swift; sourceTree = "<group>"; };
+		A11FA719C0DE0002CAFE0002 /* FatigueInteractionCrossValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FatigueInteractionCrossValidationTests.swift; sourceTree = "<group>"; };
 		862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelUpdateJobTests.swift; sourceTree = "<group>"; };
 		A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LateArrivalNotificationQueueTests.swift; sourceTree = "<group>"; };
 		878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelProfilesTests.swift; sourceTree = "<group>"; };
@@ -238,6 +240,7 @@
 				993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */,
 				B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */,
 				85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */,
+				A11FA719C0DE0002CAFE0002 /* FatigueInteractionCrossValidationTests.swift */,
 				878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */,
 				DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */,
 				4422DE7829C0C124138BB4B0 /* WeekFatigueSignalsHelperAgreementTests.swift */,
@@ -385,6 +388,7 @@
 				73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */,
 				A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */,
 				81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */,
+				A11FA719C0DE0001CAFE0001 /* FatigueInteractionCrossValidationTests.swift in Sources */,
 				6ECE420C1031E80360FF1EFE /* TraineeModelProfilesTests.swift in Sources */,
 				B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */,
 				5DE94F8F1D136C65C96FCAD1 /* WeekFatigueSignalsHelperAgreementTests.swift in Sources */,

--- a/ProjectApexTests/FatigueInteractionCrossValidationTests.swift
+++ b/ProjectApexTests/FatigueInteractionCrossValidationTests.swift
@@ -1,0 +1,86 @@
+// FatigueInteractionCrossValidationTests.swift
+// ProjectApexTests
+//
+// Cross-platform parity tests for `FatigueInteraction.consistencyFactor`,
+// `countFactor`, and `confidence` (TraineeModelInteractions.swift:98-117)
+// against the shared fixture file at docs/fixtures/fatigue-interaction.json.
+//
+// Per ADR-0005: the server-side Phase 2 fatigue-interaction aggregator (TS,
+// supabase/functions/_shared/fatigue-interaction.ts) and the client-side
+// Phase 1 value type (Swift, this file) must produce identical math on the
+// same inputs. The fixture file is the single source of expected outputs;
+// both sides assert against the same JSON to within 1e-12.
+//
+// A drift between the two implementations surfaces here on the Swift side or
+// on the TS side at supabase/functions/_shared/fatigue-interaction_test.ts —
+// whichever regressed.
+
+import XCTest
+@testable import ProjectApex
+
+final class FatigueInteractionCrossValidationTests: XCTestCase {
+
+    // MARK: ─── Fixture loading ────────────────────────────────────────────
+
+    private struct ExpectedValues: Decodable {
+        let consistencyFactor: Double
+        let countFactor: Double
+        let confidence: Double
+    }
+
+    private struct FixtureRow: Decodable {
+        let name: String
+        let observations: [Double]
+        let totalCount: Int
+        let expected: ExpectedValues
+    }
+
+    private struct FixtureFile: Decodable {
+        let fixtures: [FixtureRow]
+    }
+
+    private static let fixtureFileURL: URL = {
+        URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()      // ProjectApexTests/
+            .deletingLastPathComponent()      // ProjectApex/ (repo root)
+            .appendingPathComponent("docs/fixtures/fatigue-interaction.json")
+    }()
+
+    private static let rows: [FixtureRow] = {
+        let data = try! Data(contentsOf: fixtureFileURL)
+        return try! JSONDecoder().decode(FixtureFile.self, from: data).fixtures
+    }()
+
+    // MARK: ─── Parity assertion ───────────────────────────────────────────
+
+    /// One XCTest per fixture row. Failure-message includes the row name so
+    /// a regression points at the specific behavior that drifted.
+    func test_swiftMatchesFixtureExpectedValues() {
+        for row in Self.rows {
+            let interaction = FatigueInteraction(
+                fromPattern: .squat,
+                toPattern: .hipHinge,
+                observations: row.observations,
+                totalCount: row.totalCount
+            )
+            XCTAssertEqual(
+                interaction.consistencyFactor,
+                row.expected.consistencyFactor,
+                accuracy: 1e-12,
+                "consistencyFactor drifted on fixture '\(row.name)'"
+            )
+            XCTAssertEqual(
+                interaction.countFactor,
+                row.expected.countFactor,
+                accuracy: 1e-12,
+                "countFactor drifted on fixture '\(row.name)'"
+            )
+            XCTAssertEqual(
+                interaction.confidence,
+                row.expected.confidence,
+                accuracy: 1e-12,
+                "confidence drifted on fixture '\(row.name)'"
+            )
+        }
+    }
+}

--- a/docs/fixtures/fatigue-interaction.json
+++ b/docs/fixtures/fatigue-interaction.json
@@ -1,0 +1,60 @@
+{
+  "$schema_comment": "Cross-platform fixtures for the fatigue-interaction confidence math (ADR-0005). Loaded by Swift FatigueInteractionCrossValidationTests.swift and TS fatigue-interaction_test.ts. Both implementations must produce the expected values to within 1e-12. Path is referenced via the slice A11 commit; see docs/agents/domain.md if new fixture types land here.",
+  "fixtures": [
+    {
+      "name": "cycle-7-single-obs-guard",
+      "comment": "1 observation fails the recent.length >= 2 guard → consistencyFactor=0; countFactor=0.5 (totalCount<15); confidence=0.",
+      "observations": [-0.05],
+      "totalCount": 1,
+      "expected": {
+        "consistencyFactor": 0,
+        "countFactor": 0.5,
+        "confidence": 0
+      }
+    },
+    {
+      "name": "cycle-8-zero-variance-exact-1-fixup",
+      "comment": "2 identical observations → variance=0, stddev=0, clamped=1; Swift's `< 1e-12` exact-1 fixup snaps to 1.0 exactly.",
+      "observations": [-0.05, -0.05],
+      "totalCount": 2,
+      "expected": {
+        "consistencyFactor": 1,
+        "countFactor": 0.5,
+        "confidence": 0.5
+      }
+    },
+    {
+      "name": "cycle-9a-mean-guard-fires-low-stddev",
+      "comment": "[0.0001, -0.0001] → mean=0; absMean=0.001 (guarded); stddev=1e-4; ratio=0.1; consistencyFactor=0.9. Pins the 0.001 guard denominator value.",
+      "observations": [0.0001, -0.0001],
+      "totalCount": 2,
+      "expected": {
+        "consistencyFactor": 0.9,
+        "countFactor": 0.5,
+        "confidence": 0.45
+      }
+    },
+    {
+      "name": "cycle-9b-clamp-to-zero-stddev-exceeds-absMean",
+      "comment": "[0.005, -0.005] → mean=0; absMean=0.001 (guarded); stddev=0.005; ratio=5; clamp(1-5)=0. Pins the lower-clamp behavior.",
+      "observations": [0.005, -0.005],
+      "totalCount": 2,
+      "expected": {
+        "consistencyFactor": 0,
+        "countFactor": 0.5,
+        "confidence": 0
+      }
+    },
+    {
+      "name": "cycle-10-11-countFactor-boundary-and-composition",
+      "comment": "[0.1, 0.2], totalCount=15: countFactor=1.0 (boundary inclusive ≥15); consistencyFactor=2/3 (1-stddev/absMean = 1-1/3); confidence=2/3 × 1.0 = 2/3. Pins both boundaries simultaneously.",
+      "observations": [0.1, 0.2],
+      "totalCount": 15,
+      "expected": {
+        "consistencyFactor": 0.6666666666666667,
+        "countFactor": 1,
+        "confidence": 0.6666666666666667
+      }
+    }
+  ]
+}

--- a/supabase/functions/_shared/fatigue-interaction.ts
+++ b/supabase/functions/_shared/fatigue-interaction.ts
@@ -1,0 +1,202 @@
+// Project Apex — Phase 2 fatigue-interaction aggregator.
+//
+// Per ADR-0005 §"Fatigue interaction" + §"Fatigue interaction confidence:
+// count-only vs count × consistency": cross-pattern carryover detected by
+// pairing each pattern in the current session against every distinct pattern
+// in the immediately-prior session, with rolling 10-obs `consistencyFactor`
+// window, monotone `totalCount` for the count-factor hard cap at 15, and
+// confidence = consistencyFactor × countFactor.
+//
+// Phase 1 ships the Swift `FatigueInteraction` value type at
+// TraineeModelInteractions.swift:77-118 which consumes the data this slice
+// produces. The math here mirrors that Swift implementation exactly, locked
+// against drift via cross-platform fixtures at docs/fixtures/fatigue-interaction.json.
+//
+// Per #82 out-of-scope: this rule does NOT compute per-session
+// performanceDeltaPct (orchestrator A12), surfacing (Phase 1 Swift digest at
+// TraineeModelDigest.swift:62 already filters at confidence ≥ 0.7), or
+// decide what counts as "immediately prior" during late-arrival scenarios
+// (orchestrator handles via the trainee model's chronological view).
+
+import {
+  FATIGUE_INTERACTION_HARD_CAP_OBSERVATIONS,
+  FATIGUE_INTERACTION_HARD_CAP_VALUE,
+  FATIGUE_INTERACTION_MEAN_GUARD,
+  FATIGUE_INTERACTION_OBSERVATION_WINDOW,
+} from "./constants.ts";
+
+export interface SessionPatternPerformance {
+  sessionId: string;
+  loggedAt: Date;
+  pattern: string;
+  /** Aggregated performance metric for this pattern in this session.
+   *  Specifically: mean e1RM-delta-percent vs the user's recent baseline EWMA
+   *  for that pattern. Negative = pattern under-performed.
+   */
+  performanceDeltaPct: number;
+}
+
+export interface FatigueObservation {
+  fromPattern: string;
+  toPattern: string;
+  /** Performance delta-percent on toPattern in the session that
+   *  immediately followed a session containing fromPattern.
+   */
+  delta: number;
+  observedAt: Date;
+}
+
+export interface FatigueState {
+  fromPattern: string;
+  toPattern: string;
+  /** Delta-percent observations, oldest first. The Swift-side
+   *  FatigueInteraction value type stores `observations: [Double]` as the
+   *  rolling window of last FATIGUE_INTERACTION_OBSERVATION_WINDOW (=10);
+   *  appendObservations enforces that trim.
+   */
+  observations: number[];
+  /** Monotone counter of all paired observations seen across history;
+   *  feeds the count-factor hard-cap rule at FATIGUE_INTERACTION_HARD_CAP_OBSERVATIONS.
+   */
+  totalCount: number;
+}
+
+/**
+ * Detect pairs from a sequence of session-pattern performances and emit
+ * fatigue observations. Per ADR-0005, for each pattern P in `newSession`,
+ * pair against every distinct pattern Q ≠ P in the immediately-prior session.
+ *
+ * `priorSession === null` (first-ever session) → no observations.
+ *
+ * Iteration order: priorSession.patterns then newSession.patterns, both
+ * sorted by MovementPattern string value lexicographically. This ordering
+ * is convention-only (any deterministic order satisfies the determinism
+ * requirement); pinned for stable test fixtures.
+ *
+ * `delta` on each observation = `performanceDeltaPct` of the *to* pattern
+ * in `newSession`. `observedAt` = `newSession[0].loggedAt` (all entries in a
+ * session share the session's logged-at timestamp; the first entry is read
+ * as the session timestamp source).
+ */
+export function detectFatigueObservations(
+  newSession: SessionPatternPerformance[],
+  priorSession: SessionPatternPerformance[] | null,
+): FatigueObservation[] {
+  if (priorSession === null) return [];
+  if (newSession.length === 0) return [];
+
+  const sortedPrior = [...priorSession].sort((a, b) =>
+    a.pattern < b.pattern ? -1 : a.pattern > b.pattern ? 1 : 0
+  );
+  const sortedNew = [...newSession].sort((a, b) =>
+    a.pattern < b.pattern ? -1 : a.pattern > b.pattern ? 1 : 0
+  );
+  const observedAt = newSession[0].loggedAt;
+
+  const out: FatigueObservation[] = [];
+  for (const q of sortedPrior) {
+    for (const p of sortedNew) {
+      if (q.pattern === p.pattern) continue; // Q ≠ P
+      out.push({
+        fromPattern: q.pattern,
+        toPattern: p.pattern,
+        delta: p.performanceDeltaPct,
+        observedAt,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Append observations to per-pair state. New (fromPattern, toPattern) keys
+ * create a new state entry; existing keys append to their observations and
+ * increment totalCount. The observations window is trimmed to the last
+ * FATIGUE_INTERACTION_OBSERVATION_WINDOW (=10) entries — totalCount is
+ * monotone and is NOT bounded by the window.
+ */
+export function appendObservations(
+  states: FatigueState[],
+  newObservations: FatigueObservation[],
+): FatigueState[] {
+  const out: FatigueState[] = states.map((s) => ({
+    ...s,
+    observations: [...s.observations],
+  }));
+  for (const obs of newObservations) {
+    const existing = out.find(
+      (s) => s.fromPattern === obs.fromPattern && s.toPattern === obs.toPattern,
+    );
+    if (existing) {
+      existing.observations.push(obs.delta);
+      if (
+        existing.observations.length > FATIGUE_INTERACTION_OBSERVATION_WINDOW
+      ) {
+        existing.observations = existing.observations.slice(
+          -FATIGUE_INTERACTION_OBSERVATION_WINDOW,
+        );
+      }
+      existing.totalCount += 1;
+    } else {
+      out.push({
+        fromPattern: obs.fromPattern,
+        toPattern: obs.toPattern,
+        observations: [obs.delta],
+        totalCount: 1,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Re-implementation of consistencyFactor / countFactor / confidence per
+ * ADR-0005, mirroring Swift `FatigueInteraction` at
+ * TraineeModelInteractions.swift:98-117. Cross-platform parity is locked
+ * by docs/fixtures/fatigue-interaction.json.
+ *
+ * The Swift digest filter at TraineeModelDigest.swift:62 surfaces interactions
+ * at confidence ≥ FATIGUE_INTERACTION_SURFACE_THRESHOLD (=0.7); this rule
+ * does not perform that filter (out of scope per #82).
+ */
+export function fatigueConfidence(state: FatigueState): {
+  consistencyFactor: number;
+  countFactor: number;
+  confidence: number;
+} {
+  const recent = state.observations.slice(
+    -FATIGUE_INTERACTION_OBSERVATION_WINDOW,
+  );
+  let consistencyFactor = 0;
+  if (recent.length >= 2) {
+    const mean = recent.reduce((a, b) => a + b, 0) / recent.length;
+    // Guard at FATIGUE_INTERACTION_MEAN_GUARD (=0.001) prevents divide-by-zero
+    // when mean is near zero. The guard establishes a *floor* on the
+    // denominator; consistencyFactor lands near 0 only when stddev > absMean
+    // (noise overruns the guarded denominator). For low-magnitude balanced
+    // observations like [0.0001, -0.0001], the guard fires but the small
+    // stddev keeps consistency high (≈0.9). The "near-zero consistency on
+    // guard fire" intuition only holds when stddev itself is large relative
+    // to the guard floor. Cycles 9a (guard fires + high consistency) and 9b
+    // (clamp to zero when stddev > absMean) pin both behaviors.
+    const absMean = Math.max(Math.abs(mean), FATIGUE_INTERACTION_MEAN_GUARD);
+    const variance =
+      recent.reduce((a, x) => a + (x - mean) ** 2, 0) / recent.length;
+    const stddev = Math.sqrt(variance);
+    const clamped = Math.max(0, Math.min(1, 1 - stddev / absMean));
+    // Float boundary fixups matching Swift implementation
+    // (TraineeModelInteractions.swift:106-107).
+    if (Math.abs(clamped - 1) < 1e-12) consistencyFactor = 1;
+    else if (Math.abs(clamped) < 1e-12) consistencyFactor = 0;
+    else consistencyFactor = clamped;
+  }
+  const countFactor =
+    state.totalCount >= FATIGUE_INTERACTION_HARD_CAP_OBSERVATIONS
+      ? 1.0
+      : FATIGUE_INTERACTION_HARD_CAP_VALUE;
+  return {
+    consistencyFactor,
+    countFactor,
+    confidence: consistencyFactor * countFactor,
+  };
+}

--- a/supabase/functions/_shared/fatigue-interaction_test.ts
+++ b/supabase/functions/_shared/fatigue-interaction_test.ts
@@ -1,0 +1,380 @@
+// Project Apex — Phase 2 fatigue-interaction aggregator tests.
+//
+// Per ADR-0005 §"Fatigue interaction" + §"Fatigue interaction confidence:
+// count-only vs count × consistency": cross-pattern carryover detected by
+// pairing each pattern in the current session against every distinct pattern
+// in the immediately-prior session, with rolling 10-obs `consistencyFactor`
+// window, monotone `totalCount` for the count-factor hard cap at 15, and
+// confidence = consistencyFactor × countFactor. Phase 1 ships the Swift
+// value type at TraineeModelInteractions.swift:77-118 that consumes the data
+// this slice produces.
+//
+// Each test name pins the originating ADR-0005 rule so a failure surfaces the
+// rule the change touches. Test ordering matches the per-behavior TDD cycle
+// list approved on the slice plan.
+//
+// Run locally:
+//   deno test supabase/functions/_shared/fatigue-interaction_test.ts
+
+import {
+  assertAlmostEquals,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  appendObservations,
+  detectFatigueObservations,
+  fatigueConfidence,
+  type FatigueObservation,
+  type FatigueState,
+  type SessionPatternPerformance,
+} from "./fatigue-interaction.ts";
+
+// Test fixture builder for SessionPatternPerformance. `dayOffset` keeps the
+// loggedAt deterministic without a clock.
+const mkPerf = (
+  pattern: string,
+  performanceDeltaPct: number,
+  dayOffset: number,
+  sessionId = `s-${dayOffset}`,
+): SessionPatternPerformance => ({
+  sessionId,
+  loggedAt: new Date(2026, 0, 1 + dayOffset),
+  pattern,
+  performanceDeltaPct,
+});
+
+const mkObs = (
+  fromPattern: string,
+  toPattern: string,
+  delta: number,
+  dayOffset: number,
+): FatigueObservation => ({
+  fromPattern,
+  toPattern,
+  delta,
+  observedAt: new Date(2026, 0, 1 + dayOffset),
+});
+
+Deno.test(
+  "ADR-0005: pair detection — first-ever session (priorSession=null) emits no observations",
+  () => {
+    const newSession: SessionPatternPerformance[] = [
+      mkPerf("squat", -0.05, 0),
+    ];
+    const result = detectFatigueObservations(newSession, null);
+    assertEquals(result, []);
+  },
+);
+
+Deno.test(
+  "ADR-0005: pair detection — same-pattern self-pair excluded (Q ≠ P)",
+  () => {
+    // Yesterday squat, today squat — only-pattern overlap. The Cartesian
+    // product Q ∈ prior × P ∈ new contains exactly one entry (squat, squat),
+    // which the Q ≠ P clause excludes → 0 observations.
+    const prior: SessionPatternPerformance[] = [mkPerf("squat", -0.04, 0)];
+    const today: SessionPatternPerformance[] = [mkPerf("squat", -0.05, 1)];
+    const result = detectFatigueObservations(today, prior);
+    assertEquals(result, []);
+  },
+);
+
+Deno.test(
+  "ADR-0005: pair detection — Cartesian product across distinct patterns (2×2 = 4 observations, no self-pairs)",
+  () => {
+    // Yesterday: squat + horizontalPush. Today: verticalPush + hipHinge.
+    // No pattern overlap → 4 observations:
+    //   {squat → verticalPush, squat → hipHinge,
+    //    horizontalPush → verticalPush, horizontalPush → hipHinge}
+    // delta on each obs = performanceDeltaPct of the *to* pattern in newSession.
+    // observedAt on each obs = the new session's loggedAt.
+    // Iteration order: priorSession.patterns then newSession.patterns, both
+    // sorted by MovementPattern string value lexicographically (cycle 4 in
+    // the slice plan). Sorted prior: [horizontalPush, squat]. Sorted new:
+    // [hipHinge, verticalPush].
+    const prior: SessionPatternPerformance[] = [
+      mkPerf("squat", -0.02, 0, "s-prior"),
+      mkPerf("horizontalPush", -0.01, 0, "s-prior"),
+    ];
+    const today: SessionPatternPerformance[] = [
+      mkPerf("verticalPush", -0.07, 1, "s-today"),
+      mkPerf("hipHinge", -0.05, 1, "s-today"),
+    ];
+    const result = detectFatigueObservations(today, prior);
+    const todayLoggedAt = new Date(2026, 0, 2);
+    assertEquals(result, [
+      {
+        fromPattern: "horizontalPush",
+        toPattern: "hipHinge",
+        delta: -0.05,
+        observedAt: todayLoggedAt,
+      },
+      {
+        fromPattern: "horizontalPush",
+        toPattern: "verticalPush",
+        delta: -0.07,
+        observedAt: todayLoggedAt,
+      },
+      {
+        fromPattern: "squat",
+        toPattern: "hipHinge",
+        delta: -0.05,
+        observedAt: todayLoggedAt,
+      },
+      {
+        fromPattern: "squat",
+        toPattern: "verticalPush",
+        delta: -0.07,
+        observedAt: todayLoggedAt,
+      },
+    ]);
+  },
+);
+
+Deno.test(
+  "ADR-0005: appendObservations — empty state + 1 observation → new state with observations=[delta], totalCount=1",
+  () => {
+    // Tracer for appendObservations: starting with no per-pair state, the
+    // first observation creates a new FatigueState entry keyed by
+    // (fromPattern, toPattern) with the delta in observations and totalCount=1.
+    const result = appendObservations([], [mkObs("squat", "hipHinge", -0.05, 1)]);
+    assertEquals(result.length, 1);
+    assertEquals(result[0].fromPattern, "squat");
+    assertEquals(result[0].toPattern, "hipHinge");
+    assertEquals(result[0].observations, [-0.05]);
+    assertEquals(result[0].totalCount, 1);
+  },
+);
+
+Deno.test(
+  "ADR-0005: appendObservations — window slides at FATIGUE_INTERACTION_OBSERVATION_WINDOW=10 (oldest evicted on 11th)",
+  () => {
+    // Build a state at 10 obs with deltas -0.01..-0.10 (oldest first), then
+    // append an 11th delta -0.11. Window evicts the oldest (-0.01) and the
+    // new delta lands at the tail. observations.length stays at 10.
+    const seedObs: FatigueObservation[] = [];
+    for (let i = 1; i <= 10; i++) {
+      seedObs.push(mkObs("squat", "hipHinge", -0.01 * i, i));
+    }
+    const seeded = appendObservations([], seedObs);
+    assertEquals(seeded[0].observations.length, 10);
+    assertEquals(seeded[0].totalCount, 10);
+
+    const after = appendObservations(seeded, [
+      mkObs("squat", "hipHinge", -0.11, 11),
+    ]);
+    assertEquals(after[0].observations.length, 10);
+    // Oldest (-0.01) evicted; tail is -0.11.
+    assertEquals(after[0].observations[0], -0.02);
+    assertEquals(after[0].observations[9], -0.11);
+    assertEquals(after[0].totalCount, 11);
+  },
+);
+
+Deno.test(
+  "ADR-0005: appendObservations — totalCount is monotonic, NOT bounded by the window (≤10 obs in window, but totalCount keeps climbing)",
+  () => {
+    // Append 20 observations. The rolling window stays at 10, but totalCount
+    // is the unbounded count of every paired observation seen — load-bearing
+    // for the count-factor hard cap at FATIGUE_INTERACTION_HARD_CAP_OBSERVATIONS=15.
+    let state: FatigueState[] = [];
+    for (let i = 1; i <= 20; i++) {
+      state = appendObservations(state, [
+        mkObs("squat", "hipHinge", -0.001 * i, i),
+      ]);
+    }
+    assertEquals(state.length, 1);
+    assertEquals(state[0].observations.length, 10);
+    assertEquals(state[0].totalCount, 20);
+  },
+);
+
+Deno.test(
+  "ADR-0005: fatigueConfidence — 1 observation → consistencyFactor=0 (need ≥2 for sample variance)",
+  () => {
+    // Tracer for fatigueConfidence: with a single observation, the recent
+    // window has count=1, which fails the `recent.count >= 2` guard in the
+    // Swift implementation (TraineeModelInteractions.swift:100). Returns 0.
+    const state: FatigueState = {
+      fromPattern: "squat",
+      toPattern: "hipHinge",
+      observations: [-0.05],
+      totalCount: 1,
+    };
+    const result = fatigueConfidence(state);
+    assertEquals(result.consistencyFactor, 0);
+  },
+);
+
+Deno.test(
+  "ADR-0005: fatigueConfidence — 2 identical observations → consistencyFactor=1.0 (zero variance + Swift's `< 1e-12` exact-1 fixup)",
+  () => {
+    // Two identical observations have zero variance → stddev=0 → 1 - 0/|mean|
+    // = 1, which the Swift `if abs(clamped - 1) < 1e-12 { return 1 }` fixup
+    // (TraineeModelInteractions.swift:106) snaps to exactly 1.0.
+    const state: FatigueState = {
+      fromPattern: "squat",
+      toPattern: "hipHinge",
+      observations: [-0.05, -0.05],
+      totalCount: 2,
+    };
+    const result = fatigueConfidence(state);
+    assertEquals(result.consistencyFactor, 1);
+  },
+);
+
+Deno.test(
+  "ADR-0005: fatigueConfidence — mean-guard fires on near-zero mean — guard prevents NaN; with [0.0001, -0.0001] absMean=0.001 (guarded), stddev=1e-4, ratio=0.1, consistencyFactor=0.9 (issue body's 'near zero' assertion was incorrect for this fixture; see PR description for issue amendment)",
+  () => {
+    // mean = 0; absMean = max(0, 0.001) = 0.001 (guarded — without the
+    // FATIGUE_INTERACTION_MEAN_GUARD this would be a divide-by-zero / NaN).
+    // variance = ((1e-4)² + (-1e-4)²) / 2 = 1e-8; stddev = 1e-4.
+    // clamped = max(0, min(1, 1 - 1e-4/1e-3)) = max(0, min(1, 0.9)) = 0.9 exactly.
+    // The exact 0.9 assertion locks the guard's denominator value: changing
+    // FATIGUE_INTERACTION_MEAN_GUARD from 0.001 to 0.01 would shift this to
+    // 1 - 1e-4/1e-2 = 0.99 and break the test.
+    const state: FatigueState = {
+      fromPattern: "squat",
+      toPattern: "hipHinge",
+      observations: [0.0001, -0.0001],
+      totalCount: 2,
+    };
+    const result = fatigueConfidence(state);
+    assertAlmostEquals(result.consistencyFactor, 0.9, 1e-12);
+    assertEquals(Number.isFinite(result.consistencyFactor), true);
+  },
+);
+
+Deno.test(
+  "ADR-0005: fatigueConfidence — consistency clamps to 0 when stddev exceeds absMean — with [0.005, -0.005] absMean=0.001 (guarded), stddev=0.005, ratio=5, clamp(1-5)=0",
+  () => {
+    // mean = 0; absMean = max(0, 0.001) = 0.001 (guarded).
+    // variance = ((5e-3)² + (-5e-3)²) / 2 = 2.5e-5; stddev = 5e-3.
+    // 1 - stddev/absMean = 1 - 5 = -4 → clamp at 0 → exact-0 fixup yields 0.
+    // Pairs with cycle 9a to bracket the guard: 9a pins the denominator value
+    // (low stddev → high consistency); 9b pins the clamp-to-zero behavior
+    // (high stddev → zero consistency). Together they pin the full range of
+    // the guarded ratio's effect on consistencyFactor.
+    const state: FatigueState = {
+      fromPattern: "squat",
+      toPattern: "hipHinge",
+      observations: [0.005, -0.005],
+      totalCount: 2,
+    };
+    const result = fatigueConfidence(state);
+    assertEquals(result.consistencyFactor, 0);
+  },
+);
+
+Deno.test(
+  "ADR-0005: fatigueConfidence — countFactor boundary at FATIGUE_INTERACTION_HARD_CAP_OBSERVATIONS=15 (totalCount=14 → 0.5; totalCount=15 → 1.0)",
+  () => {
+    // Per Swift: `totalCount >= 15 ? 1.0 : 0.5` (TraineeModelInteractions.swift:112).
+    // Inclusive at 15 (>=, not >). Below threshold → hard cap at 0.5.
+    const below: FatigueState = {
+      fromPattern: "squat",
+      toPattern: "hipHinge",
+      observations: [-0.05, -0.05],
+      totalCount: 14,
+    };
+    assertEquals(fatigueConfidence(below).countFactor, 0.5);
+
+    const at: FatigueState = {
+      fromPattern: "squat",
+      toPattern: "hipHinge",
+      observations: [-0.05, -0.05],
+      totalCount: 15,
+    };
+    assertEquals(fatigueConfidence(at).countFactor, 1.0);
+  },
+);
+
+Deno.test(
+  "ADR-0005: fatigueConfidence — confidence = consistencyFactor × countFactor (composition with non-degenerate factors)",
+  () => {
+    // observations = [0.1, 0.2], totalCount = 14:
+    //   mean    = 0.15
+    //   absMean = max(0.15, 0.001) = 0.15  (guard does NOT fire)
+    //   variance= ((0.1-0.15)² + (0.2-0.15)²) / 2 = 0.0025
+    //   stddev  = 0.05
+    //   ratio   = 0.05 / 0.15 = 1/3
+    //   clamped = 1 - 1/3 = 2/3
+    // countFactor = 0.5 (totalCount < 15).
+    // confidence = 2/3 × 0.5 = 1/3.
+    // Non-degenerate factors (neither is 0 or 1) so a future change dropping
+    // the multiplication or swapping × for + would break this test. The
+    // user's issue-body example (0.8 × 1.0 = 0.8) was multiplicatively
+    // degenerate — × 1.0 is identity — so wouldn't catch that regression.
+    const state: FatigueState = {
+      fromPattern: "squat",
+      toPattern: "hipHinge",
+      observations: [0.1, 0.2],
+      totalCount: 14,
+    };
+    const result = fatigueConfidence(state);
+    assertAlmostEquals(result.consistencyFactor, 2 / 3, 1e-12);
+    assertEquals(result.countFactor, 0.5);
+    assertAlmostEquals(result.confidence, 1 / 3, 1e-12);
+  },
+);
+
+// ─── Cross-validation: parity with Swift FatigueInteraction.confidence ─────
+//
+// The fixture file at docs/fixtures/fatigue-interaction.json is the single
+// source of expected outputs across both implementations. Swift loads the
+// same JSON via ProjectApexTests/FatigueInteractionCrossValidationTests.swift
+// and asserts FatigueInteraction.confidence (TraineeModelInteractions.swift:115)
+// against the same expected values. A drift between TS and Swift surfaces as
+// a failure on whichever side regressed; both sides being green proves cross-
+// platform parity to within 1e-12 on every fixture row.
+
+interface FixtureFile {
+  fixtures: Array<{
+    name: string;
+    observations: number[];
+    totalCount: number;
+    expected: {
+      consistencyFactor: number;
+      countFactor: number;
+      confidence: number;
+    };
+  }>;
+}
+
+const fixturePath = new URL(
+  "../../../docs/fixtures/fatigue-interaction.json",
+  import.meta.url,
+);
+const fixtureFile: FixtureFile = JSON.parse(
+  Deno.readTextFileSync(fixturePath),
+);
+
+for (const row of fixtureFile.fixtures) {
+  Deno.test(
+    `ADR-0005: cross-validation fixture "${row.name}" — TS fatigueConfidence matches expected (Swift parity to 1e-12)`,
+    () => {
+      const state: FatigueState = {
+        fromPattern: "squat",
+        toPattern: "hipHinge",
+        observations: row.observations,
+        totalCount: row.totalCount,
+      };
+      const result = fatigueConfidence(state);
+      assertAlmostEquals(
+        result.consistencyFactor,
+        row.expected.consistencyFactor,
+        1e-12,
+      );
+      assertAlmostEquals(
+        result.countFactor,
+        row.expected.countFactor,
+        1e-12,
+      );
+      assertAlmostEquals(
+        result.confidence,
+        row.expected.confidence,
+        1e-12,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- New TS module [`supabase/functions/_shared/fatigue-interaction.ts`](supabase/functions/_shared/fatigue-interaction.ts) exporting `detectFatigueObservations` (Cartesian Q≠P pair detection across consecutive sessions, lexicographic sort), `appendObservations` (rolling 10-obs window + monotone `totalCount`), and `fatigueConfidence` (mirroring Swift `FatigueInteraction` math at `TraineeModelInteractions.swift:98-117`).
- Cross-platform fixture file [`docs/fixtures/fatigue-interaction.json`](docs/fixtures/fatigue-interaction.json) — single source of expected outputs for both implementations. New `docs/fixtures/` directory establishes the convention.
- Parallel Swift test [`ProjectApexTests/FatigueInteractionCrossValidationTests.swift`](ProjectApexTests/FatigueInteractionCrossValidationTests.swift) loads the same JSON and asserts `FatigueInteraction.confidence` parity to 1e-12.

## Decisions / corrections

- **Cycle 9 split into 9a + 9b.** The issue body's "consistencyFactor near zero" assertion for fixture `[0.0001, -0.0001]` is mathematically incorrect: the mean-guard fires (preventing NaN) but the small stddev keeps consistency at ~0.9, not near-zero. The original spec conflated "guard fires" with "consistency clamps to zero" — different properties. Cycle 9a pins the guard-fires property (`consistencyFactor=0.9` exact, locks the 0.001 denominator value); cycle 9b adds `[0.005, -0.005]` fixture pinning the clamp-to-zero property when stddev > absMean. Source comment in `fatigue-interaction.ts:173-181` documents the property distinction. **Issue amendment proposed post-merge** to reword cycle 9 to match the actual two distinct behaviors. (5th instance of the issue-prose-vs-implementation-reality pattern across slices A7/A8/A9/A11 — reinforces the design-principles.md authority-hierarchy entry queued from the A9 PR description follow-up.)
- **Surfacing-threshold cycle dropped** per slice plan Q2: already locked three ways — `FATIGUE_INTERACTION_SURFACE_THRESHOLD = 0.7` in `constants_test.ts`, Phase 1 Swift digest filter at `TraineeModelDigest.swift:62`, and the 5-row cross-validation fixture covering the math through `confidence`. No additional helper or boundary test in this slice.
- **Cartesian product ordering** pinned to lexicographic sort by pattern string for deterministic test fixtures. Convention-only (any deterministic order works); source comment at `fatigue-interaction.ts:71-74` names the convention so a future maintainer doesn't read semantic meaning into it.
- **Cycle 9a as regression pin.** `assertAlmostEquals(consistencyFactor, 0.9, 1e-12)` exact-value assertion locks the guard's denominator value: a future change of `FATIGUE_INTERACTION_MEAN_GUARD` from 0.001 to 0.01 would shift the result to 0.99 and break the test.
- **Cycle 11 picked non-degenerate factors.** Issue body's example (`0.8 × 1.0 = 0.8`) is multiplicatively degenerate — × 1.0 is identity. Used `[0.1, 0.2]` with `totalCount=14` instead, yielding `consistencyFactor=2/3, countFactor=0.5, confidence=1/3` — a future change dropping the multiplication or swapping × for + would break this test.

## Test plan

- [x] All Deno tests green (`deno test --allow-read supabase/functions/_shared/`) — 231 tests pass (17 new + 214 existing).
- [x] Swift cross-validation test green (`xcodebuild -only-testing:ProjectApexTests/FatigueInteractionCrossValidationTests`) on iPhone 17 simulator — `FatigueInteraction.confidence` matches all 5 fixture rows to 1e-12.
- [x] Constants imported (`FATIGUE_INTERACTION_OBSERVATION_WINDOW`, `_MEAN_GUARD`, `_HARD_CAP_OBSERVATIONS`, `_HARD_CAP_VALUE`) — locked at the constants-test layer in slice A1.
- [x] Branched off `origin/main` (post-A10 merge at `264442e`); no rebase risk.
- [x] No modifications to Phase 1's `FatigueInteraction` value type — out of scope per #82.

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)