### PR TITLE
feat(slice-A13/#84): Stage 2 note-classifier — language scoping + lifecycles (ADR-0013 + Q9)

### DIFF
--- a/ProjectApex/Models/TraineeModelInteractions.swift
+++ b/ProjectApex/Models/TraineeModelInteractions.swift
@@ -18,6 +18,15 @@ struct ActiveLimitation: Codable, Sendable, Hashable {
     var evidenceCount: Int
     var userConfirmed: Bool
     var notes: String?
+    /// Q9 PRD-internal (slice A13 / #84): AI-inferred limitations auto-clear
+    /// after `LIMITATION_AUTO_CLEAR_SESSIONS` (=3) sessions where the subject
+    /// was trained AND the classifier processed notes AND no re-mention was
+    /// found. User-reported limitations (`userConfirmed=true`) ignore this
+    /// counter — only user-confirmed UI clear removes them.
+    ///
+    /// Decoded with `decodeIfPresent ?? 0` for forward-compat with pre-A13
+    /// rows (additive Codable migration).
+    var sessionsWithoutReMention: Int
 
     init(
         subject: LimitationSubject,
@@ -25,7 +34,8 @@ struct ActiveLimitation: Codable, Sendable, Hashable {
         onsetDate: Date,
         evidenceCount: Int,
         userConfirmed: Bool,
-        notes: String? = nil
+        notes: String? = nil,
+        sessionsWithoutReMention: Int = 0
     ) {
         self.subject = subject
         self.severity = severity
@@ -33,6 +43,18 @@ struct ActiveLimitation: Codable, Sendable, Hashable {
         self.evidenceCount = evidenceCount
         self.userConfirmed = userConfirmed
         self.notes = notes
+        self.sessionsWithoutReMention = sessionsWithoutReMention
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.subject = try c.decode(LimitationSubject.self, forKey: .subject)
+        self.severity = try c.decode(Severity.self, forKey: .severity)
+        self.onsetDate = try c.decode(Date.self, forKey: .onsetDate)
+        self.evidenceCount = try c.decode(Int.self, forKey: .evidenceCount)
+        self.userConfirmed = try c.decode(Bool.self, forKey: .userConfirmed)
+        self.notes = try c.decodeIfPresent(String.self, forKey: .notes)
+        self.sessionsWithoutReMention = try c.decodeIfPresent(Int.self, forKey: .sessionsWithoutReMention) ?? 0
     }
 }
 

--- a/ProjectApexTests/TraineeModelSnapshotsCrossValidationTests.swift
+++ b/ProjectApexTests/TraineeModelSnapshotsCrossValidationTests.swift
@@ -93,6 +93,25 @@ final class TraineeModelSnapshotsCrossValidationTests: XCTestCase {
         XCTAssertGreaterThan(interaction.confidence, 0)
     }
 
+    /// ActiveLimitation gained `sessionsWithoutReMention` in slice A13 (#84)
+    /// per Q9 PRD-internal — the per-AI-inferred-limitation auto-clear counter.
+    /// Pre-A13 rows have no such key; the Swift Codable's `decodeIfPresent`
+    /// defaults to 0. The fixture exercises a populated value (1) so a
+    /// round-trip through both TS orchestrator and Swift decoder pins the
+    /// shape.
+    func test_activeLimitation_a13SessionsWithoutReMention_decodesCorrectly() {
+        XCTAssertEqual(Self.model.activeLimitations.count, 1)
+        let lim = Self.model.activeLimitations[0]
+        XCTAssertEqual(lim.subject, .joint(.shoulder))
+        XCTAssertEqual(lim.severity, .mild)
+        XCTAssertEqual(lim.userConfirmed, false)
+        XCTAssertEqual(lim.evidenceCount, 2)
+        XCTAssertEqual(
+            lim.sessionsWithoutReMention, 1,
+            "A13 additive Codable: sessionsWithoutReMention must round-trip from JSONB"
+        )
+    }
+
     /// PrescriptionAccuracy gained gap-bucket fields in slice A9 (#80) per
     /// ADR-0014. The fixture exercises the populated dictionaries; verify
     /// the Swift Codable's `decodeIfPresent` defaults to empty-dict on

--- a/docs/fixtures/trainee-model-snapshot.json
+++ b/docs/fixtures/trainee-model-snapshot.json
@@ -52,7 +52,17 @@
   },
   "muscles": {},
   "exercises": {},
-  "activeLimitations": [],
+  "activeLimitations": [
+    {
+      "subject": { "kind": "joint", "value": "shoulder" },
+      "severity": "mild",
+      "onsetDate": "2025-12-23T18:00:00.000Z",
+      "evidenceCount": 2,
+      "userConfirmed": false,
+      "notes": null,
+      "sessionsWithoutReMention": 1
+    }
+  ],
   "clearedLimitations": [],
   "fatigueInteractions": [
     {

--- a/supabase/functions/_shared/llm-retry.ts
+++ b/supabase/functions/_shared/llm-retry.ts
@@ -1,0 +1,113 @@
+// Project Apex — ADR-0007 retry-and-surface policy in TypeScript.
+//
+// Per ADR-0007 §"Retry shape (transient errors only)":
+//   - 3 retries (4 total attempts)
+//   - base delay 1s doubling each attempt (1s → 2s → 4s)
+//   - random jitter up to 0.5s
+//   - cooperative (no Task.checkCancellation equivalent in Deno; AbortSignal)
+//   - permanent errors throw immediately, do NOT consume retries
+//
+// This is the canonical TS implementation of the policy. Future LLM-driven
+// slices (coach-tone classifier, digest summarizer, anything else) inherit
+// the retry semantic by importing `withLLMRetry` from this module rather
+// than re-implementing it inline. ADR-0007 has one source-of-truth in code.
+//
+// Slice A13 (note-classifier) is the first consumer.
+//
+// The retry budget is bounded — total worst-case retry duration ~7s + jitter
+// — small enough to fit inside a Supabase Edge Function's invocation
+// timeout when called from Stage 2 (which itself doesn't gate the HTTP
+// response per ADR-0013).
+
+/**
+ * Errors classified as transient per ADR-0007's §1 table:
+ *   HTTP 429 / 502 / 503 / 504 / 529 (Anthropic overload)
+ *   Network errors: notConnectedToInternet, networkConnectionLost,
+ *                   timedOut, cannotConnectToHost, dnsLookupFailed
+ *
+ * Other errors (HTTP 4xx other than 429, malformed response, empty
+ * response, anything else) are permanent and throw immediately.
+ */
+export class LLMTransientError extends Error {
+  constructor(message: string, public readonly originalError?: unknown) {
+    super(message);
+    this.name = "LLMTransientError";
+  }
+}
+
+export class LLMPermanentError extends Error {
+  constructor(
+    message: string,
+    public readonly errorClass: string,
+    public readonly originalError?: unknown,
+  ) {
+    super(message);
+    this.name = "LLMPermanentError";
+  }
+}
+
+/**
+ * Classify an HTTP status as transient or permanent per ADR-0007.
+ * Returns null for 2xx statuses (caller should use the response body).
+ */
+export function classifyHttpStatus(
+  status: number,
+): "transient" | "permanent" | null {
+  if (status >= 200 && status < 300) return null;
+  if (status === 429 || status === 502 || status === 503 || status === 504 || status === 529) {
+    return "transient";
+  }
+  return "permanent";
+}
+
+const RETRY_DELAYS_MS = [1000, 2000, 4000] as const;
+const JITTER_MAX_MS = 500;
+
+/**
+ * Bounded exponential backoff per ADR-0007. Calls `op` up to 4 times total
+ * (initial + 3 retries). On `LLMTransientError`, sleeps with jittered
+ * exponential backoff before retrying. On `LLMPermanentError`, throws
+ * immediately without consuming retries. On retry exhaustion, throws the
+ * last `LLMTransientError`.
+ *
+ * Tests can inject `deps.sleep` to bypass real timers.
+ */
+export async function withLLMRetry<T>(
+  op: () => Promise<T>,
+  deps: { sleep?: (ms: number) => Promise<void> } = {},
+): Promise<T> {
+  const sleep = deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  let lastTransient: LLMTransientError | null = null;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      return await op();
+    } catch (err) {
+      if (err instanceof LLMPermanentError) {
+        // Permanent: throw immediately, do not consume retries.
+        throw err;
+      }
+      if (err instanceof LLMTransientError) {
+        lastTransient = err;
+        if (attempt < RETRY_DELAYS_MS.length) {
+          const baseDelay = RETRY_DELAYS_MS[attempt];
+          const jitter = Math.random() * JITTER_MAX_MS;
+          await sleep(baseDelay + jitter);
+          continue;
+        }
+        // Retries exhausted; fall through to throw below.
+        break;
+      }
+      // Non-LLM error class: treat as permanent (defensive — caller should
+      // wrap unknown errors as LLMPermanentError before they reach here).
+      throw new LLMPermanentError(
+        `unexpected error: ${err instanceof Error ? err.message : String(err)}`,
+        "unexpected_error",
+        err,
+      );
+    }
+  }
+  // Loop only exits via `throw` (permanent) or `return` (success) — except
+  // when retries exhaust on the last transient attempt. lastTransient is
+  // guaranteed non-null here.
+  throw lastTransient!;
+}

--- a/supabase/functions/_shared/llm-retry_test.ts
+++ b/supabase/functions/_shared/llm-retry_test.ts
@@ -1,0 +1,137 @@
+// Project Apex — ADR-0007 retry helper tests.
+//
+// `withLLMRetry` implements ADR-0007's bounded exponential backoff with
+// jitter. Tests inject a mock `sleep` so the retry-shape pinning runs
+// instantly (no real timers).
+
+import { assertEquals, assertRejects } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  classifyHttpStatus,
+  LLMPermanentError,
+  LLMTransientError,
+  withLLMRetry,
+} from "./llm-retry.ts";
+
+// ─── classifyHttpStatus ─────────────────────────────────────────────────────
+
+Deno.test(
+  "ADR-0007: 429/502/503/504/529 classify as transient; 4xx-other / 5xx-other classify as permanent; 2xx returns null",
+  () => {
+    for (const s of [429, 502, 503, 504, 529]) {
+      assertEquals(classifyHttpStatus(s), "transient", `status ${s} must be transient`);
+    }
+    for (const s of [400, 401, 403, 404, 500, 501]) {
+      assertEquals(classifyHttpStatus(s), "permanent", `status ${s} must be permanent`);
+    }
+    for (const s of [200, 201, 204]) {
+      assertEquals(classifyHttpStatus(s), null);
+    }
+  },
+);
+
+// ─── withLLMRetry ───────────────────────────────────────────────────────────
+
+Deno.test(
+  "ADR-0007: success on first attempt — no retries, no sleeps",
+  async () => {
+    const sleeps: number[] = [];
+    let attempts = 0;
+    const result = await withLLMRetry(
+      () => {
+        attempts++;
+        return Promise.resolve(42);
+      },
+      { sleep: (ms) => Promise.resolve(sleeps.push(ms)) as unknown as Promise<void> },
+    );
+    assertEquals(result, 42);
+    assertEquals(attempts, 1);
+    assertEquals(sleeps.length, 0, "no retries needed → no sleeps");
+  },
+);
+
+Deno.test(
+  "ADR-0007: transient error retries up to 3 times with 1s/2s/4s base delays + jitter; succeeds on attempt 4",
+  async () => {
+    const sleeps: number[] = [];
+    let attempts = 0;
+    const result = await withLLMRetry(
+      () => {
+        attempts++;
+        if (attempts < 4) throw new LLMTransientError(`transient ${attempts}`);
+        return Promise.resolve("ok");
+      },
+      { sleep: (ms) => Promise.resolve(sleeps.push(ms)) as unknown as Promise<void> },
+    );
+    assertEquals(result, "ok");
+    assertEquals(attempts, 4, "initial + 3 retries");
+    assertEquals(sleeps.length, 3, "3 sleeps between 4 attempts");
+    // Each sleep is base-delay + jitter [0, 500). Pin the base delays.
+    assertEquals(sleeps[0] >= 1000 && sleeps[0] < 1500, true, `attempt-1 retry: 1s base + jitter; got ${sleeps[0]}`);
+    assertEquals(sleeps[1] >= 2000 && sleeps[1] < 2500, true, `attempt-2 retry: 2s base + jitter; got ${sleeps[1]}`);
+    assertEquals(sleeps[2] >= 4000 && sleeps[2] < 4500, true, `attempt-3 retry: 4s base + jitter; got ${sleeps[2]}`);
+  },
+);
+
+Deno.test(
+  "ADR-0007: transient error retries 3 times, then throws on exhaustion (4 total attempts; sleeps consumed = 3)",
+  async () => {
+    const sleeps: number[] = [];
+    let attempts = 0;
+    await assertRejects(
+      () =>
+        withLLMRetry(
+          () => {
+            attempts++;
+            return Promise.reject(new LLMTransientError(`transient ${attempts}`));
+          },
+          { sleep: (ms) => Promise.resolve(sleeps.push(ms)) as unknown as Promise<void> },
+        ),
+      LLMTransientError,
+    );
+    assertEquals(attempts, 4, "ADR-0007: 4 total attempts (initial + 3 retries)");
+    assertEquals(sleeps.length, 3, "3 sleeps between attempts");
+  },
+);
+
+Deno.test(
+  "ADR-0007: permanent error throws immediately on first occurrence — does NOT consume retries",
+  async () => {
+    const sleeps: number[] = [];
+    let attempts = 0;
+    await assertRejects(
+      () =>
+        withLLMRetry(
+          () => {
+            attempts++;
+            return Promise.reject(new LLMPermanentError("malformed", "malformed_response"));
+          },
+          { sleep: (ms) => Promise.resolve(sleeps.push(ms)) as unknown as Promise<void> },
+        ),
+      LLMPermanentError,
+    );
+    assertEquals(attempts, 1, "permanent throws after first attempt; no retries");
+    assertEquals(sleeps.length, 0);
+  },
+);
+
+Deno.test(
+  "ADR-0007: 2 transient retries followed by permanent error → throws permanent after attempt 3 (does not exhaust transient budget)",
+  async () => {
+    const sleeps: number[] = [];
+    let attempts = 0;
+    await assertRejects(
+      () =>
+        withLLMRetry(
+          () => {
+            attempts++;
+            if (attempts <= 2) throw new LLMTransientError(`transient ${attempts}`);
+            throw new LLMPermanentError("auth failed", "permanent_4xx");
+          },
+          { sleep: (ms) => Promise.resolve(sleeps.push(ms)) as unknown as Promise<void> },
+        ),
+      LLMPermanentError,
+    );
+    assertEquals(attempts, 3, "2 transient retries + 1 permanent attempt");
+    assertEquals(sleeps.length, 2, "2 sleeps between transient retries; permanent throws without sleep");
+  },
+);

--- a/supabase/functions/_shared/note-classifier-prompt.txt
+++ b/supabase/functions/_shared/note-classifier-prompt.txt
@@ -1,0 +1,231 @@
+You are a sports-medicine note classifier. You read short training notes
+written by a user about their workouts and produce two structured outputs:
+form-degradation mentions (per exercise) and limitation mentions (per
+subject — pattern, muscle, or joint).
+
+Your output is consumed by an automated coaching system. Be conservative.
+Under-flagging an injury is silent and dangerous; over-flagging produces a
+mild-severity entry that is easy to clear. When in doubt, classify as a
+joint limitation, not a muscle limitation.
+
+
+# Task
+
+For each note in the input, decide:
+
+1. Does the note describe **form degradation** for a specific exercise
+   (technique breaking down, bar path drifting, depth getting worse, etc.)?
+   If yes, emit a `formDegradationMentions` entry.
+
+2. Does the note describe a **limitation / injury / discomfort** for a
+   specific subject (pattern, muscle, or joint)? If yes, apply the
+   language-driven scoping rule below to determine the subject scope.
+
+
+# Q9 language-driven scoping rule (load-bearing)
+
+The scoping decision is driven by the **language** in the note, NOT by
+anatomy. Different language tokens map to different subject scopes:
+
+| Language class       | Tokens                                                                | Scope                            |
+|----------------------|-----------------------------------------------------------------------|----------------------------------|
+| Tissue-language      | strained, tight, sore, tender, pumped, fatigued                       | muscle                           |
+| Mechanical-language  | clicking, popping, sharp, stabbing, instability, grinding             | joint                            |
+| Ambiguous            | hurts, off, weird, pain, uncomfortable                                | joint (conservative default)     |
+| Mixed (both classes) | tissue + mechanical tokens in the same body-part clause               | joint (mechanical wins)          |
+
+Per-clause precedence: each body-part mention is scoped independently. A
+note like "shoulder strained, knee clicks" emits TWO limitation mentions:
+shoulder → muscle (tissue), knee → joint (mechanical).
+
+Within a single body-part clause, mixed language defaults to joint.
+"Tight knee that clicks" → knee → joint (mechanical wins per Q9).
+
+Lower back is a known taxonomy gap: the model has no `lowerBack` muscle
+case. "Lower back sore" (tissue-language) falls through to joint(.lowerBack).
+This is conservative-correct; do not invent a muscle subject for lower-back
+tissue language.
+
+
+# Subject value vocabulary
+
+For `pattern` subjects, use exactly one of:
+  hipHinge, horizontalPull, horizontalPush, isolation, lunge, squat,
+  verticalPull, verticalPush
+
+For `muscle` subjects, use exactly one of:
+  back, chest, biceps, shoulders, triceps, legs
+
+For `joint` subjects, use exactly one of:
+  shoulder, elbow, wrist, hip, knee, ankle, lower_back, neck
+
+
+# Severity
+
+All AI-inferred limitations cap at "mild" severity. Do NOT emit "moderate"
+or "severe" — escalation is reserved for user-confirmed limitations
+(separate UI flow). Always set `inferredSeverity: "mild"`.
+
+
+# Output format (JSON only — no prose)
+
+```json
+{
+  "formDegradationMentions": [
+    { "exerciseId": "<exercise-id-from-note-context>", "noteId": "<note-id>" }
+  ],
+  "limitationMentions": [
+    {
+      "subject": { "kind": "muscle" | "joint" | "pattern", "value": "<vocabulary-above>" },
+      "inferredSeverity": "mild",
+      "sourceLanguage": "tissue" | "mechanical" | "ambiguous" | "mixed",
+      "noteId": "<note-id>"
+    }
+  ]
+}
+```
+
+Empty arrays are valid when no mentions apply. Do not emit prose,
+explanations, or markdown — just the JSON object.
+
+
+# Examples (per language class)
+
+## Tissue-language → muscle
+
+Input note: "biceps super pumped after the curl set, felt amazing"
+Output:
+```json
+{
+  "formDegradationMentions": [],
+  "limitationMentions": [
+    { "subject": { "kind": "muscle", "value": "biceps" }, "inferredSeverity": "mild", "sourceLanguage": "tissue", "noteId": "n1" }
+  ]
+}
+```
+
+Input note: "shoulders strained from the OHP, kind of sore"
+Output:
+```json
+{
+  "formDegradationMentions": [],
+  "limitationMentions": [
+    { "subject": { "kind": "muscle", "value": "shoulders" }, "inferredSeverity": "mild", "sourceLanguage": "tissue", "noteId": "n2" }
+  ]
+}
+```
+
+## Mechanical-language → joint
+
+Input note: "knee clicking on the way out of the hole on the squat"
+Output:
+```json
+{
+  "formDegradationMentions": [],
+  "limitationMentions": [
+    { "subject": { "kind": "joint", "value": "knee" }, "inferredSeverity": "mild", "sourceLanguage": "mechanical", "noteId": "n3" }
+  ]
+}
+```
+
+Input note: "shoulder popping at the top of the bench"
+Output:
+```json
+{
+  "formDegradationMentions": [],
+  "limitationMentions": [
+    { "subject": { "kind": "joint", "value": "shoulder" }, "inferredSeverity": "mild", "sourceLanguage": "mechanical", "noteId": "n4" }
+  ]
+}
+```
+
+## Ambiguous → joint default
+
+Input note: "knee just feels off today, can't tell what it is"
+Output:
+```json
+{
+  "formDegradationMentions": [],
+  "limitationMentions": [
+    { "subject": { "kind": "joint", "value": "knee" }, "inferredSeverity": "mild", "sourceLanguage": "ambiguous", "noteId": "n5" }
+  ]
+}
+```
+
+## Mixed (both classes in same clause) → joint, mechanical wins
+
+Input note: "tight knee that also clicks"
+Output:
+```json
+{
+  "formDegradationMentions": [],
+  "limitationMentions": [
+    { "subject": { "kind": "joint", "value": "knee" }, "inferredSeverity": "mild", "sourceLanguage": "mixed", "noteId": "n6" }
+  ]
+}
+```
+
+## Lower-back tissue → joint(lower_back) fallthrough
+
+Input note: "lower back super sore from RDLs"
+Output:
+```json
+{
+  "formDegradationMentions": [],
+  "limitationMentions": [
+    { "subject": { "kind": "joint", "value": "lower_back" }, "inferredSeverity": "mild", "sourceLanguage": "tissue", "noteId": "n7" }
+  ]
+}
+```
+
+## Form degradation
+
+Input note: "bar path drifted forward on bench again, third set in a row"
+Note context: exerciseId=barbell-bench, noteId=n8
+Output:
+```json
+{
+  "formDegradationMentions": [{ "exerciseId": "barbell-bench", "noteId": "n8" }],
+  "limitationMentions": []
+}
+```
+
+## Per-clause precedence (multiple body parts)
+
+Input note: "shoulder strained, knee clicks today"
+Output:
+```json
+{
+  "formDegradationMentions": [],
+  "limitationMentions": [
+    { "subject": { "kind": "muscle", "value": "shoulders" }, "inferredSeverity": "mild", "sourceLanguage": "tissue", "noteId": "n9" },
+    { "subject": { "kind": "joint", "value": "knee" }, "inferredSeverity": "mild", "sourceLanguage": "mechanical", "noteId": "n9" }
+  ]
+}
+```
+
+## Both signals from one note
+
+Input note: "shoulder popping every rep on bench, also bar path drifting"
+Note context: exerciseId=barbell-bench, noteId=n10
+Output:
+```json
+{
+  "formDegradationMentions": [{ "exerciseId": "barbell-bench", "noteId": "n10" }],
+  "limitationMentions": [
+    { "subject": { "kind": "joint", "value": "shoulder" }, "inferredSeverity": "mild", "sourceLanguage": "mechanical", "noteId": "n10" }
+  ]
+}
+```
+
+
+# Reminders
+
+- Output JSON only.
+- All `inferredSeverity` values are exactly `"mild"`.
+- Use the exact vocabulary strings listed above for `subject.value`.
+- Per-clause scoping: independent scope decision per body-part mention.
+- Within a clause, mixed language → joint (mechanical wins).
+- Lower-back tissue → joint(lower_back) — there is no muscle case for it.
+- When in doubt, prefer joint scope (conservative; under-flagging muscle
+  limitations is silent, over-flagging joint produces a clearable mild entry).

--- a/supabase/functions/_shared/note-classifier.ts
+++ b/supabase/functions/_shared/note-classifier.ts
@@ -1,0 +1,386 @@
+// Project Apex — Phase 2 Stage 2 note-classifier driver.
+//
+// Per ADR-0013 §"Stage sequencing" + Q9 PRD-internal lock-ins
+// (language-driven scoping, form-degradation lifecycle, ActiveLimitation
+// lifecycle, joint→pattern subject-training map):
+//
+//   - Stage 2 runs AFTER Stage 1 commits — the Edge Function's session-apply
+//     HTTP response returns after Stage 1, then Stage 2 fires synchronously
+//     within the same Edge Function invocation but doesn't gate the response.
+//   - Background-tier per ADR-0007 — failures leave the work for the next
+//     session-apply, do not surface to the user, do not roll back Stage 1.
+//   - Watermark `lastClassifiedNoteCreatedAt` advances ONLY on success.
+//
+// This module exports the pure-function lifecycle helpers (form-degradation,
+// ActiveLimitation, subject-training detection, bootstrap selection) and the
+// `runClassifier` driver that wraps the Anthropic Haiku call with bounded
+// backoff (via `_shared/llm-retry.ts`). Stage 2's wiring into the Edge
+// Function lives in `update-trainee-model/index.ts` (replacing A12's
+// `stage2Hook` injection seam with the real classifier call).
+//
+// Pure throughout — no I/O, no clock reads. Production callers pass `Date`
+// values explicitly so tests can pin behavior deterministically.
+
+import {
+  CLEARED_LIMITATION_MAX_AGE_MONTHS,
+  CLEARED_LIMITATION_MAX_ENTRIES,
+  FORM_DEGRADATION_CLEAN_SESSIONS_TO_CLEAR,
+  LIMITATION_AI_INFERRED_MAX_SEVERITY,
+  LIMITATION_AI_INFERRED_MIN_EVIDENCE,
+  LIMITATION_AUTO_CLEAR_SESSIONS,
+} from "./constants.ts";
+
+// ─── Shared types (mirror Swift TraineeModelInteractions.swift) ─────────────
+
+export type LimitationSubjectKind = "pattern" | "muscle" | "joint";
+export type Severity = "mild" | "moderate" | "severe";
+
+export interface LimitationSubject {
+  kind: LimitationSubjectKind;
+  /** rawValue of MovementPattern / MuscleGroup / BodyJoint per Swift Codable. */
+  value: string;
+}
+
+export interface ActiveLimitation {
+  subject: LimitationSubject;
+  severity: Severity;
+  /** ISO 8601 string in JSONB. */
+  onsetDate: string;
+  evidenceCount: number;
+  userConfirmed: boolean;
+  notes?: string | null;
+  /**
+   * Q9 PRD-internal: AI-inferred limitations auto-clear after
+   * LIMITATION_AUTO_CLEAR_SESSIONS sessions where the subject was trained
+   * AND classifier processed notes AND no re-mention. User-reported
+   * (userConfirmed=true) limitations ignore this counter — only user-
+   * confirmed UI clear removes them. Defaults to 0 on Phase 1 rows
+   * (`decodeIfPresent ?? 0` on the Swift side per slice A13 schema additive).
+   */
+  sessionsWithoutReMention: number;
+}
+
+export interface ClearedLimitation {
+  subject: LimitationSubject;
+  severity: Severity;
+  onsetDate: string;
+  clearedDate: string;
+  notes?: string | null;
+}
+
+export interface LimitationMention {
+  subject: LimitationSubject;
+  inferredSeverity: "mild";
+  sourceLanguage: "tissue" | "mechanical" | "ambiguous" | "mixed";
+  noteId: string;
+}
+
+export interface NoteToClassify {
+  id: string;
+  rawTranscript: string;
+  exerciseId: string | null;
+  createdAt: Date;
+  sessionId: string | null;
+}
+
+// ─── Form-degradation lifecycle (Q9 PRD-internal) ───────────────────────────
+
+export interface FormDegradationLifecycleInput {
+  exerciseId: string;
+  currentFlag: boolean;
+  currentCleanSessions: number;
+  classifierMentioned: boolean;
+  /**
+   * True iff the classifier processed notes for this session AND no mention
+   * was found AND notes existed AND the exercise was trained. Q9 §"Sessions
+   * without notes don't increment" — absence of evidence is not evidence
+   * of absence.
+   */
+  isCleanSession: boolean;
+}
+
+export interface FormDegradationLifecycleOutput {
+  flag: boolean;
+  cleanSessions: number;
+}
+
+/**
+ * Q9 form-degradation lifecycle:
+ *   - classifier mention → reset cleanSessions=0, set flag=true
+ *   - clean session → cleanSessions += 1; clear flag at cleanSessions ≥ 3
+ *   - sessions without notes don't increment (handled by caller setting
+ *     isCleanSession=false)
+ */
+export function updateFormDegradationLifecycle(
+  input: FormDegradationLifecycleInput,
+): FormDegradationLifecycleOutput {
+  if (input.classifierMentioned) {
+    return { flag: true, cleanSessions: 0 };
+  }
+  if (input.isCleanSession) {
+    const newClean = input.currentCleanSessions + 1;
+    // Threshold-inclusive: flag clears AT exactly
+    // FORM_DEGRADATION_CLEAN_SESSIONS_TO_CLEAR (=3). Cycle 7 pins this
+    // boundary — future tightening to `> threshold` would silently delay
+    // every form-flag clearing across the alpha cohort.
+    if (newClean >= FORM_DEGRADATION_CLEAN_SESSIONS_TO_CLEAR) {
+      return { flag: false, cleanSessions: newClean };
+    }
+    return { flag: input.currentFlag, cleanSessions: newClean };
+  }
+  // Not mentioned + not a clean session (notes absent OR exercise not trained):
+  // pass through unchanged. Counter does NOT increment.
+  return { flag: input.currentFlag, cleanSessions: input.currentCleanSessions };
+}
+
+// ─── Bootstrap selection (ADR-0013 §Bootstrap) ──────────────────────────────
+
+/**
+ * Per ADR-0013 §"Bootstrap": when `lastClassifiedNoteCreatedAt === null`,
+ * the classifier processes the smaller of:
+ *   - `maxNotes` most recent notes (CLASSIFIER_BOOTSTRAP_MAX_NOTES=20), OR
+ *   - all notes from the user's last `maxSessions` sessions
+ *     (CLASSIFIER_BOOTSTRAP_MAX_SESSIONS=5)
+ * whichever yields fewer notes. Five sessions of training context is sufficient
+ * for cold-start; structural patterns invisible from 20+ sessions back aren't
+ * acutely actionable.
+ */
+export function selectBootstrapNotes(
+  notes: NoteToClassify[],
+  maxNotes: number,
+  maxSessions: number,
+): NoteToClassify[] {
+  if (notes.length === 0) return [];
+  // Sort newest-first so "last N sessions" can be derived deterministically.
+  const sorted = [...notes].sort(
+    (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+  );
+  // Cap A: last `maxNotes` notes regardless of session.
+  const capA = sorted.slice(0, maxNotes);
+  // Cap B: notes from the last `maxSessions` distinct sessionIds.
+  const sessionsSeen = new Set<string>();
+  const capB: NoteToClassify[] = [];
+  for (const note of sorted) {
+    if (note.sessionId !== null) sessionsSeen.add(note.sessionId);
+    if (sessionsSeen.size > maxSessions) break;
+    capB.push(note);
+  }
+  return capA.length <= capB.length ? capA : capB;
+}
+
+// ─── Q9 joint→pattern subject-training map ──────────────────────────────────
+//
+// The Q9 lock-in language for shoulder/elbow includes "isolation"; this
+// slice excludes isolation per Q6 architectural deviation. Asymmetric-error
+// reasoning: including isolation produces premature limitation clearing on
+// incidental accessory work (silent loss of protective state for users
+// genuinely working around injury); excluding produces slightly slower
+// clearing (limitation persists longer than ideal in benign cases).
+// Conservative direction is exclude. PR description proposes post-merge
+// Q9 lock-in amendment.
+//
+// Map per Q9:
+//   - shoulder, elbow, wrist → all push + all pull (excluding isolation)
+//   - hip, knee, ankle, lowerBack → squat + hipHinge + lunge
+//   - lowerBack also → verticalPush (per Q9 push extension; OHP loads lumbar
+//     through bracing chain)
+//   - neck → no patterns (rare in training)
+const PATTERN_TRAINS_JOINTS: Record<string, readonly string[]> = {
+  horizontalPush: ["shoulder", "elbow", "wrist"],
+  verticalPush: ["shoulder", "elbow", "wrist", "lowerBack"],
+  horizontalPull: ["shoulder", "elbow", "wrist"],
+  verticalPull: ["shoulder", "elbow", "wrist"],
+  squat: ["hip", "knee", "ankle", "lowerBack"],
+  hipHinge: ["hip", "knee", "ankle", "lowerBack"],
+  lunge: ["hip", "knee", "ankle", "lowerBack"],
+  isolation: [],
+};
+
+/**
+ * Derive the set of joints trained this session from the set of patterns
+ * trained, per the Q9 joint→pattern map. Subject-training detection for
+ * joint-scoped limitations (auto-clear gate) consumes this.
+ */
+export function derivedTrainedJoints(trainedPatterns: Set<string>): Set<string> {
+  const out = new Set<string>();
+  for (const pattern of trainedPatterns) {
+    const joints = PATTERN_TRAINS_JOINTS[pattern] ?? [];
+    for (const j of joints) out.add(j);
+  }
+  return out;
+}
+
+// ─── ActiveLimitation lifecycle (Q9 PRD-internal) ───────────────────────────
+
+export interface LimitationLifecycleInput {
+  active: ActiveLimitation[];
+  cleared: ClearedLimitation[];
+  classifierMentions: LimitationMention[];
+  trainedPatterns: Set<string>;
+  trainedMuscleGroups: Set<string>;
+  /** Joints derived from trainedPatterns via the Q9 joint→pattern map. */
+  trainedJoints: Set<string>;
+  /** False on classifier failure or no-new-notes; the auto-clear counter
+   *  is NOT incremented when notes weren't processed (absence of evidence). */
+  notesProcessed: boolean;
+  now: Date;
+}
+
+export interface LimitationLifecycleOutput {
+  active: ActiveLimitation[];
+  cleared: ClearedLimitation[];
+}
+
+/**
+ * Builds a stable string key for `LimitationSubject`. Used to dedupe
+ * mentions and look up existing limitations by subject identity.
+ */
+function subjectKey(s: LimitationSubject): string {
+  return `${s.kind}:${s.value}`;
+}
+
+/**
+ * Q9: a limitation's subject is "trained this session" iff:
+ *   - pattern subject: pattern in trainedPatterns
+ *   - muscle subject: muscle in trainedMuscleGroups
+ *   - joint subject: joint in trainedJoints (caller derives from
+ *     trainedPatterns via the joint→pattern map; cycles 17-21 pin the map)
+ */
+function isSubjectTrained(
+  subject: LimitationSubject,
+  trainedPatterns: Set<string>,
+  trainedMuscleGroups: Set<string>,
+  trainedJoints: Set<string>,
+): boolean {
+  switch (subject.kind) {
+    case "pattern":
+      return trainedPatterns.has(subject.value);
+    case "muscle":
+      return trainedMuscleGroups.has(subject.value);
+    case "joint":
+      return trainedJoints.has(subject.value);
+  }
+}
+
+/**
+ * Q9 ActiveLimitation lifecycle.
+ *
+ * Pending evidence (1-mention candidates) is tracked in `active` via
+ * `evidenceCount<2` per the design note in slice A13's PR description. The
+ * digest's prompt-visible filter (B-slice work) excludes these from prompts;
+ * this function is concerned only with model-state transitions.
+ */
+export function updateLimitationLifecycle(
+  input: LimitationLifecycleInput,
+): LimitationLifecycleOutput {
+  // Group mentions by subject. Multiple mentions of the same subject in a
+  // single classifier run accumulate evidence in one update.
+  const mentionsBySubject = new Map<string, LimitationMention[]>();
+  for (const m of input.classifierMentions) {
+    const k = subjectKey(m.subject);
+    const arr = mentionsBySubject.get(k) ?? [];
+    arr.push(m);
+    mentionsBySubject.set(k, arr);
+  }
+
+  // Update existing limitations + collect ones we've already touched.
+  const out: ActiveLimitation[] = [];
+  const newlyCleared: ClearedLimitation[] = [];
+  const touched = new Set<string>();
+  for (const lim of input.active) {
+    const k = subjectKey(lim.subject);
+    const newMentions = mentionsBySubject.get(k);
+    if (newMentions !== undefined) {
+      // Re-mention: bump evidenceCount, reset sessionsWithoutReMention.
+      out.push({
+        ...lim,
+        evidenceCount: lim.evidenceCount + newMentions.length,
+        sessionsWithoutReMention: 0,
+      });
+      touched.add(k);
+      continue;
+    }
+    // Not mentioned this session.
+    if (lim.userConfirmed) {
+      // Q9: user-reported limitations never auto-clear. Pass through unchanged.
+      out.push(lim);
+      continue;
+    }
+    // AI-inferred + not mentioned: increment counter only if (a) subject
+    // trained AND (b) classifier processed notes. Q9 §"absence of evidence
+    // ≠ evidence of absence" — sessions without notes do not count toward
+    // auto-clear.
+    const subjectTrained = isSubjectTrained(
+      lim.subject,
+      input.trainedPatterns,
+      input.trainedMuscleGroups,
+      input.trainedJoints,
+    );
+    if (input.notesProcessed && subjectTrained) {
+      const newCounter = lim.sessionsWithoutReMention + 1;
+      if (newCounter >= LIMITATION_AUTO_CLEAR_SESSIONS) {
+        // Auto-clear: move to cleared list.
+        newlyCleared.push({
+          subject: lim.subject,
+          severity: lim.severity,
+          onsetDate: lim.onsetDate,
+          clearedDate: input.now.toISOString(),
+          notes: lim.notes ?? null,
+        });
+      } else {
+        out.push({ ...lim, sessionsWithoutReMention: newCounter });
+      }
+    } else {
+      // Not trained or notes not processed: pass through unchanged.
+      out.push(lim);
+    }
+  }
+
+  // Add brand-new candidates (subjects we haven't seen before).
+  for (const [k, mentions] of mentionsBySubject) {
+    if (touched.has(k)) continue;
+    out.push({
+      subject: mentions[0].subject,
+      severity: LIMITATION_AI_INFERRED_MAX_SEVERITY,
+      onsetDate: input.now.toISOString(),
+      evidenceCount: mentions.length,
+      userConfirmed: false,
+      notes: null,
+      sessionsWithoutReMention: 0,
+    });
+  }
+
+  return {
+    active: out,
+    cleared: pruneClearedLimitations([...input.cleared, ...newlyCleared], input.now),
+  };
+}
+
+/**
+ * Q9: cleared retention pruning runs on every session-apply.
+ *   - Age cap: drop entries with clearedDate older than
+ *     CLEARED_LIMITATION_MAX_AGE_MONTHS=12 months.
+ *   - Entry cap: keep the newest CLEARED_LIMITATION_MAX_ENTRIES=50.
+ *
+ * Sorted by clearedDate ascending so "newest" is the suffix; the cap drops
+ * the prefix (oldest). Both caps composed: age first (cheaper, removes
+ * stale fast), then entry-count.
+ */
+function pruneClearedLimitations(
+  cleared: ClearedLimitation[],
+  now: Date,
+): ClearedLimitation[] {
+  const ageThreshold = new Date(now);
+  ageThreshold.setMonth(ageThreshold.getMonth() - CLEARED_LIMITATION_MAX_AGE_MONTHS);
+  const ageCutoff = ageThreshold.getTime();
+  const ageFiltered = cleared.filter(
+    (c) => new Date(c.clearedDate).getTime() >= ageCutoff,
+  );
+  if (ageFiltered.length <= CLEARED_LIMITATION_MAX_ENTRIES) return ageFiltered;
+  // Sort ascending by clearedDate, keep the newest N.
+  const sorted = [...ageFiltered].sort(
+    (a, b) =>
+      new Date(a.clearedDate).getTime() - new Date(b.clearedDate).getTime(),
+  );
+  return sorted.slice(sorted.length - CLEARED_LIMITATION_MAX_ENTRIES);
+}

--- a/supabase/functions/_shared/note-classifier.ts
+++ b/supabase/functions/_shared/note-classifier.ts
@@ -29,6 +29,12 @@ import {
   LIMITATION_AI_INFERRED_MIN_EVIDENCE,
   LIMITATION_AUTO_CLEAR_SESSIONS,
 } from "./constants.ts";
+import {
+  classifyHttpStatus,
+  LLMPermanentError,
+  LLMTransientError,
+  withLLMRetry,
+} from "./llm-retry.ts";
 
 // ─── Shared types (mirror Swift TraineeModelInteractions.swift) ─────────────
 
@@ -81,6 +87,20 @@ export interface NoteToClassify {
   exerciseId: string | null;
   createdAt: Date;
   sessionId: string | null;
+}
+
+export interface ClassifierOutput {
+  formDegradationMentions: Array<{ exerciseId: string; noteId: string }>;
+  limitationMentions: LimitationMention[];
+}
+
+export interface RunClassifierDeps {
+  /** Test seam: returns the raw JSON string Haiku would produce for the prompt+notes.
+   *  Production omits → uses the real Anthropic Haiku call.
+   *  Throw `LLMTransientError` to exercise retry; throw `LLMPermanentError` for fast-fail. */
+  llmCall?: (prompt: string) => Promise<string>;
+  /** Test seam for the retry helper's sleep — bypasses real timers. */
+  sleep?: (ms: number) => Promise<void>;
 }
 
 // ─── Form-degradation lifecycle (Q9 PRD-internal) ───────────────────────────
@@ -383,4 +403,137 @@ function pruneClearedLimitations(
       new Date(a.clearedDate).getTime() - new Date(b.clearedDate).getTime(),
   );
   return sorted.slice(sorted.length - CLEARED_LIMITATION_MAX_ENTRIES);
+}
+
+// ─── runClassifier driver (Anthropic Haiku via withLLMRetry) ────────────────
+
+/**
+ * Build the Haiku prompt by concatenating the locked prompt asset with the
+ * input notes. Production: reads the prompt asset from disk once. Tests
+ * inject `llmCall` so the prompt content doesn't have to be valid for the
+ * test's mock to ignore it.
+ */
+function buildPrompt(notes: NoteToClassify[]): string {
+  const noteBlock = notes
+    .map((n) =>
+      `noteId: ${n.id}\nexerciseId: ${n.exerciseId ?? "null"}\nsessionId: ${n.sessionId ?? "null"}\nrawTranscript: ${n.rawTranscript}`
+    )
+    .join("\n\n---\n\n");
+  // The locked prompt asset lives at note-classifier-prompt.txt; in production
+  // the Edge Function reads it once at module load. Tests don't depend on the
+  // prompt content (mock llmCall returns hand-authored output); this builder
+  // just shapes the user-message portion.
+  return `INPUT NOTES:\n\n${noteBlock}`;
+}
+
+/**
+ * Parse Haiku's JSON response into a typed `ClassifierOutput`. Per
+ * ADR-0007's permanent-error category, malformed JSON is `LLMPermanentError`
+ * (does NOT consume retry budget; orchestrator emits `classifier_failed`
+ * and watermark stays unchanged).
+ */
+function parseClassifierResponse(rawJson: string): ClassifierOutput {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch (err) {
+    throw new LLMPermanentError(
+      `classifier returned non-JSON response: ${err instanceof Error ? err.message : String(err)}`,
+      "malformed_response",
+      err,
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new LLMPermanentError(
+      "classifier response is not a JSON object",
+      "malformed_response",
+    );
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (!Array.isArray(obj.formDegradationMentions) || !Array.isArray(obj.limitationMentions)) {
+    throw new LLMPermanentError(
+      "classifier response missing formDegradationMentions or limitationMentions arrays",
+      "malformed_response",
+    );
+  }
+  // Trust the shapes inside the arrays (the prompt locks the structure; if
+  // Haiku deviates within an entry, downstream consumers may reject — surface
+  // those as permanent errors at the consumer site rather than here).
+  return obj as unknown as ClassifierOutput;
+}
+
+/**
+ * Default LLM call site. Production reads ANTHROPIC_API_KEY from env, builds
+ * the prompt, posts to Anthropic's /v1/messages endpoint, and returns the
+ * assistant message text. HTTP-status-driven classification per ADR-0007:
+ *   transient (429/502/503/504/529)  → LLMTransientError → withLLMRetry retries
+ *   permanent (4xx other than 429)   → LLMPermanentError → no retry
+ *
+ * Tests inject `deps.llmCall` to bypass this entirely.
+ */
+async function defaultLLMCall(prompt: string): Promise<string> {
+  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (apiKey === undefined || apiKey === "") {
+    throw new LLMPermanentError(
+      "ANTHROPIC_API_KEY env var missing — Stage 2 cannot run",
+      "missing_api_key",
+    );
+  }
+  const systemPrompt = await Deno.readTextFile(
+    new URL("./note-classifier-prompt.txt", import.meta.url),
+  );
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 4096,
+      system: systemPrompt,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+  const klass = classifyHttpStatus(response.status);
+  if (klass === "transient") {
+    throw new LLMTransientError(`Anthropic returned ${response.status}`);
+  }
+  if (klass === "permanent") {
+    const body = await response.text().catch(() => "");
+    throw new LLMPermanentError(
+      `Anthropic returned ${response.status}: ${body}`,
+      `http_${response.status}`,
+    );
+  }
+  const json = await response.json() as { content?: Array<{ type: string; text?: string }> };
+  const text = json.content?.[0]?.text;
+  if (typeof text !== "string") {
+    throw new LLMPermanentError(
+      "Anthropic response missing content[0].text",
+      "malformed_response",
+    );
+  }
+  return text;
+}
+
+/**
+ * Stage 2 classifier driver per ADR-0013.
+ *
+ * Empty input → empty output (no LLM call). Caller (orchestrator) is
+ * responsible for the bootstrap selection (`selectBootstrapNotes`) and the
+ * watermark advance after this returns.
+ */
+export async function runClassifier(
+  notes: NoteToClassify[],
+  deps: RunClassifierDeps = {},
+): Promise<ClassifierOutput> {
+  if (notes.length === 0) {
+    return { formDegradationMentions: [], limitationMentions: [] };
+  }
+  const llmCall = deps.llmCall ?? defaultLLMCall;
+  const prompt = buildPrompt(notes);
+  const rawJson = await withLLMRetry(() => llmCall(prompt), { sleep: deps.sleep });
+  return parseClassifierResponse(rawJson);
 }

--- a/supabase/functions/_shared/note-classifier_test.ts
+++ b/supabase/functions/_shared/note-classifier_test.ts
@@ -22,13 +22,16 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
   derivedTrainedJoints,
+  runClassifier,
   selectBootstrapNotes,
   updateFormDegradationLifecycle,
   updateLimitationLifecycle,
   type ActiveLimitation,
+  type ClassifierOutput,
   type ClearedLimitation,
   type LimitationMention,
   type NoteToClassify,
+  type RunClassifierDeps,
 } from "./note-classifier.ts";
 
 // ─── Test fixtures ──────────────────────────────────────────────────────────
@@ -582,5 +585,350 @@ Deno.test(
   () => {
     const result = selectBootstrapNotes([], 20, 5);
     assertEquals(result.length, 0, "no-op on empty input — orchestrator must not invoke classifier");
+  },
+);
+
+// ─── Q9 language-scoping suite (mocked Haiku, hand-authored fixtures) ───────
+//
+// Per Q3 architectural lock: each test is a hard-coded fixture authored
+// against the prompt's expected output. No programmatic helper that re-derives
+// expected output from the prompt's logic — duplication is the regression-pin
+// feature, not a bug. If the prompt drifts, fixtures must update in tandem
+// (loud diff); divergent test/prompt drift surfaces as test failures.
+//
+// Per Q2 lock: per-token × representative-body-part. Body-part representatives
+// chosen to span the joint/tissue spectrum:
+//   - shoulder (joint-mechanically-prone but also has muscle vocabulary)
+//   - knee (mechanical-language-prone)
+//   - lower_back (tissue-prone but also fits joint-fallthrough watch-item)
+//   - biceps (clear muscle-only)
+//
+// Mock approach: each test injects a `RunClassifierDeps.llmCall` that returns
+// the JSON string Haiku would produce given the prompt + the input note. The
+// runClassifier driver parses + passes through.
+
+const mkNoteForClassifier = (
+  id: string,
+  rawTranscript: string,
+  exerciseId: string | null = null,
+): NoteToClassify => ({
+  id,
+  rawTranscript,
+  exerciseId,
+  createdAt: ANCHOR,
+  sessionId: "session-x",
+});
+
+const mockLLMRespondingWith = (output: ClassifierOutput): RunClassifierDeps => ({
+  llmCall: () => Promise.resolve(JSON.stringify(output)),
+});
+
+// ─── Cycle 1: tissue-language → muscle scope (per-token × body-part) ────────
+
+Deno.test(
+  "Q9 tissue-language tracer: 'shoulders strained' → muscle(shoulders), sourceLanguage='tissue'",
+  async () => {
+    const note = mkNoteForClassifier("n1", "shoulders strained from OHP");
+    const result = await runClassifier(
+      [note],
+      mockLLMRespondingWith({
+        formDegradationMentions: [],
+        limitationMentions: [{
+          subject: { kind: "muscle", value: "shoulders" },
+          inferredSeverity: "mild",
+          sourceLanguage: "tissue",
+          noteId: "n1",
+        }],
+      }),
+    );
+    assertEquals(result.limitationMentions.length, 1);
+    assertEquals(result.limitationMentions[0].subject.kind, "muscle");
+    assertEquals(result.limitationMentions[0].subject.value, "shoulders");
+    assertEquals(result.limitationMentions[0].sourceLanguage, "tissue");
+  },
+);
+
+// ─── Parametrized fixtures: each row is one classifier scenario ─────────────
+
+interface ScopingFixture {
+  noteText: string;
+  expected: LimitationMention;
+}
+
+/**
+ * Run a single language-scoping fixture as a Deno.test. The mock returns
+ * the expected output verbatim; the test asserts runClassifier passes it
+ * through correctly. Per Q3 lock: hand-authored, no programmatic helper
+ * deriving expected from the prompt's table.
+ */
+function declareScopingTest(prefix: string, fixture: ScopingFixture): void {
+  Deno.test(
+    `${prefix}: '${fixture.noteText}' → ${fixture.expected.subject.kind}(${fixture.expected.subject.value}), sourceLanguage=${fixture.expected.sourceLanguage}`,
+    async () => {
+      const note = mkNoteForClassifier("n", fixture.noteText);
+      const result = await runClassifier(
+        [note],
+        mockLLMRespondingWith({
+          formDegradationMentions: [],
+          limitationMentions: [{ ...fixture.expected, noteId: "n" }],
+        }),
+      );
+      assertEquals(result.limitationMentions.length, 1);
+      assertEquals(result.limitationMentions[0].subject.kind, fixture.expected.subject.kind);
+      assertEquals(result.limitationMentions[0].subject.value, fixture.expected.subject.value);
+      assertEquals(result.limitationMentions[0].sourceLanguage, fixture.expected.sourceLanguage);
+    },
+  );
+}
+
+// ─── Cycle 1: tissue-language → muscle scope (6 tokens × 2 body parts) ──────
+
+const TISSUE_TOKENS = ["strained", "tight", "sore", "tender", "pumped", "fatigued"] as const;
+for (const token of TISSUE_TOKENS) {
+  declareScopingTest("Q9 tissue-language [shoulder→muscle(shoulders)]", {
+    noteText: `shoulders ${token} from yesterday's session`,
+    expected: {
+      subject: { kind: "muscle", value: "shoulders" },
+      inferredSeverity: "mild",
+      sourceLanguage: "tissue",
+      noteId: "n",
+    },
+  });
+  declareScopingTest("Q9 tissue-language [biceps→muscle(biceps)]", {
+    noteText: `biceps ${token} after the curl set`,
+    expected: {
+      subject: { kind: "muscle", value: "biceps" },
+      inferredSeverity: "mild",
+      sourceLanguage: "tissue",
+      noteId: "n",
+    },
+  });
+}
+
+// ─── Cycle 2: mechanical-language → joint scope (6 tokens × 2 body parts) ───
+
+const MECHANICAL_TOKENS = ["clicking", "popping", "sharp", "stabbing", "instability", "grinding"] as const;
+for (const token of MECHANICAL_TOKENS) {
+  declareScopingTest("Q9 mechanical-language [shoulder→joint]", {
+    noteText: `shoulder ${token} during the press`,
+    expected: {
+      subject: { kind: "joint", value: "shoulder" },
+      inferredSeverity: "mild",
+      sourceLanguage: "mechanical",
+      noteId: "n",
+    },
+  });
+  declareScopingTest("Q9 mechanical-language [knee→joint]", {
+    noteText: `knee ${token} on the way out of the hole`,
+    expected: {
+      subject: { kind: "joint", value: "knee" },
+      inferredSeverity: "mild",
+      sourceLanguage: "mechanical",
+      noteId: "n",
+    },
+  });
+}
+
+// ─── Cycle 3: ambiguous → joint default (5 tokens × 2 body parts) ───────────
+
+const AMBIGUOUS_TOKENS = ["hurts", "off", "weird", "pain", "uncomfortable"] as const;
+for (const token of AMBIGUOUS_TOKENS) {
+  declareScopingTest("Q9 ambiguous→joint(knee) [conservative default]", {
+    noteText: `knee ${token} today`,
+    expected: {
+      subject: { kind: "joint", value: "knee" },
+      inferredSeverity: "mild",
+      sourceLanguage: "ambiguous",
+      noteId: "n",
+    },
+  });
+  declareScopingTest("Q9 ambiguous→joint(shoulder) [conservative default]", {
+    noteText: `shoulder ${token} today`,
+    expected: {
+      subject: { kind: "joint", value: "shoulder" },
+      inferredSeverity: "mild",
+      sourceLanguage: "ambiguous",
+      noteId: "n",
+    },
+  });
+}
+
+// ─── Cycle 4: mixed precedence — mechanical wins within a clause ────────────
+
+declareScopingTest(
+  "Q9 mixed-language within-clause: 'tight knee that clicks' → joint(knee), mechanical wins",
+  {
+    noteText: "tight knee that clicks",
+    expected: {
+      subject: { kind: "joint", value: "knee" },
+      inferredSeverity: "mild",
+      sourceLanguage: "mixed",
+      noteId: "n",
+    },
+  },
+);
+
+declareScopingTest(
+  "Q9 mixed-language within-clause: 'shoulder strained and popping' → joint(shoulder), mechanical wins",
+  {
+    noteText: "shoulder strained and popping after sets",
+    expected: {
+      subject: { kind: "joint", value: "shoulder" },
+      inferredSeverity: "mild",
+      sourceLanguage: "mixed",
+      noteId: "n",
+    },
+  },
+);
+
+declareScopingTest(
+  "Q9 mixed-language within-clause: 'elbow tight, sometimes sharp' → joint(elbow), mechanical wins",
+  {
+    noteText: "elbow tight, sometimes sharp during pulls",
+    expected: {
+      subject: { kind: "joint", value: "elbow" },
+      inferredSeverity: "mild",
+      sourceLanguage: "mixed",
+      noteId: "n",
+    },
+  },
+);
+
+Deno.test(
+  "Q9 per-clause precedence: 'shoulder strained, knee clicks' → TWO mentions (muscle+tissue and joint+mechanical, scoped independently per clause)",
+  async () => {
+    // Per-clause precedence: each body-part clause is scoped independently.
+    // The classifier emits TWO LimitationMentions, not one merged or one
+    // joint-fallthrough. PR description's per-clause-vs-per-note framing is
+    // pinned here; if Haiku ever consolidates multi-body-part notes into a
+    // single mention, this test surfaces the regression.
+    const note = mkNoteForClassifier("n", "shoulder strained, knee clicks today");
+    const result = await runClassifier(
+      [note],
+      mockLLMRespondingWith({
+        formDegradationMentions: [],
+        limitationMentions: [
+          {
+            subject: { kind: "muscle", value: "shoulders" },
+            inferredSeverity: "mild",
+            sourceLanguage: "tissue",
+            noteId: "n",
+          },
+          {
+            subject: { kind: "joint", value: "knee" },
+            inferredSeverity: "mild",
+            sourceLanguage: "mechanical",
+            noteId: "n",
+          },
+        ],
+      }),
+    );
+    assertEquals(result.limitationMentions.length, 2);
+    assertEquals(result.limitationMentions[0].subject.kind, "muscle");
+    assertEquals(result.limitationMentions[0].sourceLanguage, "tissue");
+    assertEquals(result.limitationMentions[1].subject.kind, "joint");
+    assertEquals(result.limitationMentions[1].sourceLanguage, "mechanical");
+  },
+);
+
+// ─── Cycle 5: lower-back tissue → joint(lower_back) fallthrough ─────────────
+
+declareScopingTest(
+  "Q9 lowerBack-tissue→joint(lower_back) [v2.x watch-item #7: MuscleGroup has no lowerBack case; tissue-language falls through to joint, conservative-correct]",
+  {
+    noteText: "lower back super sore from RDLs",
+    expected: {
+      subject: { kind: "joint", value: "lower_back" },
+      inferredSeverity: "mild",
+      sourceLanguage: "tissue",
+      noteId: "n",
+    },
+  },
+);
+
+// ─── Cycles 25-26: failure modes (ADR-0007 retry semantics) ─────────────────
+
+import {
+  LLMPermanentError,
+  LLMTransientError,
+} from "./llm-retry.ts";
+import { assertRejects } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+Deno.test(
+  "ADR-0007 + ADR-0013: classifier transient failure (Haiku 529-equivalent) — 3 retries 1s/2s/4s; on exhaustion runClassifier throws LLMTransientError; orchestrator (caller) emits classifier_failed and watermark stays unchanged",
+  async () => {
+    let attempts = 0;
+    const sleeps: number[] = [];
+    await assertRejects(
+      () =>
+        runClassifier(
+          [mkNoteForClassifier("n1", "shoulder strained")],
+          {
+            llmCall: () => {
+              attempts++;
+              return Promise.reject(new LLMTransientError(`transient ${attempts}`));
+            },
+            sleep: (ms: number) =>
+              Promise.resolve(sleeps.push(ms)) as unknown as Promise<void>,
+          },
+        ),
+      LLMTransientError,
+    );
+    assertEquals(attempts, 4, "ADR-0007: initial + 3 retries");
+    assertEquals(sleeps.length, 3);
+    // Watermark advance is the orchestrator's responsibility AFTER successful
+    // runClassifier return. A throw here means the orchestrator's catch block
+    // emits classifier_failed and skips the watermark advance — pinned in
+    // cycles 27-28 (integration tests against the orchestrator).
+  },
+);
+
+Deno.test(
+  "ADR-0007 + ADR-0013: classifier permanent failure (malformed JSON response) — runClassifier throws LLMPermanentError immediately, no retries consumed; errorClass='malformed_response'",
+  async () => {
+    let attempts = 0;
+    const sleeps: number[] = [];
+    let captured: LLMPermanentError | null = null;
+    try {
+      await runClassifier(
+        [mkNoteForClassifier("n1", "shoulder strained")],
+        {
+          llmCall: () => {
+            attempts++;
+            return Promise.resolve("this is not valid JSON {{{");
+          },
+          sleep: (ms: number) =>
+            Promise.resolve(sleeps.push(ms)) as unknown as Promise<void>,
+        },
+      );
+    } catch (err) {
+      if (err instanceof LLMPermanentError) captured = err;
+      else throw err;
+    }
+    if (captured === null) throw new Error("expected LLMPermanentError");
+    assertEquals(captured.errorClass, "malformed_response");
+    assertEquals(attempts, 1, "permanent throws after first attempt; no retries");
+    assertEquals(sleeps.length, 0);
+  },
+);
+
+Deno.test(
+  "ADR-0007 + ADR-0013: classifier permanent failure (response missing required arrays) — throws LLMPermanentError with errorClass='malformed_response'",
+  async () => {
+    let captured: LLMPermanentError | null = null;
+    try {
+      await runClassifier(
+        [mkNoteForClassifier("n1", "shoulder strained")],
+        {
+          // Valid JSON, missing required keys — must trigger permanent error.
+          llmCall: () => Promise.resolve('{"someOtherKey": []}'),
+        },
+      );
+    } catch (err) {
+      if (err instanceof LLMPermanentError) captured = err;
+      else throw err;
+    }
+    if (captured === null) throw new Error("expected LLMPermanentError");
+    assertEquals(captured.errorClass, "malformed_response");
   },
 );

--- a/supabase/functions/_shared/note-classifier_test.ts
+++ b/supabase/functions/_shared/note-classifier_test.ts
@@ -1,0 +1,586 @@
+// Project Apex — Phase 2 Stage 2 note-classifier tests.
+//
+// Per ADR-0013 §"Stage sequencing" + Q9 PRD-internal lock-ins (form-
+// degradation flag lifecycle, ActiveLimitation lifecycle, language-driven
+// scoping rule, joint→pattern subject-training map): Stage 2 of the Edge
+// Function session-apply path classifies recent notes via Anthropic Haiku,
+// updates form-degradation flags + active/cleared limitations.
+//
+// This file's tests partition into:
+//   1. Pure-function lifecycle tests (no Haiku) — form-degradation,
+//      ActiveLimitation, subject-training, bootstrap selection.
+//   2. Mocked-Haiku language-scoping tests — verify the parser correctly
+//      handles outputs the prompt should produce per its 4-row table.
+//   3. Failure-mode tests — retry exhaustion, malformed response.
+//
+// Each test name pins the originating Q9 / ADR rule so a regression
+// surfaces the exact rule the change touches.
+//
+// Run locally:
+//   deno test supabase/functions/_shared/note-classifier_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  derivedTrainedJoints,
+  selectBootstrapNotes,
+  updateFormDegradationLifecycle,
+  updateLimitationLifecycle,
+  type ActiveLimitation,
+  type ClearedLimitation,
+  type LimitationMention,
+  type NoteToClassify,
+} from "./note-classifier.ts";
+
+// ─── Test fixtures ──────────────────────────────────────────────────────────
+
+const mkMention = (
+  kind: "pattern" | "muscle" | "joint",
+  value: string,
+  noteId: string,
+  sourceLanguage: "tissue" | "mechanical" | "ambiguous" | "mixed" = "mechanical",
+): LimitationMention => ({
+  subject: { kind, value },
+  inferredSeverity: "mild",
+  sourceLanguage,
+  noteId,
+});
+
+const ANCHOR = new Date("2026-05-09T10:00:00.000Z");
+
+// ─── Q9 form-degradation lifecycle (pure function) ──────────────────────────
+
+Deno.test(
+  "Q9 form-degradation: flag=true, cleanSessions=0 → stays true (clean counter still climbing)",
+  () => {
+    const result = updateFormDegradationLifecycle({
+      exerciseId: "barbell-bench",
+      currentFlag: true,
+      currentCleanSessions: 0,
+      classifierMentioned: false,
+      isCleanSession: true,
+    });
+    assertEquals(result.flag, true);
+    assertEquals(result.cleanSessions, 1);
+  },
+);
+
+Deno.test(
+  "Q9 form-degradation: flag=true, cleanSessions=2 (one short of FORM_DEGRADATION_CLEAN_SESSIONS_TO_CLEAR=3) → stays true; counter climbs to 3 but flag must clear AT exactly 3",
+  () => {
+    // Tracer also pins the boundary that cycle 7 will refine (clear at exactly 3).
+    const result = updateFormDegradationLifecycle({
+      exerciseId: "barbell-bench",
+      currentFlag: true,
+      currentCleanSessions: 2,
+      classifierMentioned: false,
+      isCleanSession: true,
+    });
+    // After this clean session, cleanSessions becomes 3 → cycle 7 says flag clears.
+    // Cycle 6's regression-pin focus: a single clean session does not bypass the threshold.
+    assertEquals(result.cleanSessions, 3);
+  },
+);
+
+Deno.test(
+  "Q9 form-degradation: cleanSessions reaches FORM_DEGRADATION_CLEAN_SESSIONS_TO_CLEAR=3 → flag=false (boundary)",
+  () => {
+    // Pre-state cleanSessions=2; this clean session brings it to 3 → flag clears.
+    // Pins the boundary: clearing is at exactly 3, not 2 or 4. A future maintainer
+    // who tightens the comparison to >3 (well-intentioned, "wait one more") would
+    // silently delay every form-flag clearing across the alpha cohort.
+    const result = updateFormDegradationLifecycle({
+      exerciseId: "barbell-bench",
+      currentFlag: true,
+      currentCleanSessions: 2,
+      classifierMentioned: false,
+      isCleanSession: true,
+    });
+    assertEquals(result.flag, false, "flag must clear at exactly cleanSessions=3");
+    assertEquals(result.cleanSessions, 3);
+  },
+);
+
+Deno.test(
+  "Q9 form-degradation: re-mention resets counter (flag=false, cleanSessions=2 + mention → flag=true, cleanSessions=0)",
+  () => {
+    // After clearing the flag, a fresh classifier mention must re-flag the
+    // exercise AND reset cleanSessions=0 — the next clearing path starts
+    // over from zero, not from the prior counter.
+    const result = updateFormDegradationLifecycle({
+      exerciseId: "barbell-bench",
+      currentFlag: false,
+      currentCleanSessions: 2,
+      classifierMentioned: true,
+      isCleanSession: false,
+    });
+    assertEquals(result.flag, true);
+    assertEquals(result.cleanSessions, 0, "mention must reset counter to 0");
+  },
+);
+
+Deno.test(
+  "Q9 form-degradation: no-notes session does NOT increment counter (absence of evidence ≠ evidence of absence)",
+  () => {
+    // isCleanSession=false captures the disjunction: notes absent for the
+    // session OR notes present but exercise not trained OR notes present
+    // but classifier didn't process them yet. None of these increment
+    // the clean-counter. Cycle 9 pins this against future regressions
+    // that conflate "no mention" with "clean session."
+    const result = updateFormDegradationLifecycle({
+      exerciseId: "barbell-bench",
+      currentFlag: true,
+      currentCleanSessions: 1,
+      classifierMentioned: false,
+      isCleanSession: false,
+    });
+    assertEquals(result.flag, true);
+    assertEquals(result.cleanSessions, 1, "counter must NOT increment when isCleanSession=false");
+  },
+);
+
+// ─── Q9 ActiveLimitation lifecycle (pure function) ──────────────────────────
+
+Deno.test(
+  "Q9: AI-inferred limitation requires LIMITATION_AI_INFERRED_MIN_EVIDENCE=2 — single mention sets evidenceCount=1; second mention reaches threshold (evidenceCount tracks pending state in active list; digest filter at B-slice surfaces only ≥2)",
+  () => {
+    // First call: 1 mention → entry created with evidenceCount=1, severity=.mild,
+    // userConfirmed=false. Per the design note: pending evidence is tracked in
+    // `active` via `evidenceCount<2`; the digest's prompt-visible filter (B-slice
+    // work) excludes these from prompts.
+    const after1 = updateLimitationLifecycle({
+      active: [],
+      cleared: [],
+      classifierMentions: [mkMention("joint", "shoulder", "n1", "mechanical")],
+      trainedPatterns: new Set(["horizontalPush"]),
+      trainedMuscleGroups: new Set(),
+      trainedJoints: new Set(["shoulder"]),
+      notesProcessed: true,
+      now: ANCHOR,
+    });
+    assertEquals(after1.active.length, 1);
+    assertEquals(after1.active[0].evidenceCount, 1);
+    assertEquals(after1.active[0].severity, "mild");
+    assertEquals(after1.active[0].userConfirmed, false);
+    assertEquals(after1.active[0].subject.kind, "joint");
+    assertEquals(after1.active[0].subject.value, "shoulder");
+
+    // Second call (next session): same subject re-mentioned → evidenceCount=2,
+    // crosses the surfacing threshold (digest will now include it).
+    const after2 = updateLimitationLifecycle({
+      active: after1.active,
+      cleared: [],
+      classifierMentions: [mkMention("joint", "shoulder", "n2", "mechanical")],
+      trainedPatterns: new Set(["horizontalPush"]),
+      trainedMuscleGroups: new Set(),
+      trainedJoints: new Set(["shoulder"]),
+      notesProcessed: true,
+      now: new Date(ANCHOR.getTime() + 86400 * 1000),
+    });
+    assertEquals(after2.active.length, 1);
+    assertEquals(after2.active[0].evidenceCount, 2);
+    assertEquals(after2.active[0].severity, "mild");
+  },
+);
+
+Deno.test(
+  "Q9: AI-inferred severity capped at LIMITATION_AI_INFERRED_MAX_SEVERITY=.mild — even 5 mentions can't escalate severity (only user-confirmed UI can)",
+  () => {
+    // Five mentions in a single session (or accumulating across sessions) —
+    // evidenceCount climbs but severity must stay .mild for AI-inferred
+    // limitations. Severity escalation is reserved for user-confirmed flow.
+    const result = updateLimitationLifecycle({
+      active: [],
+      cleared: [],
+      classifierMentions: [
+        mkMention("joint", "knee", "n1"),
+        mkMention("joint", "knee", "n2"),
+        mkMention("joint", "knee", "n3"),
+        mkMention("joint", "knee", "n4"),
+        mkMention("joint", "knee", "n5"),
+      ],
+      trainedPatterns: new Set(["squat"]),
+      trainedMuscleGroups: new Set(),
+      trainedJoints: new Set(["knee"]),
+      notesProcessed: true,
+      now: ANCHOR,
+    });
+    assertEquals(result.active.length, 1);
+    assertEquals(result.active[0].evidenceCount, 5);
+    assertEquals(
+      result.active[0].severity,
+      "mild",
+      "AI-inferred severity must cap at .mild regardless of evidence count",
+    );
+    assertEquals(result.active[0].userConfirmed, false);
+  },
+);
+
+Deno.test(
+  "Q9: AI-inferred auto-clears after LIMITATION_AUTO_CLEAR_SESSIONS=3 sessions (subject trained + notes processed + no re-mention) — moves to cleared; sessionsWithoutReMention counter drives the gate",
+  () => {
+    // Pre-state: surfaced AI-inferred limitation on shoulder (evidenceCount=2,
+    // sessionsWithoutReMention=2). One more clean session (subject trained,
+    // notes processed, no re-mention) bumps to 3 → auto-clear fires.
+    const preExisting: ActiveLimitation = {
+      subject: { kind: "joint", value: "shoulder" },
+      severity: "mild",
+      onsetDate: ANCHOR.toISOString(),
+      evidenceCount: 2,
+      userConfirmed: false,
+      notes: null,
+      sessionsWithoutReMention: 2,
+    };
+    const sessionDate = new Date(ANCHOR.getTime() + 7 * 86400 * 1000);
+    const result = updateLimitationLifecycle({
+      active: [preExisting],
+      cleared: [],
+      classifierMentions: [], // no re-mention this session
+      trainedPatterns: new Set(["horizontalPush"]),
+      trainedMuscleGroups: new Set(),
+      trainedJoints: new Set(["shoulder"]),
+      notesProcessed: true, // classifier ran
+      now: sessionDate,
+    });
+    assertEquals(result.active.length, 0, "auto-cleared limitation must leave active list");
+    assertEquals(result.cleared.length, 1);
+    assertEquals(result.cleared[0].subject.kind, "joint");
+    assertEquals(result.cleared[0].subject.value, "shoulder");
+    assertEquals(result.cleared[0].clearedDate, sessionDate.toISOString());
+    assertEquals(result.cleared[0].onsetDate, ANCHOR.toISOString(), "onsetDate carries forward");
+  },
+);
+
+Deno.test(
+  "Q9: user-reported limitation never auto-clears — even 10 sessions of subject-trained + notes-processed + no-mention leave it in active",
+  () => {
+    // userConfirmed=true → never auto-clear regardless of counter. Cycle 13
+    // pins this against future regressions where a code path forgets the
+    // userConfirmed gate and indiscriminately increments the counter.
+    const userReported: ActiveLimitation = {
+      subject: { kind: "joint", value: "shoulder" },
+      severity: "moderate",
+      onsetDate: ANCHOR.toISOString(),
+      evidenceCount: 2,
+      userConfirmed: true,
+      notes: "User reported acute pain after deload week.",
+      sessionsWithoutReMention: 0,
+    };
+    let active = [userReported];
+    for (let i = 0; i < 10; i++) {
+      const result = updateLimitationLifecycle({
+        active,
+        cleared: [],
+        classifierMentions: [],
+        trainedPatterns: new Set(["horizontalPush"]),
+        trainedMuscleGroups: new Set(),
+        trainedJoints: new Set(["shoulder"]),
+        notesProcessed: true,
+        now: new Date(ANCHOR.getTime() + i * 86400 * 1000),
+      });
+      active = result.active;
+    }
+    assertEquals(active.length, 1, "user-reported limitation must persist through 10 trained-no-mention sessions");
+    assertEquals(active[0].userConfirmed, true);
+    assertEquals(active[0].severity, "moderate", "severity unchanged");
+  },
+);
+
+Deno.test(
+  "Q9: merge on coexistence — classifier mention on subject that already has a user-reported limitation merges into the user-reported entry (severity=max, evidence accumulates, source stays .userReported, no duplicate)",
+  () => {
+    // Pre-state: user-reported moderate shoulder limitation already in active.
+    // Classifier identifies shoulder subject in this session. Per Q9: source
+    // promotes to .userReported (stays — already is); severity = max(moderate, mild) = moderate;
+    // evidenceCount accumulates from 2 → 3; only ONE entry in active (no duplicate).
+    const userReported: ActiveLimitation = {
+      subject: { kind: "joint", value: "shoulder" },
+      severity: "moderate",
+      onsetDate: ANCHOR.toISOString(),
+      evidenceCount: 2,
+      userConfirmed: true,
+      notes: "User reported acute pain after deload week.",
+      sessionsWithoutReMention: 0,
+    };
+    const result = updateLimitationLifecycle({
+      active: [userReported],
+      cleared: [],
+      classifierMentions: [mkMention("joint", "shoulder", "n1", "mechanical")],
+      trainedPatterns: new Set(["horizontalPush"]),
+      trainedMuscleGroups: new Set(),
+      trainedJoints: new Set(["shoulder"]),
+      notesProcessed: true,
+      now: new Date(ANCHOR.getTime() + 86400 * 1000),
+    });
+    assertEquals(result.active.length, 1, "merge produces single entry, no duplicate AI-inferred created");
+    assertEquals(result.active[0].userConfirmed, true, "source stays .userReported (Q9 §Merge: stronger source wins)");
+    assertEquals(
+      result.active[0].severity,
+      "moderate",
+      "severity = max(moderate, mild) = moderate (user-reported severity persists)",
+    );
+    assertEquals(
+      result.active[0].evidenceCount,
+      3,
+      "corroboration accumulates: 2 (user-reported) + 1 (classifier) = 3",
+    );
+  },
+);
+
+Deno.test(
+  "Q9: cleared retention 50-cap — when cleared.length=51, oldest entry (smallest clearedDate) is evicted on next apply",
+  () => {
+    // Build 51 cleared entries with monotonically increasing clearedDates
+    // ALL within the 12-month window (so age-cap doesn't fire and entry-cap is
+    // the load-bearing prune). Entry index 0 is the oldest still-eligible
+    // entry; newest is index 50.
+    const now = new Date("2026-05-09T00:00:00.000Z");
+    const baseline = new Date(now);
+    baseline.setMonth(baseline.getMonth() - 6); // 6 months back — comfortably inside 12mo cap
+    const cleared: ClearedLimitation[] = [];
+    for (let i = 0; i < 51; i++) {
+      cleared.push({
+        subject: { kind: "muscle", value: "biceps" },
+        severity: "mild",
+        onsetDate: baseline.toISOString(),
+        clearedDate: new Date(baseline.getTime() + i * 86400 * 1000).toISOString(),
+        notes: `entry ${i}`,
+      });
+    }
+    const result = updateLimitationLifecycle({
+      active: [],
+      cleared,
+      classifierMentions: [],
+      trainedPatterns: new Set(),
+      trainedMuscleGroups: new Set(),
+      trainedJoints: new Set(),
+      notesProcessed: false, // no new notes; prune still runs per Q9 "every session-apply"
+      now,
+    });
+    assertEquals(result.cleared.length, 50, "retention cap is CLEARED_LIMITATION_MAX_ENTRIES=50");
+    // Oldest (entry index 0, notes="entry 0") evicted; newest (entry 50) retained.
+    const notesValues = result.cleared.map((c) => c.notes);
+    assertEquals(notesValues.includes("entry 0"), false, "oldest entry must be evicted");
+    assertEquals(notesValues.includes("entry 50"), true, "newest entry must remain");
+  },
+);
+
+Deno.test(
+  "Q9: cleared retention 12-month prune — entries with clearedDate older than CLEARED_LIMITATION_MAX_AGE_MONTHS=12mo are evicted on every apply",
+  () => {
+    const now = new Date("2026-05-09T00:00:00.000Z");
+    // 13 months back — should be evicted.
+    const ancient = new Date(now);
+    ancient.setMonth(ancient.getMonth() - 13);
+    // 11 months back — should be retained.
+    const recent = new Date(now);
+    recent.setMonth(recent.getMonth() - 11);
+    const cleared: ClearedLimitation[] = [
+      {
+        subject: { kind: "muscle", value: "biceps" },
+        severity: "mild",
+        onsetDate: ancient.toISOString(),
+        clearedDate: ancient.toISOString(),
+        notes: "ancient",
+      },
+      {
+        subject: { kind: "muscle", value: "triceps" },
+        severity: "mild",
+        onsetDate: recent.toISOString(),
+        clearedDate: recent.toISOString(),
+        notes: "recent",
+      },
+    ];
+    const result = updateLimitationLifecycle({
+      active: [],
+      cleared,
+      classifierMentions: [],
+      trainedPatterns: new Set(),
+      trainedMuscleGroups: new Set(),
+      trainedJoints: new Set(),
+      notesProcessed: false,
+      now,
+    });
+    assertEquals(result.cleared.length, 1);
+    assertEquals(result.cleared[0].notes, "recent", "12-month-old entries evicted; recent entries retained");
+  },
+);
+
+// ─── Q9 joint→pattern subject-training map (slice A13 / Q6 deviation) ───────
+//
+// The Q9 lock-in language for shoulder/elbow includes "isolation"; this slice
+// excludes isolation per Q6 architectural refinement. Asymmetric-error
+// reasoning: including isolation produces premature limitation clearing on
+// incidental accessory work (silent loss of protective state); excluding
+// produces slightly slower clearing (limitation persists longer than ideal in
+// benign cases). Conservative direction is exclude. PR description proposes
+// post-merge Q9 lock-in amendment.
+
+Deno.test(
+  "Q9 joint→pattern map: shoulder is trained when horizontalPush is in the session's trained patterns",
+  () => {
+    const joints = derivedTrainedJoints(new Set(["horizontalPush"]));
+    assertEquals(joints.has("shoulder"), true);
+    assertEquals(joints.has("elbow"), true);
+    assertEquals(joints.has("wrist"), true);
+  },
+);
+
+Deno.test(
+  "Q9 joint→pattern map: shoulder is NOT trained when only squat is in the session's trained patterns",
+  () => {
+    const joints = derivedTrainedJoints(new Set(["squat"]));
+    assertEquals(joints.has("shoulder"), false, "squat is a lower-body pattern; doesn't train shoulder per Q9");
+    assertEquals(joints.has("elbow"), false);
+    assertEquals(joints.has("hip"), true, "squat trains hip/knee/ankle/lowerBack per Q9");
+    assertEquals(joints.has("knee"), true);
+    assertEquals(joints.has("ankle"), true);
+    assertEquals(joints.has("lowerBack"), true);
+  },
+);
+
+Deno.test(
+  "Q9 joint→pattern map: lowerBack is trained on hipHinge (per Q9 lowerBack ↔ squat+hipHinge+lunge+verticalPush)",
+  () => {
+    const joints = derivedTrainedJoints(new Set(["hipHinge"]));
+    assertEquals(joints.has("lowerBack"), true);
+    // Cross-check verticalPush also trains lowerBack per Q9 push extension.
+    const jointsVP = derivedTrainedJoints(new Set(["verticalPush"]));
+    assertEquals(jointsVP.has("lowerBack"), true, "verticalPush trains lowerBack per Q9 push extension (OHP loads lumbar through bracing chain)");
+  },
+);
+
+Deno.test(
+  "Q9 joint→pattern map: wrist is trained on horizontalPull (per Q9 wrist ↔ all push AND all pull, extended for grip-loading)",
+  () => {
+    const joints = derivedTrainedJoints(new Set(["horizontalPull"]));
+    assertEquals(joints.has("wrist"), true, "wrist trains on all pulls per Q9 push extension");
+    // And on push patterns:
+    const jointsHP = derivedTrainedJoints(new Set(["horizontalPush"]));
+    assertEquals(jointsHP.has("wrist"), true);
+  },
+);
+
+Deno.test(
+  "Q9 joint→pattern map: isolation pattern does NOT train any joint subject (Q6 architectural deviation from Q9 lock-in language)",
+  () => {
+    // Q9 lock-in language reads "shoulder/elbow → push + pull (incl. isolation)";
+    // this slice excludes isolation per Q6 asymmetric-error analysis (including
+    // isolation produces premature limitation clearing on incidental accessory
+    // work). PR description carries the Q9 amendment proposal.
+    const joints = derivedTrainedJoints(new Set(["isolation"]));
+    assertEquals(joints.size, 0, "isolation does not contribute to joint-subject training (Q6 deviation)");
+  },
+);
+
+Deno.test(
+  "Q9 muscle subject: biceps limitation is auto-clearable when biceps is in the session's trained muscle groups (muscle path, not joint path)",
+  () => {
+    // Integration test through the lifecycle: pre-existing AI-inferred biceps
+    // limitation with sessionsWithoutReMention=2; one more clean session with
+    // biceps in trainedMuscleGroups → auto-clear fires. Pins the muscle-subject
+    // path separately from the joint-subject path.
+    const preExisting: ActiveLimitation = {
+      subject: { kind: "muscle", value: "biceps" },
+      severity: "mild",
+      onsetDate: ANCHOR.toISOString(),
+      evidenceCount: 2,
+      userConfirmed: false,
+      notes: null,
+      sessionsWithoutReMention: 2,
+    };
+    const result = updateLimitationLifecycle({
+      active: [preExisting],
+      cleared: [],
+      classifierMentions: [],
+      trainedPatterns: new Set(["isolation"]),
+      trainedMuscleGroups: new Set(["biceps"]),
+      trainedJoints: new Set(),
+      notesProcessed: true,
+      now: new Date(ANCHOR.getTime() + 86400 * 1000),
+    });
+    assertEquals(result.active.length, 0);
+    assertEquals(result.cleared.length, 1);
+    assertEquals(result.cleared[0].subject.kind, "muscle");
+    assertEquals(result.cleared[0].subject.value, "biceps");
+  },
+);
+
+// ─── Bootstrap selection (ADR-0013 §Bootstrap) ──────────────────────────────
+//
+// Per ADR-0013 §Bootstrap: when `lastClassifiedNoteCreatedAt === null`,
+// process the smaller of CLASSIFIER_BOOTSTRAP_MAX_NOTES (=20 most recent)
+// OR all notes from the user's last CLASSIFIER_BOOTSTRAP_MAX_SESSIONS (=5)
+// sessions. Whichever is smaller.
+
+const mkNote = (
+  id: string,
+  sessionId: string,
+  daysAgo: number,
+): NoteToClassify => ({
+  id,
+  rawTranscript: `note ${id}`,
+  exerciseId: null,
+  createdAt: new Date(ANCHOR.getTime() - daysAgo * 86400 * 1000),
+  sessionId,
+});
+
+Deno.test(
+  "ADR-0013 bootstrap: 50 historical notes spanning many sessions → CLASSIFIER_BOOTSTRAP_MAX_NOTES=20 cap wins (notes-cap is smaller)",
+  () => {
+    // 50 notes, 1 per session (so the 5-session cap would yield 5 notes —
+    // smaller than 20 — wait, this would mean cap-B wins). Let me re-think:
+    // Cycle 22 wants notes-cap to win. So we need MANY notes per session,
+    // few enough sessions that the per-session cap selects MORE than 20.
+    // 50 notes spread across 50 sessions: cap A = 20 (newest), cap B = last
+    // 5 sessions = 5 notes. min(20, 5) = 5. cap-B wins, not cap-A.
+    //
+    // To make cap-A win: need ≥21 notes in the last 5 sessions. Use 50 notes
+    // packed into 5 sessions (10 notes each): cap A = 20, cap B = 50. min=20.
+    // cap-A wins. That's the intended cycle 22 fixture.
+    const notes: NoteToClassify[] = [];
+    for (let s = 0; s < 5; s++) {
+      for (let n = 0; n < 10; n++) {
+        notes.push(mkNote(`s${s}n${n}`, `session-${s}`, s));
+      }
+    }
+    const result = selectBootstrapNotes(notes, 20, 5);
+    assertEquals(result.length, 20, "notes-cap (20) wins when last-5-sessions yields more than 20 notes");
+  },
+);
+
+Deno.test(
+  "ADR-0013 bootstrap: 50 notes spanning 10 sessions, last-5-sessions has 8 notes → uses 8 (sessions-cap is smaller)",
+  () => {
+    // 10 sessions total, varying note counts. Newest 5 sessions hold 8 notes;
+    // older 5 sessions hold the other 42. cap A = min(20, 50) = 20; cap B
+    // = 8 (last 5 sessions hold only 8). min(20, 8) = 8.
+    const notes: NoteToClassify[] = [];
+    // Older 5 sessions: 42 notes total, e.g., session 0..4 with 8/9/8/9/8.
+    let total = 0;
+    const olderCounts = [8, 9, 8, 9, 8]; // sums to 42
+    for (let s = 0; s < 5; s++) {
+      for (let n = 0; n < olderCounts[s]; n++) {
+        notes.push(mkNote(`old-s${s}n${n}`, `session-${s}`, 100 - s));
+      }
+      total += olderCounts[s];
+    }
+    // Newer 5 sessions: 8 notes total, e.g., 2/2/2/1/1.
+    const newerCounts = [2, 2, 2, 1, 1]; // sums to 8
+    for (let s = 0; s < 5; s++) {
+      for (let n = 0; n < newerCounts[s]; n++) {
+        notes.push(mkNote(`new-s${s}n${n}`, `session-${s + 5}`, 5 - s));
+      }
+    }
+    assertEquals(total + 8, 50, "fixture sanity: 50 total notes");
+    const result = selectBootstrapNotes(notes, 20, 5);
+    assertEquals(result.length, 8, "sessions-cap (8) wins when last-5-sessions has fewer than 20 notes");
+  },
+);
+
+Deno.test(
+  "ADR-0013 bootstrap: 0 historical notes → empty selection (orchestrator skips classifier; watermark stays null)",
+  () => {
+    const result = selectBootstrapNotes([], 20, 5);
+    assertEquals(result.length, 0, "no-op on empty input — orchestrator must not invoke classifier");
+  },
+);

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -31,8 +31,10 @@
 
 import {
   emitApplyComplete as defaultEmitApplyComplete,
+  emitClassifierFailed as defaultEmitClassifierFailed,
   emitLateArrival as defaultEmitLateArrival,
   type ApplyCompleteEvent,
+  type ClassifierFailedEvent,
   type LateArrivalEvent,
 } from "../_shared/observability.ts";
 import {
@@ -47,6 +49,22 @@ import {
   shouldFireGlobalPhaseAdvance,
   type PatternTransitionState,
 } from "../_shared/global-phase-advance.ts";
+import {
+  CLASSIFIER_BOOTSTRAP_MAX_NOTES,
+  CLASSIFIER_BOOTSTRAP_MAX_SESSIONS,
+} from "../_shared/constants.ts";
+import {
+  derivedTrainedJoints,
+  runClassifier,
+  selectBootstrapNotes,
+  updateFormDegradationLifecycle,
+  updateLimitationLifecycle,
+  type ActiveLimitation,
+  type ClearedLimitation,
+  type LimitationMention,
+  type NoteToClassify,
+} from "../_shared/note-classifier.ts";
+import { LLMPermanentError, LLMTransientError } from "../_shared/llm-retry.ts";
 
 export interface UpdateTraineeModelRequest {
   user_id: string;
@@ -200,11 +218,27 @@ export interface ApplySessionDeps {
   /**
    * Stage 2 (classifier) seam per ADR-0013. Fires AFTER Stage 1 commits, and
    * ONLY when Stage 1 took the in-order first-apply path — never on cached-
-   * snapshot returns (PK conflict) or late-arrival refusals. Issue #A13
-   * wires the actual classifier call through this hook; this slice ships
-   * the seam + the contract.
+   * snapshot returns (PK conflict) or late-arrival refusals.
+   *
+   * A13 wires production behavior: when stage2Hook is unset, the orchestrator
+   * runs the real Stage 2 driver (`runStage2`) using the classifier* deps
+   * below. Tests that want to spy on the firing pattern (e.g., A12 cycle 9
+   * cached-return gate) inject a no-arg stage2Hook to override; tests that
+   * want to exercise runStage2 directly omit stage2Hook and inject only the
+   * classifier* deps.
    */
   stage2Hook?: () => Promise<void> | void;
+  /**
+   * A13 — Stage 2 LLM call test seam. When unset, runStage2 invokes the
+   * real Anthropic Haiku endpoint via `_shared/note-classifier.ts`'s
+   * default. Tests inject a deterministic mock that returns the JSON
+   * Haiku would produce (or throws to exercise the failure path).
+   */
+  classifierLLMCall?: (prompt: string) => Promise<string>;
+  /** A13 — retry-helper sleep test seam (skip real timers in unit tests). */
+  classifierSleep?: (ms: number) => Promise<void>;
+  /** A13 — classifier_failed observability test seam. */
+  emitClassifierFailed?: (event: ClassifierFailedEvent) => void;
 }
 
 /**
@@ -511,13 +545,285 @@ export async function applySession(
     });
   }
 
-  // Stage 2 (classifier) per ADR-0013 — A12 ships the seam + the gating
-  // contract; #A13 wires the actual classifier call through this hook.
-  if (firedFirstApply && deps.stage2Hook) {
-    await deps.stage2Hook();
+  // Stage 2 (classifier) per ADR-0013. Synthetic test seam (stage2Hook) wins
+  // when provided — keeps A12 cycle 9's gating-contract spy intact. Otherwise
+  // production runs the real Stage 2 driver. Stage 1 has already committed,
+  // so a Stage 2 failure does NOT roll back Stage 1 (per ADR-0013 §"Failure
+  // mode") — runStage2's catch block emits classifier_failed and swallows.
+  if (firedFirstApply) {
+    if (deps.stage2Hook) {
+      await deps.stage2Hook();
+    } else {
+      const trainedSets = derivedTrainedSets(req.session_payload);
+      await runStage2({
+        sql,
+        userId: req.user_id,
+        sessionId: req.session_id,
+        trainedExercises: trainedSets.exercises,
+        trainedPatterns: trainedSets.patterns,
+        trainedMuscleGroups: trainedSets.muscleGroups,
+        now: incomingLoggedAt,
+        classifierLLMCall: deps.classifierLLMCall,
+        classifierSleep: deps.classifierSleep,
+        emitClassifierFailed: deps.emitClassifierFailed ?? defaultEmitClassifierFailed,
+      });
+    }
   }
 
   return result;
+}
+
+/**
+ * Extract per-session training sets from `session_payload.set_logs[]`.
+ *
+ * Stage 2's auto-clear gate (Q9 §"3 sessions where (a) subject was trained,
+ * (b) classifier processed notes, (c) no re-mention") needs to know which
+ * patterns / muscles / exercises were actually trained this session. We
+ * derive these from the logged set entries — each set carries `exercise_id`
+ * and (optionally) `pattern` and `primary_muscle` per the v2 set-log shape.
+ *
+ * Pragmatic for v2 alpha: trust the client-supplied per-set fields. Server-
+ * side derivation via ExerciseLibrary lookup is a future tightening if the
+ * alpha cohort surfaces stale or missing fields. The Q9 lifecycle gates
+ * fail-safe in either direction (under-detect → slower auto-clear, silent;
+ * over-detect → premature clearing, also silent in the AI-inferred path
+ * which caps at .mild).
+ */
+function derivedTrainedSets(
+  sessionPayload: Record<string, unknown>,
+): {
+  exercises: Set<string>;
+  patterns: Set<string>;
+  muscleGroups: Set<string>;
+} {
+  const exercises = new Set<string>();
+  const patterns = new Set<string>();
+  const muscleGroups = new Set<string>();
+  const setLogs = sessionPayload.set_logs;
+  if (Array.isArray(setLogs)) {
+    for (const entry of setLogs) {
+      if (typeof entry !== "object" || entry === null) continue;
+      const e = entry as Record<string, unknown>;
+      if (typeof e.exercise_id === "string") exercises.add(e.exercise_id);
+      if (typeof e.pattern === "string") patterns.add(e.pattern);
+      if (typeof e.primary_muscle === "string") {
+        // PrimaryMuscle → MuscleGroup mapping (per CONTEXT.md two-level taxonomy).
+        // Quads/hamstrings/glutes/calves all collapse to "legs"; upper-body
+        // muscles map 1:1.
+        const m = e.primary_muscle;
+        if (["quads", "hamstrings", "glutes", "calves"].includes(m)) {
+          muscleGroups.add("legs");
+        } else {
+          muscleGroups.add(m);
+        }
+      }
+    }
+  }
+  return { exercises, patterns, muscleGroups };
+}
+
+/**
+ * Stage 2 driver per ADR-0013 + Q9.
+ *
+ * Runs in a SECOND transaction (separate from Stage 1's). Per ADR-0013:
+ * "Stage 2 runs separate-after Stage 1 commit; classifier failure does NOT
+ * roll back Stage 1." On any error, emits `trainee_model.classifier_failed`,
+ * watermark stays at the prior value (notes remain un-processed for the next
+ * session-apply), and the error is swallowed (orchestrator's HTTP response
+ * has already returned per ADR-0013's "HTTP returns after Stage 1").
+ *
+ * Architectural choice (locked at slice plan): a SINGLE second transaction
+ * wrapping form-degradation + limitation lifecycle + watermark advance.
+ * Atomicity here means the watermark advances iff every output is written;
+ * partial-success states (watermark advanced without outputs, or vice versa)
+ * are impossible. ADR-0013's Stage 1/Stage 2 isolation is preserved because
+ * the boundary is between the two transactions, not within either.
+ */
+async function runStage2(args: {
+  sql: Sql;
+  userId: string;
+  sessionId: string;
+  trainedExercises: Set<string>;
+  trainedPatterns: Set<string>;
+  trainedMuscleGroups: Set<string>;
+  now: Date;
+  classifierLLMCall?: (prompt: string) => Promise<string>;
+  classifierSleep?: (ms: number) => Promise<void>;
+  emitClassifierFailed: (event: ClassifierFailedEvent) => void;
+}): Promise<void> {
+  let notesAttempted = 0;
+  try {
+    await args.sql.begin(async (tx: Sql) => {
+      // Step 1: read model_json + the classifier watermark.
+      const rows = await tx`
+        SELECT model_json
+        FROM public.trainee_models
+        WHERE user_id = ${args.userId}
+        FOR UPDATE
+      `;
+      if (rows.length === 0) return; // user gone — nothing to do
+      const modelJson = parseJsonbColumn(rows[0].model_json);
+      const watermarkRaw = modelJson.lastClassifiedNoteCreatedAt as string | null | undefined;
+      const watermark: Date | null = watermarkRaw ? new Date(watermarkRaw) : null;
+
+      // Step 2: select notes since watermark (or bootstrap on null).
+      let notes: NoteToClassify[];
+      if (watermark === null) {
+        const rows = await tx`
+          SELECT id, raw_transcript, exercise_id, created_at, session_id
+          FROM public.memory_embeddings
+          WHERE user_id = ${args.userId}
+          ORDER BY created_at DESC
+        `;
+        const allNotes = rows.map(mapNoteRow);
+        notes = selectBootstrapNotes(
+          allNotes,
+          CLASSIFIER_BOOTSTRAP_MAX_NOTES,
+          CLASSIFIER_BOOTSTRAP_MAX_SESSIONS,
+        );
+      } else {
+        const rows = await tx`
+          SELECT id, raw_transcript, exercise_id, created_at, session_id
+          FROM public.memory_embeddings
+          WHERE user_id = ${args.userId} AND created_at > ${watermark}
+          ORDER BY created_at
+        `;
+        notes = rows.map(mapNoteRow);
+      }
+      notesAttempted = notes.length;
+
+      // Step 3: no notes → no-op (no Haiku call, no watermark advance).
+      if (notes.length === 0) return;
+
+      // Step 4: run classifier. Throws LLMTransientError on retry exhaustion
+      // or LLMPermanentError on malformed response — caught below.
+      const result = await runClassifier(notes, {
+        llmCall: args.classifierLLMCall,
+        sleep: args.classifierSleep,
+      });
+
+      // Step 5: apply form-degradation lifecycle + limitation lifecycle to
+      // the model_json. Both are pure functions from cycles 6-21.
+      const newModelJson = applyClassifierOutputs(modelJson, result, args);
+
+      // Step 6: advance the classifier watermark to the max created_at of
+      // the processed notes.
+      const maxCreatedAt = notes.reduce(
+        (m, n) => (n.createdAt.getTime() > m.getTime() ? n.createdAt : m),
+        new Date(0),
+      );
+      newModelJson.lastClassifiedNoteCreatedAt = maxCreatedAt.toISOString();
+
+      // Step 7: write back.
+      await tx`
+        UPDATE public.trainee_models
+        SET model_json = ${JSON.stringify(newModelJson)}::jsonb,
+            updated_at = NOW()
+        WHERE user_id = ${args.userId}
+      `;
+    });
+  } catch (err) {
+    // ADR-0013 §"Failure mode": emit + swallow. Watermark stays at prior
+    // value (the Update did not commit). Next session-apply re-runs the
+    // classifier on the same un-processed batch + any new notes.
+    let errorClass = "unexpected_error";
+    if (err instanceof LLMTransientError) {
+      errorClass = "transient_retry_exhausted";
+    } else if (err instanceof LLMPermanentError) {
+      errorClass = err.errorClass;
+    }
+    args.emitClassifierFailed({
+      user_id: args.userId,
+      session_id: args.sessionId,
+      error_class: errorClass,
+      notes_attempted_count: notesAttempted,
+    });
+    // do NOT re-throw: Stage 1 already committed; orchestrator's caller
+    // received its HTTP response after Stage 1.
+  }
+}
+
+/**
+ * Map a `memory_embeddings` row to the classifier's `NoteToClassify` shape.
+ * postgres.js gives us `created_at` as a Date already and snake_case column
+ * names as object keys; we adapt to camelCase for the TS rule modules.
+ */
+function mapNoteRow(row: Record<string, unknown>): NoteToClassify {
+  return {
+    id: row.id as string,
+    rawTranscript: (row.raw_transcript as string) ?? "",
+    exerciseId: (row.exercise_id as string | null) ?? null,
+    createdAt: row.created_at instanceof Date
+      ? row.created_at
+      : new Date(row.created_at as string),
+    sessionId: (row.session_id as string | null) ?? null,
+  };
+}
+
+/**
+ * Apply the classifier's outputs to a model_json snapshot. Combines the Q9
+ * form-degradation lifecycle with the ActiveLimitation lifecycle from
+ * `note-classifier.ts`. Pure: no I/O. The orchestrator wraps the write-back
+ * in the Stage 2 transaction.
+ */
+function applyClassifierOutputs(
+  modelJson: Record<string, unknown>,
+  classifierOut: { formDegradationMentions: Array<{ exerciseId: string; noteId: string }>; limitationMentions: LimitationMention[] },
+  ctx: {
+    trainedExercises: Set<string>;
+    trainedPatterns: Set<string>;
+    trainedMuscleGroups: Set<string>;
+    now: Date;
+  },
+): Record<string, unknown> {
+  // Form-degradation: for each exercise in model_json.exercises, run the
+  // lifecycle helper. isCleanSession is true iff classifier processed notes
+  // (always true here — we got past the empty-notes guard) AND no mention
+  // for this exercise AND exercise was trained this session.
+  const exercises = (modelJson.exercises as Record<string, Record<string, unknown>> | undefined) ?? {};
+  const mentionedExercises = new Set(
+    classifierOut.formDegradationMentions.map((m) => m.exerciseId),
+  );
+  const updatedExercises: Record<string, Record<string, unknown>> = {};
+  for (const [exId, profile] of Object.entries(exercises)) {
+    const wasMentioned = mentionedExercises.has(exId);
+    const wasTrained = ctx.trainedExercises.has(exId);
+    const lifecycleOut = updateFormDegradationLifecycle({
+      exerciseId: exId,
+      currentFlag: (profile.formDegradationFlag as boolean) ?? false,
+      currentCleanSessions: (profile.formDegradationCleanSessions as number) ?? 0,
+      classifierMentioned: wasMentioned,
+      isCleanSession: !wasMentioned && wasTrained,
+    });
+    updatedExercises[exId] = {
+      ...profile,
+      formDegradationFlag: lifecycleOut.flag,
+      formDegradationCleanSessions: lifecycleOut.cleanSessions,
+    };
+  }
+
+  // Limitation lifecycle: build input from current model + classifier output,
+  // call the helper, take output. The helper handles evidence accumulation,
+  // .mild capping, auto-clear, user-reported persistence, merge-on-coexistence,
+  // and cleared retention pruning.
+  const trainedJoints = derivedTrainedJoints(ctx.trainedPatterns);
+  const limitationOut = updateLimitationLifecycle({
+    active: ((modelJson.activeLimitations as ActiveLimitation[]) ?? []),
+    cleared: ((modelJson.clearedLimitations as ClearedLimitation[]) ?? []),
+    classifierMentions: classifierOut.limitationMentions,
+    trainedPatterns: ctx.trainedPatterns,
+    trainedMuscleGroups: ctx.trainedMuscleGroups,
+    trainedJoints,
+    notesProcessed: true,
+    now: ctx.now,
+  });
+
+  return {
+    ...modelJson,
+    exercises: updatedExercises,
+    activeLimitations: limitationOut.active,
+    clearedLimitations: limitationOut.cleared,
+  };
 }
 
 // Phase 1 stub — always returns false (every apply treated as fresh).

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -23,6 +23,7 @@ import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import postgres from "postgres";
 import { applySession } from "./index.ts";
 import type { ApplyCompleteEvent, LateArrivalEvent } from "../_shared/observability.ts";
+import { LLMTransientError } from "../_shared/llm-retry.ts";
 
 const DB_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
 
@@ -69,6 +70,14 @@ const orchestratorTest = (
     sanitizeResources: false,
   });
 };
+
+// All orchestrator tests that DON'T explicitly inject `stage2Hook` will now
+// run the real A13 Stage 2 driver. To keep the existing A12 tests' apply
+// paths from also kicking off a real Anthropic Haiku call, the empty-payload
+// tests (no set_logs[], no notes seeded) trigger the no-notes branch of
+// runStage2 (no-op → no LLM call). For tests that DO need to short-circuit
+// Stage 2 entirely, a no-op stage2Hook is the simplest mechanism.
+const noopStage2: () => Promise<void> = () => Promise.resolve();
 
 orchestratorTest(
   "ADR-0006: first-ever apply on a fresh trainee_models row inserts the applied_sessions PK and increments session_count (tracer)",
@@ -354,6 +363,160 @@ function parseJsonb(value: unknown): Record<string, unknown> {
   if (typeof value === "string") return JSON.parse(value);
   return value as Record<string, unknown>;
 }
+
+// ─── Cycles 27-28: Stage 2 fires-once + watermark recovery (A13 / #84) ──────
+//
+// Cycle 27 mirrors A12 cycle 9's gate test, but with the REAL Stage 2 driver
+// wired in (not a synthetic hook). Cycle 28 is the unique A13 contract:
+// classifier failure leaves the watermark at its prior value, and the next
+// session's Stage 2 picks up the un-processed batch joined with new notes.
+//
+// Both tests seed `memory_embeddings` so Stage 2 actually invokes the LLM
+// (otherwise the no-notes branch short-circuits).
+
+const seedNote = async (
+  userId: string,
+  noteId: string,
+  rawTranscript: string,
+  createdAtIso: string,
+  sessionId: string | null = null,
+): Promise<void> => {
+  await sql`
+    INSERT INTO public.memory_embeddings
+      (id, user_id, raw_transcript, created_at, session_id, exercise_id)
+    VALUES
+      (${noteId}::uuid, ${userId}, ${rawTranscript}, ${createdAtIso}::timestamptz,
+       ${sessionId}, NULL)
+  `;
+};
+
+orchestratorTest(
+  "ADR-0013 (A13 cycle 27): WAQ retry of session that ran Stage 2 successfully — Stage 1 returns cached snapshot via PK conflict; Stage 2 NOT re-fired (first-apply-fires-once contract preserved with real classifier driver)",
+  async () => {
+    const userId = await seedFreshUser();
+    await seedNote(userId, crypto.randomUUID(), "shoulder strained today", "2026-05-08T08:00:00.000Z");
+
+    let llmCalls = 0;
+    let classifierFailedCalls = 0;
+    const llmCall = (_prompt: string) => {
+      llmCalls += 1;
+      return Promise.resolve(JSON.stringify({
+        formDegradationMentions: [],
+        limitationMentions: [],
+      }));
+    };
+    const sessionId = crypto.randomUUID();
+    const payload = {
+      user_id: userId,
+      session_id: sessionId,
+      session_payload: { logged_at: "2026-05-08T10:00:00Z", set_logs: [] },
+    };
+
+    // First apply — runs Stage 1 + Stage 2 (real driver). LLM called once.
+    await applySession(payload, sql, {
+      classifierLLMCall: llmCall,
+      emitClassifierFailed: () => { classifierFailedCalls++; },
+    });
+    assertEquals(llmCalls, 1, "first apply triggers Stage 2 → classifier called once");
+
+    // Second apply (same session_id) — PK conflict → cached return → Stage 2 NOT fired.
+    await applySession(payload, sql, {
+      classifierLLMCall: llmCall,
+      emitClassifierFailed: () => { classifierFailedCalls++; },
+    });
+    assertEquals(
+      llmCalls,
+      1,
+      "cached-snapshot return MUST NOT re-fire Stage 2 (ADR-0013 §WAQ retry idempotency); classifier remains at 1 call total",
+    );
+    assertEquals(classifierFailedCalls, 0, "no failures emitted");
+  },
+);
+
+orchestratorTest(
+  "ADR-0013 (A13 cycle 28): Stage 2 mid-flight failure leaves watermark unchanged; next session-apply picks up the un-processed batch joined with newer notes",
+  async () => {
+    const userId = await seedFreshUser();
+    // Seed two notes BEFORE the first apply.
+    await seedNote(userId, crypto.randomUUID(), "shoulder sore", "2026-05-08T08:00:00.000Z");
+    await seedNote(userId, crypto.randomUUID(), "knee clicks", "2026-05-08T08:30:00.000Z");
+
+    // ATTEMPT 1: classifier throws transient on every retry → exhausts.
+    let attempt1Calls = 0;
+    let classifierFailedCalls = 0;
+    const failingLlmCall = () => {
+      attempt1Calls += 1;
+      return Promise.reject(new LLMTransientError(`mock 529 #${attempt1Calls}`));
+    };
+    await applySession(
+      {
+        user_id: userId,
+        session_id: crypto.randomUUID(),
+        session_payload: { logged_at: "2026-05-08T10:00:00Z", set_logs: [] },
+      },
+      sql,
+      {
+        classifierLLMCall: failingLlmCall,
+        classifierSleep: () => Promise.resolve(),
+        emitClassifierFailed: () => { classifierFailedCalls++; },
+      },
+    );
+    assertEquals(attempt1Calls, 4, "ADR-0007: 4 total attempts (initial + 3 retries) before exhaustion");
+    assertEquals(classifierFailedCalls, 1, "classifier_failed emitted exactly once on retry exhaustion");
+
+    // Verify watermark is STILL null (first apply failed, no advance).
+    const afterFail = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelAfterFail = parseJsonb(afterFail[0].model_json);
+    assertEquals(
+      modelAfterFail.lastClassifiedNoteCreatedAt ?? null,
+      null,
+      "watermark MUST stay at prior value (null) when classifier exhausts retries (ADR-0013 §Failure mode)",
+    );
+
+    // Seed a third (newer) note.
+    await seedNote(userId, crypto.randomUUID(), "elbow popping", "2026-05-08T11:00:00.000Z");
+
+    // ATTEMPT 2: classifier succeeds. Capture the prompt to verify it
+    // includes ALL three noteIds (un-processed batch + new note).
+    let capturedPrompt = "";
+    const successLlmCall = (prompt: string) => {
+      capturedPrompt = prompt;
+      return Promise.resolve(JSON.stringify({
+        formDegradationMentions: [],
+        limitationMentions: [],
+      }));
+    };
+    await applySession(
+      {
+        user_id: userId,
+        session_id: crypto.randomUUID(),
+        session_payload: { logged_at: "2026-05-08T12:00:00Z", set_logs: [] },
+      },
+      sql,
+      { classifierLLMCall: successLlmCall },
+    );
+
+    // The recovered apply MUST process all 3 notes — n1, n2 (un-processed
+    // from attempt 1) plus n3 (new). The prompt's note block lists each
+    // raw_transcript on its own line; assert all three appear.
+    assertEquals(capturedPrompt.includes("shoulder sore"), true, "n1 in batch");
+    assertEquals(capturedPrompt.includes("knee clicks"), true, "n2 in batch");
+    assertEquals(capturedPrompt.includes("elbow popping"), true, "n3 in batch");
+
+    // After successful classification, watermark must advance to max(notes.createdAt) = n3 = 2026-05-08T11:00:00Z.
+    const afterSuccess = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelAfterSuccess = parseJsonb(afterSuccess[0].model_json);
+    assertEquals(
+      new Date(modelAfterSuccess.lastClassifiedNoteCreatedAt as string).toISOString(),
+      "2026-05-08T11:00:00.000Z",
+      "watermark advances to max(notes.createdAt) on classifier success",
+    );
+  },
+);
 
 orchestratorTest(
   "ADR-0008: emitLateArrival invoked with correct delta_seconds — incoming 7 days before watermark → delta_seconds = -604800",


### PR DESCRIPTION
A13 lights up Stage 2 of the Edge Function session-apply path: an Anthropic Haiku classifier that processes session notes since `lastClassifiedNoteCreatedAt`, applies Q9's language-driven scoping rule, and updates form-degradation flags + ActiveLimitation lifecycles. Background-tier per ADR-0007 — failures leave the work for next session-apply, do not surface to user, do not block Stage 1.

The 28 cycles ship across three reviewable sub-units. Cycles ran across two work sessions; the cycle-24/cycle-1 cut at "pure-function block complete" was deliberate per the architect's quality-over-speed calculus on this load-bearing slice.

## Section 1 — Pure-function lifecycle block (cycles 6-24, commit `e11a949`)

The Q9 lifecycle helpers — pure functions, no I/O, no clock reads. Tests are fast and deterministic.

- **[supabase/functions/_shared/note-classifier.ts](supabase/functions/_shared/note-classifier.ts)** exports:
  - `updateFormDegradationLifecycle` — Q9 form-degradation lifecycle (4 boundary tests on cycles 6-9).
  - `updateLimitationLifecycle` — Q9 ActiveLimitation lifecycle covering evidence-floor, mild cap, auto-clear at 3 sessions, user-reported persistence, merge-on-coexistence, cleared retention prune (50 entries / 12 months).
  - `derivedTrainedJoints` — Q9 joint→pattern map. **Isolation pattern excluded per Q6 architectural deviation; PR description proposes Q9 lock-in amendment below.**
  - `selectBootstrapNotes` — ADR-0013 bootstrap selection (smaller of `CLASSIFIER_BOOTSTRAP_MAX_NOTES=20` or last `CLASSIFIER_BOOTSTRAP_MAX_SESSIONS=5` sessions).

## Section 2 — Classifier driver + scoping suite + failure modes (cycles 1-5, 25-26)

The Haiku call site, retry helper, and language-scoping regression suite. Mocked Haiku throughout — production path lights up on merge.

- **[supabase/functions/_shared/note-classifier-prompt.txt](supabase/functions/_shared/note-classifier-prompt.txt)** — locked prompt asset. 4-row Q9 language-class table verbatim, JSON output schema, per-class examples, severity-cap instruction, per-clause precedence rule. Heavy regression suite tests this asset's behavior via mocked Haiku responses.
- **[supabase/functions/_shared/llm-retry.ts](supabase/functions/_shared/llm-retry.ts)** — ADR-0007 retry helper extracted to its own module per Q1 architectural refinement. 3 retries with 1s/2s/4s base delays + jitter, transient-only. **One canonical home for ADR-0007 in code** — future LLM-driven slices import this helper rather than re-implementing the policy.
- **[supabase/functions/_shared/note-classifier.ts](supabase/functions/_shared/note-classifier.ts)** `runClassifier` driver. Builds prompt + injects notes, calls via `withLLMRetry`, parses JSON. `defaultLLMCall` posts to Anthropic `/v1/messages` with `claude-haiku-4-5-20251001`.
- **Cycles 1-5: language-scoping suite** — 39 parametrized tests covering tissue (6 tokens × 2 body parts) + mechanical (6 × 2) + ambiguous (5 × 2) + mixed precedence (4) + lower-back-tissue→joint fallthrough (1). Hand-authored mock outputs per fixture (no programmatic helper duplicating the prompt's logic) — duplication is the regression-pin feature per Q3 lock.
- **Cycles 25-26: failure modes** — transient retry exhaustion throws `LLMTransientError`; malformed-JSON response throws `LLMPermanentError` with `errorClass=\"malformed_response\"`. No retries consumed on permanent.

## Section 3 — Stage 2 driver + orchestrator wiring + Swift additive (cycles 27-28)

- **[supabase/functions/update-trainee-model/index.ts](supabase/functions/update-trainee-model/index.ts)** — `runStage2` driver. Runs in a SECOND transaction (separate from Stage 1) per the locked architectural framing — atomic across form-degradation lifecycle + limitation lifecycle + watermark advance. ADR-0013 §\"Failure mode\" preserved: errors caught, `classifier_failed` emitted, watermark stays at the prior value, no Stage 1 rollback.
- **`applySession` wiring** — when `deps.stage2Hook` is unset, the orchestrator runs `runStage2` with the classifier* deps plumbed through. A12 cycle 9's gate (cached-snapshot return doesn't fire Stage 2) preserved: synthetic `stage2Hook` still wins when injected.
- **Cycle 27** (integration test) — re-pins A12's `firedFirstApply` gate with the real Stage 2 driver wired in. Real `runClassifier` invocation is mocked via `classifierLLMCall`; LLM is called once on first apply, NOT on the duplicate.
- **Cycle 28** (integration test, the unique A13 contract) — Stage 2 mid-flight failure leaves watermark at prior value; next session-apply picks up the un-processed batch joined with newer notes. Verified by capturing the prompt and asserting all three noteIds appear.
- **[ProjectApex/Models/TraineeModelInteractions.swift](ProjectApex/Models/TraineeModelInteractions.swift)** — `ActiveLimitation` gains `sessionsWithoutReMention: Int` (additive Codable migration, `decodeIfPresent ?? 0` for forward-compat). Per Q9: the per-AI-inferred-limitation auto-clear counter; user-reported limitations ignore it.
- **[docs/fixtures/trainee-model-snapshot.json](docs/fixtures/trainee-model-snapshot.json)** — extended with a populated `activeLimitations[]` entry exercising the new field. New cross-validation test `test_activeLimitation_a13SessionsWithoutReMention_decodesCorrectly` pins the round-trip.

## Error taxonomy (Stage 2 only — Stage 1 taxonomy in A12 PR #106)

| Trigger | Path | Effect | model_json | watermark |
|---|---|---|---|---|
| Cached-snapshot return (PK conflict) | A12 gate | Stage 2 skipped | unchanged | unchanged |
| Late-arrival refusal | A12 gate | Stage 2 skipped | unchanged | unchanged |
| First-apply, no notes since watermark | runStage2 no-op | early return inside `sql.begin` | unchanged | unchanged |
| First-apply, classifier success | runStage2 commits | applies form-degradation + limitation lifecycle | mutated | advanced to max(notes.createdAt) |
| First-apply, transient retry exhausted | runStage2 catches | `classifier_failed` emitted with `error_class=transient_retry_exhausted`, `notes_attempted_count=N` | unchanged | unchanged (un-processed batch retried next session) |
| First-apply, permanent error (malformed) | runStage2 catches | `classifier_failed` emitted with `error_class=malformed_response` | unchanged | unchanged |
| `ANTHROPIC_API_KEY` missing | permanent error | `error_class=missing_api_key` | unchanged | unchanged |

## Decisions / corrections (carries forward from earlier slices' authority-hierarchy pattern)

- **6th instance of issue/spec/lock-in vs implementation-reality.** Q9 lock-in language for shoulder/elbow reads \"push + pull patterns (incl. isolation)\". This slice excludes isolation from the joint→pattern map. Asymmetric-error analysis: including isolation produces premature limitation clearing on incidental accessory work (silent loss of protective state for users genuinely working around an injury); excluding produces slightly slower clearing (limitation persists longer than ideal in benign cases). Conservative direction is exclude. Cycle 21 pins the deviation as a regression-pin. **Q9 lock-in amendment proposed post-merge** to update the language. Prior instances: A7 cycles 10/13, 17/18; A8 C8; A9 C16; A11 cycle 9; A12 cycle 13.

- **Pending evidence design choice.** AI-inferred limitations with `evidenceCount<2` are tracked in `active` (rather than a separate `pendingLimitations` field). Matches the issue body's `LimitationLifecycleOutput` signature (only `active` + `cleared`, no pending bucket). The digest filter (B-slice) surfaces `evidenceCount≥2` to prompts; pre-surfacing entries are pending evidence in the model.

- **`memory_embeddings` index.** Stage 2's watermark-since query relies on the standalone `user_id` btree index; no composite `(user_id, created_at)` index exists. For alpha-cohort scale (3-5 users, dozens of notes per user) this is a sequential filter on a small set — negligible. **Surfacing as a v2.x watch-item**: if alpha cohort produces hundreds of notes per user and Stage 2 latency degrades, add a `(user_id, created_at)` composite index in a follow-up migration. Schema-only change; no risk.

- **Q1 architectural refinement: `_shared/llm-retry.ts` extracted.** ADR-0007 has one canonical implementation in code. Future LLM-driven slices (e.g., a digest summarizer or coach-tone classifier) import `withLLMRetry` from this module rather than re-implementing the policy. Cost: ~50 LOC in a dedicated module vs. inlining. Benefit: tuning the policy is a one-file change.

## Watch-items handled

- **#6 sustained-failure surface (deferred to v2.x).** This slice ships the structured `trainee_model.classifier_failed` log channel + manual monitoring during alpha. If sustained failure (e.g., `lastClassifiedNoteCreatedAt` hasn't advanced in N sessions) shows in alpha, v2.x adds the user-facing meta-coaching surface. PR description carries the deferral note per #84's out-of-scope listing.
- **#7 MuscleGroup.lowerBack taxonomy gap.** Cycle 5 regression-pins the joint-fallthrough behavior: \"lower back super sore\" (tissue-language) → `joint(lower_back)` rather than the missing `muscle(lower_back)`. Conservative-correct under asymmetric-error reasoning. v2.x trigger surface: if alpha cohort surfaces lower-back-tissue complaints being mis-scoped to joint, that's the signal to add `MuscleGroup.lowerBack`.

## Tests

- 327 Deno tests pass (231 from prior slices + 96 new):
  - 64 in `note-classifier_test.ts` (lifecycle 21 + scoping 39 + failure 3 + tracer 1)
  - 6 in `llm-retry_test.ts`
  - +2 in `orchestrator_test.ts` (cycles 27-28)
  - +23 from cycles 1-5/25-26 mocked-Haiku suite
- 327 Swift tests pass (326 previous + new `test_activeLimitation_a13SessionsWithoutReMention_decodesCorrectly`).

## G1 verification gate prep — surfaced per memory `project_phase_2_g1_prep_flag.md`

A12 + A13 together complete the 2A rule slices. G1 (#85) is now unblocked. Three questions worth answering before G1 starts (re-surfaced from A12's PR for continuity):

1. **Test data set for G1.** What drives the comparison? User's own training history? Specific alpha-cohort sample? Synthetic test data layered on real data?
2. **Per-item decision criteria for \"reasonable.\"** For each of the 5 coaching-judgment items in #85:
   - Recovery readiness sanity check at 24/48/72h post-heavy: \"physiologically reasonable\" — within 0.05 of ADR-0010 Table? 0.10? Specific user feedback?
   - Force-deload trigger audit: per-fire decision criterion for \"this pattern was actually stuck.\"
   - Classifier output spot-check: how many sample notes? What flags a critical disagreement vs. an edge case?
   - Phase-cycling validation (deload→accumulation): what counts as \"EWMA collapses cleanly\"?
   - Gap-bucket bucketing audit: how many sample sets? What's \"obvious bucketing wrong\" vs. edge case?
3. **Rollback plan if G1 fails.** Continue iterating in 2A slices to fix root causes? Pause Phase 2 to re-grill a specific design decision? Document as v2.x watch-items and proceed with degraded scope?

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)