### PR TITLE
feat(slice-A14/#109): wire handleRequest → applySession + bootstrap UPSERT + JSONB encoding fix

### DIFF
--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -29,6 +29,7 @@
 //   - ADR-0013 (Stage 2 separation)
 //   - docs/agents/edge-functions.md (secrets, deploy, local dev)
 
+import postgres from "postgres";
 import {
   emitApplyComplete as defaultEmitApplyComplete,
   emitClassifierFailed as defaultEmitClassifierFailed,
@@ -513,13 +514,31 @@ export async function applySession(
 
     // Step 5: write back + advance watermark (ADR-0008 §"In-order").
     // session_count drives ADR-0012's 6-session-window cooldown.
+    //
+    // UPSERT (not plain UPDATE): a fresh user has no trainee_models row,
+    // and there is no separate bootstrap path in production — the row is
+    // created on first session-apply. Plain UPDATE would no-op on the
+    // first apply and silently leave the model un-persisted (caught by
+    // G1 verification gate). ON CONFLICT (user_id) preserves the
+    // semantics for the common case (row exists) while letting the
+    // first-ever apply create it.
+    // Use tx.json(...) — postgres.js's typed JSONB parameter helper. The
+    // older `${JSON.stringify(obj)}::jsonb` pattern double-encodes (the
+    // driver re-quotes the string as a JSON value), storing the model
+    // as a scalar JSON string instead of an object. The bug was latent
+    // in this slice's predecessor UPDATE because no production HTTP path
+    // exercised the write step until G1.
     await tx`
-      UPDATE public.trainee_models
-      SET session_count = ${newSessionCount},
-          last_applied_logged_at = ${incomingLoggedAt},
-          model_json = ${JSON.stringify(newModelJson)}::jsonb,
-          updated_at = NOW()
-      WHERE user_id = ${req.user_id}
+      INSERT INTO public.trainee_models
+        (user_id, session_count, last_applied_logged_at, model_json, updated_at)
+      VALUES
+        (${req.user_id}, ${newSessionCount}, ${incomingLoggedAt},
+         ${tx.json(newModelJson)}, NOW())
+      ON CONFLICT (user_id) DO UPDATE
+        SET session_count = EXCLUDED.session_count,
+            last_applied_logged_at = EXCLUDED.last_applied_logged_at,
+            model_json = EXCLUDED.model_json,
+            updated_at = EXCLUDED.updated_at
     `;
 
     firedFirstApply = true;
@@ -826,15 +845,23 @@ function applyClassifierOutputs(
   };
 }
 
-// Phase 1 stub — always returns false (every apply treated as fresh).
-// Phase 2 (#83 / A12) replaced this with applySession's PK insert above.
-// Retained as a callable boundary so handleRequest's existing structure
-// can route through applySession without restructuring.
-async function checkAlreadyApplied(
-  _userId: string,
-  _sessionId: string,
-): Promise<boolean> {
-  return false;
+// Lazy module-level postgres client per ADR-0006. Edge Functions cold-start;
+// production deploy uses Supabase's pgbouncer endpoint via SUPABASE_DB_URL
+// (see docs/agents/edge-functions.md §Decisions for connection-string
+// policy). Tests bypass this by injecting an Sql client directly into
+// `applySession` via deps.
+let cachedSql: Sql | undefined;
+function getSql(): Sql {
+  if (cachedSql) return cachedSql;
+  const url = Deno.env.get("SUPABASE_DB_URL");
+  if (!url) {
+    throw new Error(
+      "SUPABASE_DB_URL env var must be set to invoke applySession from " +
+        "the HTTP path (see docs/agents/edge-functions.md)",
+    );
+  }
+  cachedSql = postgres(url);
+  return cachedSql;
 }
 
 export async function handleRequest(req: Request): Promise<Response> {
@@ -854,23 +881,26 @@ export async function handleRequest(req: Request): Promise<Response> {
     return jsonResponse({ error: validated.error }, 400);
   }
 
-  const { user_id, session_id } = validated;
-
-  if (await checkAlreadyApplied(user_id, session_id)) {
-    // Phase 2: SELECT model_json FROM trainee_models WHERE user_id = $1
-    //          and return that snapshot rather than the empty default.
-    return jsonResponse({ trainee_model: {} }, 200);
+  let sql: Sql;
+  try {
+    sql = getSql();
+  } catch (e) {
+    return jsonResponse(
+      { error: e instanceof Error ? e.message : "DB unavailable" },
+      500,
+    );
   }
 
-  // Phase 2: rule logic plugs in here.
-  // Reads previous trainee_models.model_json + session_payload, runs the
-  // update routine (EWMA, transition mode, two-dimensional recovery,
-  // fatigue-interaction confidence, prescription accuracy, transfer
-  // regression, etc. — see ADR-0005), writes the updated row + the
-  // idempotency record in a single transaction (see ADR-0006 §2),
-  // returns the updated snapshot.
-
-  return jsonResponse({ trainee_model: {} }, 200);
+  try {
+    const result = await applySession(validated, sql, {});
+    return jsonResponse(result, 200);
+  } catch (e) {
+    console.error("[update-trainee-model] applySession failed:", e);
+    return jsonResponse(
+      { error: e instanceof Error ? e.message : "internal error" },
+      500,
+    );
+  }
 }
 
 // Only boot the server when this module is invoked as the entrypoint —

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -117,6 +117,51 @@ orchestratorTest(
 );
 
 orchestratorTest(
+  "first apply against empty trainee_models bootstraps the row (UPSERT) — production HTTP path drives the orchestrator without a separate bootstrap step",
+  async () => {
+    // Seed users row only — DO NOT pre-INSERT trainee_models. Mirrors the
+    // production case where handleRequest receives the first-ever apply.
+    const userId = crypto.randomUUID();
+    await sql`
+      INSERT INTO public.users (id, display_name)
+      VALUES (${userId}, ${"orchestrator-bootstrap-" + userId.slice(0, 8)})
+    `;
+
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-08T10:00:00Z";
+
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: { logged_at: loggedAt, set_logs: [] },
+      },
+      sql,
+    );
+
+    assertEquals(result.late_arrival, false);
+
+    // The row was created by the UPSERT.
+    const model = await sql`
+      SELECT user_id, session_count, last_applied_logged_at, model_json,
+             jsonb_typeof(model_json) AS model_json_type
+      FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    assertEquals(model.length, 1);
+    assertEquals(model[0].session_count, 1);
+    assertEquals(
+      (model[0].last_applied_logged_at as Date).toISOString(),
+      new Date(loggedAt).toISOString(),
+    );
+    // model_json must round-trip as an object, not a scalar JSON string.
+    // (The pre-fix `${JSON.stringify(...)}::jsonb` pattern stored
+    // `"{\"patterns\":{}}"` — a scalar — which would silently break every
+    // downstream consumer that calls `model_json -> 'patterns'`.)
+    assertEquals(model[0].model_json_type, "object");
+  },
+);
+
+orchestratorTest(
   "ADR-0006 §2: second apply with same (user_id, session_id) returns cached snapshot — model_json unchanged, session_count unchanged",
   async () => {
     const userId = await seedFreshUser();


### PR DESCRIPTION
## Summary

- Three production-HTTP-path wiring gaps surfaced by G1 (#85) on its first end-to-end replay run against single-user historical data, all latent before G1 because no production caller exercised the HTTP path end-to-end.
- `handleRequest` now invokes `applySession` (was a Phase 1 stub); `applySession` UPSERTs the `trainee_models` row (was UPDATE-only, no-op'd on first apply); model_json writes use `tx.json(...)` (was `${JSON.stringify(obj)}::jsonb`, double-encoded as a scalar JSON string).
- Out of scope, filed as #110 (slice A15): pattern profile bootstrap from `session_payload`. G1 remains paused on `gate/phase-2-verification` pending #110.

## Changes

### `supabase/functions/update-trainee-model/index.ts`

- `import postgres from \"postgres\"` + lazy module-level `getSql()` factory reading `Deno.env.get(\"SUPABASE_DB_URL\")`
- `handleRequest`: validates body, constructs Sql client, invokes `applySession(validated, sql, {})`, returns the result; errors map to HTTP 500 with diagnostic body
- Removed orphaned `checkAlreadyApplied` Phase 1 stub
- `applySession`'s final write: `UPDATE` → `INSERT ... ON CONFLICT (user_id) DO UPDATE` using `tx.json(newModelJson)` for JSONB encoding

### `supabase/functions/update-trainee-model/orchestrator_test.ts`

- New test: \"first apply against empty trainee_models bootstraps the row (UPSERT) — production HTTP path drives the orchestrator without a separate bootstrap step\"
- Seeds users row only (no pre-INSERT to trainee_models, mirroring production); asserts session_count=1, watermark advances, and `jsonb_typeof(model_json) = 'object'` (would have caught the encoding bug)

## Test plan

- [x] `deno test --allow-net --allow-env --allow-read` against local Supabase — 26 passed, 0 failed (was 25 pre-fix; +1 new bootstrap test)
- [x] G1 single-user replay re-run end-to-end against the wired EF: 19/19 sessions OK, late=0, failed=0; verified `trainee_models` row has `session_count=19`, `last_applied_logged_at` advances correctly, `jsonb_typeof(model_json) = 'object'`
- [x] 19 dedupe rows in `trainee_model_applied_sessions` (idempotency PK confirms applySession's transaction ran)

## Closes

- Closes #109

## Cross-references

- #85 (G1 — surfaced these gaps; G1 paused on `gate/phase-2-verification` until #110 also lands)
- #110 (A15 — pattern profile bootstrap; the next blocker for G1 resume)
- #83 (A12 — Stage 1 orchestrator; this slice completes the production wiring A12 implied but didn't ship)

🤖 Generated with [Claude Code](https://claude.com/claude-code)