### PR TITLE
feat(program-gen): wire UI entry points to MacroPlanService (FB-008)

### DIFF
--- a/ProjectApex/Features/Onboarding/OnboardingView.swift
+++ b/ProjectApex/Features/Onboarding/OnboardingView.swift
@@ -869,20 +869,19 @@ struct OnboardingView: View {
         }
 
         do {
-            let userId = deps.resolvedUserId.uuidString
-            let userProfile = UserProfile(
+            let userId = deps.resolvedUserId
+            print("[OnboardingView] runProgramGeneration — training_days_per_week: \(profile.daysPerWeek)")
+            let skeleton = try await deps.macroPlanService.generateSkeleton(
                 userId: userId,
+                gymProfile: gymProf,
                 experienceLevel: profile.trainingAge.rawValue,
                 goals: [profile.primaryGoal.rawValue],
                 bodyweightKg: profile.bodyweightKg,
-                ageYears: profile.age
-            )
-            print("[OnboardingView] runProgramGeneration — training_days_per_week: \(profile.daysPerWeek)")
-            let mesocycle = try await deps.programGenerationService.generate(
-                userProfile: userProfile,
-                gymProfile: gymProf,
+                ageYears: profile.age,
+                trainingAge: profile.trainingAge.rawValue,
                 trainingDaysPerWeek: profile.daysPerWeek
             )
+            let mesocycle = MacroPlanService.buildPendingMesocycle(from: skeleton, userId: userId)
             // Cache immediately so ProgramViewModel.loadProgram() finds it on the fast path.
             mesocycle.saveToUserDefaults()
             isGenerating = false

--- a/ProjectApex/Features/Program/ProgramOverviewView.swift
+++ b/ProjectApex/Features/Program/ProgramOverviewView.swift
@@ -143,7 +143,7 @@ struct ProgramOverviewView: View {
             if gymProfile != nil {
                 Button(action: {
                     guard let profile = gymProfile else { return }
-                    Task { await viewModel.generateProgram(gymProfile: profile) }
+                    Task { await viewModel.generateMacroSkeleton(gymProfile: profile) }
                 }) {
                     Label("Generate My Program", systemImage: "wand.and.stars")
                         .font(.headline)

--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -148,8 +148,8 @@ final class ProgramViewModel {
         // 2. Clear the local cache so generation is not shadowed by old data.
         Mesocycle.clearUserDefaults()
 
-        // 3. Generate new program via the shared path (skip Supabase — we persist after grafting).
-        await generateProgram(gymProfile: gymProfile, persistToSupabase: false)
+        // 3. Generate a new skeleton via FB-008 path (skip Supabase — we persist after grafting).
+        await generateMacroSkeleton(gymProfile: gymProfile, persistToSupabase: false)
 
         // 4. Graft completed days back if we have any and generation succeeded.
         guard !completedDaySnapshots.isEmpty,
@@ -269,7 +269,10 @@ final class ProgramViewModel {
 
     /// Generates a 12-week skeleton (phase structure + week intents, no exercises).
     /// The resulting Mesocycle has all TrainingDays as `.pending` stubs.
-    func generateMacroSkeleton(gymProfile: GymProfile) async {
+    ///
+    /// - Parameter persistToSupabase: When false, skips the Supabase write so the
+    ///   caller (e.g. regenerateProgram) can write after applying its own post-processing.
+    func generateMacroSkeleton(gymProfile: GymProfile, persistToSupabase: Bool = true) async {
         guard await !macroPlanService.isGenerating else { return }
         viewState = .generating
 
@@ -304,16 +307,18 @@ final class ProgramViewModel {
             // Build pending mesocycle from skeleton
             let mesocycle = MacroPlanService.buildPendingMesocycle(from: skeleton, userId: userId)
 
-            // Persist to Supabase (fire-and-forget)
-            let capturedUserId = userId
-            let capturedClient = supabaseClient
-            Task.detached {
-                do {
-                    try await capturedClient.deactivatePrograms(userId: capturedUserId)
-                    let row = ProgramRow.forInsert(from: mesocycle, userId: capturedUserId)
-                    try await capturedClient.insert(row, table: "programs")
-                } catch {
-                    // Non-fatal
+            if persistToSupabase {
+                // Persist to Supabase (fire-and-forget)
+                let capturedUserId = userId
+                let capturedClient = supabaseClient
+                Task.detached {
+                    do {
+                        try await capturedClient.deactivatePrograms(userId: capturedUserId)
+                        let row = ProgramRow.forInsert(from: mesocycle, userId: capturedUserId)
+                        try await capturedClient.insert(row, table: "programs")
+                    } catch {
+                        // Non-fatal
+                    }
                 }
             }
             mesocycle.saveToUserDefaults()


### PR DESCRIPTION
## Summary

- Switches all three production program-generation call sites off the legacy `ProgramGenerationService` and onto the two-stage architecture (`MacroPlanService` + on-demand `SessionPlanService`) whose infrastructure already shipped in FB-008 but was never wired to the UI.
- Adds `persistToSupabase` to `generateMacroSkeleton` so `regenerateProgram` can graft completed days before persisting, matching the existing `generateProgram` pattern.
- Files #132 for the equipment-constraint validation gap (legacy service validated at program-gen time; new path needs equivalent in `SessionPlanService`).

## User-visible change

Program generation now produces a 12-week skeleton (phase structure + week intents, no exercises). Each day's exercises are generated on-demand via `SessionPlanService` when the user opens the day. The skeleton/on-demand flow is what lets the upcoming B1–B4 trainee-model digest cutover series deliver history-informed personalization per session — without this slice, that work would never reach the UI.

## Changes by file

- [ProgramViewModel.swift](ProjectApex/Features/Program/ProgramViewModel.swift) — `generateMacroSkeleton` gains `persistToSupabase: Bool = true`; `regenerateProgram` now calls `generateMacroSkeleton(persistToSupabase: false)` instead of legacy `generateProgram(...)`. Graft logic unchanged.
- [ProgramOverviewView.swift](ProjectApex/Features/Program/ProgramOverviewView.swift) — empty-state "Generate My Program" CTA calls `generateMacroSkeleton`.
- [OnboardingView.swift](ProjectApex/Features/Onboarding/OnboardingView.swift) — `runProgramGeneration` switched from `deps.programGenerationService.generate(...)` to `deps.macroPlanService.generateSkeleton(...)` + `MacroPlanService.buildPendingMesocycle(...)`.

## What's deliberately not in this PR

- **Deletion of `ProgramGenerationService.swift`** — left in tree as unused production code; its tests (`ProgramGenerationServiceTests`, `EquipmentConstraintValidationTests`, payload-threading test in `MacroPlanServiceDayCountTests`) continue to pass. Deletion is a separate cleanup slice once equipment validation has a new home.
- **Equipment-constraint validation port** — filed as #132. For the n=1 alpha cohort with a stable gym profile this gap is acceptable short-term.
- **Trainee model digest consumption in `SessionPlanService` prompts** — that's the B1–B4 series and the natural next step once this lands.

## Test plan

- [x] `xcodebuild build` succeeds (iPhone 17 simulator)
- [x] Full test suite passes (263 tests, 54 suites) — no regressions in `ProgramGenerationServiceTests`, `EquipmentConstraintValidationTests`, `MacroPlanServiceDayCountTests`, `SkipFeatureTests`
- [ ] Manual: empty-state CTA generates a skeleton with pending days
- [ ] Manual: Settings → Regenerate Program preserves completed days, replaces upcoming days with pending
- [ ] Manual: fresh onboarding produces a skeleton with pending days
- [ ] Manual: tapping "Generate Session" on a pending day produces a full day plan (existing `SessionPlanService` flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)