### PR TITLE
feat(slice-A17/#116): wire ewma-engine — populate ExerciseProfile.e1rmCurrent

### DIFF
--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -32,6 +32,10 @@
 import postgres from "postgres";
 import { lookupPattern } from "../_shared/exercise-library.ts";
 import {
+  computeE1RM,
+  type TopSet as EwmaTopSet,
+} from "../_shared/ewma-engine.ts";
+import {
   emitApplyComplete as defaultEmitApplyComplete,
   emitClassifierFailed as defaultEmitClassifierFailed,
   emitLateArrival as defaultEmitLateArrival,
@@ -284,6 +288,121 @@ function sessionsCadenceDays(recentSessionDates: string[]): number | null {
  * assertion-cycle here. The pipeline framework supports adding them later
  * by extending this loop.
  */
+/**
+ * Per-exercise rule pipeline per #116 (A17). Each ExerciseProfile carries
+ * its own top-set history + EWMA estimate per ADR-0005's ExerciseProfile
+ * shape. Production bootstrap (no separate path elsewhere): create a fresh
+ * profile when the user trains an exercise for the first time.
+ *
+ * Slice scope: A17 ships ewma-engine wiring. Other ExerciseProfile fields
+ * (e1rmMedian, e1rmPeak, formDegradationFlag, confidence) are owned by
+ * subsequent slices that extend this loop.
+ */
+function applyPerExerciseRules(
+  exercises: Record<string, Record<string, unknown>>,
+  setLogs: Array<Record<string, unknown>>,
+  incomingLoggedAt: Date,
+  sessionId: string,
+): {
+  exercises: Record<string, Record<string, unknown>>;
+  rulesFired: Set<string>;
+  fieldsChanged: string[];
+} {
+  const rulesFired = new Set<string>();
+  const fieldsChanged: string[] = [];
+
+  // Group sets by exercise_id; keep a single Map<exerciseId, sets> in
+  // session_payload order so multi-set sessions (5×5 etc.) iterate the
+  // hardest top set last (per ADR-0005's heaviest-per-session convention).
+  const setsByExercise = new Map<string, Array<Record<string, unknown>>>();
+  for (const entry of setLogs) {
+    const exerciseId = entry.exercise_id;
+    if (typeof exerciseId !== "string") continue;
+    const list = setsByExercise.get(exerciseId) ?? [];
+    list.push(entry);
+    setsByExercise.set(exerciseId, list);
+  }
+
+  const merged: Record<string, Record<string, unknown>> = { ...exercises };
+
+  // Bootstrap any exercise trained this session that doesn't yet have a
+  // profile. ADR-0005 ExerciseProfile defaults — only the fields A17 owns
+  // are meaningful here; other fields populate as their slices wire.
+  for (const exerciseId of setsByExercise.keys()) {
+    if (!(exerciseId in merged)) {
+      merged[exerciseId] = {
+        exerciseId,
+        topSets: [],
+        sessionSnapshots: [],
+        e1rmCurrent: 0,
+        e1rmMedian: 0,
+        e1rmPeak: 0,
+        sessionCount: 0,
+        formDegradationFlag: false,
+        confidence: "bootstrapping",
+        formDegradationCleanSessions: 0,
+      };
+      fieldsChanged.push(`exercises.${exerciseId}.bootstrapped`);
+    }
+  }
+
+  const newExercises: Record<string, Record<string, unknown>> = {};
+
+  for (const [exerciseId, profile] of Object.entries(merged)) {
+    const newProfile: Record<string, unknown> = { ...profile };
+    const trainedSets = setsByExercise.get(exerciseId);
+
+    if (trainedSets && trainedSets.length > 0) {
+      // sessionCount increments by 1 per session-apply, regardless of how
+      // many sets land — counts sessions, not sets (ADR-0005 ExerciseProfile.sessionCount).
+      newProfile.sessionCount = ((profile.sessionCount as number) ?? 0) + 1;
+
+      // Append top-intent sets with reps in the validity range. The
+      // ewma-engine's filter would skip out-of-range sets internally, but
+      // appending out-of-range to topSets bloats the array uselessly.
+      const baseTopSets = (profile.topSets as Array<Record<string, unknown>> | undefined) ?? [];
+      const newTopSets = [...baseTopSets];
+      for (const set of trainedSets) {
+        if (set.intent !== "top") continue;
+        const weight = typeof set.weight_kg === "number" ? set.weight_kg : null;
+        const reps = typeof set.reps_completed === "number" ? set.reps_completed : null;
+        if (weight === null || reps === null) continue;
+        // ADR-0005 validity window: 3..10 reps. ewma-engine filters again
+        // internally, but skipping at append-time keeps topSets lean.
+        if (reps < 3 || reps > 10) continue;
+        newTopSets.push({
+          weight,
+          reps,
+          loggedAt: incomingLoggedAt.toISOString(),
+          sessionId,
+        });
+      }
+
+      newProfile.topSets = newTopSets;
+
+      // Compute EWMA over the full topSets list (ewma-engine windows the
+      // last 5 valid internally per ADR-0005). Standard branch — transition
+      // mode wires when transition triggers ship.
+      const ewmaInput: EwmaTopSet[] = newTopSets.map((s) => ({
+        weight: s.weight as number,
+        reps: s.reps as number,
+        loggedAt: new Date(s.loggedAt as string),
+        sessionId: s.sessionId as string,
+      }));
+      const newE1RM = computeE1RM(ewmaInput, false);
+      if (newE1RM !== null) {
+        newProfile.e1rmCurrent = newE1RM;
+        rulesFired.add("ewma");
+        fieldsChanged.push(`exercises.${exerciseId}.e1rmCurrent`);
+      }
+    }
+
+    newExercises[exerciseId] = newProfile;
+  }
+
+  return { exercises: newExercises, rulesFired, fieldsChanged };
+}
+
 function applyPerPatternRules(
   patterns: Record<string, Record<string, unknown>>,
   trainedPatterns: Set<string>,
@@ -531,6 +650,21 @@ export async function applySession(
       newModelJson = { ...modelJson, patterns: ruled.patterns };
       rulesFired = [...ruled.rulesFired];
       fieldsChanged = ruled.fieldsChanged;
+
+      // Per-exercise rule pipeline per #116 (A17). Wires ewma-engine into
+      // ExerciseProfile.e1rmCurrent. Other ExerciseProfile fields land
+      // with subsequent slices.
+      const exercisesIn = (modelJson.exercises as Record<string, Record<string, unknown>> | undefined) ?? {};
+      const setLogsArr = ((req.session_payload as Record<string, unknown>).set_logs as Array<Record<string, unknown>> | undefined) ?? [];
+      const exerciseRuled = applyPerExerciseRules(
+        exercisesIn,
+        setLogsArr,
+        incomingLoggedAt,
+        req.session_id,
+      );
+      newModelJson = { ...newModelJson, exercises: exerciseRuled.exercises };
+      rulesFired.push(...exerciseRuled.rulesFired);
+      fieldsChanged.push(...exerciseRuled.fieldsChanged);
 
       // ADR-0012: global phase-advance trigger. Reads each pattern's
       // post-loop lastPhaseTransitionAtSessionCount (which the per-pattern

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -117,6 +117,79 @@ orchestratorTest(
 );
 
 orchestratorTest(
+  "A17 / #116: ewma-engine wired — first apply with valid top sets bootstraps ExerciseProfile + populates e1rmCurrent via Epley × EWMA",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-10T10:00:00Z";
+
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: {
+          logged_at: loggedAt,
+          set_logs: [
+            // bench: 100kg × 5 reps → e1rm = 100 × (1 + 5/30) = 116.666...
+            { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "top" },
+            // squat: 130kg × 5 reps → e1rm = 130 × (1 + 5/30) = 151.666...
+            { exercise_id: "barbell_back_squat", set_number: 1, weight_kg: 130, reps_completed: 5, intent: "top" },
+            // row: 70kg × 8 reps → e1rm = 70 × (1 + 8/30) = 88.666...
+            { exercise_id: "barbell_row", set_number: 1, weight_kg: 70, reps_completed: 8, intent: "top" },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    assertEquals(result.late_arrival, false);
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    const exercises = modelJson.exercises as Record<string, Record<string, unknown>>;
+
+    // Three exercises bootstrapped + populated.
+    assertEquals(
+      Object.keys(exercises).sort(),
+      ["barbell_back_squat", "barbell_bench_press", "barbell_row"],
+    );
+
+    // EWMA over a single valid top set = the e1rm of that set (no smoothing).
+    // Allow small floating-point tolerance via fixed-precision compare.
+    const bench = exercises["barbell_bench_press"];
+    const squat = exercises["barbell_back_squat"];
+    const row = exercises["barbell_row"];
+
+    assertEquals(
+      Number((bench.e1rmCurrent as number).toFixed(4)),
+      Number((100 * (1 + 5 / 30)).toFixed(4)),
+    );
+    assertEquals(
+      Number((squat.e1rmCurrent as number).toFixed(4)),
+      Number((130 * (1 + 5 / 30)).toFixed(4)),
+    );
+    assertEquals(
+      Number((row.e1rmCurrent as number).toFixed(4)),
+      Number((70 * (1 + 8 / 30)).toFixed(4)),
+    );
+
+    // sessionCount increments by 1 per apply per exercise (counts sessions,
+    // not sets — see applyPerExerciseRules comment).
+    assertEquals(bench.sessionCount, 1);
+    assertEquals(squat.sessionCount, 1);
+    assertEquals(row.sessionCount, 1);
+
+    // topSets appended once per valid top-intent set.
+    assertEquals((bench.topSets as unknown[]).length, 1);
+    assertEquals((squat.topSets as unknown[]).length, 1);
+    assertEquals((row.topSets as unknown[]).length, 1);
+  },
+);
+
+orchestratorTest(
   "A15 / #110: first apply with set_logs across 3 movement patterns bootstraps each PatternProfile with ADR-0011 defaults + sessionsInPhase=1 + recentSessionDates=[loggedAt]",
   async () => {
     const userId = await seedFreshUser();

--- a/supabase/functions/update-trainee-model/smoke_test.ts
+++ b/supabase/functions/update-trainee-model/smoke_test.ts
@@ -167,8 +167,21 @@ smokeTest(
       assertEquals(profile.recentSessionDates, [expectedLoggedAtIso]);
     }
 
+    // ExerciseProfile.e1rmCurrent populated for each top-intent exercise
+    // (#116 / A17). The fixture's bench/squat/row carry top sets with
+    // valid reps (3..10), so EWMA should produce non-zero values.
+    const exercises = modelJson.exercises as Record<string, Record<string, unknown>>;
+    for (const exerciseId of ["barbell_bench_press", "barbell_back_squat", "barbell_row"]) {
+      const profile = exercises[exerciseId];
+      assertExists(profile, `exercise ${exerciseId} should have a profile`);
+      const e1rm = profile.e1rmCurrent as number;
+      if (!(e1rm > 0)) {
+        throw new Error(`expected ${exerciseId}.e1rmCurrent > 0, got ${e1rm}`);
+      }
+      assertEquals(profile.sessionCount, 1);
+    }
+
     // INTENTIONALLY NOT ASSERTED YET (extended by subsequent slices):
-    //   - PatternProfile.e1RMEwma populated (A17)
     //   - RecoveryProfile.last*StimulusAt populated (A18)
     //   - RecoveryProfile.*Readiness populated (A19)
     //   - PatternProfile.trend populated (A20)


### PR DESCRIPTION
## Summary

- Wires \`_shared/ewma-engine.ts\` into the orchestrator's per-exercise loop. \`model_json.exercises[id].e1rmCurrent\` now populates with Epley × EWMA over the last 5 valid top sets per ADR-0005.
- New \`applyPerExerciseRules\` helper mirrors A15's \`applyPerPatternRules\` shape: bootstrap missing exercises with ADR-0005 defaults, then per-exercise compute.
- Orchestrator test + smoke extension confirm 3 exercises bootstrap and e1rmCurrent populates with the expected Epley value.

## Why this is Phase 3 of the audit's revised slice plan

Per [docs/phase-2-integration-audit-2026-05-10.md](https://github.com/thearnavmenon/ProjectApex/blob/main/docs/phase-2-integration-audit-2026-05-10.md), this is the first of seven Phase 3 slices that wire each unwired rule module. Each slice extends the smoke's assertion set per the growing-oracle pattern.

## Test plan

- [x] 31 EF tests pass locally (was 30; +1 new A17 orchestrator test asserting Epley × EWMA values)
- [x] Smoke first-apply asserts \`e1rmCurrent > 0\` + \`sessionCount = 1\` for bench/squat/row
- [x] Existing 30 tests still pass under the refactor
- [ ] CI ef-test job (#114) validates this on PR

## Closes

- Closes #116

## Stacked on

- #115 (A15 — pattern bootstrap; needs to merge first)
- #114 (A16 — smoke infra; needs to merge first)
- #112 (audit doc)

## Out of scope (subsequent Phase 3 slices)

- A18 stimulus-classifier — populates RecoveryProfile timestamps
- A19 recovery-curve — reads stimulus timestamps, computes readiness
- A20 plateau-verdict — uses ewma data; populates PatternProfile.trend
- A21 prescription-accuracy + gap-bucket
- A22 transfer-regression
- A23 fatigue-interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)