### PR TITLE
feat(slice-A22/#126): wire transfer-regression — populate transferRegressions

### DIFF
--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -69,6 +69,11 @@ import {
   type SetObservation,
 } from "../_shared/prescription-accuracy.ts";
 import {
+  fitTransfer,
+  type PairedObservation,
+  type TransferFit,
+} from "../_shared/transfer-regression.ts";
+import {
   shouldFireGlobalPhaseAdvance,
   type PatternTransitionState,
 } from "../_shared/global-phase-advance.ts";
@@ -1008,6 +1013,113 @@ function applyPrescriptionAccuracy(
 }
 
 /**
+ * Per #126 (A22): wire transfer-regression. v1 alpha-cohort pair-detection
+ * rule = "trained in the same session": for each pair of exercises with
+ * top-intent sets in the current session, record a directional
+ * `PairedObservation` for both `(from, to)` orderings.
+ *
+ * Per-exercise session e1rm: `max(weight × (1 + reps/30))` over the
+ * session's top-intent sets. Sets without numeric weight/reps or with
+ * reps outside ADR-0005's 3..10 validity window are skipped (mirrors
+ * `applyPerExerciseRules`'s topSets filter).
+ *
+ * Fit recomputation: only when `observations.length >= 2`. n=1 yields
+ * sxx=0 → `coefficient = NaN`, which would break JSONB serialisation; the
+ * placeholder fit (zeroed coefficients, state=candidate) keeps storage
+ * clean while still tracking the observation.
+ */
+function applyTransferRegressions(
+  transferRegressions: Record<string, Record<string, {
+    observations: PairedObservation[];
+    fit: TransferFit;
+  }>>,
+  setLogs: Array<Record<string, unknown>>,
+  incomingLoggedAt: Date,
+): {
+  transferRegressions: Record<string, Record<string, {
+    observations: PairedObservation[];
+    fit: TransferFit;
+  }>>;
+  rulesFired: Set<string>;
+  fieldsChanged: string[];
+} {
+  const rulesFired = new Set<string>();
+  const fieldsChanged: string[] = [];
+
+  // Compute per-exercise session-max e1rm over top-intent valid-reps sets.
+  const sessionE1rmByExercise = new Map<string, number>();
+  for (const set of setLogs) {
+    if (typeof set.exercise_id !== "string") continue;
+    if (set.intent !== "top") continue;
+    const w = typeof set.weight_kg === "number" ? set.weight_kg : null;
+    const r = typeof set.reps_completed === "number" ? set.reps_completed : null;
+    if (w === null || r === null) continue;
+    if (r < 3 || r > 10) continue;
+    const e1rm = w * (1 + r / 30);
+    const prior = sessionE1rmByExercise.get(set.exercise_id);
+    if (prior === undefined || e1rm > prior) {
+      sessionE1rmByExercise.set(set.exercise_id, e1rm);
+    }
+  }
+
+  if (sessionE1rmByExercise.size < 2) {
+    return { transferRegressions, rulesFired, fieldsChanged };
+  }
+
+  // Clone storage shape so updates remain immutable from caller's POV.
+  const next: Record<string, Record<string, {
+    observations: PairedObservation[];
+    fit: TransferFit;
+  }>> = {};
+  for (const [from, m] of Object.entries(transferRegressions)) {
+    next[from] = { ...m };
+  }
+
+  const exercises = Array.from(sessionE1rmByExercise.keys());
+  for (const fromEx of exercises) {
+    for (const toEx of exercises) {
+      if (fromEx === toEx) continue;
+      const fromE1RM = sessionE1rmByExercise.get(fromEx)!;
+      const toE1RM = sessionE1rmByExercise.get(toEx)!;
+      const fromMap = next[fromEx] ?? {};
+      const cell = fromMap[toEx] ?? {
+        observations: [],
+        fit: {
+          coefficient: 0,
+          intercept: 0,
+          rSquared: 0,
+          pairedObservations: 0,
+          spearmanFlagged: false,
+          seWidening: 0,
+          state: "candidate" as const,
+        },
+      };
+      const newObservations: PairedObservation[] = [
+        ...cell.observations,
+        { fromE1RM, toE1RM, observedAt: incomingLoggedAt },
+      ];
+      const newFit: TransferFit = newObservations.length >= 2
+        ? fitTransfer(newObservations)
+        : {
+            coefficient: 0,
+            intercept: 0,
+            rSquared: 0,
+            pairedObservations: newObservations.length,
+            spearmanFlagged: false,
+            seWidening: 0,
+            state: "candidate",
+          };
+      fromMap[toEx] = { observations: newObservations, fit: newFit };
+      next[fromEx] = fromMap;
+      rulesFired.add("transfer-regression");
+      fieldsChanged.push(`transferRegressions.${fromEx}.${toEx}`);
+    }
+  }
+
+  return { transferRegressions: next, rulesFired, fieldsChanged };
+}
+
+/**
  * Stage 1 orchestrator core. Pure of HTTP concerns — accepts the validated
  * request shape and a SQL client; returns the response body. Tests bypass
  * the HTTP wrapper and call this directly against the local Supabase DB.
@@ -1189,6 +1301,28 @@ export async function applySession(
       };
       rulesFired.push(...accuracyRuled.rulesFired);
       fieldsChanged.push(...accuracyRuled.fieldsChanged);
+
+      // Transfer-regression pipeline per #126 (A22). Pair-detects within
+      // the current session and recomputes the log-log fit per ordered
+      // exercise pair.
+      const transferIn =
+        (modelJson.transferRegressions as
+          | Record<string, Record<string, {
+              observations: PairedObservation[];
+              fit: TransferFit;
+            }>>
+          | undefined) ?? {};
+      const transferRuled = applyTransferRegressions(
+        transferIn,
+        setLogsArr,
+        incomingLoggedAt,
+      );
+      newModelJson = {
+        ...newModelJson,
+        transferRegressions: transferRuled.transferRegressions,
+      };
+      rulesFired.push(...transferRuled.rulesFired);
+      fieldsChanged.push(...transferRuled.fieldsChanged);
 
       // Per-set stimulus pipeline per #118 (A18). Wires stimulus-classifier
       // into RecoveryProfile.last*StimulusAt. Readiness scalars wire in A19.

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -341,6 +341,76 @@ orchestratorTest(
 );
 
 orchestratorTest(
+  "A22 / #126: transfer-regression wired — single session with 2 top-intent exercises records both ordered pairs (candidate state, n=1, no NaN)",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-10T17:00:00Z";
+
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: {
+          logged_at: loggedAt,
+          set_logs: [
+            { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "top", rpe_felt: 8 },
+            { exercise_id: "barbell_row", set_number: 1, weight_kg: 70, reps_completed: 8, intent: "top", rpe_felt: 8 },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const tr = (rows[0].model_json as Record<string, unknown>).transferRegressions as Record<string, Record<string, Record<string, unknown>>>;
+    const benchToRow = tr["barbell_bench_press"]["barbell_row"];
+    const rowToBench = tr["barbell_row"]["barbell_bench_press"];
+    assertEquals((benchToRow.observations as unknown[]).length, 1);
+    assertEquals((rowToBench.observations as unknown[]).length, 1);
+    const benchToRowFit = benchToRow.fit as Record<string, unknown>;
+    assertEquals(benchToRowFit.state, "candidate");
+    // Placeholder fit values — n<2 path returns zeroed coefficients (no NaN).
+    assertEquals(benchToRowFit.coefficient, 0);
+    assertEquals(benchToRowFit.rSquared, 0);
+    assertEquals(benchToRowFit.pairedObservations, 1);
+  },
+);
+
+orchestratorTest(
+  "A22 / #126: transfer-regression — session with one top-intent exercise records no pairs (single-exercise sessions can't pair)",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-10T18:00:00Z";
+
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: {
+          logged_at: loggedAt,
+          set_logs: [
+            { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "top", rpe_felt: 8 },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const tr = (rows[0].model_json as Record<string, unknown>).transferRegressions as Record<string, unknown>;
+    assertEquals(Object.keys(tr).length, 0);
+  },
+);
+
+orchestratorTest(
   "A21 / #124: prescription-accuracy filter — user_corrected_weight=true is rejected by shouldContribute; cell stays absent",
   async () => {
     const userId = await seedFreshUser();

--- a/supabase/functions/update-trainee-model/smoke_test.ts
+++ b/supabase/functions/update-trainee-model/smoke_test.ts
@@ -212,6 +212,23 @@ smokeTest(
     assertEquals(typeof accuracy, "object");
     assertEquals(Object.keys(accuracy).length, 0);
 
+    // A22 / #126: transfer-regression — fixture has 3 top-intent exercises
+    // (bench, squat, row) → 6 ordered pairs (3×2 = each pair recorded both
+    // directions). Single session → n=1, candidate state, placeholder fit.
+    const transfers = modelJson.transferRegressions as Record<string, Record<string, Record<string, unknown>>>;
+    const expectedExercises = ["barbell_back_squat", "barbell_bench_press", "barbell_row"];
+    assertEquals(Object.keys(transfers).sort(), expectedExercises);
+    for (const fromEx of expectedExercises) {
+      for (const toEx of expectedExercises) {
+        if (fromEx === toEx) continue;
+        const cell = transfers[fromEx][toEx];
+        assertExists(cell, `transferRegressions[${fromEx}][${toEx}] should exist`);
+        assertEquals((cell.observations as unknown[]).length, 1);
+        const fit = cell.fit as Record<string, unknown>;
+        assertEquals(fit.state, "candidate");
+      }
+    }
+
     // INTENTIONALLY NOT ASSERTED YET (extended by subsequent slices):
     //   - PatternProfile.trend populated (A20)
     //   - prescriptionAccuracy cells populated (A21)


### PR DESCRIPTION
Closes #126. Phase 3 wiring slice 6 of 6 from the [G1 audit slice plan](https://github.com/thearnavmenon/ProjectApex/blob/main/docs/phase-2-integration-audit-2026-05-10.md). Standalone — no upstream dep on other Phase 3 slices.

## Summary

- New `applyTransferRegressions` helper does v1 alpha-cohort same-session pair detection: for each pair of distinct top-intent exercises, records a directional `PairedObservation` for both orderings, recomputes the log-log fit when `n >= 2`.
- Per-exercise session e1rm = `max` Epley over top-intent valid-reps (3..10) sets.
- NaN-guard: n=1 returns a placeholder fit (zeroed coefficients, candidate state) since `fitTransfer`'s n=1 path produces NaN coefficients that would break JSONB serialisation.

## Storage shape

```ts
transferRegressions[fromExerciseId][toExerciseId] = {
  observations: [{ fromE1RM, toE1RM, observedAt }],
  fit: TransferFit
}
```

## Test plan

- [x] Orchestrator: 2-exercise session (bench + row top-intent) → both ordered pairs recorded; observations.length === 1; fit.state === "candidate"; coefficient/rSquared zeroed (no NaN)
- [x] Orchestrator: single-exercise session → no pairs
- [x] Smoke: 3 top-intent exercises (bench, squat, row) → 6 ordered pairs, all candidate state
- [x] Local: 29 orchestrator + 3 smoke tests pass

## Out of scope

- Time-window pair-detection (paired across sessions within ±48h) — v1 uses same-session pairing
- Negative-coefficient observability emit — v2.x watch-item

🤖 Generated with [Claude Code](https://claude.com/claude-code)