### PR TITLE
feat(slice-A23/#128): wire fatigue-interaction — populate fatigueInteractions

### DIFF
--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -74,6 +74,12 @@ import {
   type TransferFit,
 } from "../_shared/transfer-regression.ts";
 import {
+  appendObservations as appendFatigueObservations,
+  detectFatigueObservations,
+  type FatigueState,
+  type SessionPatternPerformance,
+} from "../_shared/fatigue-interaction.ts";
+import {
   shouldFireGlobalPhaseAdvance,
   type PatternTransitionState,
 } from "../_shared/global-phase-advance.ts";
@@ -1120,6 +1126,115 @@ function applyTransferRegressions(
 }
 
 /**
+ * Per #128 (A23): wire fatigue-interaction. Builds the current session's
+ * SessionPatternPerformance[] from set_logs + the PRE-A17 exercises
+ * snapshot, runs the rule's pair detector against the prior session's
+ * stored performance, and accumulates pair observations.
+ *
+ * `performanceDeltaPct` per pattern P:
+ *   sessionMaxE1RM(P) = max Epley over current session's top-intent
+ *                       valid-reps (3..10) sets in P's exercises
+ *   priorEwma(P)      = max e1rmCurrent across P's exercises from the
+ *                       PRE-A17 snapshot (so the delta isn't artificially
+ *                       zeroed by A17's just-applied EWMA update)
+ *   deltaPct = priorEwma > 0 ? (sessionMaxE1RM - priorEwma) / priorEwma : 0
+ *
+ * On first-ever pattern P session: priorEwma = 0 → deltaPct = 0. Pair
+ * detection still runs (P appears in currentSession with deltaPct=0); the
+ * rule's first-session-no-observations rule fires via the priorSession===null
+ * gate, not via the deltaPct value.
+ */
+function applyFatigueInteractions(
+  fatigueInteractions: FatigueState[],
+  lastSessionPatternPerformance: SessionPatternPerformance[],
+  setLogs: Array<Record<string, unknown>>,
+  exercisesPreA17: Record<string, Record<string, unknown>>,
+  trainedPatterns: Set<string>,
+  sessionId: string,
+  incomingLoggedAt: Date,
+): {
+  fatigueInteractions: FatigueState[];
+  lastSessionPatternPerformance: SessionPatternPerformance[];
+  rulesFired: Set<string>;
+  fieldsChanged: string[];
+} {
+  const rulesFired = new Set<string>();
+  const fieldsChanged: string[] = [];
+
+  // Per pattern, gather (1) this session's max Epley and (2) prior EWMA.
+  const sessionMaxByPattern = new Map<string, number>();
+  for (const set of setLogs) {
+    if (typeof set.exercise_id !== "string") continue;
+    const patternKey = lookupPattern(set.exercise_id);
+    if (!patternKey) continue;
+    if (set.intent !== "top") continue;
+    const w = typeof set.weight_kg === "number" ? set.weight_kg : null;
+    const r = typeof set.reps_completed === "number" ? set.reps_completed : null;
+    if (w === null || r === null) continue;
+    if (r < 3 || r > 10) continue;
+    const e1rm = w * (1 + r / 30);
+    const prior = sessionMaxByPattern.get(patternKey);
+    if (prior === undefined || e1rm > prior) {
+      sessionMaxByPattern.set(patternKey, e1rm);
+    }
+  }
+
+  const priorEwmaByPattern = new Map<string, number>();
+  for (const [exId, profile] of Object.entries(exercisesPreA17)) {
+    const patternKey = lookupPattern(exId);
+    if (!patternKey) continue;
+    const e = (profile.e1rmCurrent as number | undefined) ?? 0;
+    const prior = priorEwmaByPattern.get(patternKey) ?? 0;
+    if (e > prior) priorEwmaByPattern.set(patternKey, e);
+  }
+
+  const currentSession: SessionPatternPerformance[] = [];
+  for (const patternKey of trainedPatterns) {
+    const sessionMax = sessionMaxByPattern.get(patternKey);
+    if (sessionMax === undefined) continue; // pattern trained without valid top sets
+    const priorEwma = priorEwmaByPattern.get(patternKey) ?? 0;
+    const performanceDeltaPct = priorEwma > 0
+      ? (sessionMax - priorEwma) / priorEwma
+      : 0;
+    currentSession.push({
+      sessionId,
+      loggedAt: incomingLoggedAt,
+      pattern: patternKey,
+      performanceDeltaPct,
+    });
+  }
+
+  // Hydrate prior session timestamps (JSONB stores them as ISO strings).
+  const priorSession = lastSessionPatternPerformance.length > 0
+    ? lastSessionPatternPerformance.map((p) => ({
+        ...p,
+        loggedAt: p.loggedAt instanceof Date ? p.loggedAt : new Date(p.loggedAt as unknown as string),
+      }))
+    : null;
+
+  const observations = detectFatigueObservations(currentSession, priorSession);
+  const newStates = appendFatigueObservations(
+    fatigueInteractions,
+    observations,
+  );
+
+  if (observations.length > 0) {
+    rulesFired.add("fatigue-interaction");
+    fieldsChanged.push("fatigueInteractions");
+  }
+  if (currentSession.length > 0) {
+    fieldsChanged.push("lastSessionPatternPerformance");
+  }
+
+  return {
+    fatigueInteractions: newStates,
+    lastSessionPatternPerformance: currentSession,
+    rulesFired,
+    fieldsChanged,
+  };
+}
+
+/**
  * Stage 1 orchestrator core. Pure of HTTP concerns — accepts the validated
  * request shape and a SQL client; returns the response body. Tests bypass
  * the HTTP wrapper and call this directly against the local Supabase DB.
@@ -1253,6 +1368,11 @@ export async function applySession(
       // verdict (which derives per-pattern e1rm history from post-A17
       // exercise.topSets).
       const exercisesIn = (modelJson.exercises as Record<string, Record<string, unknown>> | undefined) ?? {};
+      // A23 (#128): preserve the pre-A17 exercises snapshot so
+      // applyFatigueInteractions can compute performanceDeltaPct against
+      // the prior EWMA (not the just-updated EWMA that already absorbed
+      // this session's contribution).
+      const exercisesPreA17 = exercisesIn;
       const setLogsArr = ((req.session_payload as Record<string, unknown>).set_logs as Array<Record<string, unknown>> | undefined) ?? [];
       const exerciseRuled = applyPerExerciseRules(
         exercisesIn,
@@ -1323,6 +1443,32 @@ export async function applySession(
       };
       rulesFired.push(...transferRuled.rulesFired);
       fieldsChanged.push(...transferRuled.fieldsChanged);
+
+      // Fatigue-interaction pipeline per #128 (A23). Pair-detects against
+      // the immediately-prior session's stored performance and accumulates.
+      const fatigueIn =
+        (modelJson.fatigueInteractions as FatigueState[] | undefined) ?? [];
+      const lastSessionPerfIn =
+        (modelJson.lastSessionPatternPerformance as
+          | SessionPatternPerformance[]
+          | undefined) ?? [];
+      const fatigueRuled = applyFatigueInteractions(
+        fatigueIn,
+        lastSessionPerfIn,
+        setLogsArr,
+        exercisesPreA17,
+        trainedSets.patterns,
+        req.session_id,
+        incomingLoggedAt,
+      );
+      newModelJson = {
+        ...newModelJson,
+        fatigueInteractions: fatigueRuled.fatigueInteractions,
+        lastSessionPatternPerformance:
+          fatigueRuled.lastSessionPatternPerformance,
+      };
+      rulesFired.push(...fatigueRuled.rulesFired);
+      fieldsChanged.push(...fatigueRuled.fieldsChanged);
 
       // Per-set stimulus pipeline per #118 (A18). Wires stimulus-classifier
       // into RecoveryProfile.last*StimulusAt. Readiness scalars wire in A19.

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -381,6 +381,95 @@ orchestratorTest(
 );
 
 orchestratorTest(
+  "A23 / #128: fatigue-interaction wired — first session populates lastSessionPatternPerformance; fatigueInteractions stays empty (no prior session to pair against)",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-10T19:00:00Z";
+
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: {
+          logged_at: loggedAt,
+          set_logs: [
+            { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "top", rpe_felt: 8 },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    const interactions = modelJson.fatigueInteractions as unknown[];
+    const lastPerf = modelJson.lastSessionPatternPerformance as Array<Record<string, unknown>>;
+    assertEquals(interactions.length, 0);
+    assertEquals(lastPerf.length, 1);
+    assertEquals(lastPerf[0].pattern, "horizontalPush");
+    // First-ever pattern → priorEwma = 0 → performanceDeltaPct = 0
+    assertEquals(lastPerf[0].performanceDeltaPct, 0);
+  },
+);
+
+orchestratorTest(
+  "A23 / #128: fatigue-interaction — second session with different pattern records (prior → current) pair observation; totalCount === 1",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId1 = crypto.randomUUID();
+    const sessionId2 = crypto.randomUUID();
+    const loggedAt1 = "2026-05-09T10:00:00Z";
+    const loggedAt2 = "2026-05-10T10:00:00Z";
+
+    // Session 1: bench (horizontalPush)
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId1,
+        session_payload: {
+          logged_at: loggedAt1,
+          set_logs: [
+            { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "top", rpe_felt: 8 },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    // Session 2: row (horizontalPull)
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId2,
+        session_payload: {
+          logged_at: loggedAt2,
+          set_logs: [
+            { exercise_id: "barbell_row", set_number: 1, weight_kg: 70, reps_completed: 8, intent: "top", rpe_felt: 8 },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const interactions = (rows[0].model_json as Record<string, unknown>).fatigueInteractions as Array<Record<string, unknown>>;
+    assertEquals(interactions.length, 1);
+    assertEquals(interactions[0].fromPattern, "horizontalPush");
+    assertEquals(interactions[0].toPattern, "horizontalPull");
+    assertEquals(interactions[0].totalCount, 1);
+    assertEquals((interactions[0].observations as number[]).length, 1);
+  },
+);
+
+orchestratorTest(
   "A22 / #126: transfer-regression — session with one top-intent exercise records no pairs (single-exercise sessions can't pair)",
   async () => {
     const userId = await seedFreshUser();

--- a/supabase/functions/update-trainee-model/smoke_test.ts
+++ b/supabase/functions/update-trainee-model/smoke_test.ts
@@ -229,12 +229,19 @@ smokeTest(
       }
     }
 
-    // INTENTIONALLY NOT ASSERTED YET (extended by subsequent slices):
-    //   - PatternProfile.trend populated (A20)
-    //   - prescriptionAccuracy cells populated (A21)
-    //   - transferRegressions populated (A22)
-    //   - fatigueInteractions populated (A23)
-    // Each Phase 3 wiring slice MUST extend the assertion set here.
+    // A23 / #128: fatigue-interaction — first-ever session has no prior
+    // to pair against, so fatigueInteractions stays empty.
+    // lastSessionPatternPerformance gets one entry per trained pattern.
+    const fatigueInteractions = modelJson.fatigueInteractions as unknown[];
+    assertEquals(fatigueInteractions.length, 0);
+    const lastSessionPerf =
+      modelJson.lastSessionPatternPerformance as Array<Record<string, unknown>>;
+    assertEquals(lastSessionPerf.length, 3);
+    const perfPatterns = lastSessionPerf.map((p) => p.pattern as string).sort();
+    assertEquals(perfPatterns, ["horizontalPull", "horizontalPush", "squat"]);
+
+    // All 7 G1-audit unwired modules now have orchestrator-side wiring +
+    // smoke coverage. Phase 4 (G1 redefinition) closes #85.
   },
 );
 


### PR DESCRIPTION
Closes #128. Final unwired-rule-module slice — all 7 modules from the [G1 audit](https://github.com/thearnavmenon/ProjectApex/blob/main/docs/phase-2-integration-audit-2026-05-10.md) now have orchestrator-side wiring + smoke-test coverage.

## Summary

- New `applyFatigueInteractions` helper builds current session's `SessionPatternPerformance[]` from set_logs + the PRE-A17 exercises snapshot, runs the rule's pair detector against the prior session, and accumulates pair observations.
- `performanceDeltaPct` per pattern P uses `priorEwma` from the PRE-A17 exercises snapshot so the delta isn't artificially zeroed by A17's just-applied EWMA update.
- Bootstrap adds `fatigueInteractions: []` and `lastSessionPatternPerformance: []` to `model_json`.

## Test plan

- [x] Orchestrator: first session populates `lastSessionPatternPerformance` with one entry; `fatigueInteractions` empty (no prior to pair against); `deltaPct === 0` (priorEwma === 0)
- [x] Orchestrator: second session with different pattern (push → pull) records `(push → pull)` pair observation; `totalCount === 1`
- [x] Smoke: first-session fixture leaves `fatigueInteractions` empty; `lastSessionPatternPerformance.length === 3` (one per trained pattern)
- [x] Local: 31 orchestrator + 3 smoke tests pass

## Out of scope

- Stage 3 / iOS digest surfacing rule (confidence ≥ 0.7) — consumed by digest paths
- `performanceDeltaPct` baseline-EWMA refinements (median over last 3 sessions vs single prior EWMA) — v2.x watch-item

🤖 Generated with [Claude Code](https://claude.com/claude-code)