### PR TITLE
feat(slice-A12/#83): Stage 1 orchestrator + late-arrival watermark + WAQ adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ supabase/.temp/
 # deploy`; tracks the active local branch for preview-branch features.
 # Local-machine-only — never commit.
 supabase/.branches/
+
+# Deno's auto-generated node_modules dir (created when nodeModulesDir:"auto"
+# is set in a per-function deno.json — A12 ships this for npm:postgres@3.4.4).
+# Local-machine-only — restored by `deno install` / first `deno test` run.
+supabase/functions/*/node_modules/
+
+# Local agent state (worktrees, notes, scratch). Never commit.
+.claude/

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		7D8C4E6ADC8DEDCA31B72B1D /* ManualLogIntentGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */; };
 		81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */; };
 		A11FA719C0DE0001CAFE0001 /* FatigueInteractionCrossValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11FA719C0DE0002CAFE0002 /* FatigueInteractionCrossValidationTests.swift */; };
+		A12FA719C0DE0001CAFE0001 /* TraineeModelSnapshotsCrossValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12FA719C0DE0002CAFE0002 /* TraineeModelSnapshotsCrossValidationTests.swift */; };
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
 		8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */; };
@@ -105,6 +106,7 @@
 		7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelDigestTests.swift; sourceTree = "<group>"; };
 		85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelInteractionsTests.swift; sourceTree = "<group>"; };
 		A11FA719C0DE0002CAFE0002 /* FatigueInteractionCrossValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FatigueInteractionCrossValidationTests.swift; sourceTree = "<group>"; };
+		A12FA719C0DE0002CAFE0002 /* TraineeModelSnapshotsCrossValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelSnapshotsCrossValidationTests.swift; sourceTree = "<group>"; };
 		862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelUpdateJobTests.swift; sourceTree = "<group>"; };
 		A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LateArrivalNotificationQueueTests.swift; sourceTree = "<group>"; };
 		878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelProfilesTests.swift; sourceTree = "<group>"; };
@@ -241,6 +243,7 @@
 				B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */,
 				85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */,
 				A11FA719C0DE0002CAFE0002 /* FatigueInteractionCrossValidationTests.swift */,
+				A12FA719C0DE0002CAFE0002 /* TraineeModelSnapshotsCrossValidationTests.swift */,
 				878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */,
 				DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */,
 				4422DE7829C0C124138BB4B0 /* WeekFatigueSignalsHelperAgreementTests.swift */,
@@ -389,6 +392,7 @@
 				A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */,
 				81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */,
 				A11FA719C0DE0001CAFE0001 /* FatigueInteractionCrossValidationTests.swift in Sources */,
+				A12FA719C0DE0001CAFE0001 /* TraineeModelSnapshotsCrossValidationTests.swift in Sources */,
 				6ECE420C1031E80360FF1EFE /* TraineeModelProfilesTests.swift in Sources */,
 				B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */,
 				5DE94F8F1D136C65C96FCAD1 /* WeekFatigueSignalsHelperAgreementTests.swift in Sources */,

--- a/ProjectApex/Models/JSONBCodable.swift
+++ b/ProjectApex/Models/JSONBCodable.swift
@@ -1,0 +1,87 @@
+// JSONBCodable.swift
+// ProjectApex — Models
+//
+// Helpers for encoding/decoding enum-keyed `Dictionary` fields as JSON
+// objects (`{ "rawValue": ... }`) instead of Swift's default alternating
+// array shape (`["rawValue", value, "rawValue", value]`).
+//
+// Why: Swift's synthesized `Dictionary<K, V>` Codable conformance encodes
+// as a JSON object **only** when `K` is `String` or `Int`. For other
+// `Hashable` keys — including `RawRepresentable` enums with `String` raw
+// values like `MovementPattern` / `MuscleGroup` / `SetIntent` — Codable
+// falls back to a flat alternating `[key, value, key, value, ...]` array.
+// Swift's internal round-trips work fine on this shape, but it makes the
+// JSONB unintelligible in Postgres Studio inspection and forces the TS
+// Edge Function orchestrator (slice A12 / #83, ADR-0006 contract author)
+// to emit non-idiomatic shapes. ADR-0006 §"Implementation consequences":
+// "the trainee-model JSONB column is a contract between Edge Function
+// (writer) and client (reader) for digest assembly" — that contract is
+// cleaner with object-keyed shapes both sides can produce naturally.
+//
+// The cross-platform shape parity is locked by
+// docs/fixtures/trainee-model-snapshot.json + the TS round-trip test +
+// `TraineeModelSnapshotsCrossValidationTests`.
+
+import Foundation
+
+/// Dynamic CodingKey accepting any string. Used as the key type when
+/// decoding JSON objects whose keys are dynamically derived (i.e., enum
+/// raw values) rather than statically known.
+struct AnyCodingKey: CodingKey {
+    let stringValue: String
+    var intValue: Int? { nil }
+    init?(stringValue: String) { self.stringValue = stringValue }
+    init?(intValue _: Int) { return nil }
+    init(_ value: String) { self.stringValue = value }
+}
+
+extension KeyedDecodingContainer {
+    /// Decode a dictionary whose keys are `RawRepresentable<String>` enums
+    /// from a JSON object. Unknown rawValues (forward-compat: a key from a
+    /// future `MovementPattern` case the local Swift binary doesn't know
+    /// about) are silently skipped — matches the trainee-model evolution
+    /// rule from ADR-0006 §"Rule-versioning: forward-only".
+    func decodeEnumKeyedDict<EK, V>(
+        _ valueType: V.Type,
+        forKey key: Key
+    ) throws -> [EK: V]
+    where EK: RawRepresentable & Hashable, EK.RawValue == String, V: Decodable {
+        let nested = try nestedContainer(keyedBy: AnyCodingKey.self, forKey: key)
+        var result: [EK: V] = [:]
+        for k in nested.allKeys {
+            guard let typed = EK(rawValue: k.stringValue) else { continue }
+            result[typed] = try nested.decode(V.self, forKey: k)
+        }
+        return result
+    }
+
+    /// Variant for dictionaries that may be absent in older snapshots; returns
+    /// an empty dictionary on missing key. Used for additive Codable migrations
+    /// where the field is optional in the on-disk shape.
+    func decodeEnumKeyedDictIfPresent<EK, V>(
+        _ valueType: V.Type,
+        forKey key: Key
+    ) throws -> [EK: V]
+    where EK: RawRepresentable & Hashable, EK.RawValue == String, V: Decodable {
+        guard contains(key) else { return [:] }
+        return try decodeEnumKeyedDict(valueType, forKey: key)
+    }
+}
+
+extension KeyedEncodingContainer {
+    /// Encode a dictionary whose keys are `RawRepresentable<String>` enums
+    /// as a JSON object. Keys are sorted by rawValue for deterministic
+    /// output (matters for snapshot-fixture stability and JSONB equality
+    /// comparisons).
+    mutating func encodeEnumKeyedDict<EK, V>(
+        _ dict: [EK: V],
+        forKey key: Key
+    ) throws
+    where EK: RawRepresentable & Hashable, EK.RawValue == String, V: Encodable {
+        var nested = nestedContainer(keyedBy: AnyCodingKey.self, forKey: key)
+        let sorted = dict.sorted { $0.key.rawValue < $1.key.rawValue }
+        for (k, v) in sorted {
+            try nested.encode(v, forKey: AnyCodingKey(k.rawValue))
+        }
+    }
+}

--- a/ProjectApex/Models/TraineeModel.swift
+++ b/ProjectApex/Models/TraineeModel.swift
@@ -81,6 +81,142 @@ struct TraineeModel: Codable, Sendable, Hashable {
         self.lastGlobalPhaseAdvanceFiredAtSessionCount = lastGlobalPhaseAdvanceFiredAtSessionCount
     }
 
+    // MARK: Custom Codable for JSONB shape parity (slice A12 / #83)
+
+    // Per ADR-0006 §"Implementation consequences", the trainee-model JSONB
+    // column is a contract between the TS Edge Function orchestrator (writer)
+    // and the Swift client (reader for digest assembly). Swift's synthesized
+    // Dictionary Codable encodes enum-keyed dicts as flat alternating arrays
+    // (`["squat", {...}, "horizontal_push", {...}]`), which the TS orchestrator
+    // can't produce idiomatically and which makes JSONB unintelligible to
+    // Studio inspection. This custom Codable encodes `patterns`, `muscles`,
+    // and `prescriptionAccuracy` as JSON objects keyed by enum rawValue; the
+    // shape parity is locked by docs/fixtures/trainee-model-snapshot.json and
+    // its cross-platform tests on both TS and Swift sides.
+
+    enum CodingKeys: String, CodingKey {
+        case activeProgramId
+        case goal
+        case projections
+        case patterns
+        case muscles
+        case exercises
+        case activeLimitations
+        case clearedLimitations
+        case fatigueInteractions
+        case prescriptionAccuracy
+        case prescriptionIntentMismatches
+        case transfers
+        case bodyweight
+        case lifeContextEvents
+        case reassessmentRecords
+        case totalSessionCount
+        case lastClassifiedNoteCreatedAt
+        case lastGlobalPhaseAdvanceFiredAtSessionCount
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.activeProgramId = try c.decodeIfPresent(UUID.self, forKey: .activeProgramId)
+        self.goal = try c.decode(GoalState.self, forKey: .goal)
+        self.projections = try c.decodeIfPresent(ProjectionState.self, forKey: .projections)
+        self.patterns = try c.decodeEnumKeyedDictIfPresent(
+            PatternProfile.self, forKey: .patterns
+        )
+        self.muscles = try c.decodeEnumKeyedDictIfPresent(
+            MuscleProfile.self, forKey: .muscles
+        )
+        self.exercises = try c.decodeIfPresent(
+            [String: ExerciseProfile].self, forKey: .exercises
+        ) ?? [:]
+        self.activeLimitations = try c.decodeIfPresent(
+            [ActiveLimitation].self, forKey: .activeLimitations
+        ) ?? []
+        self.clearedLimitations = try c.decodeIfPresent(
+            [ClearedLimitation].self, forKey: .clearedLimitations
+        ) ?? []
+        self.fatigueInteractions = try c.decodeIfPresent(
+            [FatigueInteraction].self, forKey: .fatigueInteractions
+        ) ?? []
+        // Doubly-nested dict: outer key MovementPattern (rawValue), inner key
+        // SetIntent (rawValue). Both layers must decode as JSON objects so the
+        // shape matches the TS orchestrator's per-pattern × per-intent table.
+        if c.contains(.prescriptionAccuracy) {
+            let outer = try c.nestedContainer(keyedBy: AnyCodingKey.self, forKey: .prescriptionAccuracy)
+            var prescriptionAccuracy: [MovementPattern: [SetIntent: PrescriptionAccuracy]] = [:]
+            for outerKey in outer.allKeys {
+                guard let pattern = MovementPattern(rawValue: outerKey.stringValue) else { continue }
+                let inner = try outer.nestedContainer(keyedBy: AnyCodingKey.self, forKey: outerKey)
+                var byIntent: [SetIntent: PrescriptionAccuracy] = [:]
+                for innerKey in inner.allKeys {
+                    guard let intent = SetIntent(rawValue: innerKey.stringValue) else { continue }
+                    byIntent[intent] = try inner.decode(PrescriptionAccuracy.self, forKey: innerKey)
+                }
+                prescriptionAccuracy[pattern] = byIntent
+            }
+            self.prescriptionAccuracy = prescriptionAccuracy
+        } else {
+            self.prescriptionAccuracy = [:]
+        }
+        self.prescriptionIntentMismatches = try c.decodeIfPresent(
+            [PrescriptionIntentMismatch].self, forKey: .prescriptionIntentMismatches
+        ) ?? []
+        self.transfers = try c.decodeIfPresent(
+            [ExerciseTransfer].self, forKey: .transfers
+        ) ?? []
+        self.bodyweight = try c.decodeIfPresent(
+            BodyweightHistory.self, forKey: .bodyweight
+        ) ?? BodyweightHistory()
+        self.lifeContextEvents = try c.decodeIfPresent(
+            [LifeContextEvent].self, forKey: .lifeContextEvents
+        ) ?? []
+        self.reassessmentRecords = try c.decodeIfPresent(
+            [ReassessmentRecord].self, forKey: .reassessmentRecords
+        ) ?? []
+        self.totalSessionCount = try c.decodeIfPresent(
+            Int.self, forKey: .totalSessionCount
+        ) ?? 0
+        self.lastClassifiedNoteCreatedAt = try c.decodeIfPresent(
+            Date.self, forKey: .lastClassifiedNoteCreatedAt
+        )
+        self.lastGlobalPhaseAdvanceFiredAtSessionCount = try c.decodeIfPresent(
+            Int.self, forKey: .lastGlobalPhaseAdvanceFiredAtSessionCount
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encodeIfPresent(activeProgramId, forKey: .activeProgramId)
+        try c.encode(goal, forKey: .goal)
+        try c.encodeIfPresent(projections, forKey: .projections)
+        try c.encodeEnumKeyedDict(patterns, forKey: .patterns)
+        try c.encodeEnumKeyedDict(muscles, forKey: .muscles)
+        try c.encode(exercises, forKey: .exercises)
+        try c.encode(activeLimitations, forKey: .activeLimitations)
+        try c.encode(clearedLimitations, forKey: .clearedLimitations)
+        try c.encode(fatigueInteractions, forKey: .fatigueInteractions)
+        // Doubly-nested encode mirroring the decoder above. Outer + inner
+        // sorted by rawValue for deterministic output.
+        var pac = c.nestedContainer(keyedBy: AnyCodingKey.self, forKey: .prescriptionAccuracy)
+        for (pattern, byIntent) in prescriptionAccuracy.sorted(by: { $0.key.rawValue < $1.key.rawValue }) {
+            var inner = pac.nestedContainer(
+                keyedBy: AnyCodingKey.self,
+                forKey: AnyCodingKey(pattern.rawValue)
+            )
+            for (intent, accuracy) in byIntent.sorted(by: { $0.key.rawValue < $1.key.rawValue }) {
+                try inner.encode(accuracy, forKey: AnyCodingKey(intent.rawValue))
+            }
+        }
+        try c.encode(prescriptionIntentMismatches, forKey: .prescriptionIntentMismatches)
+        try c.encode(transfers, forKey: .transfers)
+        try c.encode(bodyweight, forKey: .bodyweight)
+        try c.encode(lifeContextEvents, forKey: .lifeContextEvents)
+        try c.encode(reassessmentRecords, forKey: .reassessmentRecords)
+        try c.encode(totalSessionCount, forKey: .totalSessionCount)
+        try c.encodeIfPresent(lastClassifiedNoteCreatedAt, forKey: .lastClassifiedNoteCreatedAt)
+        try c.encodeIfPresent(lastGlobalPhaseAdvanceFiredAtSessionCount, forKey: .lastGlobalPhaseAdvanceFiredAtSessionCount)
+    }
+
     // MARK: Major patterns (calibration / phase-advance gating)
 
     static let majorPatterns: Set<MovementPattern> = [

--- a/ProjectApex/Models/TraineeModelInteractions.swift
+++ b/ProjectApex/Models/TraineeModelInteractions.swift
@@ -154,6 +154,11 @@ struct PrescriptionAccuracy: Codable, Sendable, Hashable {
         self.sampleCountByGapBucket = sampleCountByGapBucket
     }
 
+    enum CodingKeys: String, CodingKey {
+        case pattern, intent, bias, rmse, sampleCount
+        case biasByGapBucket, rmseByGapBucket, sampleCountByGapBucket
+    }
+
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.pattern = try c.decode(MovementPattern.self, forKey: .pattern)
@@ -161,9 +166,25 @@ struct PrescriptionAccuracy: Codable, Sendable, Hashable {
         self.bias = try c.decode(Double.self, forKey: .bias)
         self.rmse = try c.decode(Double.self, forKey: .rmse)
         self.sampleCount = try c.decode(Int.self, forKey: .sampleCount)
-        self.biasByGapBucket = try c.decodeIfPresent([InterSessionGapBucket: Double].self, forKey: .biasByGapBucket) ?? [:]
-        self.rmseByGapBucket = try c.decodeIfPresent([InterSessionGapBucket: Double].self, forKey: .rmseByGapBucket) ?? [:]
-        self.sampleCountByGapBucket = try c.decodeIfPresent([InterSessionGapBucket: Int].self, forKey: .sampleCountByGapBucket) ?? [:]
+        // Gap-bucket dicts are enum-keyed (InterSessionGapBucket) — encoded as
+        // JSON objects to match the TS orchestrator's idiomatic shape per the
+        // ADR-0006 JSONB contract (slice A12 / #83). See JSONBCodable.swift.
+        self.biasByGapBucket = try c.decodeEnumKeyedDictIfPresent(Double.self, forKey: .biasByGapBucket)
+        self.rmseByGapBucket = try c.decodeEnumKeyedDictIfPresent(Double.self, forKey: .rmseByGapBucket)
+        self.sampleCountByGapBucket = try c.decodeEnumKeyedDictIfPresent(Int.self, forKey: .sampleCountByGapBucket)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(pattern, forKey: .pattern)
+        try c.encode(intent, forKey: .intent)
+        try c.encode(bias, forKey: .bias)
+        try c.encode(rmse, forKey: .rmse)
+        try c.encode(sampleCount, forKey: .sampleCount)
+        // Mirror the decode path — gap-bucket dicts encode as JSON objects.
+        try c.encodeEnumKeyedDict(biasByGapBucket, forKey: .biasByGapBucket)
+        try c.encodeEnumKeyedDict(rmseByGapBucket, forKey: .rmseByGapBucket)
+        try c.encodeEnumKeyedDict(sampleCountByGapBucket, forKey: .sampleCountByGapBucket)
     }
 }
 

--- a/ProjectApex/Services/TraineeModelUpdateJob.swift
+++ b/ProjectApex/Services/TraineeModelUpdateJob.swift
@@ -148,17 +148,29 @@ final class TraineeModelUpdateJob {
         // in the (unlikely) race. Dequeue identically (return .success),
         // skip the local snapshot update, and enqueue a soft notification
         // for the post-session summary surface.
+        //
+        // Slice A12 (#83) ships the richer response shape:
+        //   { late_arrival: true,
+        //     late_arrival_details: {
+        //       session_id: UUID,
+        //       incoming_logged_at: ISO 8601,
+        //       watermark: ISO 8601
+        //     } }
+        // The three optional fields on LateArrivalNotification are populated
+        // here when present; pre-A12 responses (bool-only) leave them nil.
         if json["late_arrival"] as? Bool == true {
+            let details = json["late_arrival_details"] as? [String: Any]
+            let parsedSessionId = (details?["session_id"] as? String).flatMap(UUID.init(uuidString:))
+            let isoFormatter = ISO8601DateFormatter()
+            let parsedIncoming = (details?["incoming_logged_at"] as? String).flatMap { isoFormatter.date(from: $0) }
+            let parsedWatermark = (details?["watermark"] as? String).flatMap { isoFormatter.date(from: $0) }
             let notification = LateArrivalNotification(
                 id: UUID(),
                 message: LateArrivalNotification.lockedMessage,
                 receiptDate: Date(),
-                // sessionId / incomingLoggedAt / watermark are populated
-                // when A12 ships the richer Edge Function response shape.
-                // A3's bool-only response leaves them nil.
-                sessionId: nil,
-                incomingLoggedAt: nil,
-                watermark: nil
+                sessionId: parsedSessionId,
+                incomingLoggedAt: parsedIncoming,
+                watermark: parsedWatermark
             )
             await notificationQueue.enqueue(notification)
             return .success

--- a/ProjectApexTests/TraineeModelSnapshotsCrossValidationTests.swift
+++ b/ProjectApexTests/TraineeModelSnapshotsCrossValidationTests.swift
@@ -1,0 +1,116 @@
+// TraineeModelSnapshotsCrossValidationTests.swift
+// ProjectApexTests
+//
+// Cross-platform shape-parity tests for the TS Edge Function orchestrator's
+// JSONB output (slice A12 / #83). Loads the canonical fixture at
+// docs/fixtures/trainee-model-snapshot.json — the same JSON that the TS
+// orchestrator round-trip test asserts against — and verifies that the
+// Phase 1 Swift `TraineeModel` Codable decodes it cleanly with every Phase 2
+// field populated correctly.
+//
+// Per ADR-0006: the trainee_models.model_json column is a contract between
+// the Edge Function (writer) and the Swift client (reader for digest
+// assembly). Drift on either side silently corrupts user state. This test
+// catches Swift-side decoder regressions; the TS-side round-trip test in
+// orchestrator_test.ts catches TS-side regressions; together they pin the
+// shape contract.
+//
+// Anchor date 2026-01-01T00:00:00Z is deterministic (no Date.now() in
+// the fixture or tests).
+
+import XCTest
+@testable import ProjectApex
+
+final class TraineeModelSnapshotsCrossValidationTests: XCTestCase {
+
+    // MARK: ─── Fixture loading ────────────────────────────────────────────
+
+    private static let fixtureFileURL: URL = {
+        URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()      // ProjectApexTests/
+            .deletingLastPathComponent()      // ProjectApex/ (repo root)
+            .appendingPathComponent("docs/fixtures/trainee-model-snapshot.json")
+    }()
+
+    private static let model: TraineeModel = {
+        let data = try! Data(contentsOf: fixtureFileURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try! decoder.decode(TraineeModel.self, from: data)
+    }()
+
+    // MARK: ─── Phase 2 fields decode correctly ────────────────────────────
+
+    /// Phase 2 added two top-level optional fields. Both must round-trip
+    /// the populated values from the fixture.
+    func test_phase2TopLevelFields_decodeCorrectly() {
+        XCTAssertEqual(
+            Self.model.lastGlobalPhaseAdvanceFiredAtSessionCount, 18,
+            "lastGlobalPhaseAdvanceFiredAtSessionCount must round-trip from JSONB"
+        )
+        XCTAssertEqual(
+            Self.model.lastClassifiedNoteCreatedAt,
+            ISO8601DateFormatter().date(from: "2026-01-04T18:00:00Z"),
+            "lastClassifiedNoteCreatedAt must decode as ISO-8601"
+        )
+        XCTAssertEqual(Self.model.totalSessionCount, 24)
+    }
+
+    /// PatternProfile gained `consecutiveForceDeloadsOnPattern` and uses
+    /// `transitionModeUntil` (Phase 1 field exercised by Phase 2 rules).
+    func test_patternProfilePhase2Fields_decodeCorrectly() {
+        guard let squat = Self.model.patterns[.squat] else {
+            return XCTFail("squat pattern must be present in fixture")
+        }
+        XCTAssertEqual(squat.currentPhase, .deload)
+        XCTAssertEqual(squat.sessionsInPhase, 2)
+        XCTAssertEqual(squat.consecutiveForceDeloadsOnPattern, 1)
+        XCTAssertEqual(squat.trend, .plateaued)
+        XCTAssertNotNil(squat.transitionModeUntil)
+        XCTAssertEqual(
+            squat.transitionModeUntil,
+            ISO8601DateFormatter().date(from: "2026-01-15T00:00:00Z")
+        )
+    }
+
+    /// FatigueInteraction.confidence is computed; the persisted shape carries
+    /// observations + totalCount (per ADR-0005). Verifies the orchestrator's
+    /// JSONB shape can hydrate the value type and produce a meaningful
+    /// confidence reading.
+    func test_fatigueInteraction_decodesAndComputesConfidence() {
+        XCTAssertEqual(Self.model.fatigueInteractions.count, 1)
+        let interaction = Self.model.fatigueInteractions[0]
+        XCTAssertEqual(interaction.fromPattern, .squat)
+        XCTAssertEqual(interaction.toPattern, .horizontalPush)
+        XCTAssertEqual(interaction.observations.count, 10)
+        XCTAssertEqual(interaction.totalCount, 22)
+        // Computed: countFactor=1.0 (totalCount >=15), consistency > 0
+        // (variance < |mean|), confidence > 0. Specific values pinned by
+        // FatigueInteractionCrossValidationTests; here we just verify the
+        // shape feeds the derived properties without throw.
+        XCTAssertEqual(interaction.countFactor, 1.0)
+        XCTAssertGreaterThan(interaction.consistencyFactor, 0)
+        XCTAssertGreaterThan(interaction.confidence, 0)
+    }
+
+    /// PrescriptionAccuracy gained gap-bucket fields in slice A9 (#80) per
+    /// ADR-0014. The fixture exercises the populated dictionaries; verify
+    /// the Swift Codable's `decodeIfPresent` defaults to empty-dict on
+    /// missing keys but populates correctly when present.
+    func test_prescriptionAccuracy_gapBucketFieldsDecodeCorrectly() {
+        guard
+            let squatCells = Self.model.prescriptionAccuracy[.squat],
+            let topCell = squatCells[.top]
+        else {
+            return XCTFail("prescriptionAccuracy[.squat][.top] must be present in fixture")
+        }
+        XCTAssertEqual(topCell.bias, 0.04)
+        XCTAssertEqual(topCell.rmse, 0.08)
+        XCTAssertEqual(topCell.sampleCount, 12)
+        XCTAssertEqual(topCell.biasByGapBucket[.under48h], -0.02)
+        XCTAssertEqual(topCell.biasByGapBucket[.between48And72h], 0.05)
+        XCTAssertEqual(topCell.biasByGapBucket[.over72h], 0.06)
+        XCTAssertEqual(topCell.sampleCountByGapBucket[.under48h], 4)
+        XCTAssertEqual(topCell.sampleCountByGapBucket[.over72h], 3)
+    }
+}

--- a/ProjectApexTests/TraineeModelUpdateJobTests.swift
+++ b/ProjectApexTests/TraineeModelUpdateJobTests.swift
@@ -400,6 +400,105 @@ final class TraineeModelUpdateJobTests: XCTestCase {
         )
     }
 
+    /// Slice A12 (#83) richer response shape: when the orchestrator refuses a
+    /// late arrival, it returns `late_arrival_details: { session_id,
+    /// incoming_logged_at, watermark }` alongside the bool flag. The WAQ
+    /// adapter must populate the corresponding optional fields on the queued
+    /// LateArrivalNotification so the post-session UI can show details (e.g.,
+    /// "logged X minutes ago" or the gap delta).
+    func test_flushHandler_onLateArrivalTrue_populatesRicherNotificationFields_fromA12Response() async throws {
+        // Construct a response body matching the A12 contract: the bool flag
+        // PLUS the late_arrival_details object. The WAQ adapter is expected
+        // to parse the nested fields and stash them on LateArrivalNotification.
+        struct A12Wrapper: Encodable {
+            let traineeModel: TraineeModel
+            let lateArrival: Bool
+            let lateArrivalDetails: Details
+            struct Details: Encodable {
+                let sessionId: String
+                let incomingLoggedAt: String
+                let watermark: String
+                enum CodingKeys: String, CodingKey {
+                    case sessionId       = "session_id"
+                    case incomingLoggedAt = "incoming_logged_at"
+                    case watermark
+                }
+            }
+            enum CodingKeys: String, CodingKey {
+                case traineeModel       = "trainee_model"
+                case lateArrival        = "late_arrival"
+                case lateArrivalDetails = "late_arrival_details"
+            }
+        }
+        let sessionId        = UUID()
+        let incomingLoggedAt = "2026-05-01T08:00:00.000Z"
+        let watermark        = "2026-05-08T10:00:00.000Z"
+        let wrapper = A12Wrapper(
+            traineeModel: makeSimpleModel(),
+            lateArrival: true,
+            lateArrivalDetails: .init(
+                sessionId: sessionId.uuidString.lowercased(),
+                incomingLoggedAt: incomingLoggedAt,
+                watermark: watermark
+            )
+        )
+        let enc = JSONEncoder()
+        enc.dateEncodingStrategy = .iso8601
+        let body = try enc.encode(wrapper)
+        respond(status: 200, body: body)
+
+        let outcome = await job.makeHandler()(try makeQueuedItem())
+        XCTAssertEqual(outcome, .success)
+
+        let pending = notificationQueue.dequeueAll()
+        XCTAssertEqual(pending.count, 1)
+        let notification = pending[0]
+        XCTAssertEqual(
+            notification.sessionId, sessionId,
+            "A12 response shape: sessionId must round-trip from late_arrival_details.session_id"
+        )
+        XCTAssertEqual(
+            notification.incomingLoggedAt,
+            ISO8601DateFormatter().date(from: incomingLoggedAt),
+            "incomingLoggedAt must decode as ISO-8601"
+        )
+        XCTAssertEqual(
+            notification.watermark,
+            ISO8601DateFormatter().date(from: watermark),
+            "watermark must decode as ISO-8601"
+        )
+    }
+
+    /// Slice A12 (#83) cached-snapshot path: when the orchestrator's PK
+    /// constraint short-circuits a duplicate session (WAQ retry replay), the
+    /// response is `late_arrival: false` with the cached snapshot in
+    /// `trainee_model`. From the WAQ adapter's perspective this is
+    /// indistinguishable from a fresh in-order apply — same path, same
+    /// `.success` outcome, same store update with whatever shape `trainee_model`
+    /// carries. ADR-0006 §"Idempotency at the DB layer" + ADR-0013 §"WAQ
+    /// retry idempotency": Stage 2 doesn't re-fire here, but the *client*
+    /// doesn't need to know that. This test pins that the WAQ adapter does
+    /// NOT distinguish the cached-snapshot case from a fresh apply (no third
+    /// branch beyond late_arrival:true / late_arrival:false).
+    func test_flushHandler_onCachedSnapshotReturn_treatedAsLateArrivalFalse() async throws {
+        // Construct two responses for two consecutive flushes of the same
+        // session_id. First apply: late_arrival:false + fresh snapshot. Second
+        // apply (PK conflict simulating WAQ retry): late_arrival:false + the
+        // *same* cached snapshot. From the WAQ's POV both responses look
+        // identical — they take the same flushHandler path.
+        let cachedSnapshot = makeSimpleModel()
+        let cachedBody = try makeLateArrivalResponse(model: cachedSnapshot, late: false)
+        respond(status: 200, body: cachedBody)
+
+        let outcome = await job.makeHandler()(try makeQueuedItem())
+        XCTAssertEqual(outcome, .success,
+                       "Cached-snapshot return MUST yield .success identically to a fresh apply (ADR-0006 §2)")
+        XCTAssertEqual(store.load(), cachedSnapshot,
+                       "Cached snapshot lands in the local store on this path — the client doesn't differentiate cached vs fresh writes")
+        XCTAssertEqual(notificationQueue.pendingCount, 0,
+                       "Cached-snapshot return MUST NOT enqueue a late-arrival notification (only late_arrival:true does)")
+    }
+
     /// ADR-0008 contract for the in-order branch: explicit `late_arrival:false`
     /// (the shape A12 will return for accepted sessions) MUST behave identically
     /// to the existing no-flag case — store updates, queue stays empty. Locks

--- a/docs/fixtures/trainee-model-snapshot.json
+++ b/docs/fixtures/trainee-model-snapshot.json
@@ -1,0 +1,101 @@
+{
+  "$comment": "Cross-platform shape-parity fixture for Phase 2 TraineeModel. Loaded by both the TS orchestrator round-trip test and the Swift TraineeModelSnapshotsCrossValidationTests. Drift on either side surfaces via these tests. Anchor date 2026-01-01T00:00:00Z is deterministic (no Date.now() in tests). Keys use Swift's MovementPattern rawValues (snake_case) and SetIntent rawValues (lowercase) so the JSON decodes cleanly via the synthesized Codable on TraineeModel.",
+  "goal": {
+    "statement": "Build broad strength and hypertrophy across the lower and upper body.",
+    "focusAreas": ["legs", "back"],
+    "updatedAt": "2026-01-01T00:00:00.000Z"
+  },
+  "projections": null,
+  "patterns": {
+    "squat": {
+      "pattern": "squat",
+      "currentPhase": "deload",
+      "sessionsInPhase": 2,
+      "lastPhaseTransitionAtSessionCount": 18,
+      "rpeOffset": 0.3,
+      "recovery": {
+        "lastNeuromuscularStimulusAt": "2026-01-04T18:00:00.000Z",
+        "lastMetabolicStimulusAt": "2026-01-04T18:00:00.000Z",
+        "neuromuscularReadiness": 0.74,
+        "metabolicReadiness": 0.94
+      },
+      "confidence": "established",
+      "transitionModeUntil": "2026-01-15T00:00:00.000Z",
+      "trend": "plateaued",
+      "recentSessionDates": [
+        "2025-12-23T18:00:00.000Z",
+        "2025-12-26T18:00:00.000Z",
+        "2025-12-29T18:00:00.000Z",
+        "2026-01-01T18:00:00.000Z",
+        "2026-01-04T18:00:00.000Z"
+      ],
+      "consecutiveForceDeloadsOnPattern": 1
+    },
+    "horizontal_push": {
+      "pattern": "horizontal_push",
+      "currentPhase": "accumulation",
+      "sessionsInPhase": 0,
+      "lastPhaseTransitionAtSessionCount": 22,
+      "rpeOffset": 0.0,
+      "recovery": {
+        "lastNeuromuscularStimulusAt": null,
+        "lastMetabolicStimulusAt": null,
+        "neuromuscularReadiness": 1.0,
+        "metabolicReadiness": 1.0
+      },
+      "confidence": "calibrating",
+      "transitionModeUntil": null,
+      "trend": "progressing",
+      "recentSessionDates": [],
+      "consecutiveForceDeloadsOnPattern": 0
+    }
+  },
+  "muscles": {},
+  "exercises": {},
+  "activeLimitations": [],
+  "clearedLimitations": [],
+  "fatigueInteractions": [
+    {
+      "fromPattern": "squat",
+      "toPattern": "horizontal_push",
+      "observations": [-0.05, -0.06, -0.04, -0.05, -0.07, -0.05, -0.06, -0.05, -0.05, -0.04],
+      "totalCount": 22
+    }
+  ],
+  "prescriptionAccuracy": {
+    "squat": {
+      "top": {
+        "pattern": "squat",
+        "intent": "top",
+        "bias": 0.04,
+        "rmse": 0.08,
+        "sampleCount": 12,
+        "biasByGapBucket": {
+          "under48h": -0.02,
+          "between_48_and_72h": 0.05,
+          "over72h": 0.06
+        },
+        "rmseByGapBucket": {
+          "under48h": 0.07,
+          "between_48_and_72h": 0.08,
+          "over72h": 0.09
+        },
+        "sampleCountByGapBucket": {
+          "under48h": 4,
+          "between_48_and_72h": 5,
+          "over72h": 3
+        }
+      }
+    }
+  },
+  "prescriptionIntentMismatches": [],
+  "transfers": [],
+  "bodyweight": {
+    "entries": []
+  },
+  "lifeContextEvents": [],
+  "reassessmentRecords": [],
+  "totalSessionCount": 24,
+  "lastClassifiedNoteCreatedAt": "2026-01-04T18:00:00.000Z",
+  "lastGlobalPhaseAdvanceFiredAtSessionCount": 18
+}

--- a/supabase/functions/_shared/observability.ts
+++ b/supabase/functions/_shared/observability.ts
@@ -91,3 +91,31 @@ export function emitTransferNegativeCoefficient(
 ): void {
   emit("trainee_model.transfer_negative_coefficient", event);
 }
+
+// ─── emitApplyComplete (slice A12 — per-apply summary) ──────────────────────
+//
+// Per-apply observability scaffolded by A12 so production debugging can
+// correlate session-applies with which rules fired, what changed on the
+// snapshot, and how long Stage 1 took. Three named-event channels above
+// cover specific failure modes (late arrival, classifier fail, clock skew);
+// this helper covers normal operations.
+//
+// Call site: orchestrator's first-apply success path, after Stage 1 commit
+// and alongside stage2Hook (ADR-0013 §"Stage sequencing"). Cached-snapshot
+// returns and late-arrival refusals do NOT emit — the envelope describes a
+// *mutation*, and those paths don't mutate.
+
+export interface ApplyCompleteEvent {
+  user_id: string;
+  session_id: string;
+  /** Wall-clock duration of Stage 1 (PK insert through COMMIT). */
+  duration_ms: number;
+  /** Names of rules that fired this apply, in invocation order. */
+  rules_fired: string[];
+  /** Dot-paths into model_json that mutated this apply. */
+  fields_changed: string[];
+}
+
+export function emitApplyComplete(event: ApplyCompleteEvent): void {
+  emit("trainee_model.apply_complete", event);
+}

--- a/supabase/functions/_shared/observability_test.ts
+++ b/supabase/functions/_shared/observability_test.ts
@@ -15,6 +15,7 @@
 
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
+  emitApplyComplete,
   emitClassifierFailed,
   emitClockSkew,
   emitLateArrival,
@@ -120,5 +121,29 @@ Deno.test("Q10 (slice A10): emitTransferNegativeCoefficient emits JSON envelope 
   assertEquals(lines.length, 1, "emitTransferNegativeCoefficient must call console.log exactly once");
   const envelope = JSON.parse(lines[0]);
   assertEquals(envelope.channel, "trainee_model.transfer_negative_coefficient");
+  assertEquals(envelope.event, event);
+});
+
+// ─── emitApplyComplete (slice A12 — per-apply summary) ──────────────────────
+
+Deno.test("A12: emitApplyComplete emits JSON envelope on channel trainee_model.apply_complete with all 5 fields", () => {
+  // Per-apply observability summary scaffolded by A12 so production debugging
+  // can correlate session-applies with rule fires + duration. Call site is
+  // the orchestrator's first-apply success path (after Stage 1 commit, on the
+  // same path as stage2Hook); cached returns and late-arrival refusals do
+  // NOT emit. Required-payload-only typing keeps the envelope shape stable.
+  const event = {
+    user_id: "99999999-9999-9999-9999-999999999999",
+    session_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    duration_ms: 47,
+    rules_fired: ["phase-advance", "transition-mode-expiry"],
+    fields_changed: ["patterns.squat.currentPhase", "patterns.squat.transitionModeUntil"],
+  };
+
+  const lines = captureConsoleLog(() => emitApplyComplete(event));
+
+  assertEquals(lines.length, 1, "emitApplyComplete must call console.log exactly once");
+  const envelope = JSON.parse(lines[0]);
+  assertEquals(envelope.channel, "trainee_model.apply_complete");
   assertEquals(envelope.event, event);
 });

--- a/supabase/functions/update-trainee-model/deno.json
+++ b/supabase/functions/update-trainee-model/deno.json
@@ -1,0 +1,6 @@
+{
+  "nodeModulesDir": "auto",
+  "imports": {
+    "postgres": "npm:postgres@3.4.4"
+  }
+}

--- a/supabase/functions/update-trainee-model/deno.lock
+++ b/supabase/functions/update-trainee-model/deno.lock
@@ -1,0 +1,51 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:postgres@3.4.4": "3.4.4"
+  },
+  "npm": {
+    "postgres@3.4.4": {
+      "integrity": "sha512-IbyN+9KslkqcXa8AO9fxpk97PA4pzewvpi2B3Dwy9u4zpV32QicaEdgmF3eSQUzdRk7ttDHQejNgAEr4XoeH4A=="
+    }
+  },
+  "remote": {
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:postgres@3.4.4"
+    ]
+  }
+}

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -1,23 +1,38 @@
 // Project Apex — update-trainee-model Edge Function.
 //
-// Phase 1 (Slice 9b, issue #9): no-op stub. Validates request shape,
-// returns an empty TraineeModel JSON. No DB writes, no Anthropic calls,
-// no rule logic. The structural slots for Phase 2 (idempotency check,
-// rule logic, cached-snapshot return) are present but inert so that
-// Phase 2 plugs into the same lifecycle without restructuring.
+// Phase 2 / Slice A12 (issue #83): Stage 1 orchestrator. Wires every Phase 2
+// rule module into a single transactional commit on every session-apply.
+// Replaces Phase 1's no-op stub. Per ADR-0006 §"Idempotency at the DB layer",
+// ADR-0008 §"Late arrival", and ADR-0013 §"Stage sequencing":
+//   1. INSERT into trainee_model_applied_sessions ON CONFLICT DO NOTHING.
+//      If row already existed → return cached snapshot (idempotent retry).
+//   2. SELECT model_json + watermark FOR UPDATE.
+//   3. Watermark check: if incoming.loggedAt < watermark → emit event,
+//      do not mutate, return cached snapshot with late_arrival:true.
+//   4. Apply rules in dependency order (cycles 8-12 below; cycle 1 is the
+//      tracer — increments session_count without rule application).
+//   5. Write back model_json + advance watermark.
 //
-// Slice 6 (issue #10): payload validator now descends into
+// Stage 2 (classifier per ADR-0013) is owned by issue #A13 and is NOT
+// triggered here. Cached-snapshot returns and late-arrival refusals MUST
+// NOT fire Stage 2 — first-apply-fires-once is the contract.
+//
+// Slice 6 (issue #10): payload validator descends into
 // session_payload.set_logs[] (when present) and rejects any element
-// missing or carrying an invalid `intent` field. Forward-compatible —
-// the actual set_logs[] payload is wired in Slice 9c+; this validator
-// is the contract that wiring will satisfy. See ADR-0005 (no silent
+// missing or carrying an invalid `intent` field. See ADR-0005 (no silent
 // defaults at any layer).
 //
-// Contract: POST { user_id, session_id, session_payload } → 200
-// { trainee_model: {} }. See:
+// See:
 //   - ADR-0005 (TraineeModel shape, set-intent invariant)
 //   - ADR-0006 (server-side placement, idempotency at DB layer)
+//   - ADR-0008 (late-arrival watermark)
+//   - ADR-0013 (Stage 2 separation)
 //   - docs/agents/edge-functions.md (secrets, deploy, local dev)
+
+import {
+  emitLateArrival as defaultEmitLateArrival,
+  type LateArrivalEvent,
+} from "../_shared/observability.ts";
 
 export interface UpdateTraineeModelRequest {
   user_id: string;
@@ -110,13 +125,220 @@ export function validateRequest(
   };
 }
 
+/**
+ * Stage 1 orchestrator output. Mirrors the HTTP response body shape: the
+ * snapshot returned to the client + the late_arrival flag from ADR-0008.
+ *
+ * `late_arrival_details` is populated only when `late_arrival === true`,
+ * carrying the fields the WAQ adapter passes into LateArrivalNotification
+ * (sessionId, incomingLoggedAt, watermark) per A12's richer-response contract.
+ */
+export interface ApplySessionResult {
+  trainee_model: Record<string, unknown>;
+  late_arrival: boolean;
+  late_arrival_details?: {
+    session_id: string;
+    incoming_logged_at: string;
+    watermark: string;
+  };
+}
+
+/**
+ * Type alias for the postgres.js client. Tests inject a shared client; the
+ * production HTTP wrapper opens one per cold start.
+ *
+ * Production note: when this Edge Function deploys, the connection should
+ * use Supabase's pgbouncer endpoint (port 6543) rather than the direct
+ * Postgres port (5432) — Edge Functions are stateless with cold-start
+ * potential, and pgbouncer handles connection multiplexing across
+ * invocations. Tests use the direct port since they're long-running.
+ */
+// deno-lint-ignore no-explicit-any
+type Sql = any;
+
+/**
+ * Optional dependency injections for `applySession`. Tests use these to
+ * spy on observability emits and inject synthetic rule failures (cycle 8's
+ * atomic-rollback test). Production omits them entirely — defaults route
+ * to the real observability module.
+ *
+ * `ruleHook` is the injection seam for cycles 10-12: the orchestrator will
+ * thread real rule composition through this hook in the resume session.
+ * For cycle 8 (atomic rollback), tests inject a hook that throws so the
+ * surrounding sql.begin() rolls back atomically.
+ */
+export interface ApplySessionDeps {
+  emitLateArrival?: (event: LateArrivalEvent) => void;
+  /**
+   * Hook called between SELECT FOR UPDATE and the UPDATE write-back. Receives
+   * the parsed model_json; returns the new model_json. Throws abort the
+   * transaction. Cycles 10-12 will replace synthetic test usage with the
+   * real rule composition pipeline.
+   */
+  ruleHook?: (modelJson: Record<string, unknown>) => Record<string, unknown>;
+  /**
+   * Stage 2 (classifier) seam per ADR-0013. Fires AFTER Stage 1 commits, and
+   * ONLY when Stage 1 took the in-order first-apply path — never on cached-
+   * snapshot returns (PK conflict) or late-arrival refusals. Issue #A13
+   * wires the actual classifier call through this hook; this slice ships
+   * the seam + the contract.
+   */
+  stage2Hook?: () => Promise<void> | void;
+}
+
+/**
+ * postgres.js returns jsonb columns as parsed JS values most of the time,
+ * but `'{}'::jsonb` literals seeded in tests can come back as strings
+ * depending on driver-version quirks. Normalize defensively so the
+ * orchestrator always works with an object.
+ */
+function parseJsonbColumn(value: unknown): Record<string, unknown> {
+  if (value == null) return {};
+  if (typeof value === "string") return JSON.parse(value);
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Stage 1 orchestrator core. Pure of HTTP concerns — accepts the validated
+ * request shape and a SQL client; returns the response body. Tests bypass
+ * the HTTP wrapper and call this directly against the local Supabase DB.
+ *
+ * Input validation boundary: `applySession` trusts that
+ * `validateRequest` has already verified the shape (UUIDs, set_logs[].intent).
+ * Rule modules trust `applySession` to feed them well-formed JSONB-derived
+ * state. Bad data inside `model_json` (e.g., a wrong-type field from an
+ * older Phase 1 row) MUST surface as a clean `applySession` error rather
+ * than a runtime exception inside a rule module — the orchestrator is the
+ * boundary for upstream-data validation; rule modules are pure.
+ */
+export async function applySession(
+  req: UpdateTraineeModelRequest,
+  sql: Sql,
+  deps: ApplySessionDeps = {},
+): Promise<ApplySessionResult> {
+  const emitLateArrival = deps.emitLateArrival ?? defaultEmitLateArrival;
+  // Extract logged_at from session_payload — load-bearing for watermark check
+  // (ADR-0008). Fail fast at the orchestrator boundary if missing/invalid;
+  // rule modules trust this is present.
+  const loggedAtRaw = (req.session_payload as Record<string, unknown>).logged_at;
+  if (typeof loggedAtRaw !== "string") {
+    throw new Error("session_payload.logged_at must be an ISO 8601 string");
+  }
+  const incomingLoggedAt = new Date(loggedAtRaw);
+  if (Number.isNaN(incomingLoggedAt.getTime())) {
+    throw new Error(`session_payload.logged_at is not a valid date: ${loggedAtRaw}`);
+  }
+
+  // Tracks whether Stage 1 took the in-order first-apply path — the only
+  // path that fires Stage 2 per ADR-0013 §"WAQ retry idempotency". Cached
+  // returns and late-arrival refusals leave this false; the post-commit
+  // stage2Hook call is gated on it.
+  let firedFirstApply = false;
+
+  const result: ApplySessionResult = await sql.begin(async (tx: Sql) => {
+    // Step 1: idempotency PK insert (ADR-0006 §2). RETURNING xmax=0 returns
+    // true when this transaction inserted the row, false when ON CONFLICT
+    // matched a prior insert. The PK enforces single-application globally.
+    const inserted = await tx`
+      INSERT INTO public.trainee_model_applied_sessions (user_id, session_id)
+      VALUES (${req.user_id}, ${req.session_id})
+      ON CONFLICT DO NOTHING
+      RETURNING xmax = 0 AS inserted
+    `;
+
+    if (inserted.length === 0) {
+      // PK conflict — duplicate session-apply. Return cached snapshot per
+      // ADR-0006 §2; ADR-0013 contract: Stage 2 is NOT re-triggered here.
+      const cached = await tx`
+        SELECT model_json FROM public.trainee_models WHERE user_id = ${req.user_id}
+      `;
+      return {
+        trainee_model: parseJsonbColumn(cached[0]?.model_json),
+        late_arrival: false,
+      } satisfies ApplySessionResult;
+    }
+
+    // Step 2: load current model + watermark with row lock.
+    const rows = await tx`
+      SELECT model_json, last_applied_logged_at
+      FROM public.trainee_models
+      WHERE user_id = ${req.user_id}
+      FOR UPDATE
+    `;
+    const modelJson = parseJsonbColumn(rows[0]?.model_json);
+    const watermark: Date | null = rows[0]?.last_applied_logged_at ?? null;
+
+    // Step 3: watermark check (ADR-0008 §"Late arrival"). Strict less-than:
+    // incoming === watermark is in-order (see cycle 5b). The PK insert from
+    // step 1 stays committed so WAQ retries dedupe via the cached path on
+    // subsequent calls. Watermark + model_json are NOT mutated on refusal.
+    if (watermark !== null && incomingLoggedAt < watermark) {
+      // delta_seconds is negative — incoming is `delta_seconds` before watermark
+      // per the LateArrivalEvent contract (observability.ts).
+      const deltaSeconds = Math.round(
+        (incomingLoggedAt.getTime() - watermark.getTime()) / 1000,
+      );
+      emitLateArrival({
+        user_id: req.user_id,
+        session_id: req.session_id,
+        incoming_logged_at: incomingLoggedAt.toISOString(),
+        watermark: watermark.toISOString(),
+        delta_seconds: deltaSeconds,
+      });
+      return {
+        trainee_model: modelJson,
+        late_arrival: true,
+        late_arrival_details: {
+          session_id: req.session_id,
+          incoming_logged_at: incomingLoggedAt.toISOString(),
+          watermark: watermark.toISOString(),
+        },
+      } satisfies ApplySessionResult;
+    }
+
+    // Step 4: rule composition. Cycles 10-12 will replace the synthetic
+    // hook with real rule pipeline. A throw here aborts sql.begin() and
+    // rolls back the whole transaction — PK insert, watermark advance, and
+    // model_json write all revert atomically (cycle 8's contract).
+    const newModelJson = deps.ruleHook
+      ? deps.ruleHook(modelJson)
+      : modelJson;
+
+    // Step 5: write back + advance watermark (ADR-0008 §"In-order").
+    // session_count drives ADR-0012's 6-session-window cooldown, so even the
+    // empty-rules path mutates it.
+    await tx`
+      UPDATE public.trainee_models
+      SET session_count = session_count + 1,
+          last_applied_logged_at = ${incomingLoggedAt},
+          model_json = ${JSON.stringify(newModelJson)}::jsonb,
+          updated_at = NOW()
+      WHERE user_id = ${req.user_id}
+    `;
+
+    firedFirstApply = true;
+    return {
+      trainee_model: newModelJson,
+      late_arrival: false,
+    } satisfies ApplySessionResult;
+  });
+
+  // Stage 2 fires AFTER Stage 1 commits, ONLY on first-apply (per ADR-0013
+  // §"WAQ retry idempotency"). Cached-snapshot returns (PK conflict) and
+  // late-arrival refusals (watermark check) leave firedFirstApply=false and
+  // skip Stage 2. A12 ships the seam + the gating contract; #A13 wires the
+  // actual classifier call through this hook.
+  if (firedFirstApply && deps.stage2Hook) {
+    await deps.stage2Hook();
+  }
+
+  return result;
+}
+
 // Phase 1 stub — always returns false (every apply treated as fresh).
-// Phase 2 replaces the body with:
-//   INSERT INTO trainee_model_applied_sessions (user_id, session_id)
-//   VALUES ($1, $2) ON CONFLICT DO NOTHING RETURNING xmax = 0 AS inserted;
-// then returns true iff the row already existed (cached-snapshot path).
-// Kept as a callable boundary now so Phase 2 only changes the body, not
-// the call site or its surrounding control flow. See ADR-0006 §2.
+// Phase 2 (#83 / A12) replaced this with applySession's PK insert above.
+// Retained as a callable boundary so handleRequest's existing structure
+// can route through applySession without restructuring.
 async function checkAlreadyApplied(
   _userId: string,
   _sessionId: string,

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -30,9 +30,23 @@
 //   - docs/agents/edge-functions.md (secrets, deploy, local dev)
 
 import {
+  emitApplyComplete as defaultEmitApplyComplete,
   emitLateArrival as defaultEmitLateArrival,
+  type ApplyCompleteEvent,
   type LateArrivalEvent,
 } from "../_shared/observability.ts";
+import {
+  advancePhase,
+  sessionsRequiredFor,
+  type MesocyclePhase,
+  type PerPatternState,
+} from "../_shared/phase-advance.ts";
+import { computeTransitionModeUntil } from "../_shared/transition-mode-expiry.ts";
+import type { ProgressionTrend } from "../_shared/plateau-verdict.ts";
+import {
+  shouldFireGlobalPhaseAdvance,
+  type PatternTransitionState,
+} from "../_shared/global-phase-advance.ts";
 
 export interface UpdateTraineeModelRequest {
   user_id: string;
@@ -170,10 +184,17 @@ type Sql = any;
 export interface ApplySessionDeps {
   emitLateArrival?: (event: LateArrivalEvent) => void;
   /**
-   * Hook called between SELECT FOR UPDATE and the UPDATE write-back. Receives
-   * the parsed model_json; returns the new model_json. Throws abort the
-   * transaction. Cycles 10-12 will replace synthetic test usage with the
-   * real rule composition pipeline.
+   * Per-apply summary observability per slice A12. Called on the in-order
+   * first-apply path (after Stage 1 commit, alongside stage2Hook). Cached
+   * returns and late-arrival refusals do NOT emit — the envelope describes
+   * a mutation, and those paths don't mutate.
+   */
+  emitApplyComplete?: (event: ApplyCompleteEvent) => void;
+  /**
+   * Synthetic-failure injection seam used by cycle 8's atomic-rollback test.
+   * When provided, runs INSTEAD of the real rule pipeline (so tests can throw
+   * without competing with real rule logic). Production omits this; the real
+   * pipeline runs unconditionally.
    */
   ruleHook?: (modelJson: Record<string, unknown>) => Record<string, unknown>;
   /**
@@ -199,6 +220,109 @@ function parseJsonbColumn(value: unknown): Record<string, unknown> {
 }
 
 /**
+ * Mean inter-session delta in days from a list of ISO-8601 session dates,
+ * or null when fewer than 2 sessions exist (long-absence-returner case).
+ * Mirrors `PatternProfile.sessionsCadenceDays` Swift derived property
+ * (TraineeModelProfiles.swift:185).
+ */
+function sessionsCadenceDays(recentSessionDates: string[]): number | null {
+  if (recentSessionDates.length < 2) return null;
+  const sorted = [...recentSessionDates].sort();
+  const ms = sorted.map((s) => new Date(s).getTime());
+  let totalDelta = 0;
+  for (let i = 1; i < ms.length; i++) {
+    totalDelta += (ms[i] - ms[i - 1]) / (24 * 60 * 60 * 1000);
+  }
+  return totalDelta / (ms.length - 1);
+}
+
+/**
+ * Per-pattern rule pipeline. Reads patterns dict from model_json, runs the
+ * rules each pattern needs, returns updated patterns dict + rule-fired list +
+ * field-change list for the per-apply observability emit.
+ *
+ * Cycles 10-12 wire only the rules with assertion-cycles in this slice:
+ * advancePhase + composeTransitionModeUntil. Other rule modules (EWMA,
+ * plateau-verdict, recovery, prescription-accuracy, transfer-regression,
+ * fatigue-interaction) ship in follow-up slices because they have no
+ * assertion-cycle here. The pipeline framework supports adding them later
+ * by extending this loop.
+ */
+function applyPerPatternRules(
+  patterns: Record<string, Record<string, unknown>>,
+  incomingLoggedAt: Date,
+  newSessionCount: number,
+): {
+  patterns: Record<string, Record<string, unknown>>;
+  rulesFired: Set<string>;
+  fieldsChanged: string[];
+} {
+  const rulesFired = new Set<string>();
+  const fieldsChanged: string[] = [];
+  const newPatterns: Record<string, Record<string, unknown>> = {};
+
+  for (const [patternKey, raw] of Object.entries(patterns)) {
+    const profile = raw;
+    const recentDates = (profile.recentSessionDates as string[] | undefined) ?? [];
+    const cadenceDays = sessionsCadenceDays(recentDates);
+    // ADR-0011 Option-B threshold input: derive daysPerWeek from cadence.
+    // Cadence-aware (ADR-0015) — high-frequency cadence → larger daysPerWeek;
+    // null cadence (long-absence-returner) defaults to 4 (alpha-cohort
+    // typical 4×/week). The orchestrator owns this default; rule modules
+    // are pure and trust the input.
+    const daysPerWeek = cadenceDays !== null ? 7 / cadenceDays : 4;
+
+    const advanceState: PerPatternState = {
+      currentPhase: profile.currentPhase as MesocyclePhase,
+      sessionsInPhase: (profile.sessionsInPhase as number) ?? 0,
+      sessionsRequiredForPhase: sessionsRequiredFor(
+        profile.currentPhase as MesocyclePhase,
+        daysPerWeek,
+      ),
+      trend: ((profile.trend as ProgressionTrend) ?? "progressing"),
+      consecutiveForceDeloadsOnPattern:
+        (profile.consecutiveForceDeloadsOnPattern as number) ?? 0,
+      lastPhaseTransitionAtSessionCount:
+        (profile.lastPhaseTransitionAtSessionCount as number) ?? 0,
+    };
+
+    const advanced = advancePhase(advanceState, newSessionCount);
+    rulesFired.add("phase-advance");
+
+    let newTransitionModeUntil: string | null =
+      (profile.transitionModeUntil as string | null) ?? null;
+
+    if (advanced.firesDeloadEndTransitionMode) {
+      const currentUntil =
+        newTransitionModeUntil !== null ? new Date(newTransitionModeUntil) : null;
+      newTransitionModeUntil = computeTransitionModeUntil(
+        incomingLoggedAt,
+        cadenceDays,
+        currentUntil,
+      ).toISOString();
+      rulesFired.add("transition-mode-expiry");
+      fieldsChanged.push(`patterns.${patternKey}.transitionModeUntil`);
+    }
+
+    if (advanced.fired !== "no-op") {
+      fieldsChanged.push(`patterns.${patternKey}.currentPhase`);
+    }
+
+    newPatterns[patternKey] = {
+      ...profile,
+      currentPhase: advanced.newPhase,
+      sessionsInPhase: advanced.newSessionsInPhase,
+      consecutiveForceDeloadsOnPattern: advanced.newConsecutiveForceDeloads,
+      lastPhaseTransitionAtSessionCount:
+        advanced.newLastPhaseTransitionAtSessionCount,
+      transitionModeUntil: newTransitionModeUntil,
+    };
+  }
+
+  return { patterns: newPatterns, rulesFired, fieldsChanged };
+}
+
+/**
  * Stage 1 orchestrator core. Pure of HTTP concerns — accepts the validated
  * request shape and a SQL client; returns the response body. Tests bypass
  * the HTTP wrapper and call this directly against the local Supabase DB.
@@ -216,7 +340,9 @@ export async function applySession(
   sql: Sql,
   deps: ApplySessionDeps = {},
 ): Promise<ApplySessionResult> {
+  const applyStartMs = Date.now();
   const emitLateArrival = deps.emitLateArrival ?? defaultEmitLateArrival;
+  const emitApplyComplete = deps.emitApplyComplete ?? defaultEmitApplyComplete;
   // Extract logged_at from session_payload — load-bearing for watermark check
   // (ADR-0008). Fail fast at the orchestrator boundary if missing/invalid;
   // rule modules trust this is present.
@@ -232,8 +358,10 @@ export async function applySession(
   // Tracks whether Stage 1 took the in-order first-apply path — the only
   // path that fires Stage 2 per ADR-0013 §"WAQ retry idempotency". Cached
   // returns and late-arrival refusals leave this false; the post-commit
-  // stage2Hook call is gated on it.
+  // stage2Hook + emitApplyComplete calls are gated on it.
   let firedFirstApply = false;
+  let rulesFired: string[] = [];
+  let fieldsChanged: string[] = [];
 
   const result: ApplySessionResult = await sql.begin(async (tx: Sql) => {
     // Step 1: idempotency PK insert (ADR-0006 §2). RETURNING xmax=0 returns
@@ -258,15 +386,19 @@ export async function applySession(
       } satisfies ApplySessionResult;
     }
 
-    // Step 2: load current model + watermark with row lock.
+    // Step 2: load current model + watermark + session_count with row lock.
+    // session_count is read explicitly so the rule pipeline can pass the
+    // post-increment value into rules whose outputs depend on it (e.g.,
+    // advancePhase's lastPhaseTransitionAtSessionCount).
     const rows = await tx`
-      SELECT model_json, last_applied_logged_at
+      SELECT model_json, last_applied_logged_at, session_count
       FROM public.trainee_models
       WHERE user_id = ${req.user_id}
       FOR UPDATE
     `;
     const modelJson = parseJsonbColumn(rows[0]?.model_json);
     const watermark: Date | null = rows[0]?.last_applied_logged_at ?? null;
+    const newSessionCount = (rows[0]?.session_count ?? 0) + 1;
 
     // Step 3: watermark check (ADR-0008 §"Late arrival"). Strict less-than:
     // incoming === watermark is in-order (see cycle 5b). The PK insert from
@@ -296,20 +428,60 @@ export async function applySession(
       } satisfies ApplySessionResult;
     }
 
-    // Step 4: rule composition. Cycles 10-12 will replace the synthetic
-    // hook with real rule pipeline. A throw here aborts sql.begin() and
-    // rolls back the whole transaction — PK insert, watermark advance, and
-    // model_json write all revert atomically (cycle 8's contract).
-    const newModelJson = deps.ruleHook
-      ? deps.ruleHook(modelJson)
-      : modelJson;
+    // Step 4: rule composition. The synthetic ruleHook (cycle 8 atomic-
+    // rollback test) overrides the real pipeline when provided so tests can
+    // throw without competing with rule logic. A throw here — synthetic or
+    // real — aborts sql.begin() and rolls back the whole transaction (PK
+    // insert, watermark advance, and model_json write all revert).
+    //
+    // Rule scope this slice: phase-advance + transition-mode-expiry per the
+    // assertion-cycles 10-12. Other rule modules (EWMA, plateau-verdict,
+    // recovery, prescription-accuracy, transfer-regression, fatigue-
+    // interaction) ship in follow-up slices because they have no assertion-
+    // cycle in this slice; the per-pattern loop is the framework they'll
+    // extend into.
+    let newModelJson: Record<string, unknown>;
+    if (deps.ruleHook) {
+      newModelJson = deps.ruleHook(modelJson);
+    } else {
+      const patternsIn = (modelJson.patterns as Record<string, Record<string, unknown>> | undefined) ?? {};
+      const ruled = applyPerPatternRules(patternsIn, incomingLoggedAt, newSessionCount);
+      newModelJson = { ...modelJson, patterns: ruled.patterns };
+      rulesFired = [...ruled.rulesFired];
+      fieldsChanged = ruled.fieldsChanged;
+
+      // ADR-0012: global phase-advance trigger. Reads each pattern's
+      // post-loop lastPhaseTransitionAtSessionCount (which the per-pattern
+      // loop above just updated for any pattern that transitioned this
+      // apply). Force-deload-as-transition is feature, not bug — see
+      // ADR-0012 §Consequences.
+      const patternStates: PatternTransitionState[] = Object.entries(
+        ruled.patterns,
+      ).map(([pattern, profile]) => ({
+        pattern,
+        lastPhaseTransitionAtSessionCount:
+          (profile.lastPhaseTransitionAtSessionCount as number) ?? 0,
+      }));
+      const lastFired =
+        (modelJson.lastGlobalPhaseAdvanceFiredAtSessionCount as number | null | undefined) ??
+        null;
+      if (
+        shouldFireGlobalPhaseAdvance(patternStates, newSessionCount, lastFired)
+      ) {
+        newModelJson = {
+          ...newModelJson,
+          lastGlobalPhaseAdvanceFiredAtSessionCount: newSessionCount,
+        };
+        rulesFired.push("global-phase-advance");
+        fieldsChanged.push("lastGlobalPhaseAdvanceFiredAtSessionCount");
+      }
+    }
 
     // Step 5: write back + advance watermark (ADR-0008 §"In-order").
-    // session_count drives ADR-0012's 6-session-window cooldown, so even the
-    // empty-rules path mutates it.
+    // session_count drives ADR-0012's 6-session-window cooldown.
     await tx`
       UPDATE public.trainee_models
-      SET session_count = session_count + 1,
+      SET session_count = ${newSessionCount},
           last_applied_logged_at = ${incomingLoggedAt},
           model_json = ${JSON.stringify(newModelJson)}::jsonb,
           updated_at = NOW()
@@ -323,11 +495,24 @@ export async function applySession(
     } satisfies ApplySessionResult;
   });
 
-  // Stage 2 fires AFTER Stage 1 commits, ONLY on first-apply (per ADR-0013
-  // §"WAQ retry idempotency"). Cached-snapshot returns (PK conflict) and
-  // late-arrival refusals (watermark check) leave firedFirstApply=false and
-  // skip Stage 2. A12 ships the seam + the gating contract; #A13 wires the
-  // actual classifier call through this hook.
+  // emitApplyComplete + Stage 2 BOTH fire AFTER Stage 1 commits, ONLY on
+  // first-apply (per ADR-0013 §"WAQ retry idempotency"). Cached-snapshot
+  // returns and late-arrival refusals leave firedFirstApply=false; both
+  // emit the structured apply summary and gate Stage 2 here. emitApplyComplete
+  // describes a *mutation* — the cached/refusal paths don't mutate, so
+  // they're correctly silent on this channel.
+  if (firedFirstApply) {
+    emitApplyComplete({
+      user_id: req.user_id,
+      session_id: req.session_id,
+      duration_ms: Date.now() - applyStartMs,
+      rules_fired: rulesFired,
+      fields_changed: fieldsChanged,
+    });
+  }
+
+  // Stage 2 (classifier) per ADR-0013 — A12 ships the seam + the gating
+  // contract; #A13 wires the actual classifier call through this hook.
   if (firedFirstApply && deps.stage2Hook) {
     await deps.stage2Hook();
   }

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -1,0 +1,501 @@
+// Project Apex — Phase 2 Stage 1 orchestrator integration tests.
+//
+// Per ADR-0006 §"Idempotency at the DB layer", ADR-0008 §"Late arrival",
+// and ADR-0013 §"Stage sequencing": the orchestrator wires every Phase 2
+// rule module into a single transactional commit on every session-apply.
+// These tests run against the local Supabase Postgres (54322) — they are
+// integration tests, not unit tests, because the load-bearing concerns
+// (PK constraints, FOR UPDATE row locks, transactional rollback, JSONB
+// round-trip) only have meaning against real Postgres.
+//
+// Prereqs:
+//   - `supabase start` running (DB at postgresql://postgres:postgres@127.0.0.1:54322/postgres)
+//   - Migrations applied (20260506091314 baseline + 20260507210000 phase 2)
+//
+// Each test uses unique UUIDs (no cross-test contamination, no cleanup
+// between tests). Local DB orphans accumulate harmlessly across runs;
+// CI resets the DB per build.
+//
+// Run locally:
+//   deno test --allow-net --allow-env supabase/functions/update-trainee-model/orchestrator_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import postgres from "postgres";
+import { applySession } from "./index.ts";
+import type { LateArrivalEvent } from "../_shared/observability.ts";
+
+const DB_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
+
+/**
+ * Module-scoped SQL client shared across tests in this file. Each test
+ * uses unique UUIDs, so there's no cross-test state to clear; the client
+ * is opened once and closed at the end of the file's test run via
+ * Deno's `globalSetup`-style sentinel test.
+ */
+const sql = postgres(DB_URL, { max: 4 });
+
+/**
+ * Seeds a fresh user + empty trainee_models row. Returns the user_id so
+ * the caller can drive the orchestrator with it. The trainee_models row
+ * starts with `model_json = {}` and `last_applied_logged_at = null`,
+ * mirroring the Phase 1 Slice 9b initialization shape.
+ */
+async function seedFreshUser(): Promise<string> {
+  const userId = crypto.randomUUID();
+  await sql`
+    INSERT INTO public.users (id, display_name)
+    VALUES (${userId}, ${"orchestrator-test-" + userId.slice(0, 8)})
+  `;
+  await sql`
+    INSERT INTO public.trainee_models (user_id, model_json)
+    VALUES (${userId}, ${"{}"}::jsonb)
+  `;
+  return userId;
+}
+
+// All orchestrator tests share the module-scoped postgres.js client. The
+// driver keeps a keepalive timer alive between queries, which Deno's per-test
+// resource sanitizer flags as a leak. Disabling sanitizeOps + sanitizeResources
+// on each test is the right choice here: leaks ARE checked at file-end via
+// the sentinel `_zz_close_sql_pool` test that calls `await sql.end()`.
+const orchestratorTest = (
+  name: string,
+  fn: () => Promise<void>,
+): void => {
+  Deno.test({
+    name,
+    fn,
+    sanitizeOps: false,
+    sanitizeResources: false,
+  });
+};
+
+orchestratorTest(
+  "ADR-0006: first-ever apply on a fresh trainee_models row inserts the applied_sessions PK and increments session_count (tracer)",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-08T10:00:00Z";
+
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: { logged_at: loggedAt, set_logs: [] },
+      },
+      sql,
+    );
+
+    // Response shape per ADR-0008's §"Late arrival" decision: a successful
+    // in-order apply returns { trainee_model, late_arrival: false }.
+    assertEquals(result.late_arrival, false);
+    assertEquals(typeof result.trainee_model, "object");
+
+    // PK insert sticks — duplicate retries will see this row and short-circuit
+    // on cycle 2.
+    const applied = await sql`
+      SELECT user_id, session_id FROM public.trainee_model_applied_sessions
+      WHERE user_id = ${userId} AND session_id = ${sessionId}
+    `;
+    assertEquals(applied.length, 1);
+
+    // session_count incremented from the seed's default of 0.
+    const model = await sql`
+      SELECT session_count FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    assertEquals(model[0].session_count, 1);
+  },
+);
+
+orchestratorTest(
+  "ADR-0006 §2: second apply with same (user_id, session_id) returns cached snapshot — model_json unchanged, session_count unchanged",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const payload = { user_id: userId, session_id: sessionId, session_payload: { logged_at: "2026-05-08T10:00:00Z", set_logs: [] } };
+
+    // First apply: takes the inserted=true path, increments session_count.
+    await applySession(payload, sql);
+
+    // Seed a sentinel value into model_json so the cached return is verifiable
+    // — if the second apply re-ran the rule path, this sentinel would be overwritten.
+    await sql`
+      UPDATE public.trainee_models
+      SET model_json = ${'{"sentinel":"cached-snapshot-token"}'}::jsonb
+      WHERE user_id = ${userId}
+    `;
+
+    // Second apply: same session_id → ON CONFLICT DO NOTHING → cached path.
+    const result = await applySession(payload, sql);
+
+    assertEquals(result.late_arrival, false);
+    assertEquals(
+      (result.trainee_model as Record<string, unknown>).sentinel,
+      "cached-snapshot-token",
+      "second apply must return the cached snapshot — orchestrator is the read source, not a re-applied rule path",
+    );
+
+    // session_count must NOT have advanced again.
+    const model = await sql`
+      SELECT session_count FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    assertEquals(model[0].session_count, 1);
+
+    // Single applied_sessions row — PK constraint held.
+    const applied = await sql`
+      SELECT COUNT(*)::int AS count FROM public.trainee_model_applied_sessions
+      WHERE user_id = ${userId} AND session_id = ${sessionId}
+    `;
+    assertEquals(applied[0].count, 1);
+  },
+);
+
+orchestratorTest(
+  "ADR-0006: orchestrator handles pre-A12 JSONB blobs missing Phase 2 fields without throwing — pre-existing fields preserved through round-trip (migration story)",
+  async () => {
+    // Pre-A12 row: has Phase 1 fields but NOT the Phase 2 additions
+    // (lastGlobalPhaseAdvanceFiredAtSessionCount, consecutiveForceDeloadsOnPattern,
+    // lastClassifiedNoteCreatedAt, etc.). The orchestrator's read path must not
+    // throw when these are absent — first-production-apply on existing alpha-cohort
+    // rows must succeed.
+    const userId = crypto.randomUUID();
+    await sql`
+      INSERT INTO public.users (id, display_name)
+      VALUES (${userId}, ${"orchestrator-test-" + userId.slice(0, 8)})
+    `;
+    const partialBlob = {
+      goal: { focusAreas: [] },
+      patterns: {},
+      muscles: {},
+      exercises: {},
+      activeLimitations: [],
+      clearedLimitations: [],
+      fatigueInteractions: [],
+      prescriptionAccuracy: {},
+      prescriptionIntentMismatches: [],
+      transfers: [],
+      bodyweight: { entries: [] },
+      lifeContextEvents: [],
+      reassessmentRecords: [],
+      totalSessionCount: 0,
+      // Phase 2 additions missing on purpose.
+    };
+    await sql`
+      INSERT INTO public.trainee_models (user_id, model_json)
+      VALUES (${userId}, ${JSON.stringify(partialBlob)}::jsonb)
+    `;
+    const sessionId = crypto.randomUUID();
+
+    // Must not throw.
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: { logged_at: "2026-05-08T10:00:00Z", set_logs: [] },
+      },
+      sql,
+    );
+
+    assertEquals(result.late_arrival, false);
+    // Pre-existing Phase 1 fields round-tripped intact.
+    const model = result.trainee_model as Record<string, unknown>;
+    assertEquals(Array.isArray(model.activeLimitations), true);
+    assertEquals(Array.isArray(model.transfers), true);
+    assertEquals(typeof model.goal, "object");
+  },
+);
+
+orchestratorTest(
+  "ADR-0008: in-order apply (incoming.loggedAt > watermark) advances watermark to incoming.loggedAt",
+  async () => {
+    const userId = await seedFreshUser();
+    // Seed with a prior watermark in the past.
+    const priorWatermark = "2026-05-01T08:00:00Z";
+    await sql`
+      UPDATE public.trainee_models
+      SET last_applied_logged_at = ${priorWatermark}::timestamptz
+      WHERE user_id = ${userId}
+    `;
+
+    const sessionId = crypto.randomUUID();
+    const incomingLoggedAt = "2026-05-08T10:00:00Z"; // strictly later
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: { logged_at: incomingLoggedAt, set_logs: [] },
+      },
+      sql,
+    );
+
+    assertEquals(result.late_arrival, false);
+
+    const row = await sql`
+      SELECT last_applied_logged_at FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    assertEquals(
+      new Date(row[0].last_applied_logged_at).toISOString(),
+      new Date(incomingLoggedAt).toISOString(),
+      "watermark must advance to incoming.loggedAt on in-order apply (ADR-0008 §Decision)",
+    );
+  },
+);
+
+orchestratorTest(
+  "ADR-0008: watermark equality boundary — incoming.loggedAt === watermark is treated as in-order (strict-< refusal, not <=)",
+  async () => {
+    // ADR-0008's decision: refusal fires "if incoming.loggedAt < watermark"
+    // (strict less-than). Exactly-equal is in-order. A future maintainer
+    // who tightens the comparison to <= (well-intentioned, "treat replay as
+    // already-applied") would silently break session-replay scenarios.
+    // This boundary cycle catches that drift exactly the way A7 cycle 12
+    // catches an analogous tightening on overreach (1.15× exact).
+    const userId = await seedFreshUser();
+    const sharedTimestamp = "2026-05-08T10:00:00Z";
+    await sql`
+      UPDATE public.trainee_models
+      SET last_applied_logged_at = ${sharedTimestamp}::timestamptz
+      WHERE user_id = ${userId}
+    `;
+
+    const sessionId = crypto.randomUUID();
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: { logged_at: sharedTimestamp, set_logs: [] },
+      },
+      sql,
+    );
+
+    assertEquals(
+      result.late_arrival,
+      false,
+      "incoming === watermark must NOT trigger late-arrival refusal (strict-< boundary, not <=)",
+    );
+
+    // PK row inserted (in-order branch took it).
+    const applied = await sql`
+      SELECT COUNT(*)::int AS count FROM public.trainee_model_applied_sessions
+      WHERE user_id = ${userId} AND session_id = ${sessionId}
+    `;
+    assertEquals(applied[0].count, 1);
+  },
+);
+
+orchestratorTest(
+  "ADR-0008: late arrival (incoming.loggedAt < watermark) → late_arrival:true; model_json unchanged; watermark unchanged; PK row sticks for dedupe; richer response carries session/incoming/watermark fields",
+  async () => {
+    const userId = await seedFreshUser();
+    const watermark = "2026-05-08T10:00:00Z";
+    await sql`
+      UPDATE public.trainee_models
+      SET last_applied_logged_at = ${watermark}::timestamptz,
+          model_json = ${'{"sentinel":"pre-late-arrival-token"}'}::jsonb
+      WHERE user_id = ${userId}
+    `;
+
+    const sessionId = crypto.randomUUID();
+    const lateLoggedAt = "2026-05-01T08:00:00Z"; // 7 days before watermark
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: { logged_at: lateLoggedAt, set_logs: [] },
+      },
+      sql,
+    );
+
+    // Response shape per ADR-0008 + A12's richer-shape contract: late_arrival
+    // flag plus the three optional fields the WAQ adapter passes into
+    // LateArrivalNotification (sessionId/incomingLoggedAt/watermark).
+    assertEquals(result.late_arrival, true);
+    assertEquals(result.late_arrival_details?.session_id, sessionId);
+    assertEquals(result.late_arrival_details?.incoming_logged_at, new Date(lateLoggedAt).toISOString());
+    assertEquals(result.late_arrival_details?.watermark, new Date(watermark).toISOString());
+    // Cached snapshot returned (the sentinel proves it's the pre-call blob).
+    assertEquals(
+      (result.trainee_model as Record<string, unknown>).sentinel,
+      "pre-late-arrival-token",
+    );
+
+    // Watermark unchanged — refusal does NOT advance.
+    const row = await sql`
+      SELECT last_applied_logged_at, session_count, model_json
+      FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    assertEquals(
+      new Date(row[0].last_applied_logged_at).toISOString(),
+      new Date(watermark).toISOString(),
+      "watermark must NOT advance on late-arrival refusal (ADR-0008 §Decision)",
+    );
+    // session_count unchanged — refusal is a no-op on the model.
+    assertEquals(row[0].session_count, 0);
+    // model_json unchanged.
+    const modelAfter = parseJsonb(row[0].model_json);
+    assertEquals(modelAfter.sentinel, "pre-late-arrival-token");
+
+    // PK row INSERTED — refusal still inserts the dedupe row so WAQ retries
+    // converge to the cached path on subsequent calls (ADR-0008 §Decision).
+    const applied = await sql`
+      SELECT COUNT(*)::int AS count FROM public.trainee_model_applied_sessions
+      WHERE user_id = ${userId} AND session_id = ${sessionId}
+    `;
+    assertEquals(
+      applied[0].count,
+      1,
+      "PK insert must stick on late-arrival refusal — WAQ retries dedupe via this row (ADR-0008)",
+    );
+  },
+);
+
+function parseJsonb(value: unknown): Record<string, unknown> {
+  if (value == null) return {};
+  if (typeof value === "string") return JSON.parse(value);
+  return value as Record<string, unknown>;
+}
+
+orchestratorTest(
+  "ADR-0008: emitLateArrival invoked with correct delta_seconds — incoming 7 days before watermark → delta_seconds = -604800",
+  async () => {
+    const userId = await seedFreshUser();
+    const watermark = "2026-05-08T10:00:00Z";
+    await sql`
+      UPDATE public.trainee_models
+      SET last_applied_logged_at = ${watermark}::timestamptz
+      WHERE user_id = ${userId}
+    `;
+
+    const sessionId = crypto.randomUUID();
+    const lateLoggedAt = "2026-05-01T10:00:00Z"; // exactly 7 days = 604800s before
+    const captured: LateArrivalEvent[] = [];
+
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: { logged_at: lateLoggedAt, set_logs: [] },
+      },
+      sql,
+      {
+        emitLateArrival: (event) => {
+          captured.push(event);
+        },
+      },
+    );
+
+    assertEquals(captured.length, 1, "emitLateArrival must fire exactly once on refusal");
+    const event = captured[0];
+    assertEquals(event.user_id, userId);
+    assertEquals(event.session_id, sessionId);
+    assertEquals(event.incoming_logged_at, new Date(lateLoggedAt).toISOString());
+    assertEquals(event.watermark, new Date(watermark).toISOString());
+    // delta_seconds is negative — incoming is `delta_seconds` before watermark per
+    // observability.ts's LateArrivalEvent contract. 7 days = 7 × 86400 = 604800.
+    assertEquals(event.delta_seconds, -604800);
+  },
+);
+
+orchestratorTest(
+  "ADR-0006: atomic rollback — synthetic rule throw mid-pipeline reverts PK insert + watermark advance + model_json write (single-transaction guarantee)",
+  async () => {
+    const userId = await seedFreshUser();
+    const priorWatermark = "2026-05-01T08:00:00Z";
+    await sql`
+      UPDATE public.trainee_models
+      SET last_applied_logged_at = ${priorWatermark}::timestamptz,
+          model_json = ${'{"sentinel":"pre-throw-token"}'}::jsonb
+      WHERE user_id = ${userId}
+    `;
+    const sessionId = crypto.randomUUID();
+
+    // Synthetic failure injected via the ruleHook seam — same seam cycles
+    // 10-12 will use for real rule composition. The throw must propagate out
+    // of sql.begin(), which by postgres.js's transaction contract aborts +
+    // rolls back the whole block.
+    let threw = false;
+    try {
+      await applySession(
+        {
+          user_id: userId,
+          session_id: sessionId,
+          session_payload: { logged_at: "2026-05-08T10:00:00Z", set_logs: [] },
+        },
+        sql,
+        {
+          ruleHook: () => {
+            throw new Error("synthetic rule failure for atomic-rollback test");
+          },
+        },
+      );
+    } catch (err) {
+      threw = true;
+      assertEquals((err as Error).message.includes("synthetic"), true);
+    }
+    assertEquals(threw, true, "applySession must propagate ruleHook throws");
+
+    // Verify rollback: PK row NOT inserted, watermark NOT advanced, model_json
+    // unchanged.
+    const applied = await sql`
+      SELECT COUNT(*)::int AS count FROM public.trainee_model_applied_sessions
+      WHERE user_id = ${userId} AND session_id = ${sessionId}
+    `;
+    assertEquals(
+      applied[0].count,
+      0,
+      "PK insert must roll back when rule throws — single-transaction guarantee",
+    );
+
+    const row = await sql`
+      SELECT last_applied_logged_at, session_count, model_json
+      FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    assertEquals(
+      new Date(row[0].last_applied_logged_at).toISOString(),
+      new Date(priorWatermark).toISOString(),
+      "watermark must NOT advance when rule throws",
+    );
+    assertEquals(row[0].session_count, 0, "session_count must NOT increment when rule throws");
+    assertEquals(parseJsonb(row[0].model_json).sentinel, "pre-throw-token");
+  },
+);
+
+orchestratorTest(
+  "ADR-0013: Stage 2 (classifier) is NOT triggered on cached-snapshot return — first-apply-fires-once contract holds across WAQ retries",
+  async () => {
+    // Stage 2 is owned by #A13. This slice exposes a stage2Hook seam so the
+    // orchestrator's "fires only on in-order first-apply" contract is pinned
+    // before A13 lands the actual classifier call. ADR-0013: Stage 2 runs
+    // separate-after Stage 1 commit, ONLY when Stage 1 took the in-order
+    // first-apply path. Cached-snapshot returns and late-arrival refusals
+    // MUST NOT fire Stage 2.
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const payload = { user_id: userId, session_id: sessionId, session_payload: { logged_at: "2026-05-08T10:00:00Z", set_logs: [] } };
+
+    let stage2Calls = 0;
+    const stage2Hook = () => {
+      stage2Calls += 1;
+    };
+
+    // First apply — Stage 1 succeeds, Stage 2 should fire.
+    await applySession(payload, sql, { stage2Hook });
+    assertEquals(stage2Calls, 1, "first-apply success path must fire Stage 2 (ADR-0013 §Stage sequencing)");
+
+    // Second apply — PK conflict, cached path, Stage 2 must NOT fire.
+    await applySession(payload, sql, { stage2Hook });
+    assertEquals(stage2Calls, 1, "cached-snapshot return MUST NOT re-fire Stage 2 (ADR-0013 §WAQ retry idempotency)");
+  },
+);
+
+// Sentinel "test" that runs last (alphabetically — Deno runs tests in file
+// order, but this trailing close keeps the connection lifecycle local to
+// the test file rather than relying on process-exit cleanup).
+Deno.test({
+  name: "_zz_close_sql_pool",
+  fn: async () => {
+    await sql.end();
+  },
+  sanitizeOps: false,
+  sanitizeResources: false,
+});

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -22,7 +22,7 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import postgres from "postgres";
 import { applySession } from "./index.ts";
-import type { LateArrivalEvent } from "../_shared/observability.ts";
+import type { ApplyCompleteEvent, LateArrivalEvent } from "../_shared/observability.ts";
 
 const DB_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
 
@@ -485,6 +485,305 @@ orchestratorTest(
     // Second apply — PK conflict, cached path, Stage 2 must NOT fire.
     await applySession(payload, sql, { stage2Hook });
     assertEquals(stage2Calls, 1, "cached-snapshot return MUST NOT re-fire Stage 2 (ADR-0013 §WAQ retry idempotency)");
+  },
+);
+
+orchestratorTest(
+  "ADR-0011 §(c) + Q5: pattern in .deload at sessionsRequiredForPhase threshold → cyclic advance to .accumulation; transitionModeUntil set per cadence-aware composer; emitApplyComplete fires with the rules-fired list",
+  async () => {
+    // Synthetic deload-end fixture. Pattern is in .deload with sessionsInPhase
+    // well above any reasonable Option-B threshold. Recent session dates are
+    // spread ~4 days apart so cadence-derived daysPerWeek lands at ~1.75
+    // (sessionsRequired = max(3, 1×1) = 3 for the deload phase). The pattern
+    // crosses the threshold and the cyclic deload→accumulation rule fires;
+    // composeTransitionModeUntil sets transitionModeUntil per ADR-0015.
+    const userId = crypto.randomUUID();
+    await sql`
+      INSERT INTO public.users (id, display_name)
+      VALUES (${userId}, ${"orchestrator-test-" + userId.slice(0, 8)})
+    `;
+    const seedModel = {
+      patterns: {
+        squat: {
+          pattern: "squat",
+          currentPhase: "deload",
+          sessionsInPhase: 10,
+          lastPhaseTransitionAtSessionCount: 5,
+          rpeOffset: 0,
+          recovery: { neuromuscularReadiness: 1, metabolicReadiness: 1 },
+          confidence: "established",
+          transitionModeUntil: null,
+          trend: "progressing",
+          recentSessionDates: [
+            "2026-04-22T10:00:00.000Z",
+            "2026-04-26T10:00:00.000Z",
+            "2026-04-30T10:00:00.000Z",
+            "2026-05-04T10:00:00.000Z",
+          ],
+          consecutiveForceDeloadsOnPattern: 0,
+        },
+      },
+    };
+    await sql`
+      INSERT INTO public.trainee_models (user_id, model_json)
+      VALUES (${userId}, ${JSON.stringify(seedModel)}::jsonb)
+    `;
+
+    const sessionId = crypto.randomUUID();
+    const incomingLoggedAt = "2026-05-08T10:00:00.000Z";
+    const captured: ApplyCompleteEvent[] = [];
+
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: { logged_at: incomingLoggedAt, set_logs: [] },
+      },
+      sql,
+      {
+        emitApplyComplete: (event) => {
+          captured.push(event);
+        },
+      },
+    );
+
+    assertEquals(result.late_arrival, false);
+
+    // Pattern advanced from .deload → .accumulation per ADR-0011 §(c).
+    const patterns = (result.trainee_model as Record<string, unknown>).patterns as Record<string, Record<string, unknown>>;
+    assertEquals(patterns.squat.currentPhase, "accumulation");
+    assertEquals(patterns.squat.sessionsInPhase, 0);
+    assertEquals(patterns.squat.lastPhaseTransitionAtSessionCount, 1, "lastPhaseTransitionAtSessionCount = the new session_count after this apply");
+
+    // transitionModeUntil set per Q5 / ADR-0015. Concrete value is incoming +
+    // max(14d, 3×cadence). Cadence ≈ 4d → 3×cadence = 12d → max(14, 12) = 14d.
+    // So transitionModeUntil = 2026-05-08 + 14d = 2026-05-22T10:00:00Z.
+    const until = new Date(patterns.squat.transitionModeUntil as string);
+    const expected = new Date("2026-05-22T10:00:00.000Z");
+    assertEquals(
+      until.toISOString(),
+      expected.toISOString(),
+      "transitionModeUntil must be incomingLoggedAt + max(14d, 3×cadence) per Q5 + ADR-0015",
+    );
+
+    // emitApplyComplete fires with the list of rules that ran. The architect's
+    // procedural note: per-apply summary belongs in the apply flow from cycle 10,
+    // not added later.
+    assertEquals(captured.length, 1, "emitApplyComplete must fire exactly once on first-apply success");
+    assertEquals(captured[0].user_id, userId);
+    assertEquals(captured[0].session_id, sessionId);
+    assertEquals(captured[0].rules_fired.includes("phase-advance"), true);
+    assertEquals(captured[0].rules_fired.includes("transition-mode-expiry"), true);
+  },
+);
+
+orchestratorTest(
+  "ADR-0011 §(b): pattern at 2× threshold + trend=plateaued → force-deload safety valve fires; consecutiveForceDeloadsOnPattern increments by 1; phase jumps directly to .deload (skips intensification/peaking)",
+  async () => {
+    // Synthetic force-deload fixture. Pattern in .accumulation with
+    // sessionsInPhase well above 2 × sessionsRequiredForPhase + trend
+    // already classified as plateaued (synthetic — A12 doesn't run plateau-
+    // verdict; the seed pre-sets the trend that the real pipeline will
+    // produce in a later slice). The force-deload safety valve at
+    // ≥ 2× threshold AND stuck-trend fires per ADR-0011 §(b).
+    const userId = crypto.randomUUID();
+    await sql`
+      INSERT INTO public.users (id, display_name)
+      VALUES (${userId}, ${"orchestrator-test-" + userId.slice(0, 8)})
+    `;
+    const seedModel = {
+      patterns: {
+        squat: {
+          pattern: "squat",
+          currentPhase: "accumulation",
+          // Need sessionsInPhase ≥ 2 × sessionsRequiredForPhase. With cadence
+          // ≈ 4d (daysPerWeek ≈ 1.75 → multiplier=1) and accumulation
+          // (phaseWeeks=4): sessionsRequired = max(3, 4×1) = 4. 2× = 8.
+          // Setting sessionsInPhase=20 trivially clears the boundary.
+          sessionsInPhase: 20,
+          lastPhaseTransitionAtSessionCount: 5,
+          rpeOffset: 0,
+          recovery: { neuromuscularReadiness: 0.6, metabolicReadiness: 0.9 },
+          confidence: "established",
+          transitionModeUntil: null,
+          trend: "plateaued", // synthetic — would be set by plateau-verdict in a future slice
+          recentSessionDates: [
+            "2026-04-22T10:00:00.000Z",
+            "2026-04-26T10:00:00.000Z",
+            "2026-04-30T10:00:00.000Z",
+            "2026-05-04T10:00:00.000Z",
+          ],
+          consecutiveForceDeloadsOnPattern: 0,
+        },
+      },
+    };
+    await sql`
+      INSERT INTO public.trainee_models (user_id, model_json)
+      VALUES (${userId}, ${JSON.stringify(seedModel)}::jsonb)
+    `;
+
+    const sessionId = crypto.randomUUID();
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: { logged_at: "2026-05-08T10:00:00.000Z", set_logs: [] },
+      },
+      sql,
+    );
+
+    const patterns = (result.trainee_model as Record<string, unknown>).patterns as Record<string, Record<string, unknown>>;
+    assertEquals(patterns.squat.currentPhase, "deload", "force-deload jumps directly to .deload (skips intensification + peaking) per ADR-0011 §(b)");
+    assertEquals(patterns.squat.sessionsInPhase, 0);
+    assertEquals(
+      patterns.squat.consecutiveForceDeloadsOnPattern,
+      1,
+      "consecutiveForceDeloadsOnPattern must increment on force-deload (only this path increments; natural progressing-advance resets per ADR-0011 §(b))",
+    );
+  },
+);
+
+orchestratorTest(
+  "ADR-0012: 4-of-6 major patterns transitioned within last 6 sessions → globalPhaseAdvance fires; lastGlobalPhaseAdvanceFiredAtSessionCount = current session_count",
+  async () => {
+    // Synthetic 4-of-6 major-pattern transitions fixture. Pre-set
+    // lastPhaseTransitionAtSessionCount within the 6-session window for
+    // squat / hipHinge / horizontalPush / verticalPush; the remaining
+    // major patterns (horizontalPull / verticalPull) sit outside the
+    // window. session_count post-increment = 7 (above the bootstrap guard
+    // of 6). lastGlobalPhaseAdvanceFiredAtSessionCount starts null —
+    // never-fired.
+    const userId = crypto.randomUUID();
+    await sql`
+      INSERT INTO public.users (id, display_name)
+      VALUES (${userId}, ${"orchestrator-test-" + userId.slice(0, 8)})
+    `;
+    const inWindowProfile = (pattern: string) => ({
+      pattern,
+      currentPhase: "accumulation",
+      sessionsInPhase: 0,
+      lastPhaseTransitionAtSessionCount: 4, // session_count post-increment is 7, delta=3 (≤6)
+      rpeOffset: 0,
+      recovery: { neuromuscularReadiness: 1, metabolicReadiness: 1 },
+      confidence: "established",
+      transitionModeUntil: null,
+      trend: "progressing",
+      recentSessionDates: [
+        "2026-04-22T10:00:00.000Z",
+        "2026-04-26T10:00:00.000Z",
+        "2026-04-30T10:00:00.000Z",
+        "2026-05-04T10:00:00.000Z",
+      ],
+      consecutiveForceDeloadsOnPattern: 0,
+    });
+    const seedModel = {
+      patterns: {
+        squat: inWindowProfile("squat"),
+        hipHinge: inWindowProfile("hipHinge"),
+        horizontalPush: inWindowProfile("horizontalPush"),
+        verticalPush: inWindowProfile("verticalPush"),
+        // horizontalPull / verticalPull intentionally absent — they do not
+        // contribute to the count, leaving 4-of-6 satisfied.
+      },
+      lastGlobalPhaseAdvanceFiredAtSessionCount: null,
+    };
+    await sql`
+      INSERT INTO public.trainee_models (user_id, model_json, session_count)
+      VALUES (${userId}, ${JSON.stringify(seedModel)}::jsonb, 6)
+    `;
+
+    const sessionId = crypto.randomUUID();
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: { logged_at: "2026-05-08T10:00:00.000Z", set_logs: [] },
+      },
+      sql,
+    );
+
+    // Post-increment session_count = 7. ADR-0012's gate: 4-of-6 majors with
+    // (7 - 4) = 3 ≤ 6 → fires. Bootstrap guard (sessionCount ≥ 6) cleared.
+    // Cooldown gate (null lastFired) cleared.
+    const model = result.trainee_model as Record<string, unknown>;
+    assertEquals(
+      model.lastGlobalPhaseAdvanceFiredAtSessionCount,
+      7,
+      "lastGlobalPhaseAdvanceFiredAtSessionCount must equal current session_count (7) when the trigger fires per ADR-0012",
+    );
+  },
+);
+
+orchestratorTest(
+  "ADR-0006 (cross-platform JSONB shape parity): the canonical fixture at docs/fixtures/trainee-model-snapshot.json round-trips through the orchestrator unchanged on the in-order watermark-refusal path (no rule mutations) — TS side of the shape parity contract",
+  async () => {
+    // Loads the same canonical fixture that the Swift
+    // TraineeModelSnapshotsCrossValidationTests decodes. Drift on either
+    // side surfaces here (TS) or there (Swift). The fixture is the
+    // single source of expected shape — Phase 2 fields populated, enum-
+    // keyed dicts as JSON objects with rawValue keys.
+    const fixturePath = new URL(
+      "../../../docs/fixtures/trainee-model-snapshot.json",
+      import.meta.url,
+    );
+    const raw = JSON.parse(Deno.readTextFileSync(fixturePath));
+    // Strip the docs-only $comment field — Postgres jsonb doesn't care
+    // but Swift's TraineeModel decoder ignores unknown keys by default,
+    // and we keep the shape minimal-surface for the round-trip assertion.
+    delete raw.$comment;
+
+    // Seed the user + trainee_models row with the fixture as the model_json,
+    // and a watermark in the FUTURE so the orchestrator takes the late-
+    // arrival refusal path (which returns the cached snapshot unmutated).
+    // This isolates the round-trip assertion from rule-mutation effects.
+    const userId = crypto.randomUUID();
+    await sql`
+      INSERT INTO public.users (id, display_name)
+      VALUES (${userId}, ${"orchestrator-test-" + userId.slice(0, 8)})
+    `;
+    const futureWatermark = "2026-12-31T23:59:59.000Z";
+    await sql`
+      INSERT INTO public.trainee_models (user_id, model_json, last_applied_logged_at, session_count)
+      VALUES (${userId}, ${JSON.stringify(raw)}::jsonb, ${futureWatermark}::timestamptz, 24)
+    `;
+    const sessionId = crypto.randomUUID();
+
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        // earlier than watermark → refusal path → orchestrator returns the
+        // cached snapshot verbatim.
+        session_payload: { logged_at: "2026-01-15T00:00:00.000Z", set_logs: [] },
+      },
+      sql,
+      { emitLateArrival: () => {} },
+    );
+
+    assertEquals(result.late_arrival, true);
+    // Round-trip: every top-level key in the fixture must be present in
+    // the orchestrator's response with the same value. This catches TS-
+    // side regressions on the JSONB read path (parseJsonbColumn defaults,
+    // unintended field elision, type coercion).
+    const returned = result.trainee_model as Record<string, unknown>;
+    assertEquals(returned.totalSessionCount, 24);
+    assertEquals(returned.lastGlobalPhaseAdvanceFiredAtSessionCount, 18);
+    assertEquals(returned.lastClassifiedNoteCreatedAt, "2026-01-04T18:00:00.000Z");
+    // patterns must be a JSON object with rawValue keys (snake_case for the
+    // multi-word ones) — NOT Swift's default alternating-array form.
+    const patterns = returned.patterns as Record<string, unknown>;
+    assertEquals(Array.isArray(patterns), false, "patterns must be a JSON object, not an array (cross-platform shape contract)");
+    assertEquals(typeof patterns.squat, "object");
+    assertEquals(typeof patterns.horizontal_push, "object");
+    // Doubly-nested prescriptionAccuracy: outer key MovementPattern.rawValue,
+    // inner key SetIntent.rawValue — both as JSON objects.
+    const pa = returned.prescriptionAccuracy as Record<string, Record<string, Record<string, unknown>>>;
+    assertEquals(pa.squat.top.bias, 0.04);
+    assertEquals(pa.squat.top.biasByGapBucket, {
+      "under48h": -0.02,
+      "between_48_and_72h": 0.05,
+      "over72h": 0.06,
+    });
   },
 );
 


### PR DESCRIPTION
This is the load-bearing slice — its merge marks the moment Phase 2 begins silently populating the trainee model.

The 16 cycles ship across three reviewable sub-units, structured for incremental reading. Cycles ran across two work sessions; the cycle-9 cut at the transactional shell was deliberate (architectural calculus locked at slice-plan time: quality over speed on the load-bearing slice).

## Section 1 — Transactional shell (cycles 1-9, commit `1b1bc9a`)

The DB plumbing layer. PK idempotency, watermark dance, atomic rollback, Stage 2 isolation seam.

- **[supabase/functions/update-trainee-model/index.ts](supabase/functions/update-trainee-model/index.ts)** — `applySession(req, sql, deps?)` extracted as the testable orchestrator core. HTTP wrapper unchanged. PK insert via `INSERT...ON CONFLICT DO NOTHING RETURNING xmax = 0 AS inserted`; cached-snapshot return on conflict; SELECT FOR UPDATE row lock; watermark check (strict `<`, equality is in-order — cycle 5b pins this against future tightening); late-arrival refusal with richer response shape; `emitLateArrival` invoked with `delta_seconds = round((incoming - watermark)/1000)`.
- **[supabase/functions/update-trainee-model/orchestrator_test.ts](supabase/functions/update-trainee-model/orchestrator_test.ts)** — integration tests against local Supabase Postgres. Each test uses unique UUIDs (no cross-test contamination, no cleanup needed). `sanitizeOps:false` per-test to handle postgres.js's keepalive timer.
- **[supabase/functions/update-trainee-model/deno.json](supabase/functions/update-trainee-model/deno.json)** — `npm:postgres@3.4.4` pin via per-function deno.json. Production note in `index.ts` flags pgbouncer endpoint (port 6543) for cold-start connection multiplexing.

Seams established for cycles 10-16 + future #A13:
- `deps.ruleHook` — synthetic-failure injection seam (cycle 8 atomic rollback).
- `deps.stage2Hook` — fires AFTER `sql.begin()` commits, ONLY on `firedFirstApply=true` path. #A13 wires the actual classifier through here.
- `deps.emitLateArrival` / `deps.emitApplyComplete` — observability spy seams.

## Section 2 — Rule composition + observability (cycles 10-12)

The rule pipeline. Per-pattern loop wires the three rules tested by assertion-cycles in this slice:

- Cycle 10: `applyPerPatternRules` runs `advancePhase` per pattern; on `firesDeloadEndTransitionMode=true`, calls `computeTransitionModeUntil` per Q5/ADR-0015. Pattern in `.deload` at threshold → cyclic advance to `.accumulation`; `transitionModeUntil` set to `incoming + max(14d, 3×cadence)`.
- Cycle 11: same loop catches `force-deload` (2× threshold + plateaued); increments `consecutiveForceDeloadsOnPattern`.
- Cycle 12: after the per-pattern loop, `shouldFireGlobalPhaseAdvance` reads each pattern's post-loop `lastPhaseTransitionAtSessionCount`; on fire, sets `lastGlobalPhaseAdvanceFiredAtSessionCount` per ADR-0012.

`emitApplyComplete` helper added to [supabase/functions/_shared/observability.ts](supabase/functions/_shared/observability.ts) per the architect's \"land it INSIDE cycle 10\" sequencing note. Per-apply summary `{ user_id, session_id, duration_ms, rules_fired, fields_changed }`. Call site in `applySession`'s first-apply success path; cached returns and late-arrival refusals do NOT emit.

## Section 3 — Cross-platform JSONB fixture + Swift WAQ wiring (cycles 13-16)

- **Cycle 13** locked the cross-platform JSONB shape contract via [docs/fixtures/trainee-model-snapshot.json](docs/fixtures/trainee-model-snapshot.json). TS round-trip test asserts orchestrator preserves the fixture; new Swift [TraineeModelSnapshotsCrossValidationTests](ProjectApexTests/TraineeModelSnapshotsCrossValidationTests.swift) decodes it. Pinned anchor `2026-01-01T00:00:00Z` for deterministic behavior.
- Cycle 13 surfaced a real production-relevant drift: Swift's synthesized `Dictionary<EnumKey, V>` Codable encodes as a **flat alternating array** (`[\"squat\", {...}, \"horizontal_push\", {...}]`), not as a JSON object. The TS orchestrator can't produce this idiomatically; ADR-0006 \"the JSONB column is a contract between Edge Function (writer) and client (reader)\" makes it load-bearing. Resolution per locked path A: [JSONBCodable.swift](ProjectApex/Models/JSONBCodable.swift) helper + custom `init(from:)`/`encode(to:)` on `TraineeModel` (patterns/muscles/prescriptionAccuracy as JSON objects with enum rawValue keys) + custom `encode(to:)` on `PrescriptionAccuracy` (gap-bucket dicts as JSON objects).
- Cycles 14-16 extend the WAQ adapter at [TraineeModelUpdateJob.swift](ProjectApex/Services/TraineeModelUpdateJob.swift) to parse the A12 richer response shape (`late_arrival_details: { session_id, incoming_logged_at, watermark }`) and populate the previously-nil-defaulted fields on `LateArrivalNotification`. Tests cover (14) richer-fields populated; (15) `late_arrival:false` regression — covered by existing test; (16) cached-snapshot return treated identically to fresh apply from the client perspective.

## Error taxonomy

Failure mode → response mapping. Tests pin each row.

| Trigger | Path | HTTP | Body | DB state |
|---|---|---|---|---|
| First-ever apply succeeds | in-order, rules run | 200 | `{trainee_model: <fresh>, late_arrival: false}` | applied_sessions PK, model_json + watermark advance, session_count++, emitApplyComplete fires, stage2Hook fires |
| Duplicate session_id (WAQ retry) | PK conflict, cached path | 200 | `{trainee_model: <cached>, late_arrival: false}` | unchanged; **stage2Hook does NOT fire** (ADR-0013 contract) |
| Watermark refusal (late arrival) | `incoming.loggedAt < watermark` | 200 | `{trainee_model: <cached>, late_arrival: true, late_arrival_details: {...}}` | applied_sessions PK sticks for dedupe, model_json + watermark unchanged, emitLateArrival fires |
| Watermark equality (`incoming === watermark`) | in-order (strict-< only) | 200 | `{..., late_arrival: false}` | normal apply (cycle 5b regression-pin) |
| Synthetic rule throw mid-pipeline | rollback | (propagates) | (propagates) | **all reverts atomically** — no PK row, no watermark advance, no model write (cycle 8) |
| Validation error (bad UUID, missing intent) | pre-orchestrator | 400 | `{error: <message>}` | unchanged |
| Bad method (not POST) | pre-orchestrator | 405 | `{error: \"method not allowed\"}` | unchanged |
| `session_payload.logged_at` missing/invalid | orchestrator boundary throw | (propagates) | (propagates) | unchanged |

## Scope notes (rule pipeline is sparse)

Cycles 10-12 wire only the rules with assertion-cycles in this slice: **phase-advance + transition-mode-expiry + global-phase-advance**. The remaining 6 rule modules — EWMA, plateau-verdict, recovery, prescription-accuracy, transfer-regression, fatigue-interaction — ship in follow-up slices because they have no assertion-cycle here. Per Karpathy \"Simplicity First\": minimum-per-cycle. The `applyPerPatternRules` framework hosts future rules cleanly.

`detectTransferPairs` extraction (Q6 architectural refinement) **is NOT in this slice**. The first cycle that wires `fitTransfer` is the cycle where extraction belongs — none of cycles 10-12 invoke it, so extracting now would be premature scaffolding. Defers to the follow-up slice.

## Decisions surfaced during execution

- **Cycle 13 enum-rawValue inconsistency.** `InterSessionGapBucket.between48And72h` has explicit rawValue `\"between_48_and_72h\"` ([TraineeModelEnums.swift:108](ProjectApex/Models/TraineeModelEnums.swift#L108)); the other two cases (`under48h`, `over72h`) use implicit name-as-rawValue. Fixture initially used `\"between48And72h\"` (name) — corrected to `\"between_48_and_72h\"` (explicit rawValue). Cross-validation test pins this.
- **Cycle 8 ruleHook + cycles 10-12 default pipeline coexist.** When `deps.ruleHook` is provided (cycle 8 synthetic throw), it runs INSTEAD of the real pipeline. When unset (production + cycles 10-12), the real pipeline runs. Same `sql.begin()` boundary — both paths roll back atomically on throw.
- **Phase 1 value type Codable was technically out-of-scope per #83**, but adding custom Codable for JSONB shape contract is a Codable-only change with no semantic effect on Swift consumers. 326 Swift tests pass — backward-compatible.

## Tests

- 255 Deno tests passing (`deno test --allow-net --allow-env --allow-read --allow-sys --allow-write supabase/functions/`). Local Supabase required for orchestrator integration tests.
- 326 Swift tests passing (319 + 7 skipped under `APEX_INTEGRATION_TESTS=1` gate). Includes new `TraineeModelSnapshotsCrossValidationTests` (4 tests) and extended `TraineeModelUpdateJobTests` (cycles 14, 16 added — 17 → 19 total).
- All Phase 1 round-trip tests on `TraineeModel`, `PrescriptionAccuracy`, etc. continue to pass (custom Codable is internally consistent: encode→decode round-trips preserve all fields).

## G1 verification gate prep — surfaced per memory `project_phase_2_g1_prep_flag.md`

A12's merge unblocks #85 (G1 verification gate). G1's \"5 coaching-judgment items\" are the riskiest part of Phase 2 — judgment is the user's, not Claude's, and decision criteria for \"reasonable\" cannot be derived during G1 itself. Three questions worth answering before G1 starts:

1. **Test data set for G1.** What drives the comparison? User's own training history? Specific alpha-cohort sample? Synthetic test data layered on real data?
2. **Per-item decision criteria for \"reasonable.\"** For each of the 5 coaching-judgment items in #85:
   - Recovery readiness sanity check at 24/48/72h post-heavy: \"physiologically reasonable\" — within 0.05 of ADR-0010 Table? 0.10? Specific user feedback?
   - Force-deload trigger audit: per-fire decision criterion for \"this pattern was actually stuck.\"
   - Classifier output spot-check: how many sample notes? What flags a critical disagreement vs. an edge case?
   - Phase-cycling validation (deload→accumulation): what counts as \"EWMA collapses cleanly\"?
   - Gap-bucket bucketing audit: how many sample sets? What's \"obvious bucketing wrong\" vs. edge case?
3. **Rollback plan if G1 fails.** Continue iterating in 2A slices to fix root causes (which 2A slice is most likely the culprit per the failing item)? Pause Phase 2 to re-grill a specific design decision? Document as v2.x watch-items and proceed with degraded scope?

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)