### PR TITLE
refactor(workout-nav): single interactive WorkoutView + in-session plan sheet

### DIFF
--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -83,7 +83,8 @@ struct ContentView: View {
                 if let vm = programViewModel {
                     ProgramOverviewView(
                         viewModel: vm,
-                        gymProfile: confirmedProfile
+                        gymProfile: confirmedProfile,
+                        onSwitchToWorkoutTab: { selectedTab = 1 }
                     )
                 } else {
                     loadingPlaceholder
@@ -392,7 +393,8 @@ struct ContentView: View {
                                 mesocycleCreatedAt: mesocycle.createdAt,
                                 programId: mesocycle.id,
                                 viewModel: vm,
-                                gymProfile: confirmedProfile
+                                gymProfile: confirmedProfile,
+                                onSwitchToWorkoutTab: { selectedTab = 1 }
                             )
                             .environment(deps)
                         }

--- a/ProjectApex/Features/Program/ProgramDayDetailView.swift
+++ b/ProjectApex/Features/Program/ProgramDayDetailView.swift
@@ -69,6 +69,10 @@ struct ProgramDayDetailView: View {
     var viewModel: ProgramViewModel? = nil
     /// FB-008: gym profile needed for SessionPlanService equipment constraints.
     var gymProfile: GymProfile? = nil
+    /// Switches the root TabView to the Workout tab. Wired so the "Continue Workout"
+    /// CTA for a live session reuses Tab 1's existing WorkoutView instead of pushing
+    /// a second one under Tab 0's nav stack.
+    var onSwitchToWorkoutTab: (() -> Void)? = nil
 
     @Environment(AppDependencies.self) private var deps
 
@@ -134,7 +138,8 @@ struct ProgramDayDetailView: View {
         programId: UUID = UUID(),
         devOverride: Bool = false,
         viewModel: ProgramViewModel? = nil,
-        gymProfile: GymProfile? = nil
+        gymProfile: GymProfile? = nil,
+        onSwitchToWorkoutTab: (() -> Void)? = nil
     ) {
         self.day = day
         self.week = week
@@ -143,6 +148,7 @@ struct ProgramDayDetailView: View {
         self.devOverride = devOverride
         self.viewModel = viewModel
         self.gymProfile = gymProfile
+        self.onSwitchToWorkoutTab = onSwitchToWorkoutTab
         _currentDay = State(initialValue: day)
     }
 
@@ -643,8 +649,16 @@ struct ProgramDayDetailView: View {
         let _ = isSkipped
 
         if isSessionActiveForThisDay && !isCompleted {
-            // Active session for this day — show Continue Workout button
-            Button(action: { navigateToWorkout = true }) {
+            // Active session for this day — route to Tab 1's WorkoutView rather than
+            // pushing a second one under this stack. Falls back to the local push if
+            // no tab-switch closure was wired (older call sites / previews).
+            Button(action: {
+                if let onSwitchToWorkoutTab {
+                    onSwitchToWorkoutTab()
+                } else {
+                    navigateToWorkout = true
+                }
+            }) {
                 HStack(spacing: 10) {
                     Image(systemName: "play.circle.fill")
                         .font(.system(size: 17, weight: .semibold))

--- a/ProjectApex/Features/Program/ProgramOverviewView.swift
+++ b/ProjectApex/Features/Program/ProgramOverviewView.swift
@@ -25,6 +25,9 @@ struct ProgramOverviewView: View {
     @Bindable var viewModel: ProgramViewModel
     /// The confirmed gym profile passed in from ContentView.
     let gymProfile: GymProfile?
+    /// Switches the root TabView to the Workout tab. Forwarded to ProgramDayDetailView
+    /// so its "Continue Workout" CTA can reuse Tab 1 instead of pushing a duplicate.
+    var onSwitchToWorkoutTab: (() -> Void)? = nil
 
     /// Controls the collapsed/expanded state of the pattern progress section.
     @State private var isPatternProgressExpanded = false
@@ -272,7 +275,8 @@ struct ProgramOverviewView: View {
                             phaseWeekNumber: phaseWeekNum,
                             phaseWeekTotal: phaseWeekTot,
                             liveTrainingDayId: liveTrainingDayId,
-                            liveSetSummary: liveSetSummary
+                            liveSetSummary: liveSetSummary,
+                            onSwitchToWorkoutTab: onSwitchToWorkoutTab
                         )
                         .padding(.horizontal, 12)
                         .padding(.vertical, 4)
@@ -481,6 +485,9 @@ private struct WeekRowView: View {
     var liveTrainingDayId: UUID? = nil
     /// Aggregated set progress for the live session (nil when no session active).
     var liveSetSummary: LiveSetSummary? = nil
+    /// Forwarded to ProgramDayDetailView so the "Continue Workout" CTA can route
+    /// back to Tab 1's WorkoutView instead of pushing a duplicate under this stack.
+    var onSwitchToWorkoutTab: (() -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -528,7 +535,8 @@ private struct WeekRowView: View {
                                 mesocycleCreatedAt: mesocycleCreatedAt,
                                 programId: mesocycleId,
                                 viewModel: viewModel,
-                                gymProfile: gymProfile
+                                gymProfile: gymProfile,
+                                onSwitchToWorkoutTab: onSwitchToWorkoutTab
                             )
                         } label: {
                             DayCardView(

--- a/ProjectApex/Features/Workout/ActiveSetView.swift
+++ b/ProjectApex/Features/Workout/ActiveSetView.swift
@@ -217,6 +217,17 @@ struct ActiveSetView: View {
                     .tracking(0.8)
                     .lineLimit(1)
                 Spacer()
+                Button {
+                    viewModel.showSessionPlanSheet = true
+                } label: {
+                    Image(systemName: "list.bullet.clipboard")
+                        .font(.system(size: 17, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.38))
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .accessibilityLabel("Today's plan")
+                .accessibilityHint("Shows the planned exercises and what you've logged so far")
                 Menu {
                     Button {
                         viewModel.requestExerciseSwap()

--- a/ProjectApex/Features/Workout/RestTimerView.swift
+++ b/ProjectApex/Features/Workout/RestTimerView.swift
@@ -63,6 +63,17 @@ struct RestTimerView: View {
                 // Top bar with end-early menu (P3-T09)
                 HStack {
                     Spacer()
+                    Button {
+                        viewModel.showSessionPlanSheet = true
+                    } label: {
+                        Image(systemName: "list.bullet.clipboard")
+                            .font(.system(size: 17, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.38))
+                            .frame(width: 44, height: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .accessibilityLabel("Today's plan")
+                    .accessibilityHint("Shows the planned exercises and what you've logged so far")
                     Menu {
                         Button {
                             viewModel.onPauseSession()

--- a/ProjectApex/Features/Workout/SessionPlanSheet.swift
+++ b/ProjectApex/Features/Workout/SessionPlanSheet.swift
@@ -1,0 +1,171 @@
+// Features/Workout/SessionPlanSheet.swift
+// ProjectApex
+//
+// In-workout "today's plan" sheet. Surfaces the prescription for every exercise
+// in the live session alongside the sets the user has logged so far, so the
+// user gets session context without leaving the Workout tab.
+
+import SwiftUI
+
+struct SessionPlanSheet: View {
+
+    let trainingDay: TrainingDay
+    let completedSets: [SetLog]
+    /// `exerciseId` of the exercise currently being performed (or rested between),
+    /// derived from the session FSM. Used to render a subtle "current" chip.
+    let currentExerciseId: String?
+
+    @Environment(\.dismiss) private var dismiss
+
+    private var setsByExerciseId: [String: [SetLog]] {
+        Dictionary(grouping: completedSets, by: \.exerciseId)
+            .mapValues { $0.sorted(by: { $0.setNumber < $1.setNumber }) }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color(red: 0.04, green: 0.04, blue: 0.06).ignoresSafeArea()
+
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(Array(trainingDay.exercises.enumerated()), id: \.element.id) { index, exercise in
+                            exerciseRow(
+                                exercise: exercise,
+                                index: index + 1,
+                                logs: setsByExerciseId[exercise.exerciseId] ?? []
+                            )
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 16)
+                }
+            }
+            .navigationTitle("Today's Plan")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(Color(red: 0.04, green: 0.04, blue: 0.06), for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(.white)
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Exercise Row
+
+    @ViewBuilder
+    private func exerciseRow(exercise: PlannedExercise, index: Int, logs: [SetLog]) -> some View {
+        let isCurrent = exercise.exerciseId == currentExerciseId
+        let plannedSets = exercise.sets
+        let loggedCount = logs.count
+        let accent = Color(red: 0.23, green: 0.56, blue: 1.00)
+
+        VStack(alignment: .leading, spacing: 12) {
+            // Header
+            HStack(alignment: .center, spacing: 12) {
+                Text("\(index)")
+                    .font(.system(size: 13, weight: .bold, design: .rounded))
+                    .foregroundStyle(.white.opacity(0.45))
+                    .frame(width: 26, height: 26)
+                    .background(Color.white.opacity(0.08), in: Circle())
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(exercise.name)
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(.white)
+
+                    Text("\(plannedSets) sets · \(exercise.repRange.min)–\(exercise.repRange.max) reps · RIR \(exercise.rirTarget)")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.50))
+                }
+
+                Spacer()
+
+                if isCurrent {
+                    Text("CURRENT")
+                        .font(.system(size: 10, weight: .bold))
+                        .kerning(0.6)
+                        .foregroundStyle(accent)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(accent.opacity(0.15), in: Capsule())
+                }
+            }
+
+            // Set grid — one row per planned set, filled if logged
+            VStack(spacing: 6) {
+                ForEach(1...max(plannedSets, max(loggedCount, 1)), id: \.self) { setN in
+                    setRow(
+                        setNumber: setN,
+                        log: logs.first(where: { $0.setNumber == setN })
+                    )
+                }
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white.opacity(isCurrent ? 0.08 : 0.05))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(isCurrent ? accent.opacity(0.35) : Color.white.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private func setRow(setNumber: Int, log: SetLog?) -> some View {
+        HStack(spacing: 10) {
+            Text("Set \(setNumber)")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.white.opacity(log == nil ? 0.30 : 0.50))
+                .frame(width: 48, alignment: .leading)
+
+            if let log {
+                Text(formatWeight(log.weightKg))
+                    .font(.system(size: 14, weight: .semibold, design: .rounded).monospacedDigit())
+                    .foregroundStyle(.white)
+
+                Text("×")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.white.opacity(0.35))
+
+                Text("\(log.repsCompleted) reps")
+                    .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.white)
+
+                if let rpe = log.rpeFelt {
+                    Text("· RPE \(rpe)")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.45))
+                }
+
+                Spacer()
+
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color(red: 0.24, green: 0.82, blue: 0.46))
+            } else {
+                Text("pending")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.30))
+                Spacer()
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private func formatWeight(_ kg: Double) -> String {
+        let rounded = (kg * 10).rounded() / 10
+        if rounded == rounded.rounded() {
+            return "\(Int(rounded))kg"
+        }
+        return String(format: "%.1fkg", rounded)
+    }
+}

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -237,6 +237,20 @@ struct WorkoutView: View {
                     .presentationCornerRadius(24)
             }
         }
+        .sheet(isPresented: Binding(
+            get: { viewModel?.showSessionPlanSheet ?? false },
+            set: { viewModel?.showSessionPlanSheet = $0 }
+        )) {
+            if let vm = viewModel {
+                SessionPlanSheet(
+                    trainingDay: trainingDay,
+                    completedSets: vm.completedSets,
+                    currentExerciseId: currentExerciseId(in: vm.sessionState)
+                )
+                .presentationDetents([.medium, .large])
+                .presentationCornerRadius(24)
+            }
+        }
         .alert("Session Mismatch", isPresented: $showMismatchRecoveryAlert) {
             Button("Start Fresh") {
                 // Clear the orphaned sentinel so the user can start a new session.
@@ -405,6 +419,17 @@ struct WorkoutView: View {
 
     private var setCompleteTransition: AnyTransition {
         reduceMotion ? .opacity : .apexSetComplete
+    }
+
+    // MARK: - Current exercise (for SessionPlanSheet highlight)
+
+    private func currentExerciseId(in state: SessionState) -> String? {
+        switch state {
+        case .active(let exercise, _):           return exercise.exerciseId
+        case .resting(let nextExercise, _):      return nextExercise.exerciseId
+        case .exerciseComplete(let exercise, _): return exercise.exerciseId
+        case .idle, .preflight, .sessionComplete, .error: return nil
+        }
     }
 
     // MARK: - State identity for animation transitions

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -74,6 +74,11 @@ final class WorkoutViewModel {
     /// Controls the exercise swap chat sheet (P3-T10).
     var showExerciseSwapSheet: Bool = false
 
+    /// Controls the session-plan sheet — shown when the user wants planned reps
+    /// alongside what they've logged so far. Toggled from ActiveSetView and
+    /// RestTimerView via the clipboard icon next to the ellipsis menu.
+    var showSessionPlanSheet: Bool = false
+
     /// Available weight hint for the current exercise's equipment type.
     /// Non-nil only when GymFactStore has at least one confirmed correction for that equipment type.
     /// Format: "Available: 40kg · 42.5kg · 45kg · 47.5kg · 50kg"


### PR DESCRIPTION
## Summary
- **Tab 0's \"Continue Workout\" CTA now routes to Tab 1** instead of pushing a second `WorkoutView` under Tab 0's `NavigationStack`. Threads `onSwitchToWorkoutTab` from `ContentView` → `ProgramOverviewView` → `WeekRowView` → `ProgramDayDetailView`. Narrowly scoped — fresh-start and paused-resume CTAs are unchanged, so this only collapses the duplicate that appears *once a session is already live*.
- **New `SessionPlanSheet`** presented from `WorkoutView` via a `list.bullet.clipboard` icon next to the existing ellipsis menu in both `ActiveSetView` and `RestTimerView`. Renders planned exercises (sets × rep-range × RIR) alongside logged sets so far (weight × reps · RPE with a green check) and "pending" placeholders for unlogged sets. The active exercise (from `sessionState`) gets a "CURRENT" chip.
- Together: the user can see "where am I against today's plan" mid-set without leaving Tab 1, and the duplicate-pushed-WorkoutView path that justified the calendar-context detour is gone.

## Why
Before: a live workout was reachable as two `WorkoutView` instances — one at [ContentView.swift:325](ProjectApex/ContentView.swift#L325) (Tab 1), one at [ProgramDayDetailView.swift:316](ProjectApex/Features/Program/ProgramDayDetailView.swift#L316) (Tab 0 → day-detail → push). Each held its own `@State WorkoutViewModel`, its own sheet stack, its own timer hooks against the same `WorkoutSessionManager` actor. The crash-recovery / paused-banner branching in `ContentView` was partly there because both surfaces could resume the same session.

This is option **#1 (narrow)** of three patterns we discussed (#1 narrow CTA tweak, #2 strip the live mirror entirely, #3 lift the session into a global overlay). We picked session-context over calendar-context for the in-workout view, so the sheet — not a tab switch — is the right primitive for "today's plan vs. logged."

## Test plan
- [ ] Start workout from Tab 1's main entry → confirm WorkoutView renders normally; no behavior change.
- [ ] Mid-session, swap to Tab 0 → open today's day-detail → confirm "Continue Workout" CTA switches tabs back to Tab 1 (no second push, no duplicate view tree).
- [ ] Start workout from Tab 0 day-detail (fresh day, not the live one) → still pushes Tab 0's WorkoutView (unchanged narrow scope).
- [ ] Resume Session from a paused day on Tab 0 → still pushes Tab 0's WorkoutView (unchanged narrow scope).
- [ ] Live `.active` state → tap clipboard icon → SessionPlanSheet shows planned exercises with CURRENT chip on active exercise; logged sets visible with green checks; pending sets faint.
- [ ] Live `.resting` state → tap clipboard icon → same sheet shows; CURRENT chip moves to `nextExercise`.
- [ ] Sheet detents (medium / large) feel right.
- [x] `xcodebuild -scheme ProjectApex -destination 'generic/platform=iOS Simulator' build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)