### PR TITLE
feat(slice-A18/#118): wire stimulus-classifier — populate RecoveryProfile.last*StimulusAt

### DIFF
--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -36,6 +36,10 @@ import {
   type TopSet as EwmaTopSet,
 } from "../_shared/ewma-engine.ts";
 import {
+  classifyStimulus,
+  type SetIntent,
+} from "../_shared/stimulus-classifier.ts";
+import {
   emitApplyComplete as defaultEmitApplyComplete,
   emitClassifierFailed as defaultEmitClassifierFailed,
   emitLateArrival as defaultEmitLateArrival,
@@ -403,6 +407,78 @@ function applyPerExerciseRules(
   return { exercises: newExercises, rulesFired, fieldsChanged };
 }
 
+/**
+ * Per-set stimulus pipeline per #118 (A18). Each set's (intent, reps, rpeFelt)
+ * triple maps to a `StimulusDimension | null` via `classifyStimulus`; sets
+ * that drive a dimension bump the corresponding `last*StimulusAt` timestamp
+ * to the session's `incomingLoggedAt`.
+ *
+ * Bootstrap: missing `model_json.recovery` gets ADR-0005 defaults — null
+ * timestamps + 1.0 readinesses. Readiness scalars are owned by A19; this
+ * slice only updates the timestamps.
+ *
+ * Monotonicity: the orchestrator's watermark check rejects late arrivals
+ * before this helper runs, so `incomingLoggedAt >= last_applied_logged_at >=
+ * any prior last*StimulusAt`. The assignment is therefore monotonic — no
+ * `max()` guard needed.
+ */
+function applyPerSetStimulusRules(
+  recovery: Record<string, unknown> | undefined,
+  setLogs: Array<Record<string, unknown>>,
+  incomingLoggedAt: Date,
+): {
+  recovery: Record<string, unknown>;
+  rulesFired: Set<string>;
+  fieldsChanged: string[];
+} {
+  const rulesFired = new Set<string>();
+  const fieldsChanged: string[] = [];
+  const wasBootstrapped = recovery === undefined;
+  const newRecovery: Record<string, unknown> = wasBootstrapped
+    ? {
+        lastNeuromuscularStimulusAt: null,
+        lastMetabolicStimulusAt: null,
+        neuromuscularReadiness: 1.0,
+        metabolicReadiness: 1.0,
+      }
+    : { ...recovery };
+  if (wasBootstrapped) {
+    fieldsChanged.push("recovery.bootstrapped");
+  }
+
+  const loggedAtIso = incomingLoggedAt.toISOString();
+  let bumpedNm = false;
+  let bumpedMet = false;
+
+  for (const set of setLogs) {
+    const intent = set.intent;
+    if (typeof intent !== "string") continue;
+    if (typeof set.reps_completed !== "number") continue;
+    const rpeFelt = typeof set.rpe_felt === "number" ? set.rpe_felt : null;
+    const dim = classifyStimulus(
+      intent as SetIntent,
+      set.reps_completed,
+      rpeFelt,
+    );
+    if (dim === null) continue;
+    if (dim === "neuromuscular" || dim === "both") bumpedNm = true;
+    if (dim === "metabolic" || dim === "both") bumpedMet = true;
+  }
+
+  if (bumpedNm) {
+    newRecovery.lastNeuromuscularStimulusAt = loggedAtIso;
+    rulesFired.add("stimulus-classifier");
+    fieldsChanged.push("recovery.lastNeuromuscularStimulusAt");
+  }
+  if (bumpedMet) {
+    newRecovery.lastMetabolicStimulusAt = loggedAtIso;
+    rulesFired.add("stimulus-classifier");
+    fieldsChanged.push("recovery.lastMetabolicStimulusAt");
+  }
+
+  return { recovery: newRecovery, rulesFired, fieldsChanged };
+}
+
 function applyPerPatternRules(
   patterns: Record<string, Record<string, unknown>>,
   trainedPatterns: Set<string>,
@@ -665,6 +741,20 @@ export async function applySession(
       newModelJson = { ...newModelJson, exercises: exerciseRuled.exercises };
       rulesFired.push(...exerciseRuled.rulesFired);
       fieldsChanged.push(...exerciseRuled.fieldsChanged);
+
+      // Per-set stimulus pipeline per #118 (A18). Wires stimulus-classifier
+      // into RecoveryProfile.last*StimulusAt. Readiness scalars wire in A19.
+      const recoveryIn = modelJson.recovery as
+        | Record<string, unknown>
+        | undefined;
+      const stimulusRuled = applyPerSetStimulusRules(
+        recoveryIn,
+        setLogsArr,
+        incomingLoggedAt,
+      );
+      newModelJson = { ...newModelJson, recovery: stimulusRuled.recovery };
+      rulesFired.push(...stimulusRuled.rulesFired);
+      fieldsChanged.push(...stimulusRuled.fieldsChanged);
 
       // ADR-0012: global phase-advance trigger. Reads each pattern's
       // post-loop lastPhaseTransitionAtSessionCount (which the per-pattern

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -190,6 +190,89 @@ orchestratorTest(
 );
 
 orchestratorTest(
+  "A18 / #118: stimulus-classifier wired — first apply with mixed-intent sets bootstraps RecoveryProfile + bumps last*StimulusAt per Q3 mapping",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-10T10:00:00Z";
+
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: {
+          logged_at: loggedAt,
+          set_logs: [
+            // warmup → null dim, no timestamp bump
+            { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 60, reps_completed: 5, intent: "warmup" },
+            // top reps=5 → "neuromuscular" (BACKOFF_NM_REP_MAX is 5)
+            { exercise_id: "barbell_bench_press", set_number: 2, weight_kg: 100, reps_completed: 5, intent: "top", rpe_felt: 8 },
+            // top reps=8 RPE=8 → "metabolic" (no RPE bump under threshold)
+            { exercise_id: "barbell_row", set_number: 1, weight_kg: 70, reps_completed: 8, intent: "top", rpe_felt: 8 },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    assertEquals(result.late_arrival, false);
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    const recovery = modelJson.recovery as Record<string, unknown>;
+
+    // RecoveryProfile bootstrapped with ADR-0005 defaults...
+    assertEquals(recovery.neuromuscularReadiness, 1.0);
+    assertEquals(recovery.metabolicReadiness, 1.0);
+
+    // ...both timestamps bumped to loggedAt: NM (top×5) + metabolic (top×8)
+    const expectedIso = new Date(loggedAt).toISOString();
+    assertEquals(recovery.lastNeuromuscularStimulusAt, expectedIso);
+    assertEquals(recovery.lastMetabolicStimulusAt, expectedIso);
+  },
+);
+
+orchestratorTest(
+  "A18 / #118: warmup-only session leaves RecoveryProfile bootstrapped with null timestamps (no stimulus bump from low-stimulus sets)",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-10T11:00:00Z";
+
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: {
+          logged_at: loggedAt,
+          set_logs: [
+            { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 40, reps_completed: 5, intent: "warmup" },
+            { exercise_id: "barbell_bench_press", set_number: 2, weight_kg: 60, reps_completed: 5, intent: "warmup" },
+            { exercise_id: "barbell_bench_press", set_number: 3, weight_kg: 70, reps_completed: 8, intent: "technique" },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const recovery = (rows[0].model_json as Record<string, unknown>).recovery as Record<string, unknown>;
+
+    // Bootstrapped (the field exists)...
+    assertEquals(recovery.neuromuscularReadiness, 1.0);
+    // ...but no stimulus → both timestamps stay null (ADR-0005 §"low-stimulus exclusion via Optional return")
+    assertEquals(recovery.lastNeuromuscularStimulusAt, null);
+    assertEquals(recovery.lastMetabolicStimulusAt, null);
+  },
+);
+
+orchestratorTest(
   "A15 / #110: first apply with set_logs across 3 movement patterns bootstraps each PatternProfile with ADR-0011 defaults + sessionsInPhase=1 + recentSessionDates=[loggedAt]",
   async () => {
     const userId = await seedFreshUser();

--- a/supabase/functions/update-trainee-model/smoke_test.ts
+++ b/supabase/functions/update-trainee-model/smoke_test.ts
@@ -181,9 +181,18 @@ smokeTest(
       assertEquals(profile.sessionCount, 1);
     }
 
+    // RecoveryProfile.last*StimulusAt populated (A18 / #118). The synthetic
+    // fixture has top sets at reps 5 (NM) and reps 8 with RPE 8 (metabolic),
+    // plus a backoff at reps 8 RPE 7 (metabolic) — so both timestamps must
+    // bump to loggedAt. Readinesses bootstrap to 1.0 (A19 wires the curve).
+    const recovery = modelJson.recovery as Record<string, unknown>;
+    assertEquals(recovery.lastNeuromuscularStimulusAt, expectedLoggedAtIso);
+    assertEquals(recovery.lastMetabolicStimulusAt, expectedLoggedAtIso);
+    assertEquals(recovery.neuromuscularReadiness, 1.0);
+    assertEquals(recovery.metabolicReadiness, 1.0);
+
     // INTENTIONALLY NOT ASSERTED YET (extended by subsequent slices):
-    //   - RecoveryProfile.last*StimulusAt populated (A18)
-    //   - RecoveryProfile.*Readiness populated (A19)
+    //   - RecoveryProfile.*Readiness moves off 1.0 once curve wires (A19)
     //   - PatternProfile.trend populated (A20)
     //   - prescriptionAccuracy cells populated (A21)
     //   - transferRegressions populated (A22)


### PR DESCRIPTION
Closes #118. Phase 3 wiring slice 2 of 6 from the [G1 audit slice plan](https://github.com/thearnavmenon/ProjectApex/blob/main/docs/phase-2-integration-audit-2026-05-10.md).

## Summary

- New `applyPerSetStimulusRules` helper in [supabase/functions/update-trainee-model/index.ts](supabase/functions/update-trainee-model/index.ts) bootstraps `model_json.recovery` with ADR-0005 defaults (null timestamps + 1.0 readinesses) when absent.
- For each set in `session_payload.set_logs[]`, runs `classifyStimulus(intent, reps_completed, rpe_felt)` and bumps `lastNeuromuscularStimulusAt` / `lastMetabolicStimulusAt` to the session's `logged_at` per the Q3 mapping (NM / metabolic / both / null).
- Wired into `applySession`'s rule pipeline alongside `applyPerExerciseRules` (A17).
- Readiness scalars (`neuromuscularReadiness` / `metabolicReadiness`) stay at the bootstrap 1.0 — A19 owns the recovery-curve compute.

## Monotonicity

The orchestrator's watermark check rejects late arrivals before this helper runs (`incoming < watermark` → `late_arrival`), so `incomingLoggedAt >= last_applied_logged_at >= any prior last*StimulusAt`. The assignment is therefore unconditionally monotonic; no `max()` guard needed.

## Test plan

- [x] Orchestrator: mixed-intent session (warmup + top×5 NM + top×8 metabolic) bootstraps RecoveryProfile + bumps both timestamps
- [x] Orchestrator: warmup-only / technique-only session bootstraps RecoveryProfile but leaves both timestamps `null` (Q3 low-stimulus exclusion via Optional return)
- [x] Smoke (`smoke_test.ts`) extended: asserts `recovery.lastNeuromuscularStimulusAt === loggedAt`, `lastMetabolicStimulusAt === loggedAt`, and `*Readiness === 1.0` for the synthetic fixture
- [x] Local: 21 orchestrator + 3 smoke tests pass

## Out of scope (future slices)

- Readiness scalars (`neuromuscularReadiness` / `metabolicReadiness`) — A19 (recovery-curve)
- Clock-skew clamp + `recovery.clock_skew` log emit — A19
- Per-pattern recovery decomposition (Q3 lock-in keeps recovery global; deferred to v3.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)