### PR TITLE
fix(trainee-model): wire producer + fill session_payload contract

### DIFF
--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -43,6 +43,8 @@ final class AppDependencies {
     let traineeModelLocalStore: TraineeModelLocalStore
     /// WAQ adapter: routes trainee_model_updates items to the Edge Function (Phase 1 / Slice 11).
     let traineeModelUpdateJob: TraineeModelUpdateJob
+    /// Producer side: enqueues a trainee_model_updates item per completed session (#135).
+    let traineeModelService: TraineeModelService
     /// Pending late-arrival notifications surfaced on the post-session summary (Phase 2 / Slice A3, ADR-0008).
     let lateArrivalNotificationQueue: LateArrivalNotificationQueue
     /// Orchestrates the full set-by-set AI coaching loop during active workout sessions.
@@ -165,7 +167,12 @@ final class AppDependencies {
         // completes before any user interaction can trigger a WAQ flush.
         Task { await tmJob.register(with: waq) }
 
-        // 11. WorkoutSessionManager — needs AI inference, HealthKit, Memory, Supabase, GymFactStore, WAQ, streak
+        // 10b. TraineeModelService — producer side. Enqueues one trainee_model_updates
+        // item per completed session; the handler registered above dispatches them.
+        let tmService = TraineeModelService(store: tmStore, writeAheadQueue: waq)
+        self.traineeModelService = tmService
+
+        // 11. WorkoutSessionManager — needs AI inference, HealthKit, Memory, Supabase, GymFactStore, WAQ, streak, trainee model
         let manager = WorkoutSessionManager(
             aiInference: inferenceService,
             healthKit: healthKitService,
@@ -173,7 +180,8 @@ final class AppDependencies {
             supabase: supabaseClient,
             gymFactStore: gymFactStore,
             writeAheadQueue: waq,
-            gymStreakService: gymStreakService
+            gymStreakService: gymStreakService,
+            traineeModelService: tmService
         )
         self.workoutSessionManager = manager
 

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -156,6 +156,7 @@ actor WorkoutSessionManager {
     private let gymFactStore: GymFactStore
     private let writeAheadQueue: WriteAheadQueue
     private let gymStreakService: GymStreakService
+    private let traineeModelService: TraineeModelService?
 
     // MARK: - Init
 
@@ -166,7 +167,8 @@ actor WorkoutSessionManager {
         supabase: SupabaseClient,
         gymFactStore: GymFactStore,
         writeAheadQueue: WriteAheadQueue? = nil,
-        gymStreakService: GymStreakService? = nil
+        gymStreakService: GymStreakService? = nil,
+        traineeModelService: TraineeModelService? = nil
     ) {
         self.aiInference = aiInference
         self.healthKit = healthKit
@@ -176,6 +178,7 @@ actor WorkoutSessionManager {
         let waq = writeAheadQueue ?? WriteAheadQueue(supabase: supabase)
         self.writeAheadQueue = waq
         self.gymStreakService = gymStreakService ?? GymStreakService(supabase: supabase)
+        self.traineeModelService = traineeModelService
     }
 
     // MARK: - Public API
@@ -1441,6 +1444,15 @@ actor WorkoutSessionManager {
             // If the blocking write fails, enqueue it for retry
             print("[WorkoutSessionManager] Session completion write failed: \(error.localizedDescription) — enqueueing for retry")
             try? await writeAheadQueue.enqueue(patch, table: "workout_sessions")
+        }
+
+        // Producer side of the trainee-model update pipeline (#135). Only fire
+        // on real completion — early exit leaves completed=false, which the
+        // digest pipeline treats as a non-event. Must run AFTER the PATCH so
+        // the session row exists when the WAQ flush dispatches this item to
+        // the Edge Function.
+        if finalSession.completed, let traineeModelService {
+            try? await traineeModelService.enqueueUpdate(forSession: finalSession, setLogs: completedSets)
         }
 
         // Queue early-exit memory event (TDD §9.3 / P4-T07)

--- a/ProjectApex/Services/TraineeModelService.swift
+++ b/ProjectApex/Services/TraineeModelService.swift
@@ -7,7 +7,7 @@
 // Three async public methods:
 //   • read()                    -> TraineeModel?         — cached snapshot or nil
 //   • digest()                  -> TraineeModelDigest?   — narrow prompt projection
-//   • enqueueUpdate(forSession:)                         — WAQ enqueue (Phase 1 storage path)
+//   • enqueueUpdate(forSession:setLogs:)                 — WAQ enqueue (#135)
 //
 // Returning Optional from digest() rather than the issue-specified
 // `TraineeModelDigest` is a deliberate Phase-1 choice: the digest carries a
@@ -93,23 +93,31 @@ actor TraineeModelService {
         return TraineeModelDigest(from: model, asOf: now())
     }
 
-    // MARK: - Write — enqueue path only (Phase 1)
+    // MARK: - Write — enqueue path
 
     /// Enqueues a `trainee_model_update` item carrying the session-
     /// completion shape expected by the update-trainee-model Edge
     /// Function:
     ///
-    ///     { "user_id": <uuid>, "session_id": <uuid>, "session_payload": { … } }
+    ///     { "user_id": <uuid>, "session_id": <uuid>,
+    ///       "session_payload": { "logged_at": "...", "set_logs": [...] } }
     ///
-    /// Phase 1 sends an empty `session_payload` object — the
-    /// shape is the contract; the contents are filled in by Phase 2
-    /// when rule logic ships and the Edge Function actually consumes
-    /// session data.
-    func enqueueUpdate(forSession session: WorkoutSession) async throws {
+    /// `loggedAt` is generated at call time — it represents the moment the
+    /// session was applied, and is the watermark the Edge Function uses for
+    /// in-order / late-arrival classification (ADR-0008). Set logs without
+    /// an `intent` value are skipped: the Edge Function rejects the entire
+    /// payload if any element is missing intent (validateRequest in
+    /// supabase/functions/update-trainee-model/index.ts).
+    func enqueueUpdate(forSession session: WorkoutSession, setLogs: [SetLog]) async throws {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
         let payload = TraineeModelUpdatePayload(
             userId: session.userId,
             sessionId: session.id,
-            sessionPayload: SessionUpdatePayload()
+            sessionPayload: SessionUpdatePayload(
+                loggedAt: formatter.string(from: now()),
+                setLogs: setLogs.compactMap(TraineeModelSetLogPayload.init(from:))
+            )
         )
         try await writeAheadQueue.enqueue(payload, table: Self.waqTable)
     }
@@ -134,10 +142,54 @@ nonisolated struct TraineeModelUpdatePayload: Codable, Sendable {
     }
 }
 
-/// Phase 1 placeholder — encodes as an empty JSON object `{}`. Phase 2
-/// extends this struct with set_logs, session notes, and any other fields
-/// the Edge Function rule logic needs. Keeping it as a dedicated type
-/// (rather than `[String: String]()`) means Phase 2 changes are additive
-/// — the empty object remains valid against any future fields-all-optional
-/// shape.
-nonisolated struct SessionUpdatePayload: Codable, Sendable {}
+/// Session-level payload consumed by update-trainee-model Edge Function.
+/// `logged_at` is the watermark (ADR-0008) and is required — missing/invalid
+/// fails applySession before any model mutation. `set_logs` may be empty
+/// (the apply still records an idempotency row in `trainee_model_applied_sessions`).
+nonisolated struct SessionUpdatePayload: Codable, Sendable {
+    let loggedAt: String
+    let setLogs: [TraineeModelSetLogPayload]
+
+    enum CodingKeys: String, CodingKey {
+        case loggedAt = "logged_at"
+        case setLogs  = "set_logs"
+    }
+}
+
+/// Per-set entry inside `session_payload.set_logs`. Mirrors the fields the
+/// Edge Function's rule pipelines consume (per-exercise EWMA, plateau-verdict,
+/// stimulus classifier, prescription-accuracy). `intent` is required and must
+/// be one of warmup/top/backoff/technique/amrap — Swift `SetLog.intent` is
+/// Optional for backwards-compatibility with pre-Phase-2 rows, so sets without
+/// intent are filtered out before enqueue.
+///
+/// Named distinctly from `SetLogPayload` (WorkoutSessionManager's private wire
+/// type for direct `set_logs` table inserts) to avoid the module-level
+/// redeclaration clash that would otherwise surface.
+nonisolated struct TraineeModelSetLogPayload: Codable, Sendable {
+    let exerciseId: String
+    let setNumber: Int
+    let weightKg: Double
+    let repsCompleted: Int
+    let rpeFelt: Int?
+    let intent: String
+
+    enum CodingKeys: String, CodingKey {
+        case exerciseId    = "exercise_id"
+        case setNumber     = "set_number"
+        case weightKg      = "weight_kg"
+        case repsCompleted = "reps_completed"
+        case rpeFelt       = "rpe_felt"
+        case intent
+    }
+
+    init?(from setLog: SetLog) {
+        guard let intent = setLog.intent else { return nil }
+        self.exerciseId    = setLog.exerciseId
+        self.setNumber     = setLog.setNumber
+        self.weightKg      = setLog.weightKg
+        self.repsCompleted = setLog.repsCompleted
+        self.rpeFelt       = setLog.rpeFelt
+        self.intent        = intent.rawValue
+    }
+}

--- a/ProjectApexTests/TraineeModelServiceTests.swift
+++ b/ProjectApexTests/TraineeModelServiceTests.swift
@@ -5,9 +5,9 @@
 //
 // The actor is the read-side interface to the trainee model — wraps the
 // SwiftData local cache (@MainActor TraineeModelLocalStore) and the
-// WriteAheadQueue. Phase 1 ships read(), digest(), enqueueUpdate(forSession:);
+// WriteAheadQueue. Public API is read(), digest(), enqueueUpdate(forSession:setLogs:);
 // the WAQ flush handler that routes trainee_model_update items to the
-// Edge Function lands in Slice 11 (#12). Update-rule logic is Phase 2.
+// Edge Function lives in TraineeModelUpdateJob. Producer wiring landed in #135.
 //
 // The class is @MainActor because TraineeModelLocalStore must be created
 // and torn down inside an active Swift Concurrency Task — same constraint
@@ -18,10 +18,14 @@
 //   • read() returns the cached snapshot after the store is hydrated
 //   • digest() returns nil when the local cache is empty (cold-start path)
 //   • digest() returns a TraineeModelDigest assembled from the cached model
-//   • enqueueUpdate(forSession:) appends one item to the WAQ
-//   • enqueueUpdate(forSession:) targets the trainee_model_updates table
-//   • enqueueUpdate(forSession:) emits a payload whose decoded JSON shape
+//   • enqueueUpdate(forSession:setLogs:) appends one item to the WAQ
+//   • enqueueUpdate(forSession:setLogs:) targets the trainee_model_updates table
+//   • enqueueUpdate(forSession:setLogs:) emits a payload whose decoded JSON shape
 //     matches the Edge Function contract { user_id, session_id, session_payload }
+//   • session_payload carries logged_at (ISO 8601) + set_logs[] per #135
+//   • set_logs entries map SetLog → exercise_id/set_number/weight_kg/reps_completed/intent/rpe_felt
+//   • set_logs without an intent are skipped (Edge Function rejects payloads
+//     where any element omits intent)
 
 import XCTest
 @testable import ProjectApex
@@ -185,12 +189,37 @@ final class TraineeModelServiceTests: XCTestCase {
         XCTAssertEqual(patternConfidences, [.calibrating, .established])
     }
 
-    // MARK: ─── enqueueUpdate(forSession:) — WAQ shape ────────────────────────
+    // MARK: ─── enqueueUpdate(forSession:setLogs:) — WAQ shape ──────────────
+
+    private func makeSetLog(
+        setNumber: Int,
+        exerciseId: String = "barbell_bench_press",
+        weightKg: Double = 100,
+        reps: Int = 5,
+        rpe: Int? = 8,
+        intent: SetIntent? = .top
+    ) -> SetLog {
+        SetLog(
+            id: UUID(),
+            sessionId: sessionId,
+            exerciseId: exerciseId,
+            setNumber: setNumber,
+            weightKg: weightKg,
+            repsCompleted: reps,
+            rpeFelt: rpe,
+            rirEstimated: nil,
+            aiPrescribed: nil,
+            loggedAt: ref,
+            primaryMuscle: nil,
+            intent: intent,
+            completionFlags: []
+        )
+    }
 
     func test_enqueueUpdate_appendsOneItemToQueue() async throws {
         let session = makeSession()
 
-        try await service.enqueueUpdate(forSession: session)
+        try await service.enqueueUpdate(forSession: session, setLogs: [])
 
         let pending = await waq.queue
         XCTAssertEqual(pending.count, 1, "Expected exactly one queued write")
@@ -199,7 +228,7 @@ final class TraineeModelServiceTests: XCTestCase {
     func test_enqueueUpdate_targetsTraineeModelUpdatesTable() async throws {
         let session = makeSession()
 
-        try await service.enqueueUpdate(forSession: session)
+        try await service.enqueueUpdate(forSession: session, setLogs: [])
 
         let pending = await waq.queue
         let item = try XCTUnwrap(pending.first)
@@ -209,7 +238,7 @@ final class TraineeModelServiceTests: XCTestCase {
     func test_enqueueUpdate_payloadShape_matchesEdgeFunctionContract() async throws {
         let session = makeSession()
 
-        try await service.enqueueUpdate(forSession: session)
+        try await service.enqueueUpdate(forSession: session, setLogs: [])
 
         let pending = await waq.queue
         let item = try XCTUnwrap(pending.first)
@@ -217,16 +246,88 @@ final class TraineeModelServiceTests: XCTestCase {
         // Edge Function (supabase/functions/update-trainee-model/index.ts)
         // expects exactly { user_id, session_id, session_payload } with
         // user_id and session_id as UUID strings and session_payload as a
-        // JSON object. Phase 1 sends an empty session_payload object;
-        // Phase 2 fills in set_logs / notes when rule logic ships.
+        // JSON object carrying logged_at (required) and set_logs (optional).
         let json = try JSONSerialization.jsonObject(with: item.payload) as? [String: Any]
         let body = try XCTUnwrap(json)
 
         XCTAssertEqual((body["user_id"]    as? String)?.lowercased(), userId.uuidString.lowercased())
         XCTAssertEqual((body["session_id"] as? String)?.lowercased(), sessionId.uuidString.lowercased())
-        XCTAssertNotNil(body["session_payload"] as? [String: Any],
-                        "session_payload must be a JSON object per Edge Function contract")
+        let payload = try XCTUnwrap(body["session_payload"] as? [String: Any])
         XCTAssertEqual(Set(body.keys), ["user_id", "session_id", "session_payload"],
-                       "Payload must carry exactly the Edge Function contract keys")
+                       "Top-level keys must match Edge Function contract")
+        XCTAssertEqual(Set(payload.keys), ["logged_at", "set_logs"],
+                       "session_payload must carry logged_at + set_logs")
+    }
+
+    func test_enqueueUpdate_sessionPayload_loggedAtIsIso8601String() async throws {
+        let session = makeSession()
+
+        try await service.enqueueUpdate(forSession: session, setLogs: [])
+
+        let pending = await waq.queue
+        let item = try XCTUnwrap(pending.first)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: item.payload) as? [String: Any])
+        let payload = try XCTUnwrap(body["session_payload"] as? [String: Any])
+        let loggedAt = try XCTUnwrap(payload["logged_at"] as? String)
+
+        // Edge Function (applySession line 1262) throws if logged_at is not a
+        // string parseable by `new Date()`. ISO8601DateFormatter with
+        // .withInternetDateTime emits e.g. "2026-05-12T15:30:00Z" — accepted.
+        let parsed = ISO8601DateFormatter().date(from: loggedAt)
+        XCTAssertNotNil(parsed, "logged_at must parse as ISO 8601 — got \(loggedAt)")
+        XCTAssertEqual(parsed, ref, "logged_at must equal the injected now()")
+    }
+
+    func test_enqueueUpdate_setLogs_mapsAllFieldsToSnakeCase() async throws {
+        let session = makeSession()
+        let sets: [SetLog] = [
+            makeSetLog(setNumber: 1, exerciseId: "barbell_back_squat",
+                       weightKg: 130, reps: 5, rpe: 8, intent: .top),
+            makeSetLog(setNumber: 2, exerciseId: "barbell_back_squat",
+                       weightKg: 110, reps: 8, rpe: 7, intent: .backoff),
+        ]
+
+        try await service.enqueueUpdate(forSession: session, setLogs: sets)
+
+        let pending = await waq.queue
+        let item = try XCTUnwrap(pending.first)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: item.payload) as? [String: Any])
+        let payload = try XCTUnwrap(body["session_payload"] as? [String: Any])
+        let logs = try XCTUnwrap(payload["set_logs"] as? [[String: Any]])
+
+        XCTAssertEqual(logs.count, 2)
+
+        let first = logs[0]
+        XCTAssertEqual(first["exercise_id"]    as? String, "barbell_back_squat")
+        XCTAssertEqual(first["set_number"]     as? Int,    1)
+        XCTAssertEqual(first["weight_kg"]      as? Double, 130)
+        XCTAssertEqual(first["reps_completed"] as? Int,    5)
+        XCTAssertEqual(first["rpe_felt"]       as? Int,    8)
+        XCTAssertEqual(first["intent"]         as? String, "top")
+
+        let second = logs[1]
+        XCTAssertEqual(second["intent"] as? String, "backoff")
+    }
+
+    func test_enqueueUpdate_setLogs_skipsEntriesMissingIntent() async throws {
+        let session = makeSession()
+        // Mix of valid + nil-intent sets — the latter must be filtered out so
+        // the Edge Function does not reject the entire payload at validation.
+        let sets: [SetLog] = [
+            makeSetLog(setNumber: 1, intent: .top),
+            makeSetLog(setNumber: 2, intent: nil),
+            makeSetLog(setNumber: 3, intent: .backoff),
+        ]
+
+        try await service.enqueueUpdate(forSession: session, setLogs: sets)
+
+        let pending = await waq.queue
+        let item = try XCTUnwrap(pending.first)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: item.payload) as? [String: Any])
+        let payload = try XCTUnwrap(body["session_payload"] as? [String: Any])
+        let logs = try XCTUnwrap(payload["set_logs"] as? [[String: Any]])
+
+        XCTAssertEqual(logs.count, 2, "intent=nil sets must be filtered out")
+        XCTAssertEqual(logs.map { $0["intent"] as? String }, ["top", "backoff"])
     }
 }

--- a/ProjectApexTests/TraineeModelUpdateJobTests.swift
+++ b/ProjectApexTests/TraineeModelUpdateJobTests.swift
@@ -146,7 +146,7 @@ final class TraineeModelUpdateJobTests: XCTestCase {
         let payload = TraineeModelUpdatePayload(
             userId: userId,
             sessionId: sessionId,
-            sessionPayload: SessionUpdatePayload()
+            sessionPayload: SessionUpdatePayload(loggedAt: "2026-05-10T10:00:00Z", setLogs: [])
         )
         return try QueuedWrite(table: TraineeModelUpdateJob.waqTable, item: payload)
     }
@@ -300,7 +300,7 @@ final class TraineeModelUpdateJobTests: XCTestCase {
         let item = TraineeModelUpdatePayload(
             userId: userId,
             sessionId: sessionId,
-            sessionPayload: SessionUpdatePayload()
+            sessionPayload: SessionUpdatePayload(loggedAt: "2026-05-10T10:00:00Z", setLogs: [])
         )
         try await waq.enqueue(item, table: TraineeModelUpdateJob.waqTable)
 
@@ -329,7 +329,7 @@ final class TraineeModelUpdateJobTests: XCTestCase {
         let item = TraineeModelUpdatePayload(
             userId: userId,
             sessionId: sessionId,
-            sessionPayload: SessionUpdatePayload()
+            sessionPayload: SessionUpdatePayload(loggedAt: "2026-05-10T10:00:00Z", setLogs: [])
         )
         try await waq.enqueue(item, table: TraineeModelUpdateJob.waqTable)
 
@@ -539,7 +539,7 @@ final class TraineeModelUpdateJobTests: XCTestCase {
         let payload = TraineeModelUpdatePayload(
             userId: userId,
             sessionId: UUID(), // fresh UUID so idempotency key is fresh each run
-            sessionPayload: SessionUpdatePayload()
+            sessionPayload: SessionUpdatePayload(loggedAt: "2026-05-10T10:00:00Z", setLogs: [])
         )
         try await liveWAQ.enqueue(payload, table: TraineeModelUpdateJob.waqTable)
 


### PR DESCRIPTION
## Summary

- Wires `TraineeModelService` into `AppDependencies` and injects it into `WorkoutSessionManager`; the service was never instantiated, so the producer half of the trainee-model update pipeline was dead code.
- Calls `enqueueUpdate(forSession:setLogs:)` from `WorkoutSessionManager.finishSession` after the blocking PATCH succeeds and only on real completion (`finalSession.completed == true`).
- Expands `SessionUpdatePayload` from the Phase 1 empty stub to the contract the current production Edge Function actually requires: `{ logged_at, set_logs[] }`. The investigation while scoping this PR found that the stub's `{}` would throw at `applySession` line 1262 ("session_payload.logged_at must be an ISO 8601 string") — i.e. simply wiring the producer wouldn't have populated `trainee_models`, just moved the failure mode from "WAQ table empty" to "WAQ items repeatedly fail at Edge Function."

Closes #135.

## Root cause (from #135 investigation comment)

- [`TraineeModelService`](ProjectApex/Services/TraineeModelService.swift) defined but **never instantiated** in `AppDependencies`. Grep: zero `TraineeModelService(` initializer calls outside the file itself.
- [`enqueueUpdate(forSession:)`](ProjectApex/Services/TraineeModelService.swift) had **zero callers** in the codebase.
- [`WorkoutSessionManager.finishSession`](ProjectApex/Features/Workout/WorkoutSessionManager.swift) flushed WAQ, PATCHed the session as completed, ran the legacy `StagnationService` recompute — but never enqueued a `trainee_model_updates` item.
- Consequence: the WAQ table was empty, the registered flush handler had nothing to dispatch, and `trainee_models` / `trainee_model_applied_sessions` stayed empty system-wide.

## Why expand `SessionUpdatePayload` in the same PR

The Edge Function (`supabase/functions/update-trainee-model/index.ts`) requires `session_payload.logged_at` at line 1262 (throws if missing) and consumes `set_logs[]` for the per-exercise EWMA / per-pattern / prescription-accuracy / stimulus-classifier / plateau-verdict pipelines. The Phase 1 Swift stub `SessionUpdatePayload: Codable {}` (encodes as `{}`) is structurally incompatible with the production Edge Function — it was a Phase 1→2 migration left half-done.

Shipping only the wiring would have produced visible Edge Function failures in WAQ retry logs without populating any data. Bundling the payload fill makes the system actually work post-merge.

## Naming

The new per-set payload type is `TraineeModelSetLogPayload`, not `SetLogPayload`, to avoid the module-level redeclaration clash with `WorkoutSessionManager`'s existing file-private `SetLogPayload` (the wire type for direct `set_logs` table inserts).

## Test plan

- [x] `xcodebuild build` succeeds (iPhone 17 / iOS 26.4.1 simulator).
- [x] `TraineeModelServiceTests` — 11 tests pass, including the 3 new tests covering: ISO 8601 `logged_at`, snake_case mapping of all set_log fields (`exercise_id`, `set_number`, `weight_kg`, `reps_completed`, `rpe_felt`, `intent`), and the intent-skip filter.
- [x] `TraineeModelUpdateJobTests` — 19 tests pass after updating 4 stale `SessionUpdatePayload()` call sites to the new signature.
- [x] Full test target: 586 passed, 7 skipped (live-API tests, no API keys in CI Keychain), 0 failed. An earlier run hit the known iOS Build & Test flake — fresh run was clean.
- [ ] Post-merge: verify a real session-completion produces a `trainee_model_applied_sessions` row (via `supabase db query --linked` on a live user UUID).

## Open follow-ups (out of scope, file separately)

- **Backfill** — the alpha user has 19 completed historical sessions that never produced WAQ items. Decide whether to backfill via one-time admin invocation per `session_id`, or accept forward-only and rebuild from new sessions.
- **`docs/phase-2-integration-audit-2026-05-10.md`** — likely claims end-to-end wiring was complete. Correct post-merge.
- **#136** — orphan program FK on `workout_sessions.program_id`, separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)