### PR TITLE
fix(program-persist): instrument silent catch on Supabase program inserts

### DIFF
--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -14,6 +14,9 @@
 //   • `currentMesocycle` so views can observe in-place day mutations
 
 import SwiftUI
+import OSLog
+
+private let programPersistLogger = Logger(subsystem: "com.projectapex", category: "ProgramPersist")
 
 // MARK: - SessionMetaRow
 
@@ -184,7 +187,7 @@ final class ProgramViewModel {
                 let row = ProgramRow.forInsert(from: capturedMesocycle, userId: capturedUserId)
                 try await capturedClient.insert(row, table: "programs")
             } catch {
-                // Non-fatal
+                programPersistLogger.error("program insert failed (regenerateProgram): \(error.localizedDescription, privacy: .public) — user_id=\(capturedUserId.uuidString, privacy: .public), program_id=\(capturedMesocycle.id.uuidString, privacy: .public). Local cache preserved; row will not exist server-side until a successful retry.")
             }
         }
     }
@@ -251,7 +254,7 @@ final class ProgramViewModel {
                         let row = ProgramRow.forInsert(from: mesocycle, userId: capturedUserId)
                         try await capturedClient.insert(row, table: "programs")
                     } catch {
-                        // Non-fatal: program already in local cache
+                        programPersistLogger.error("program insert failed (generateProgram): \(error.localizedDescription, privacy: .public) — user_id=\(capturedUserId.uuidString, privacy: .public), program_id=\(mesocycle.id.uuidString, privacy: .public). Local cache preserved; row will not exist server-side until a successful retry.")
                     }
                 }
             }
@@ -317,7 +320,7 @@ final class ProgramViewModel {
                         let row = ProgramRow.forInsert(from: mesocycle, userId: capturedUserId)
                         try await capturedClient.insert(row, table: "programs")
                     } catch {
-                        // Non-fatal
+                        programPersistLogger.error("program insert failed (generateMacroSkeleton): \(error.localizedDescription, privacy: .public) — user_id=\(capturedUserId.uuidString, privacy: .public), program_id=\(mesocycle.id.uuidString, privacy: .public). Local cache preserved; row will not exist server-side until a successful retry.")
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Step A of the A→B plan on #136. Replaces three empty `// Non-fatal` catch blocks in [`ProgramViewModel`](ProjectApex/Features/Program/ProgramViewModel.swift) with structured `os.Logger` error logs at category `ProgramPersist`. No behaviour change — diagnostic only.

## Why

DB inspection during #136 investigation found that **zero rows in `public.programs` belong to any real user**. All 26 of the alpha user's `workout_sessions` reference a `program_id` that has never had a row. The three fire-and-forget program-write sites all caught any failure into bare `catch { }` blocks, producing no log, no retry, no surfaced error. We can't fix the root cause until we know whether the insert is failing or simply never running.

## What changed

- Added `private let programPersistLogger = Logger(subsystem: \"com.projectapex\", category: \"ProgramPersist\")` at file scope.
- Three sites get an `error()` log with `error.localizedDescription`, `user_id`, and `program_id`:
  - `regenerateProgram` (line 190)
  - `generateProgram` (line 257)
  - `generateMacroSkeleton` (line 323)

Existing behaviour preserved:
- Writes still detached (UX speed, programs are big payloads).
- Local cache (`mesocycle.saveToUserDefaults()`) remains authoritative.
- Successful inserts remain silent.
- Failures are now visible in Console.app filtered by subsystem=com.projectapex category=ProgramPersist.

## Step B (planned follow-up)

Once a real regeneration surfaces the actual error (RLS / schema / auth / network), the architectural fix is to replace `Task.detached` + bare catch with `writeAheadQueue.enqueue(...)` + ADR-0007 retry semantics. Mirrors the pattern shipped for #135 (trainee_model_updates), #138 (function deploy), #139 (schema migration) — same shape of \"code exists but doesn't persist in production\" gap.

Tracking issue: #136.

## Test plan

- [x] `xcodebuild build` succeeds.
- [ ] Post-merge: user regenerates their program. Console log surfaces the actual error from at least one of the three sites (regenerateProgram / generateProgram / generateMacroSkeleton). That error directs scope of Step B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)