### PR TITLE
feat(slice-A19/#120): wire recovery-curve — populate RecoveryProfile.*Readiness

### DIFF
--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -39,6 +39,7 @@ import {
   classifyStimulus,
   type SetIntent,
 } from "../_shared/stimulus-classifier.ts";
+import { readiness } from "../_shared/recovery-curve.ts";
 import {
   emitApplyComplete as defaultEmitApplyComplete,
   emitClassifierFailed as defaultEmitClassifierFailed,
@@ -479,6 +480,60 @@ function applyPerSetStimulusRules(
   return { recovery: newRecovery, rulesFired, fieldsChanged };
 }
 
+/**
+ * Recovery readiness pipeline per #120 (A19). Reads the just-bumped
+ * `last*StimulusAt` timestamps from `recovery` and computes the per-axis
+ * readiness scalars via ADR-0010's curve:
+ *
+ *   readiness(t) = clamp(0, 1, 0.3 + 0.7 × (1 - exp(-t / tau)))
+ *
+ * with `tau_NM = 30h` and `tau_metabolic = 12h`. `now` is the session's
+ * `incomingLoggedAt` — deterministic, watermark-bound, and consistent with
+ * A18's "as of session-apply" convention. A null timestamp means
+ * "never stimulated this axis" → readiness = 1.0 per ADR-0010 §"edge cases".
+ *
+ * Clock-skew: a future-dated `lastStimulusAt` (relative to `incomingLoggedAt`)
+ * clamps `t` to 0 and emits `recovery.clock_skew` via the recovery-curve
+ * module's existing helper. Stage 1's watermark check should preclude this
+ * on the in-order path (lastStimulusAt was set during a prior session-apply
+ * whose loggedAt is <= current watermark <= incomingLoggedAt), but defense-
+ * in-depth catches any path that bypasses the watermark.
+ */
+function applyRecoveryReadiness(
+  recovery: Record<string, unknown>,
+  incomingLoggedAt: Date,
+  userId: string,
+): {
+  recovery: Record<string, unknown>;
+  rulesFired: Set<string>;
+  fieldsChanged: string[];
+} {
+  const rulesFired = new Set<string>();
+  const fieldsChanged: string[] = [];
+
+  const nmRaw = recovery.lastNeuromuscularStimulusAt;
+  const metRaw = recovery.lastMetabolicStimulusAt;
+  const lastNm = typeof nmRaw === "string" ? new Date(nmRaw) : null;
+  const lastMet = typeof metRaw === "string" ? new Date(metRaw) : null;
+
+  const ctx = { userId };
+  const newNmReadiness = readiness("neuromuscular", lastNm, incomingLoggedAt, ctx);
+  const newMetReadiness = readiness("metabolic", lastMet, incomingLoggedAt, ctx);
+
+  const newRecovery = { ...recovery };
+  if (newRecovery.neuromuscularReadiness !== newNmReadiness) {
+    newRecovery.neuromuscularReadiness = newNmReadiness;
+    fieldsChanged.push("recovery.neuromuscularReadiness");
+  }
+  if (newRecovery.metabolicReadiness !== newMetReadiness) {
+    newRecovery.metabolicReadiness = newMetReadiness;
+    fieldsChanged.push("recovery.metabolicReadiness");
+  }
+  rulesFired.add("recovery-curve");
+
+  return { recovery: newRecovery, rulesFired, fieldsChanged };
+}
+
 function applyPerPatternRules(
   patterns: Record<string, Record<string, unknown>>,
   trainedPatterns: Set<string>,
@@ -755,6 +810,18 @@ export async function applySession(
       newModelJson = { ...newModelJson, recovery: stimulusRuled.recovery };
       rulesFired.push(...stimulusRuled.rulesFired);
       fieldsChanged.push(...stimulusRuled.fieldsChanged);
+
+      // Recovery readiness compute per #120 (A19). Reads the just-bumped
+      // last*StimulusAt timestamps from stimulusRuled.recovery and writes
+      // *Readiness scalars per ADR-0010's curve.
+      const readinessRuled = applyRecoveryReadiness(
+        stimulusRuled.recovery,
+        incomingLoggedAt,
+        req.user_id,
+      );
+      newModelJson = { ...newModelJson, recovery: readinessRuled.recovery };
+      rulesFired.push(...readinessRuled.rulesFired);
+      fieldsChanged.push(...readinessRuled.fieldsChanged);
 
       // ADR-0012: global phase-advance trigger. Reads each pattern's
       // post-loop lastPhaseTransitionAtSessionCount (which the per-pattern

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -224,14 +224,112 @@ orchestratorTest(
     const modelJson = rows[0].model_json as Record<string, unknown>;
     const recovery = modelJson.recovery as Record<string, unknown>;
 
-    // RecoveryProfile bootstrapped with ADR-0005 defaults...
-    assertEquals(recovery.neuromuscularReadiness, 1.0);
-    assertEquals(recovery.metabolicReadiness, 1.0);
-
-    // ...both timestamps bumped to loggedAt: NM (top×5) + metabolic (top×8)
+    // Both timestamps bumped to loggedAt: NM (top×5) + metabolic (top×8).
     const expectedIso = new Date(loggedAt).toISOString();
     assertEquals(recovery.lastNeuromuscularStimulusAt, expectedIso);
     assertEquals(recovery.lastMetabolicStimulusAt, expectedIso);
+
+    // Readinesses computed via A19's recovery-curve at t=0 → residual floor 0.3.
+    assertEquals(
+      Number((recovery.neuromuscularReadiness as number).toFixed(4)),
+      0.3,
+    );
+    assertEquals(
+      Number((recovery.metabolicReadiness as number).toFixed(4)),
+      0.3,
+    );
+  },
+);
+
+orchestratorTest(
+  "A19 / #120: recovery-curve wired — same-instant stimulus (lastStimulusAt === loggedAt) sets bumped axes to residual floor 0.3; null-timestamp axis stays at 1.0",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-10T12:00:00Z";
+
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: {
+          logged_at: loggedAt,
+          set_logs: [
+            // top×5 → NM; nothing else → metabolic stays null/1.0
+            { exercise_id: "barbell_back_squat", set_number: 1, weight_kg: 130, reps_completed: 5, intent: "top", rpe_felt: 8 },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const recovery = (rows[0].model_json as Record<string, unknown>).recovery as Record<string, unknown>;
+
+    // NM stimulus at loggedAt, computed at loggedAt → t=0 → readiness = floor 0.3
+    assertEquals(
+      Number((recovery.neuromuscularReadiness as number).toFixed(4)),
+      0.3,
+    );
+    // Metabolic never stimulated → null timestamp → readiness = 1.0
+    assertEquals(recovery.lastMetabolicStimulusAt, null);
+    assertEquals(recovery.metabolicReadiness, 1.0);
+  },
+);
+
+orchestratorTest(
+  "A19 / #120: recovery-curve wired — second session 24h after stimulus produces partially-recovered readiness per ADR-0010 curve (NM ~0.78, metabolic ~0.69 if re-stimulated then 0.3)",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId1 = crypto.randomUUID();
+    const sessionId2 = crypto.randomUUID();
+    const loggedAt1 = "2026-05-08T10:00:00Z";
+    const loggedAt2 = "2026-05-09T10:00:00Z"; // exactly 24h later
+
+    // Session 1: heavy bench top×5 (NM only)
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId1,
+        session_payload: {
+          logged_at: loggedAt1,
+          set_logs: [
+            { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "top", rpe_felt: 8 },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    // Session 2: empty (no stimulus). Tests "readiness recomputes from now-loggedAt
+    // even when no new stimulus arrives."
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId2,
+        session_payload: { logged_at: loggedAt2, set_logs: [] },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const recovery = (rows[0].model_json as Record<string, unknown>).recovery as Record<string, unknown>;
+
+    // NM: 24h since stimulus, tau=30h → 0.3 + 0.7 × (1 - exp(-24/30)) ≈ 0.7853
+    const expectedNm = 0.3 + 0.7 * (1 - Math.exp(-24 / 30));
+    assertEquals(
+      Number((recovery.neuromuscularReadiness as number).toFixed(4)),
+      Number(expectedNm.toFixed(4)),
+    );
+    // Metabolic never stimulated → readiness still 1.0
+    assertEquals(recovery.metabolicReadiness, 1.0);
   },
 );
 

--- a/supabase/functions/update-trainee-model/smoke_test.ts
+++ b/supabase/functions/update-trainee-model/smoke_test.ts
@@ -184,15 +184,22 @@ smokeTest(
     // RecoveryProfile.last*StimulusAt populated (A18 / #118). The synthetic
     // fixture has top sets at reps 5 (NM) and reps 8 with RPE 8 (metabolic),
     // plus a backoff at reps 8 RPE 7 (metabolic) — so both timestamps must
-    // bump to loggedAt. Readinesses bootstrap to 1.0 (A19 wires the curve).
+    // bump to loggedAt. Readinesses computed via ADR-0010 curve at t=0 →
+    // residual floor 0.3 (A19 / #120).
     const recovery = modelJson.recovery as Record<string, unknown>;
     assertEquals(recovery.lastNeuromuscularStimulusAt, expectedLoggedAtIso);
     assertEquals(recovery.lastMetabolicStimulusAt, expectedLoggedAtIso);
-    assertEquals(recovery.neuromuscularReadiness, 1.0);
-    assertEquals(recovery.metabolicReadiness, 1.0);
+    // Readiness curve: 0.3 + 0.7 × (1 - exp(-0/tau)) = 0.3
+    assertEquals(
+      Number((recovery.neuromuscularReadiness as number).toFixed(4)),
+      0.3,
+    );
+    assertEquals(
+      Number((recovery.metabolicReadiness as number).toFixed(4)),
+      0.3,
+    );
 
     // INTENTIONALLY NOT ASSERTED YET (extended by subsequent slices):
-    //   - RecoveryProfile.*Readiness moves off 1.0 once curve wires (A19)
     //   - PatternProfile.trend populated (A20)
     //   - prescriptionAccuracy cells populated (A21)
     //   - transferRegressions populated (A22)


### PR DESCRIPTION
Closes #120. Phase 3 wiring slice 3 of 6 from the [G1 audit slice plan](https://github.com/thearnavmenon/ProjectApex/blob/main/docs/phase-2-integration-audit-2026-05-10.md). Depends on #119 (A18) for `last*StimulusAt` source.

## Summary

- New `applyRecoveryReadiness` helper in [supabase/functions/update-trainee-model/index.ts](supabase/functions/update-trainee-model/index.ts) reads the just-bumped `last*StimulusAt` timestamps from `recovery` and writes per-axis readiness scalars per ADR-0010's curve.
- Curve: `readiness(t) = clamp(0, 1, 0.3 + 0.7 × (1 - exp(-t / tau)))` with `tau_NM = 30h`, `tau_metabolic = 12h`. `now` = `incomingLoggedAt`.
- Null timestamp → readiness = 1.0 per ADR-0010 §"edge cases".
- Future-dated `lastStimulusAt` (clock skew) clamps t to 0 and emits `recovery.clock_skew` via the existing observability helper. Stage 1's watermark check should preclude this on the in-order path; defense-in-depth.

## Test plan

- [x] Orchestrator: same-instant stimulus → readiness = floor 0.3 for the bumped axis; null-timestamp axis stays at 1.0
- [x] Orchestrator: empty session 24h after NM stimulus → NM readiness ≈ 0.7853 per curve; metabolic stays 1.0
- [x] A18's existing mixed-intent test updated (readiness now 0.3 instead of 1.0 — same fixture, A19 overlays)
- [x] Smoke: `recovery.*Readiness === 0.3` for the synthetic fixture (stimulus at loggedAt, t=0 → floor)
- [x] Local: 23 orchestrator + 3 smoke tests pass

## Out of scope

- Per-pattern recovery decomposition (Q3 lock-in keeps recovery global)
- Readiness-driven prescription clamps (consumed by iOS client / Stage 3, not orchestrator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)