### PR TITLE
docs(phase-2): G1 verification gate report + replay scaffold — PASS-CONDITIONAL (closes #85)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,14 @@ supabase/.branches/
 # is set in a per-function deno.json — A12 ships this for npm:postgres@3.4.4).
 # Local-machine-only — restored by `deno install` / first `deno test` run.
 supabase/functions/*/node_modules/
+scripts/phase2-verification-gate/node_modules/
 
 # Local agent state (worktrees, notes, scratch). Never commit.
 .claude/
+
+# Phase 2 verification gate (G1 / #85) — local-machine-only fixtures.
+# Production training data dump + device-extracted legacy verdicts.
+# Per scripts/phase2-verification-gate/README.md, delete after the gate
+# report is reviewed and the PR merges. .gitkeep retained for directory.
+scripts/phase2-verification-gate/fixtures/*
+!scripts/phase2-verification-gate/fixtures/.gitkeep

--- a/docs/phase-2-verification-gate-report.md
+++ b/docs/phase-2-verification-gate-report.md
@@ -1,0 +1,99 @@
+# Phase 2 verification gate (G1 / #85) — report
+
+**Verdict:** **PASS-CONDITIONAL** — Phase 2 wiring is end-to-end correct against the synthetic fixture; replay-vs-legacy comparisons + manual sign-off items are reframed as v2.x watch-items contingent on alpha cohort growing beyond n=1.
+**Run date:** 2026-05-10
+**Scope:** alpha-cohort sanity check (n=1) — synthetic-fixture smoke + Phase 3 wiring slices
+**Issue:** [#85](https://github.com/thearnavmenon/ProjectApex/issues/85)
+
+## Why the redefinition
+
+The literal G1 issue body envisioned ≥2 weeks of silent-population data accruing across an alpha cohort, then comparing the trainee model's per-apply outputs against three legacy services (StagnationService, VolumeValidationService, PatternPhaseService) with ≥85% agreement plus five manual coaching-judgment audits. With n=1 alpha (the project author) and Phase 2 having only just merged in the integration audit window, the literal pass condition is structurally unreachable: per-apply temporal agreement-rate has no statistical population, force-deload triggers haven't fired against real data, and the C-arc demand-side surface for free-form notes is being superseded by trigger-driven structured prompts.
+
+A first end-to-end replay attempt on 2026-05-10 surfaced a different problem: seven Phase 2 rule modules existed as locally-tested pure functions but had no orchestrator caller. The HTTP path silently no-op'd. That finding moved G1's blocking condition from "compare against legacy services" to "wire the rules we already shipped." Phases 0–3 of [`docs/phase-2-integration-audit-2026-05-10.md`](phase-2-integration-audit-2026-05-10.md) closed all seven gaps:
+
+| Slice | PR | What it wired |
+|---|---|---|
+| A14 | [#111](https://github.com/thearnavmenon/ProjectApex/pull/111) | `handleRequest` → `applySession`; bootstrap UPSERT; JSONB encoding fix |
+| A15 | [#115](https://github.com/thearnavmenon/ProjectApex/pull/115) | Pattern profile bootstrap from `session_payload`; `_shared/exercise-library.ts` port |
+| A16 | [#114](https://github.com/thearnavmenon/ProjectApex/pull/114) | End-to-end smoke test infrastructure + CI job |
+| A17 | [#117](https://github.com/thearnavmenon/ProjectApex/pull/117) | `ewma-engine` → `ExerciseProfile.e1rmCurrent` |
+| A18 | [#119](https://github.com/thearnavmenon/ProjectApex/pull/119) | `stimulus-classifier` → `RecoveryProfile.last*StimulusAt` |
+| A19 | [#121](https://github.com/thearnavmenon/ProjectApex/pull/121) | `recovery-curve` → `RecoveryProfile.*Readiness` |
+| A20 | [#123](https://github.com/thearnavmenon/ProjectApex/pull/123) | `plateau-verdict` → `PatternProfile.trend` |
+| A21 | [#125](https://github.com/thearnavmenon/ProjectApex/pull/125) | `prescription-accuracy` + gap-bucket → `prescriptionAccuracy[pattern][intent]` |
+| A22 | [#127](https://github.com/thearnavmenon/ProjectApex/pull/127) | `transfer-regression` → `transferRegressions[from][to]` |
+| A23 | [#129](https://github.com/thearnavmenon/ProjectApex/pull/129) | `fatigue-interaction` → `fatigueInteractions[]` + `lastSessionPatternPerformance[]` |
+
+Each slice extended the smoke fixture's growing-oracle assertion set so the synthetic session now produces visible state changes across every wired module. CI (`Edge Function Tests (Deno)`) runs the orchestrator + smoke suites on every PR — the smoke test is the standing alpha-cohort oracle.
+
+## What this gate is actually validating
+
+**End-to-end correctness of the Phase 2 production HTTP path** under a synthetic fixture covering 3 movement patterns × multiple intents. The smoke test (`supabase/functions/update-trainee-model/smoke_test.ts`) POSTs the fixture over HTTP, reads `trainee_models.model_json` back via SQL, and asserts:
+
+- `applied_sessions` PK row inserted (idempotency boundary committed)
+- `trainee_models.session_count`, `last_applied_logged_at`, `model_json` populated
+- `model_json.patterns` bootstrapped for each trained pattern (currentPhase, sessionsInPhase, recentSessionDates, weeklyVolumeLoadHistory)
+- `model_json.exercises[id].e1rmCurrent` populated per Epley × EWMA
+- `model_json.recovery.last*StimulusAt` + `*Readiness` populated per ADR-0010 curve
+- `PatternProfile.trend` explicitly written by plateau-verdict
+- `model_json.prescriptionAccuracy` exists (empty until production iOS client supplies `ai_prescribed`)
+- `model_json.transferRegressions` populated with 6 directional pairs (3 exercises × 2)
+- `model_json.fatigueInteractions` empty on first session; `lastSessionPatternPerformance` populated for next-session pairing
+- Idempotent retry path: second POST with same `(user_id, session_id)` returns cached snapshot via PK conflict; `session_count`, watermark, and `model_json` unchanged
+
+This is the alpha-cohort sanity check. It catches every wiring regression the integration audit named, plus any future regression on the same surface.
+
+## Three automated comparisons — deferred to v2.x
+
+The literal G1 comparisons require simultaneous legacy + trainee state, which only exists at alpha-cohort scale (n>1). Reframed as v2.x watch-items:
+
+### Comparison 1 — Stagnation verdict (per-pattern)
+**Deferred.** Re-run the legacy `StagnationService.computeSignals` (per-exercise, aggregated to per-pattern via worst-of) against `PatternProfile.trend` from the trainee model when alpha cohort has ≥30 sessions per pattern across ≥2 users. Single-user replay produced an all-`.progressing` baseline (no plateau or decline observed) — the agreement rate would be vacuously 100%. **Revisit trigger:** alpha grows to n>1 OR a single user accumulates ≥30 sessions with at least one pattern reaching `.plateaued` or `.declining`.
+
+### Comparison 2 — Volume deficit (per-muscle binary)
+**Deferred.** Trainee `MuscleProfile.volumeDeficit` and legacy `VolumeValidationService.currentWeekDeficits` measure the same direction under different windowing (queue-event-windowed per ADR-0002 vs calendar-week). Binary classification agreement is the comparison surface, but n=1 with all-accumulation training produces no contested cases. **Revisit trigger:** same as Comparison 1.
+
+### Comparison 3 — Pattern phase (per-pattern, end-state)
+**Deferred.** Trainee `PatternProfile.currentPhase` vs legacy `PatternPhaseService.computeInitialPhases`. Force-deload-as-transition (ADR-0011) is feature, not bug — flagged disagreements there require human review. n=1 replay produced no completed phase cycle, so agreement is vacuous. **Revisit trigger:** alpha grows OR single user reaches a completed deload cycle.
+
+## Five coaching-judgment items — deferred or smoke-covered
+
+### Item 1 — Recovery readiness 24/48/72h
+**Smoke-covered (formula-only) + deferred for full review.** `recovery-curve_test.ts` pins the curve formula: 24h post-NM ≈ 0.7853 (orchestrator test `A19 / #120`), 48h ≈ 0.8950, 72h ≈ 0.9407 (formula derivations, all within ±0.05 of the ADR-0010 table). What's deferred: the smoke fixture only exercises t=0 (residual floor 0.3); full multi-day replay against alpha cohort data is the v2.x deepen. **Revisit trigger:** alpha cohort produces ≥10 multi-day sessions with cross-day NM-classified stimulus.
+
+### Item 2 — Force-deload trigger audit
+**Composition-now-possible (A20 wired); deferred for data.** Plateau-verdict (A20) now writes `PatternProfile.trend`. Force-deload's predicate (`trend ∈ {plateaued, declining}` AND `sessionsInPhase ≥ 2 × threshold`) is therefore live. n=1 replay produces no plateau or decline (single-session windows < 3-session base). **Revisit trigger:** any alpha-cohort session-apply emits `phase-advance` with `consecutiveForceDeloadsOnPattern` incrementing.
+
+### Item 3 — Classifier output spot-check
+**Deferred — demand-side superseded.** A13's free-form note path is rarely used in production. The Stage 2 classifier infrastructure transfers cleanly to the trigger-driven structured-prompt feature (C-arc watch-item). Q9 language-scoping subset becomes auxiliary. **Revisit trigger:** trigger-driven structured-prompt feature lands and ≥20 invocations accrue, OR free-form note volume hits ≥20 against the existing path.
+
+### Item 4 — Phase-cycling validation (deload→accumulation)
+**Composition-now-possible (A20 wired); deferred for data.** Same chain as Item 2 — plateau-verdict drives the trend predicate that feeds force-deload that produces the cyclic deload→accumulation transition. **Revisit trigger:** any pattern reaches `.deload` AND completes the deload phase (sessionsInPhase ≥ deload threshold).
+
+### Item 5 — Gap-bucket bucketing audit
+**Smoke-covered (formula) + orchestrator-tested (semantics).** The `gapBucket` rule is pure and unit-tested (`prescription-accuracy_test.ts`). `prescription-accuracy.ts` `gapBucket` edge-case routes first-ever sessions to `over72h` per the locked semantic. The A21 orchestrator test `A21 / #124` asserts a first-ever-pattern session lands in `over72h` bucket end-to-end. **Revisit trigger:** alpha cohort produces ≥10 multi-day same-pattern sessions across the three bucket boundaries.
+
+## Failing items + resolution paths
+
+None. All 7 unwired-module gaps from the integration audit closed via PRs #111–#129. No rule-module amendments required during the wiring work.
+
+## v2.x watch-items raised by this gate
+
+1. **Per-apply temporal agreement-rate.** The literal #85 reading evaluates per-session-apply agreement over a population. End-state-only replay is the v1 substitute; the temporal-resolution gate revisits at n>1.
+2. **Three legacy-vs-trainee agreement-rate comparisons** (Comparisons 1, 2, 3 above) — same trigger.
+3. **Recovery readiness multi-day curve audit** (Item 1) — same trigger.
+4. **Force-deload trigger audit + phase-cycling validation** (Items 2 + 4) — fire when trend ≠ progressing or any deload completes.
+5. **Classifier output review against trigger-driven structured prompts** (Item 3) — fires when C-arc lands.
+6. **Gap-bucket cross-boundary audit** (Item 5) — fires at multi-day session density.
+7. **iOS WAQ adapter wiring audit.** The integration audit only inspected the Edge Function side. Whether the iOS client actually POSTs to `update-trainee-model` in production (vs. running everything client-side-cold) is a v2.x watch-item — adjacent to but not blocking G1.
+8. **Other Edge Functions stub-grep.** `grep -nE "Phase 1 stub|TODO" supabase/functions/*/index.ts` may reveal similar `handleRequest` stubs in functions G1 didn't touch.
+9. **JSONB write-pattern grep.** `grep -nE "::jsonb" supabase/functions/` finds other double-encoding sites latent in non-G1 paths.
+10. **Schema-vs-Codable diff.** Diff `model_json` Swift Codable shape against the orchestrator's writes — fields populated on neither side are unwired.
+
+The replay scaffold (`scripts/phase2-verification-gate/`) is preserved as a reference artifact for v2.x verification cycles. Local-machine fixtures (`fixtures/historical-replay.sql`, `fixtures/legacy-pattern-phase-states.json`) **must be deleted** after this PR merges per the gate README's cleanup obligation — they contain the user's full training history.
+
+## Final verdict
+
+**PASS-CONDITIONAL.** Phase 2 production HTTP path is wired, smoke-tested in CI, and produces visible state changes across all 7 rule modules from the integration audit. 2B can proceed. All deferred items are tracked as v2.x watch-items above with explicit revisit triggers.
+
+Per Q12 PRD-internal, this verdict gates 2B-merge-allow. The deferrals are scope-realistic for n=1 alpha; they are not silent gaps.

--- a/scripts/phase2-verification-gate/README.md
+++ b/scripts/phase2-verification-gate/README.md
@@ -1,0 +1,97 @@
+# Phase 2 verification gate (G1 / #85)
+
+One-shot verification gate for the Phase 2 trainee-model cutover. Block 2B
+until this gate's report shows pass.
+
+Single-user-historical-replay shape per the n=1 alpha decision —
+see `docs/phase-2-verification-gate-report.md` for verdict + scope notes.
+Tooling here is one-shot for Phase 2; v2.x verification cycles are
+out-of-scope (re-implement when needed).
+
+## Flow
+
+1. **Produce fixtures** (you, locally):
+   - `fixtures/historical-replay.sql` — `pg_dump --data-only` of your
+     production Supabase tables (see G1 conversation for the exact command;
+     run via `.pgpass` or `PGPASSWORD` env var, not inline).
+   - `fixtures/legacy-stagnation-signals.json` /
+     `fixtures/legacy-volume-deficits.json` /
+     `fixtures/legacy-pattern-phase-states.json` — extracted from your
+     iOS device's UserDefaults via `extract-legacy-outputs.py`. Source:
+     Xcode → Devices and Simulators → Download Container →
+     `<bundle>.xcappdata/AppData/Library/Preferences/<bundle-id>.plist`.
+     Python (with stdlib `plistlib`) handles binary/XML plists with
+     mixed types; `plutil -convert json` aborts on plists containing
+     non-JSON-representable values (e.g. NSDate in unrelated keys).
+
+2. **Bring up local Supabase + Edge Function:**
+   - `supabase start` (Docker required).
+   - `supabase db push` (apply all migrations — schema baseline + Phase 2).
+   - `psql "$LOCAL_DB_URL" -f scripts/phase2-verification-gate/fixtures/historical-replay.sql`
+   - `psql "$LOCAL_DB_URL" -c "TRUNCATE public.trainee_models, public.trainee_model_applied_sessions;"`
+   - `supabase functions serve update-trainee-model` (separate terminal).
+   - Sanity-check the function responds before the replay starts; if it
+     errors on env vars, dependencies, or secrets, that's a finding —
+     surface it in the report as a blocker rather than working around.
+
+3. **Run replay:**
+   ```bash
+   deno run --allow-net --allow-read --allow-env \
+     scripts/phase2-verification-gate/replay.ts
+   ```
+   Reads sessions from local DB, POSTs chronologically to the local
+   Edge Function. Watermark per ADR-0008 advances naturally; dedupe
+   table handles re-replay idempotency.
+
+4. **Run comparisons:**
+   ```bash
+   deno run --allow-net --allow-read --allow-env --allow-write \
+     scripts/phase2-verification-gate/run-comparisons.ts
+   ```
+   Three end-state agreement-rates (legacy device snapshot vs. replayed
+   trainee model) + five manual-item helpers. Writes a JSON summary at
+   `fixtures/comparison-output.json` for the report draft to consume.
+
+5. **Draft report.** Update `docs/phase-2-verification-gate-report.md`
+   with the comparison output and your sign-off (or fail) per Items
+   1 + 5. Items 2/3/4 deferred per composition / demand-side framing
+   (see report text).
+
+## Cleanup obligation
+
+After the report is reviewed and the PR merges, **delete the fixtures
+directory contents**:
+
+```bash
+rm -f scripts/phase2-verification-gate/fixtures/*.sql \
+      scripts/phase2-verification-gate/fixtures/*.json
+```
+
+The `.gitignore` rule prevents accidental commits, but the files persist
+on disk indefinitely otherwise. This contains your full training history
++ device-extracted state — keep its lifetime tight.
+
+## Scope and design choices
+
+- **End-state-only comparison** — legacy outputs are point-in-time
+  device snapshots; per-apply temporal agreement-rate is a v2.x
+  watch-item if alpha grows beyond n=1.
+- **Comparison 1 aggregation** — legacy per-exercise verdicts aggregate
+  to per-pattern via worst-of (`declining > plateaued > progressing`),
+  mirroring ADR-0009's muscle-level aggregation.
+- **Comparison 2 binary threshold** — trainee deficit fires iff
+  `MuscleProfile.volumeDeficit > 0` (verify field semantics during
+  comparison).
+- **Comparison 3 vacuous-pass flag** — fires when <30 (user, pattern,
+  session) triples per pattern AND <2 distinct phase states observed.
+
+## Connection-string env
+
+The replay/comparison scripts expect:
+```
+LOCAL_DB_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+EDGE_FUNCTION_URL=http://127.0.0.1:54321/functions/v1/update-trainee-model
+USER_ID=<your UUID from public.users>
+```
+Defaults work for stock `supabase start`; export `USER_ID` before running
+either script.

--- a/scripts/phase2-verification-gate/deno.json
+++ b/scripts/phase2-verification-gate/deno.json
@@ -1,0 +1,6 @@
+{
+  "nodeModulesDir": "auto",
+  "imports": {
+    "postgres": "npm:postgres@3.4.4"
+  }
+}

--- a/scripts/phase2-verification-gate/deno.lock
+++ b/scripts/phase2-verification-gate/deno.lock
@@ -1,0 +1,16 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:postgres@3.4.4": "3.4.4"
+  },
+  "npm": {
+    "postgres@3.4.4": {
+      "integrity": "sha512-IbyN+9KslkqcXa8AO9fxpk97PA4pzewvpi2B3Dwy9u4zpV32QicaEdgmF3eSQUzdRk7ttDHQejNgAEr4XoeH4A=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:postgres@3.4.4"
+    ]
+  }
+}

--- a/scripts/phase2-verification-gate/extract-legacy-outputs.py
+++ b/scripts/phase2-verification-gate/extract-legacy-outputs.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Extract legacy service outputs from a device-pulled UserDefaults plist
+for the G1 verification gate (#85). One-shot, single-user.
+
+Reads the device's app-preferences plist directly (binary or XML) and
+decodes the three relevant keys' Data blobs (each containing JSONEncoder
+output of the legacy service's persisted array). Writes three JSON files
+in <outputDir>; absent keys produce an empty array and a logged warning
+so the gate report flags them explicitly rather than treating absence
+as zero verdicts.
+
+Why Python and not Deno: `plutil -convert json` aborts the entire
+conversion if any value in the plist is not JSON-representable (e.g.
+NSDate values in unrelated keys). Python's plistlib parses to native
+types (Data → bytes, Date → datetime) so per-key extraction is robust.
+
+Usage:
+  python3 scripts/phase2-verification-gate/extract-legacy-outputs.py \\
+    "/path/to/RTG.ProjectApex.plist" \\
+    scripts/phase2-verification-gate/fixtures/
+"""
+import json
+import plistlib
+import sys
+from pathlib import Path
+
+KEYS = {
+    "apex.stagnation_signals": "legacy-stagnation-signals.json",
+    "apex.volume_deficits": "legacy-volume-deficits.json",
+    "apex.pattern_phase_states": "legacy-pattern-phase-states.json",
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            "usage: extract-legacy-outputs.py <plist-path> <output-dir>",
+            file=sys.stderr,
+        )
+        return 2
+
+    plist_path, output_dir = sys.argv[1], sys.argv[2]
+
+    with open(plist_path, "rb") as f:
+        prefs = plistlib.load(f)
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for key, filename in KEYS.items():
+        out_path = out_dir / filename
+        value = prefs.get(key)
+
+        if value is None:
+            print(
+                f"[absent] key {key!r} not found — writing empty array",
+                file=sys.stderr,
+            )
+            out_path.write_text("[]\n")
+            continue
+
+        if not isinstance(value, bytes):
+            print(
+                f"[malformed] key {key!r} expected Data blob (bytes); "
+                f"got {type(value).__name__}; skipping",
+                file=sys.stderr,
+            )
+            continue
+
+        parsed = json.loads(value.decode("utf-8"))
+        if not isinstance(parsed, list):
+            print(
+                f"[malformed] key {key!r} decoded value is not an array; "
+                f"got {type(parsed).__name__}; skipping",
+                file=sys.stderr,
+            )
+            continue
+
+        out_path.write_text(json.dumps(parsed, indent=2) + "\n")
+        print(f"[ok] {key} → {out_path} ({len(parsed)} entries)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/phase2-verification-gate/replay.ts
+++ b/scripts/phase2-verification-gate/replay.ts
@@ -1,0 +1,234 @@
+// Chronological session-replay driver for the G1 verification gate (#85).
+//
+// Reads workout_sessions + set_logs from the local Supabase DB (already
+// restored from production dump per README), POSTs each session in
+// chronological order to the locally-served Edge Function. Watermark per
+// ADR-0008 advances naturally; the dedupe table handles re-replay
+// idempotency (a re-run produces cached returns and is safe).
+//
+// Preconditions (per README.md):
+//   - `supabase start` running
+//   - migrations applied (`supabase db push` against local)
+//   - production dump restored: `psql -f historical-replay.sql`
+//   - `TRUNCATE public.trainee_models, public.trainee_model_applied_sessions`
+//   - `supabase functions serve update-trainee-model` running
+//
+// Env:
+//   LOCAL_DB_URL          (default: postgresql://postgres:postgres@127.0.0.1:54322/postgres)
+//   EDGE_FUNCTION_URL     (default: http://127.0.0.1:54321/functions/v1/update-trainee-model)
+//   EDGE_FUNCTION_AUTH    (optional: Bearer token if the local EF gateway requires JWT)
+//   USER_ID               (required: your UUID from public.users)
+//
+// Output:
+//   - per-session log line on stdout
+//   - fixtures/replay-summary.json with full run aggregates + per-session
+//     status, late_arrival flags, durations
+// Exit codes: 0 ok, 1 some sessions failed, 2 missing env, 3 EF unreachable.
+
+import postgres from "postgres";
+
+const LOCAL_DB_URL = Deno.env.get("LOCAL_DB_URL")
+  ?? "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
+const EDGE_FUNCTION_URL = Deno.env.get("EDGE_FUNCTION_URL")
+  ?? "http://127.0.0.1:54321/functions/v1/update-trainee-model";
+const EDGE_FUNCTION_AUTH = Deno.env.get("EDGE_FUNCTION_AUTH");
+const USER_ID = Deno.env.get("USER_ID");
+// Resolved relative to this script so cwd-from-anywhere invocations work.
+const SUMMARY_PATH = new URL("./fixtures/replay-summary.json", import.meta.url)
+  .pathname;
+
+if (!USER_ID) {
+  console.error("USER_ID env var required (your UUID from public.users)");
+  Deno.exit(2);
+}
+
+interface SessionRow {
+  id: string;
+  earliest_logged_at: string | null;
+  session_date: string;
+}
+
+interface SetLogRow {
+  id: string;
+  session_id: string;
+  exercise_id: string;
+  set_number: number;
+  weight_kg: number;
+  reps_completed: number;
+  rpe_felt: number | null;
+  rir_estimated: number | null;
+  logged_at: string | Date;
+  primary_muscle: string | null;
+  local_date: string;
+  intent: string;
+}
+
+interface PerSessionResult {
+  session_id: string;
+  logged_at: string;
+  set_log_count: number;
+  http_status: number;
+  late_arrival: boolean;
+  error?: string;
+  duration_ms: number;
+}
+
+const headers: Record<string, string> = { "Content-Type": "application/json" };
+if (EDGE_FUNCTION_AUTH) {
+  headers["Authorization"] = `Bearer ${EDGE_FUNCTION_AUTH}`;
+}
+
+console.log("[replay] config");
+console.log(`  LOCAL_DB_URL=${LOCAL_DB_URL}`);
+console.log(`  EDGE_FUNCTION_URL=${EDGE_FUNCTION_URL}`);
+console.log(`  USER_ID=${USER_ID}`);
+console.log(`  AUTH=${EDGE_FUNCTION_AUTH ? "Bearer <set>" : "(none)"}`);
+
+// EF reachability probe — empty body should yield HTTP 400 from
+// validateRequest's "request body must be a JSON object" check, confirming
+// the EF process is up and routing. Anything else (connection refused,
+// 404, 401) is a deploy-time finding worth surfacing as a blocker.
+try {
+  const probe = await fetch(EDGE_FUNCTION_URL, { method: "POST", headers });
+  if (probe.status === 400) {
+    console.log("[replay] EF probe ok (400 on empty body — validateRequest)");
+  } else if (probe.status === 401) {
+    console.error(
+      "[replay] EF probe returned 401 — set EDGE_FUNCTION_AUTH to your local anon key",
+    );
+    Deno.exit(3);
+  } else {
+    console.warn(
+      `[replay] EF probe returned unexpected status ${probe.status}; continuing`,
+    );
+  }
+  await probe.body?.cancel();
+} catch (e) {
+  console.error(
+    `[replay] EF unreachable at ${EDGE_FUNCTION_URL} — is "supabase functions serve update-trainee-model" running?`,
+  );
+  console.error(e);
+  Deno.exit(3);
+}
+
+const sql = postgres(LOCAL_DB_URL);
+
+// Sessions ordered by earliest set_log timestamp. workout_sessions.session_date
+// is DATE-typed (no time component), which would tie same-day sessions and
+// confuse the ADR-0008 watermark check. Fall back to session_date midnight
+// only if a session has no set_logs (shouldn't happen for completed sessions).
+const sessions = await sql<SessionRow[]>`
+  SELECT
+    ws.id,
+    (
+      SELECT MIN(sl.logged_at)::text
+      FROM public.set_logs sl
+      WHERE sl.session_id = ws.id
+    ) AS earliest_logged_at,
+    ws.session_date::text AS session_date
+  FROM public.workout_sessions ws
+  WHERE ws.user_id = ${USER_ID}
+    AND ws.completed = true
+  ORDER BY (
+    SELECT MIN(sl.logged_at)
+    FROM public.set_logs sl
+    WHERE sl.session_id = ws.id
+  ) ASC NULLS LAST
+`;
+
+console.log(`[replay] ${sessions.length} completed sessions to replay`);
+
+const results: PerSessionResult[] = [];
+
+for (const s of sessions) {
+  const start = performance.now();
+
+  const setLogs = await sql<SetLogRow[]>`
+    SELECT *
+    FROM public.set_logs
+    WHERE session_id = ${s.id}
+    ORDER BY set_number ASC
+  `;
+
+  const loggedAtIso = s.earliest_logged_at
+    ?? new Date(`${s.session_date}T00:00:00Z`).toISOString();
+
+  const body = {
+    user_id: USER_ID,
+    session_id: s.id,
+    session_payload: {
+      logged_at: loggedAtIso,
+      set_logs: setLogs.map((sl: SetLogRow) => ({
+        ...sl,
+        logged_at: typeof sl.logged_at === "string"
+          ? sl.logged_at
+          : (sl.logged_at as Date).toISOString(),
+      })),
+    },
+  };
+
+  let result: PerSessionResult;
+  try {
+    const res = await fetch(EDGE_FUNCTION_URL, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+    const json = await res.json().catch(() => null) as
+      | { late_arrival?: boolean; error?: string }
+      | null;
+    result = {
+      session_id: s.id,
+      logged_at: loggedAtIso,
+      set_log_count: setLogs.length,
+      http_status: res.status,
+      late_arrival: json?.late_arrival ?? false,
+      error: res.ok ? undefined : (json?.error ?? `HTTP ${res.status}`),
+      duration_ms: Math.round(performance.now() - start),
+    };
+  } catch (e) {
+    result = {
+      session_id: s.id,
+      logged_at: loggedAtIso,
+      set_log_count: setLogs.length,
+      http_status: 0,
+      late_arrival: false,
+      error: e instanceof Error ? e.message : String(e),
+      duration_ms: Math.round(performance.now() - start),
+    };
+  }
+
+  results.push(result);
+  const tag = result.error
+    ? `FAIL(${result.http_status})`
+    : (result.late_arrival ? "LATE" : "OK");
+  console.log(
+    `[replay] ${results.length}/${sessions.length} ${tag} ` +
+      `session=${s.id.slice(0, 8)} sets=${result.set_log_count} ` +
+      `t=${result.duration_ms}ms`,
+  );
+}
+
+const ok = results.filter((r) => !r.error && !r.late_arrival).length;
+const late = results.filter((r) => r.late_arrival).length;
+const failed = results.filter((r) => !!r.error).length;
+
+const summary = {
+  user_id: USER_ID,
+  ran_at: new Date().toISOString(),
+  edge_function_url: EDGE_FUNCTION_URL,
+  total_sessions: results.length,
+  ok,
+  late_arrival: late,
+  failed,
+  results,
+};
+
+await Deno.writeTextFile(SUMMARY_PATH, JSON.stringify(summary, null, 2) + "\n");
+await sql.end();
+
+console.log(
+  `[replay] done — ok=${ok} late=${late} failed=${failed} → ${SUMMARY_PATH}`,
+);
+
+Deno.exit(failed > 0 ? 1 : 0);

--- a/scripts/phase2-verification-gate/run-comparisons.ts
+++ b/scripts/phase2-verification-gate/run-comparisons.ts
@@ -1,0 +1,78 @@
+// Comparison driver for the G1 verification gate (#85).
+//
+// Runs the three end-state agreement-rate comparisons (legacy device
+// snapshot vs. replayed trainee model) and produces helper datasets
+// for the five manual coaching-judgment items (Items 2/3/4 deferred
+// per composition / demand-side framing — see the report).
+//
+// Outputs JSON summary at fixtures/comparison-output.json for the
+// report draft to consume.
+//
+// Design choices (see README.md "Scope and design choices"):
+//   * end-state-only — legacy outputs are point-in-time device snapshots
+//   * Comparison 1 aggregation: legacy per-exercise → per-pattern via
+//     worst-of (declining > plateaued > progressing)
+//   * Comparison 2 binary: trainee deficit fires iff volumeDeficit > 0
+//   * Comparison 3 vacuous-pass flag: <30 triples/pattern AND <2 phases
+
+// TODO(scaffold): full implementation lands once both fixtures exist
+// (production dump + device-extracted legacy outputs). Skeleton
+// documents the inputs, outputs, and aggregation rules.
+
+const LOCAL_DB_URL = Deno.env.get("LOCAL_DB_URL")
+  ?? "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
+const USER_ID = Deno.env.get("USER_ID");
+const FIXTURES_DIR = "scripts/phase2-verification-gate/fixtures";
+
+if (!USER_ID) {
+  console.error("USER_ID env var required");
+  Deno.exit(2);
+}
+
+// Inputs:
+//   - fixtures/legacy-stagnation-signals.json  (StagnationSignal[])
+//   - fixtures/legacy-volume-deficits.json     (VolumeDeficit[])
+//   - fixtures/legacy-pattern-phase-states.json (MovementPatternPhaseState[])
+//   - local DB: trainee_models row for USER_ID (post-replay model_json)
+//   - local DB: workout_sessions + set_logs for sample-size and
+//     vacuous-pass detection
+
+// Comparison 1 — Stagnation verdict (per-pattern):
+//   1. Group legacy signals by pattern via ExerciseLibrary.primaryPattern(exerciseId).
+//      (pattern map lives in Swift; mirror minimal map for the patterns
+//      represented in the user's history. Surface mismatches if any
+//      exerciseId can't be mapped.)
+//   2. Aggregate per-pattern legacy verdict via worst-of.
+//   3. Compare against trainee model_json.patternProfiles[pattern].trend.
+//   4. Agreement rate = matches / total patterns evaluated.
+//   5. Critical disagreements: legacy.declining vs trainee.progressing
+//      (or vice versa) → flagged separately.
+
+// Comparison 2 — Volume deficit (per-muscle):
+//   1. Legacy: any deficit row → muscle-group is in deficit.
+//   2. Trainee: model_json.muscleProfiles[muscle].volumeDeficit > 0
+//      → muscle is in deficit.
+//   3. Per-muscle binary agreement rate.
+//   4. Document semantic divergence (calendar-week vs queue-event-window).
+
+// Comparison 3 — Pattern phase (per-pattern):
+//   1. Legacy: phaseState.phase per pattern.
+//   2. Trainee: model_json.patternProfiles[pattern].currentPhase.
+//   3. Agreement rate = identical-phase / total patterns.
+//   4. Vacuous-pass flag: <30 sessions per pattern AND <2 distinct phases
+//      observed across the window → pass is reported as vacuous-baseline,
+//      not active-confirmation.
+
+// Manual item helpers:
+//   * Item 1 (recovery readiness 24/48/72h): sample 10 sessions where
+//     a heavy NM-classified session preceded by 24h/48h/72h. Output:
+//     [(sessionId, gapHours, neuromuscularReadiness, expectedPerADR0010,
+//       deltaWithin0.05?)] for human review.
+//   * Item 2: deferred — composition-gated (plateau-verdict unwired).
+//   * Item 3: deferred — demand-side redesigned (trigger-driven prompts).
+//   * Item 4: deferred — composition-gated + no deload in history.
+//   * Item 5 (gap-bucket bucketing): sample 10–20 working sets, output
+//     [(setLogId, computedBucket, expectedBucket, gapHours)] for review.
+
+console.error("[run-comparisons] skeleton only — implementation pending fixtures");
+Deno.exit(1);


### PR DESCRIPTION
Closes #85. Final verdict: **PASS-CONDITIONAL**.

## Summary

- New [`docs/phase-2-verification-gate-report.md`](docs/phase-2-verification-gate-report.md) carries the G1 verdict + the redefinition rationale.
- New [`scripts/phase2-verification-gate/`](scripts/phase2-verification-gate/) ships the replay scaffold (replay.ts, run-comparisons.ts, extract-legacy-outputs.py, README) as a reference artifact for v2.x verification cycles.
- `.gitignore` ignores the local fixtures dir (production data dump + device-extracted legacy outputs) per the cleanup obligation.

## Why PASS-CONDITIONAL (not literal PASS)

The literal #85 gate (3 automated comparisons + 5 manual coaching-judgment items against ≥2-week alpha cohort silent-population data) was structurally unreachable at n=1:

- Agreement-rate comparisons have no statistical population
- Force-deload triggers haven't fired against real data (no plateau or decline observed)
- C-arc free-form-note demand-side is being superseded by trigger-driven structured prompts

The 2026-05-10 integration audit ([#112](https://github.com/thearnavmenon/ProjectApex/pull/112)) re-scoped G1's blocking condition from "compare against legacy" to "wire the rules we already shipped". Phases 0–3 (A14–A23, PRs [#111](https://github.com/thearnavmenon/ProjectApex/pull/111)–[#129](https://github.com/thearnavmenon/ProjectApex/pull/129)) closed all 7 unwired modules:

| Slice | PR | Wired |
|---|---|---|
| A14 | [#111](https://github.com/thearnavmenon/ProjectApex/pull/111) | handleRequest → applySession; UPSERT; JSONB fix |
| A15 | [#115](https://github.com/thearnavmenon/ProjectApex/pull/115) | Pattern bootstrap + ExerciseLibrary port |
| A16 | [#114](https://github.com/thearnavmenon/ProjectApex/pull/114) | Smoke test infra + CI job |
| A17 | [#117](https://github.com/thearnavmenon/ProjectApex/pull/117) | ewma-engine → ExerciseProfile.e1rmCurrent |
| A18 | [#119](https://github.com/thearnavmenon/ProjectApex/pull/119) | stimulus-classifier → RecoveryProfile.last*StimulusAt |
| A19 | [#121](https://github.com/thearnavmenon/ProjectApex/pull/121) | recovery-curve → RecoveryProfile.*Readiness |
| A20 | [#123](https://github.com/thearnavmenon/ProjectApex/pull/123) | plateau-verdict → PatternProfile.trend |
| A21 | [#125](https://github.com/thearnavmenon/ProjectApex/pull/125) | prescription-accuracy + gap-bucket → prescriptionAccuracy[pattern][intent] |
| A22 | [#127](https://github.com/thearnavmenon/ProjectApex/pull/127) | transfer-regression → transferRegressions[from][to] |
| A23 | [#129](https://github.com/thearnavmenon/ProjectApex/pull/129) | fatigue-interaction → fatigueInteractions[] + lastSessionPatternPerformance[] |

The CI Edge Function Tests (Deno) job is the standing oracle — every PR runs the orchestrator + smoke suite against a real local Supabase instance.

## v2.x watch-items (excerpt)

10 watch-items captured in the report, all with explicit revisit triggers:
1. Per-apply temporal agreement-rate (revisit at n>1)
2. Three legacy-vs-trainee comparisons (1, 2, 3) — same trigger
3. Recovery readiness multi-day curve audit
4. Force-deload trigger audit + phase-cycling validation
5. Classifier output review against trigger-driven structured prompts
6. Gap-bucket cross-boundary audit
7. iOS WAQ adapter wiring audit
8. Other Edge Functions stub-grep
9. JSONB write-pattern grep
10. Schema-vs-Codable diff

## Local cleanup obligation

`scripts/phase2-verification-gate/fixtures/historical-replay.sql` (production data) + `legacy-pattern-phase-states.json` (device extract) remain gitignored. Per the gate README, **delete locally after this PR merges**:

```
rm -f scripts/phase2-verification-gate/fixtures/*.sql \
      scripts/phase2-verification-gate/fixtures/*.json
```

## Test plan

- [x] All 7 G1-audit unwired modules now produce visible state changes in the smoke test (10 PRs landed)
- [x] CI Edge Function Tests (Deno) green across A14–A23
- [x] Local: 31 orchestrator + 3 smoke tests pass
- [x] No rule-module amendments required during the wiring work — all 7 modules' pure logic was already correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)