### PR TITLE
feat(slice-A21/#124): wire prescription-accuracy + gap-bucket — populate prescriptionAccuracy

### DIFF
--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -62,6 +62,13 @@ import {
   type VolumeLoadSession,
 } from "../_shared/plateau-verdict.ts";
 import {
+  appendObservation,
+  shouldContribute,
+  type InterSessionGapBucket,
+  type PerCellAccumulator,
+  type SetObservation,
+} from "../_shared/prescription-accuracy.ts";
+import {
   shouldFireGlobalPhaseAdvance,
   type PatternTransitionState,
 } from "../_shared/global-phase-advance.ts";
@@ -850,6 +857,157 @@ function applyPerPatternRules(
 }
 
 /**
+ * Bootstrap an empty per-cell accumulator. Used by A21 (#124) when a
+ * (pattern, intent) cell first receives a contributing observation.
+ * Shape mirrors PerCellAccumulator (see _shared/prescription-accuracy.ts).
+ */
+function emptyAccuracyCell(
+  patternKey: string,
+  intent: string,
+): PerCellAccumulator {
+  return {
+    pattern: patternKey,
+    intent,
+    observations: [],
+    observationsByGapBucket: {
+      under48h: [],
+      between48And72h: [],
+      over72h: [],
+    },
+    observationBuckets: [],
+  };
+}
+
+/**
+ * Per #124 (A21): wire prescription-accuracy aggregator into the per-apply
+ * path. For each set_log carrying `ai_prescribed`, build a `SetObservation`
+ * and pass through `shouldContribute`. Contributing observations
+ * accumulate into per-cell windows (30 obs each per ADR-0014).
+ *
+ * Inputs:
+ *   - `oldPatterns`: pre-`applyPerPatternRules` snapshot — used for
+ *     `patternPhaseAtPrescription` (the prescription was issued at session
+ *     start, before this apply ran phase advance).
+ *   - `newPatterns`: post-`applyPerPatternRules` snapshot — used for
+ *     `priorSessionLoggedAt`. The just-appended `recentSessionDates`
+ *     end with the current session, so `priorSessionLoggedAt =
+ *     recentSessionDates[len-2]` (or null on first-ever pattern session).
+ *
+ * Stored shape (JSONB-friendly): `prescriptionAccuracy[pattern][intent] =
+ * PerCellAccumulator`. Mirrors the rule module's interface exactly so the
+ * accumulator object can be passed to `appendObservation` directly.
+ */
+function applyPrescriptionAccuracy(
+  prescriptionAccuracy: Record<string, Record<string, PerCellAccumulator>>,
+  setLogs: Array<Record<string, unknown>>,
+  oldPatterns: Record<string, Record<string, unknown>>,
+  newPatterns: Record<string, Record<string, unknown>>,
+  incomingLoggedAt: Date,
+): {
+  prescriptionAccuracy: Record<string, Record<string, PerCellAccumulator>>;
+  rulesFired: Set<string>;
+  fieldsChanged: string[];
+} {
+  const rulesFired = new Set<string>();
+  const fieldsChanged: string[] = [];
+  const next: Record<string, Record<string, PerCellAccumulator>> = {};
+  for (const [p, m] of Object.entries(prescriptionAccuracy)) {
+    next[p] = { ...m };
+  }
+
+  for (const set of setLogs) {
+    const exerciseId = set.exercise_id;
+    if (typeof exerciseId !== "string") continue;
+    const patternKey = lookupPattern(exerciseId);
+    if (!patternKey) continue;
+
+    const aiPrescribed = set.ai_prescribed as
+      | Record<string, unknown>
+      | undefined;
+    if (!aiPrescribed || typeof aiPrescribed !== "object") continue;
+
+    const prescribedIntent = typeof aiPrescribed.intent === "string"
+      ? aiPrescribed.intent
+      : null;
+    const prescribedReps = typeof aiPrescribed.reps === "number"
+      ? aiPrescribed.reps
+      : null;
+    if (prescribedIntent === null || prescribedReps === null) continue;
+    if (prescribedReps <= 0) continue;
+
+    const loggedIntent = typeof set.intent === "string" ? set.intent : "";
+    const repsCompleted = typeof set.reps_completed === "number"
+      ? set.reps_completed
+      : 0;
+    const userCorrectedWeight =
+      aiPrescribed.user_corrected_weight === true;
+    const completionFlags = Array.isArray(set.completion_flags)
+      ? (set.completion_flags as unknown[]).filter(
+          (x): x is string => typeof x === "string",
+        )
+      : [];
+
+    const oldProfile = oldPatterns[patternKey];
+    const phaseRaw = (oldProfile?.currentPhase as string | undefined) ??
+      "accumulation";
+    const patternPhase = (phaseRaw === "accumulation" ||
+      phaseRaw === "intensification" ||
+      phaseRaw === "peaking" ||
+      phaseRaw === "deload")
+      ? phaseRaw
+      : "accumulation";
+
+    const newProfile = newPatterns[patternKey];
+    const recentDates = (newProfile?.recentSessionDates as string[] | undefined) ?? [];
+    const priorSessionLoggedAt = recentDates.length >= 2
+      ? new Date(recentDates[recentDates.length - 2])
+      : null;
+
+    const observation: SetObservation = {
+      pattern: patternKey,
+      prescribedIntent,
+      loggedIntent,
+      prescribedReps,
+      repsCompleted,
+      userCorrectedWeight,
+      completionFlags,
+      patternPhaseAtPrescription: patternPhase,
+      loggedAt: incomingLoggedAt,
+      priorSessionLoggedAt,
+    };
+
+    if (!shouldContribute(observation)) continue;
+
+    const cellByIntent = next[patternKey] ?? {};
+    const cell = cellByIntent[prescribedIntent] ??
+      emptyAccuracyCell(patternKey, prescribedIntent);
+    // appendObservation mutates the cell in place — clone first to keep
+    // newPatterns referentially distinct from any prior reference (defense-
+    // in-depth; the rest of the pipeline treats prescriptionAccuracy as
+    // immutable updates).
+    const cellClone: PerCellAccumulator = {
+      ...cell,
+      observations: [...cell.observations],
+      observationBuckets: [...cell.observationBuckets],
+      observationsByGapBucket: {
+        under48h: [...cell.observationsByGapBucket.under48h],
+        between48And72h: [...cell.observationsByGapBucket.between48And72h],
+        over72h: [...cell.observationsByGapBucket.over72h],
+      },
+    };
+    appendObservation(cellClone, observation);
+    cellByIntent[prescribedIntent] = cellClone;
+    next[patternKey] = cellByIntent;
+    rulesFired.add("prescription-accuracy");
+    fieldsChanged.push(
+      `prescriptionAccuracy.${patternKey}.${prescribedIntent}`,
+    );
+  }
+
+  return { prescriptionAccuracy: next, rulesFired, fieldsChanged };
+}
+
+/**
  * Stage 1 orchestrator core. Pure of HTTP concerns — accepts the validated
  * request shape and a SQL client; returns the response body. Tests bypass
  * the HTTP wrapper and call this directly against the local Supabase DB.
@@ -1008,6 +1166,29 @@ export async function applySession(
       newModelJson = { ...newModelJson, patterns: ruled.patterns };
       rulesFired.push(...ruled.rulesFired);
       fieldsChanged.push(...ruled.fieldsChanged);
+
+      // Prescription-accuracy pipeline per #124 (A21). Runs after pattern
+      // rules so newPatterns has the appended recentSessionDates (for
+      // priorSessionLoggedAt). Reads the PRE-update patternsIn for
+      // patternPhaseAtPrescription (the prescription was issued at session
+      // start, before phase advance).
+      const accuracyIn =
+        (modelJson.prescriptionAccuracy as
+          | Record<string, Record<string, PerCellAccumulator>>
+          | undefined) ?? {};
+      const accuracyRuled = applyPrescriptionAccuracy(
+        accuracyIn,
+        setLogsArr,
+        patternsIn,
+        ruled.patterns,
+        incomingLoggedAt,
+      );
+      newModelJson = {
+        ...newModelJson,
+        prescriptionAccuracy: accuracyRuled.prescriptionAccuracy,
+      };
+      rulesFired.push(...accuracyRuled.rulesFired);
+      fieldsChanged.push(...accuracyRuled.fieldsChanged);
 
       // Per-set stimulus pipeline per #118 (A18). Wires stimulus-classifier
       // into RecoveryProfile.last*StimulusAt. Readiness scalars wire in A19.

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -287,6 +287,105 @@ orchestratorTest(
 );
 
 orchestratorTest(
+  "A21 / #124: prescription-accuracy wired — set with valid ai_prescribed accumulates one observation in (pattern, intent) cell with rep-error ≈ 0.0",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-10T15:00:00Z";
+
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: {
+          logged_at: loggedAt,
+          set_logs: [
+            {
+              exercise_id: "barbell_back_squat",
+              set_number: 1,
+              weight_kg: 130,
+              reps_completed: 5,
+              intent: "top",
+              rpe_felt: 8,
+              ai_prescribed: {
+                weight_kg: 130,
+                reps: 5,
+                intent: "top",
+                user_corrected_weight: false,
+              },
+              completion_flags: [],
+            },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const acc = (rows[0].model_json as Record<string, unknown>)
+      .prescriptionAccuracy as Record<string, Record<string, Record<string, unknown>>>;
+    const cell = acc["squat"]["top"];
+    const observations = cell.observations as number[];
+    assertEquals(observations.length, 1);
+    // Prescribed 5, completed 5 → rep-error = 0
+    assertEquals(observations[0], 0);
+    // First-ever pattern session → priorSessionLoggedAt = null → over72h
+    const buckets = cell.observationsByGapBucket as Record<string, number[]>;
+    assertEquals(buckets.over72h.length, 1);
+    assertEquals(buckets.under48h.length, 0);
+    assertEquals(buckets.between48And72h.length, 0);
+  },
+);
+
+orchestratorTest(
+  "A21 / #124: prescription-accuracy filter — user_corrected_weight=true is rejected by shouldContribute; cell stays absent",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-10T16:00:00Z";
+
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: {
+          logged_at: loggedAt,
+          set_logs: [
+            {
+              exercise_id: "barbell_back_squat",
+              set_number: 1,
+              weight_kg: 130,
+              reps_completed: 5,
+              intent: "top",
+              ai_prescribed: {
+                weight_kg: 125,
+                reps: 5,
+                intent: "top",
+                user_corrected_weight: true,
+              },
+              completion_flags: [],
+            },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const acc = (rows[0].model_json as Record<string, unknown>)
+      .prescriptionAccuracy as Record<string, unknown>;
+    // No cell created — set was filtered out by criterion 4
+    assertEquals(Object.keys(acc).length, 0);
+  },
+);
+
+orchestratorTest(
   "A20 / #122: warmup-only session contributes nothing to weeklyVolumeLoadHistory (warmup excluded, pattern not trained for plateau purposes)",
   async () => {
     const userId = await seedFreshUser();

--- a/supabase/functions/update-trainee-model/smoke_test.ts
+++ b/supabase/functions/update-trainee-model/smoke_test.ts
@@ -206,6 +206,12 @@ smokeTest(
       0.3,
     );
 
+    // A21 / #124: prescription-accuracy bootstrapped to {} (synthetic
+    // fixture has no ai_prescribed → no contributions accumulate).
+    const accuracy = modelJson.prescriptionAccuracy as Record<string, unknown>;
+    assertEquals(typeof accuracy, "object");
+    assertEquals(Object.keys(accuracy).length, 0);
+
     // INTENTIONALLY NOT ASSERTED YET (extended by subsequent slices):
     //   - PatternProfile.trend populated (A20)
     //   - prescriptionAccuracy cells populated (A21)


### PR DESCRIPTION
Closes #124. Phase 3 wiring slice 5 of 6 from the [G1 audit slice plan](https://github.com/thearnavmenon/ProjectApex/blob/main/docs/phase-2-integration-audit-2026-05-10.md). Depends on #119 (A18) for gap-bucket boundary semantics.

## Summary

- New `applyPrescriptionAccuracy` helper builds `SetObservation`s from `set_log.ai_prescribed`, runs `shouldContribute`, and accumulates contributing observations into per-(pattern, intent) cells.
- Runs after `applyPerPatternRules` (needs appended `recentSessionDates` for `priorSessionLoggedAt`); fed the PRE-update `patternsIn` for `patternPhaseAtPrescription` (prescription was issued at session start, before phase advance).
- Synthetic A16 fixture has no `ai_prescribed` → `prescriptionAccuracy` stays `{}` for the smoke fixture; production iOS client carries the field.
- Sliding 30-obs window + per-bucket sub-array sync handled by the rule module's existing `appendObservation`.

## Storage shape

```ts
prescriptionAccuracy[pattern][intent] = {
  pattern, intent, observations[], observationBuckets[],
  observationsByGapBucket: { under48h, between48And72h, over72h }
}
```

## Test plan

- [x] Orchestrator: set with valid `ai_prescribed` (intent match, working set, prescribed=completed=5) → one observation; rep-error === 0; over72h bucket (first-ever pattern session)
- [x] Orchestrator: `user_corrected_weight: true` → `shouldContribute` rejects → no cell created
- [x] Smoke: `prescriptionAccuracy === {}` for the synthetic fixture (no `ai_prescribed`)
- [x] Local: 27 orchestrator + 3 smoke tests pass

## Out of scope

- `shouldSurfaceInDigest` integration — consumed by digest-generation paths (Stage 3 / iOS client)
- `ai_prescribed` field-shape validation — trusted from upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)