### PR TITLE
refactor(nav): five audit-followups — env tab router, polling consolidation, resume safety

### DIFF
--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -47,6 +47,9 @@ final class AppDependencies {
     let lateArrivalNotificationQueue: LateArrivalNotificationQueue
     /// Orchestrates the full set-by-set AI coaching loop during active workout sessions.
     let workoutSessionManager: WorkoutSessionManager
+    /// Single polling source for "is a session live" + summary. Views read from
+    /// this instead of running their own .task loops against the manager actor.
+    let liveSessionWatcher: LiveSessionWatcher
 
     // MARK: - Auth (MVP)
 
@@ -163,7 +166,7 @@ final class AppDependencies {
         Task { await tmJob.register(with: waq) }
 
         // 11. WorkoutSessionManager — needs AI inference, HealthKit, Memory, Supabase, GymFactStore, WAQ, streak
-        self.workoutSessionManager = WorkoutSessionManager(
+        let manager = WorkoutSessionManager(
             aiInference: inferenceService,
             healthKit: healthKitService,
             memoryService: memoryService,
@@ -172,6 +175,11 @@ final class AppDependencies {
             writeAheadQueue: waq,
             gymStreakService: gymStreakService
         )
+        self.workoutSessionManager = manager
+
+        // 12. LiveSessionWatcher — single polling source for live-session UI signals
+        // (tab badge, calendar day highlight, set summary). Starts polling on init.
+        self.liveSessionWatcher = LiveSessionWatcher(manager: manager)
     }
 
     // MARK: - Re-initialisation

--- a/ProjectApex/App/LiveSessionWatcher.swift
+++ b/ProjectApex/App/LiveSessionWatcher.swift
@@ -1,0 +1,72 @@
+// App/LiveSessionWatcher.swift
+// ProjectApex
+//
+// Single polling source of truth for "is a workout live, and what's its
+// summary." Replaces three independent .task loops previously living in
+// ContentView (badge / pausedSessionExists), ProgramOverviewView (live-day
+// highlight / set summary), and any future view that wants this signal.
+//
+// Lifecycle: created and started by AppDependencies at app launch; runs for
+// the lifetime of the process. Reads are pure SwiftUI-observed property
+// access, so any view that reads `isLive`, `currentTrainingDayId`,
+// `liveSetSummary`, or `pausedSessionExists` re-renders automatically when
+// the watcher updates them.
+
+import SwiftUI
+
+@Observable
+@MainActor
+final class LiveSessionWatcher {
+
+    /// True when WorkoutSessionManager is in any non-terminal session state.
+    private(set) var isLive: Bool = false
+    /// Training day ID of the live session, nil when idle.
+    private(set) var currentTrainingDayId: UUID? = nil
+    /// Aggregated set progress for the live session, nil when no session active.
+    private(set) var liveSetSummary: LiveSetSummary? = nil
+    /// True when a PausedSessionState exists in UserDefaults (v2 or legacy key).
+    private(set) var pausedSessionExists: Bool = false
+
+    private let manager: WorkoutSessionManager
+    private var task: Task<Void, Never>? = nil
+
+    init(manager: WorkoutSessionManager) {
+        self.manager = manager
+        start()
+    }
+
+    func start() {
+        task?.cancel()
+        task = Task { [weak self] in
+            while let self, !Task.isCancelled {
+                await self.poll()
+                try? await Task.sleep(nanoseconds: 500_000_000)
+            }
+        }
+    }
+
+    private func poll() async {
+        let state = await manager.sessionState
+        let activeId = await manager.currentTrainingDayId
+        let live: Bool
+        switch state {
+        case .idle, .sessionComplete, .error: live = false
+        default: live = true
+        }
+        isLive = live
+        currentTrainingDayId = live ? activeId : nil
+        if live {
+            let sets = await manager.completedSets
+            let last = sets.max(by: { $0.loggedAt < $1.loggedAt })
+            liveSetSummary = LiveSetSummary(
+                setsCompleted: sets.count,
+                lastWeightKg: last?.weightKg,
+                lastRepsCompleted: last?.repsCompleted
+            )
+        } else {
+            liveSetSummary = nil
+        }
+        pausedSessionExists = UserDefaults.standard.data(forKey: PausedSessionState.v2PersistenceKey) != nil
+            || UserDefaults.standard.data(forKey: PausedSessionState.legacyPersistenceKey) != nil
+    }
+}

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -344,7 +344,15 @@ struct ContentView: View {
                             // Persistent skip — advances programme_day_index, records skippedAt.
                             programViewModel?.markDaySkipped(dayId: day.id, weekId: week.id)
                         },
-                        onCloseToTab0: { selectedTab = 0 }
+                        onCloseToTab0: { selectedTab = 0 },
+                        onResumeStateConsumed: {
+                            // One-shot — clear so subsequent tab swaps into Tab 1 don't re-apply
+                            // the same paused state on top of the now-live (or post-error)
+                            // session. crashResumeDay stays valid until the session ends
+                            // (cleared in onSessionDismissed above) because workoutTab still
+                            // needs it to select the correct trainingDay parameter.
+                            crashResumeToPass = nil
+                        }
                     )
                     // Paused-session banner — shown when a different day is paused and no
                     // session is currently live (i.e. user is on the PreWorkoutView screen).

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -64,11 +64,6 @@ struct ContentView: View {
     /// True when crash recovery's paused day cannot be found anywhere in the mesocycle.
     @State private var showOrphanedRecoveryAlert: Bool = false
 
-    // MARK: - Tab badge state
-
-    @State private var sessionIsLive: Bool = false
-    @State private var pausedSessionExists: Bool = false
-
     // MARK: - Paused-session banner navigation
 
     /// True when the user taps "Resume" on PausedSessionBannerView — pushes
@@ -199,21 +194,6 @@ struct ContentView: View {
                 }
             }
         }
-        // Badge polling — drives the Tab 1 live/paused indicator.
-        // Runs as a separate .task so it is never short-circuited by the main setup task's
-        // early returns (isLive guard, onboarding skip, etc.).
-        .task {
-            while true {
-                let state = await deps.workoutSessionManager.sessionState
-                switch state {
-                case .idle, .sessionComplete, .error: sessionIsLive = false
-                default: sessionIsLive = true
-                }
-                pausedSessionExists = UserDefaults.standard.data(forKey: PausedSessionState.v2PersistenceKey) != nil
-                    || UserDefaults.standard.data(forKey: PausedSessionState.legacyPersistenceKey) != nil
-                try? await Task.sleep(nanoseconds: 500_000_000)
-            }
-        }
         .alert("Unfinished Workout", isPresented: $showCrashRecoveryAlert) {
             Button("Resume") {
                 guard let saved = crashRecoveryState,
@@ -298,9 +278,9 @@ struct ContentView: View {
     /// Returns nil (no badge) when idle. SwiftUI renders foregroundStyle on Text badges
     /// on iOS 16+; if the tint does not render the badge defaults to the system colour.
     private var workoutTabBadge: Text? {
-        if sessionIsLive {
+        if deps.liveSessionWatcher.isLive {
             return Text("●").foregroundStyle(Color(red: 0.25, green: 0.72, blue: 1.0))
-        } else if pausedSessionExists {
+        } else if deps.liveSessionWatcher.pausedSessionExists {
             return Text("●").foregroundStyle(Color(red: 1.0, green: 0.65, blue: 0.0))
         }
         return nil
@@ -369,7 +349,7 @@ struct ContentView: View {
                     // Paused-session banner — shown when a different day is paused and no
                     // session is currently live (i.e. user is on the PreWorkoutView screen).
                     .safeAreaInset(edge: .top) {
-                        if !sessionIsLive,
+                        if !deps.liveSessionWatcher.isLive,
                            let saved = PausedSessionState.load(),
                            saved.trainingDayId != day.id,
                            let found = vm.findTrainingDay(byId: saved.trainingDayId, in: mesocycle) {

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -83,8 +83,7 @@ struct ContentView: View {
                 if let vm = programViewModel {
                     ProgramOverviewView(
                         viewModel: vm,
-                        gymProfile: confirmedProfile,
-                        onSwitchToWorkoutTab: { selectedTab = 1 }
+                        gymProfile: confirmedProfile
                     )
                 } else {
                     loadingPlaceholder
@@ -122,6 +121,7 @@ struct ContentView: View {
             }
             .tag(3)
         }
+        .environment(\.switchToTab, { selectedTab = $0 })
         .preferredColorScheme(.dark)
         .fullScreenCover(isPresented: $showOnboarding) {
             OnboardingView { completedProfile in
@@ -393,8 +393,7 @@ struct ContentView: View {
                                 mesocycleCreatedAt: mesocycle.createdAt,
                                 programId: mesocycle.id,
                                 viewModel: vm,
-                                gymProfile: confirmedProfile,
-                                onSwitchToWorkoutTab: { selectedTab = 1 }
+                                gymProfile: confirmedProfile
                             )
                             .environment(deps)
                         }
@@ -576,6 +575,25 @@ struct ContentView: View {
             // Success — switch to Program tab so user sees the new program
             selectedTab = 0
         }
+    }
+}
+
+// MARK: - Cross-tab navigation environment
+
+/// Closure that switches the root TabView's selection. Injected by ContentView so
+/// any descendant view can request a tab change (e.g. ProgramDayDetailView routing
+/// a live-session "Continue Workout" CTA back to Tab 1) without prop-drilling a
+/// dedicated callback through every intermediate view. Tab indices follow the
+/// declaration order in ContentView (0 = Program, 1 = Workout, 2 = Progress,
+/// 3 = Settings). Defaults to a no-op so previews and tests work without setup.
+private struct SwitchToTabKey: EnvironmentKey {
+    static let defaultValue: (Int) -> Void = { _ in }
+}
+
+extension EnvironmentValues {
+    var switchToTab: (Int) -> Void {
+        get { self[SwitchToTabKey.self] }
+        set { self[SwitchToTabKey.self] = newValue }
     }
 }
 

--- a/ProjectApex/Features/Program/ProgramDayDetailView.swift
+++ b/ProjectApex/Features/Program/ProgramDayDetailView.swift
@@ -69,12 +69,12 @@ struct ProgramDayDetailView: View {
     var viewModel: ProgramViewModel? = nil
     /// FB-008: gym profile needed for SessionPlanService equipment constraints.
     var gymProfile: GymProfile? = nil
-    /// Switches the root TabView to the Workout tab. Wired so the "Continue Workout"
-    /// CTA for a live session reuses Tab 1's existing WorkoutView instead of pushing
-    /// a second one under Tab 0's nav stack.
-    var onSwitchToWorkoutTab: (() -> Void)? = nil
 
     @Environment(AppDependencies.self) private var deps
+    /// Closure injected by the root TabView. Used by the "Continue Workout" CTA on
+    /// a live day so it reuses Tab 1's WorkoutView instead of pushing a second one
+    /// under Tab 0's nav stack. Defaults to a no-op outside the TabView (previews).
+    @Environment(\.switchToTab) private var switchToTab
 
     /// FB-008: local state tracking whether session generation is in progress for this view.
     @State private var isGeneratingSession: Bool = false
@@ -138,8 +138,7 @@ struct ProgramDayDetailView: View {
         programId: UUID = UUID(),
         devOverride: Bool = false,
         viewModel: ProgramViewModel? = nil,
-        gymProfile: GymProfile? = nil,
-        onSwitchToWorkoutTab: (() -> Void)? = nil
+        gymProfile: GymProfile? = nil
     ) {
         self.day = day
         self.week = week
@@ -148,7 +147,6 @@ struct ProgramDayDetailView: View {
         self.devOverride = devOverride
         self.viewModel = viewModel
         self.gymProfile = gymProfile
-        self.onSwitchToWorkoutTab = onSwitchToWorkoutTab
         _currentDay = State(initialValue: day)
     }
 
@@ -650,15 +648,9 @@ struct ProgramDayDetailView: View {
 
         if isSessionActiveForThisDay && !isCompleted {
             // Active session for this day — route to Tab 1's WorkoutView rather than
-            // pushing a second one under this stack. Falls back to the local push if
-            // no tab-switch closure was wired (older call sites / previews).
-            Button(action: {
-                if let onSwitchToWorkoutTab {
-                    onSwitchToWorkoutTab()
-                } else {
-                    navigateToWorkout = true
-                }
-            }) {
+            // pushing a second one under this stack. switchToTab defaults to a no-op
+            // outside the root TabView (previews), so this is safe to call unguarded.
+            Button(action: { switchToTab(1) }) {
                 HStack(spacing: 10) {
                     Image(systemName: "play.circle.fill")
                         .font(.system(size: 17, weight: .semibold))

--- a/ProjectApex/Features/Program/ProgramOverviewView.swift
+++ b/ProjectApex/Features/Program/ProgramOverviewView.swift
@@ -25,9 +25,6 @@ struct ProgramOverviewView: View {
     @Bindable var viewModel: ProgramViewModel
     /// The confirmed gym profile passed in from ContentView.
     let gymProfile: GymProfile?
-    /// Switches the root TabView to the Workout tab. Forwarded to ProgramDayDetailView
-    /// so its "Continue Workout" CTA can reuse Tab 1 instead of pushing a duplicate.
-    var onSwitchToWorkoutTab: (() -> Void)? = nil
 
     /// Controls the collapsed/expanded state of the pattern progress section.
     @State private var isPatternProgressExpanded = false
@@ -275,8 +272,7 @@ struct ProgramOverviewView: View {
                             phaseWeekNumber: phaseWeekNum,
                             phaseWeekTotal: phaseWeekTot,
                             liveTrainingDayId: liveTrainingDayId,
-                            liveSetSummary: liveSetSummary,
-                            onSwitchToWorkoutTab: onSwitchToWorkoutTab
+                            liveSetSummary: liveSetSummary
                         )
                         .padding(.horizontal, 12)
                         .padding(.vertical, 4)
@@ -485,9 +481,6 @@ private struct WeekRowView: View {
     var liveTrainingDayId: UUID? = nil
     /// Aggregated set progress for the live session (nil when no session active).
     var liveSetSummary: LiveSetSummary? = nil
-    /// Forwarded to ProgramDayDetailView so the "Continue Workout" CTA can route
-    /// back to Tab 1's WorkoutView instead of pushing a duplicate under this stack.
-    var onSwitchToWorkoutTab: (() -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -535,8 +528,7 @@ private struct WeekRowView: View {
                                 mesocycleCreatedAt: mesocycleCreatedAt,
                                 programId: mesocycleId,
                                 viewModel: viewModel,
-                                gymProfile: gymProfile,
-                                onSwitchToWorkoutTab: onSwitchToWorkoutTab
+                                gymProfile: gymProfile
                             )
                         } label: {
                             DayCardView(

--- a/ProjectApex/Features/Program/ProgramOverviewView.swift
+++ b/ProjectApex/Features/Program/ProgramOverviewView.swift
@@ -28,10 +28,6 @@ struct ProgramOverviewView: View {
 
     /// Controls the collapsed/expanded state of the pattern progress section.
     @State private var isPatternProgressExpanded = false
-    /// The training day ID that has an active live session, nil when idle.
-    @State private var liveTrainingDayId: UUID? = nil
-    /// Aggregated set progress for the live session, updated every poll cycle.
-    @State private var liveSetSummary: LiveSetSummary? = nil
 
     var body: some View {
         ZStack {
@@ -71,32 +67,9 @@ struct ProgramOverviewView: View {
         .task {
             await viewModel.loadProgram()
         }
-        .task {
-            // Poll the actor every 2 seconds so the live-session card highlight
-            // and set-progress numbers update without requiring view navigation.
-            while !Task.isCancelled {
-                let activeId = await deps.workoutSessionManager.currentTrainingDayId
-                let state    = await deps.workoutSessionManager.sessionState
-                let isLive: Bool
-                switch state {
-                case .idle, .sessionComplete, .error: isLive = false
-                default: isLive = true
-                }
-                liveTrainingDayId = isLive ? activeId : nil
-                if isLive {
-                    let sets = await deps.workoutSessionManager.completedSets
-                    let last = sets.max(by: { $0.loggedAt < $1.loggedAt })
-                    liveSetSummary = LiveSetSummary(
-                        setsCompleted: sets.count,
-                        lastWeightKg: last?.weightKg,
-                        lastRepsCompleted: last?.repsCompleted
-                    )
-                } else {
-                    liveSetSummary = nil
-                }
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
-            }
-        }
+        // Live-session highlight + set-progress now come from
+        // deps.liveSessionWatcher (a single 500ms poll owned by AppDependencies)
+        // so this view no longer runs its own loop against the manager actor.
     }
 
     // MARK: - Loading
@@ -271,8 +244,8 @@ struct ProgramOverviewView: View {
                             gymProfile: gymProfile,
                             phaseWeekNumber: phaseWeekNum,
                             phaseWeekTotal: phaseWeekTot,
-                            liveTrainingDayId: liveTrainingDayId,
-                            liveSetSummary: liveSetSummary
+                            liveTrainingDayId: deps.liveSessionWatcher.currentTrainingDayId,
+                            liveSetSummary: deps.liveSessionWatcher.liveSetSummary
                         )
                         .padding(.horizontal, 12)
                         .padding(.vertical, 4)

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -80,6 +80,11 @@ struct WorkoutView: View {
     /// Called when the user taps the × close button on the Tab 1 entry path (idle only).
     /// Switches the tab bar to Tab 0 without touching actor state.
     var onCloseToTab0: (() -> Void)? = nil
+    /// Fires after WorkoutView has applied `resumeState` (success or error). ContentView
+    /// uses this to clear its `crashResumeToPass` one-shot so a later Tab 1 re-entry
+    /// (e.g. after the user pauses, swaps to Tab 0, then back) doesn't re-apply the
+    /// same resume on top of an already-recovered session.
+    var onResumeStateConsumed: (() -> Void)? = nil
 
     // MARK: - Body
 
@@ -153,9 +158,11 @@ struct WorkoutView: View {
                     await deps.workoutSessionManager.flushWriteAheadQueue()
                     await deps.workoutSessionManager.abandonSession(sessionId: resume.sessionId)
                     vm.sessionState = .error("We couldn't find your previous session — it may have been reset. Your logged sets have been saved.")
+                    onResumeStateConsumed?()
                     return
                 }
                 performResume(resume, vm: vm)
+                onResumeStateConsumed?()
             } else if let saved = PausedSessionState.load() {
                 guard saved.trainingDayId == trainingDay.id else {
                     // Mismatch: a paused session exists but doesn't match this training day.

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -155,30 +155,25 @@ struct WorkoutView: View {
                     vm.sessionState = .error("We couldn't find your previous session — it may have been reset. Your logged sets have been saved.")
                     return
                 }
-                vm.resumeSession(
-                    pausedState: resume,
-                    trainingDay: trainingDay,
-                    supabase: deps.supabaseClient
-                )
+                performResume(resume, vm: vm)
             } else if let saved = PausedSessionState.load() {
-                if saved.trainingDayId == trainingDay.id {
-                    // Crash recovery path — user accepted the recovery alert in ContentView.
-                    // The PausedSessionState is still present (ContentView only clears it on Abandon).
-                    // Silently resume so the user lands directly in the active session.
-                    let isIdle = await deps.workoutSessionManager.sessionState == .idle
-                    if isIdle {
-                        vm.resumeSession(
-                            pausedState: saved,
-                            trainingDay: trainingDay,
-                            supabase: deps.supabaseClient
-                        )
-                    }
-                } else {
+                guard saved.trainingDayId == trainingDay.id else {
                     // Mismatch: a paused session exists but doesn't match this training day.
                     // ContentView normally handles this via its routing logic (Path A);
                     // this branch is a safety net for edge cases ContentView didn't catch.
                     mismatchSavedState = saved
                     showMismatchRecoveryAlert = true
+                    return
+                }
+                // Crash recovery path — user accepted the recovery alert in ContentView.
+                // The PausedSessionState is still present (ContentView only clears it on Abandon).
+                // Silently resume so the user lands directly in the active session. The
+                // isIdle gate prevents double-resumption when the actor was already revived
+                // by an earlier path (e.g. ContentView's crash-recovery alert fired Path A
+                // and the .task here is now re-firing post-navigation).
+                let isIdle = await deps.workoutSessionManager.sessionState == .idle
+                if isIdle {
+                    performResume(saved, vm: vm)
                 }
             }
         }
@@ -419,6 +414,21 @@ struct WorkoutView: View {
 
     private var setCompleteTransition: AnyTransition {
         reduceMotion ? .opacity : .apexSetComplete
+    }
+
+    // MARK: - Resume helper
+
+    /// Single resume call so the two resume paths (explicit `resumeState` from
+    /// ContentView's crash-recovery alert, and the fallback `PausedSessionState.load()`
+    /// branch) can't drift apart on the argument list. Failure handling stays
+    /// per-path because the two flows surface different UI (error state vs.
+    /// mismatch alert).
+    private func performResume(_ state: PausedSessionState, vm: WorkoutViewModel) {
+        vm.resumeSession(
+            pausedState: state,
+            trainingDay: trainingDay,
+            supabase: deps.supabaseClient
+        )
     }
 
     // MARK: - Current exercise (for SessionPlanSheet highlight)

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -235,11 +235,19 @@ final class WorkoutViewModel {
         retryFailureDescription = retryReason.map { Self.retryDescription(for: $0) }
     }
 
+    /// Token for the currently-running polling task, so a second caller (e.g.
+    /// resumeSession firing while WorkoutView.task has already begun polling)
+    /// cancels the previous loop instead of stacking a parallel one.
+    private var pollingTask: Task<Void, Never>? = nil
+
     /// Starts a Task that polls actor state on every rest-timer tick and on
-    /// state transitions. Stops automatically when the session completes or errors.
+    /// state transitions. Stops automatically when the session completes or
+    /// errors. Cancels any existing polling task first so callers never spawn
+    /// two parallel loops against the same actor.
     func beginStatePolling() {
-        Task { [weak self] in
-            while let self, await self.sessionIsLive() {
+        pollingTask?.cancel()
+        pollingTask = Task { [weak self] in
+            while let self, !Task.isCancelled, await self.sessionIsLive() {
                 await self.pullState()
                 try? await Task.sleep(nanoseconds: 500_000_000) // poll every 0.5 s
             }


### PR DESCRIPTION
## Summary
Five surgical-to-structural fixes from the navigation audit that followed PR #131. Each is its own commit so they can be reviewed independently (or reverted independently). All build green; no behavior regressions intended.

## Commits

**1. `refactor(nav)`: replace \`onSwitchToWorkoutTab\` closure with \`@Environment\`** — generalizes the tab-switch primitive PR #131 introduced. Adds \`@Environment(\\.switchToTab)\` injected once on the TabView; \`ProgramDayDetailView\` reads it directly. Removes prop drilling through \`ProgramOverviewView\` → \`WeekRowView\` → \`ProgramDayDetailView\`.

**2. `refactor(perf)`: consolidate three poll loops into \`LiveSessionWatcher\`** — single 500ms poll owned by \`AppDependencies\` replaces ContentView's 500ms badge poll, ProgramOverviewView's 2s highlight poll, and the \`@State\` mirrors they drove. Views read \`deps.liveSessionWatcher.isLive\` etc. directly; SwiftUI's \`@Observable\` tracking handles re-render. ProgramOverviewView's live-day highlight now updates at 500ms instead of 2s as a side benefit.

**3. `fix(workout)`: cancel previous polling task before starting a new one** — \`WorkoutViewModel.beginStatePolling()\` had no cancellation handle. Two known callers (\`WorkoutView.task\` on appear and \`resumeSession\` at line 415) could spawn parallel polling loops on the same actor. Adds \`pollingTask: Task<Void, Never>?\` token; cancels before re-assigning.

**4. `refactor(workout)`: DRY resume call between Path A and Path B** — both resume paths in \`WorkoutView.task\` (explicit \`resumeState\` and \`PausedSessionState.load()\` fallback) called \`vm.resumeSession\` with the same args. Extracts \`performResume(_:vm:)\` so the call lives in one place. Failure handling stays per-path (Path A → error state; Path B → mismatch alert).

**5. `fix(workout-nav)`: clear crash-resume one-shot after consumption** — \`crashResumeToPass\` is a one-shot from ContentView's crash-recovery alert, but \`WorkoutView.task\` re-fires on every Tab 1 re-entry. After a pause, the actor goes back to idle and Path A would re-apply the same paused state on every tab swap. Adds \`onResumeStateConsumed\` callback fired after Path A completes; ContentView clears the flag. \`crashResumeDay\` stays valid until the session actually ends.

## Audit candidates I pushed back on (not in this PR)
- **\`InferenceRetrySheet\` dead-set Binding** — the binding's \`set: { _ in }\` is intentional. \`WorkoutViewModel\` mutates \`showInferenceRetrySheet\` itself from internal code (set on inference failure, cleared on retry success / continue / pause). The dead set enforces "user cannot dismiss; only the viewModel can." Not a smell.
- **350ms sleep before tab switch** — covers the SwiftUI dismiss animation. Replacing it adds complexity without a clear win.

## Test plan
- [ ] **Cand 1**: live-session "Continue Workout" CTA on Tab 0 still switches to Tab 1 correctly.
- [ ] **Cand 2**: Tab 1 badge appears/disappears with live state; ProgramOverviewView day card highlights without visible lag.
- [ ] **Cand 3**: start a session, navigate Tab 1 → Tab 0 → Tab 1 several times; resume from a paused session. Verify no UI jank or duplicate-poll symptoms.
- [ ] **Cand 4**: explicit resume (from crash-recovery alert) and PausedSessionState fallback both still resume correctly.
- [ ] **Cand 5**: kill app mid-session, relaunch, accept Resume, pause mid-workout, swap tabs Tab 1 → Tab 0 → Tab 1. Verify session continues normally without re-applying the resume.
- [x] \`xcodebuild -scheme ProjectApex -destination 'generic/platform=iOS Simulator' build\` succeeds (verified after each commit and after rebase onto current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)