### PR TITLE
ci: auto-apply migrations and deploy Edge Functions on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,45 @@ jobs:
       - name: Stop Supabase
         if: always()
         run: supabase stop || true
+
+  # Auto-deploy to the linked Supabase project on merge to main.
+  # Closes the half-deployed gap pattern documented in #143: prior to this job,
+  # `supabase db push --linked` and `supabase functions deploy` were manual admin
+  # steps that got forgotten — Phase 2 shipped triple-broken on 2026-05-12 because
+  # of three independent instances of this gap (#135-shape EF stub, #139 migration
+  # not applied, plus the producer-wiring fix in #137 that was only observable
+  # after the other two landed).
+  #
+  # Required GitHub Actions secrets:
+  #   SUPABASE_ACCESS_TOKEN — personal access token for the Supabase CLI
+  #   SUPABASE_DB_PASSWORD  — database password for the linked project
+  #
+  # Failure mode: forward-only. If `db push` fails the job fails and EF deploy is
+  # skipped. If `db push` succeeds but EF deploy fails, schema is ahead of EF;
+  # operator rolls forward by re-running deploy, or rolls schema back manually
+  # via docs/migrations/down/.
+  deploy:
+    name: Deploy to linked Supabase
+    runs-on: ubuntu-latest
+    needs: [test, ef-test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link to project
+        run: supabase link --project-ref hqjgrlzvrttnyfjqjewe
+
+      - name: Apply migrations
+        run: supabase db push --linked
+
+      - name: Deploy update-trainee-model Edge Function
+        run: supabase functions deploy update-trainee-model --project-ref hqjgrlzvrttnyfjqjewe


### PR DESCRIPTION
## Summary

- Adds a `deploy` job to [.github/workflows/ci.yml](.github/workflows/ci.yml) that runs after `test` and `ef-test` pass on pushes to `main` (skipped on PRs).
- Runs `supabase db push --linked` then `supabase functions deploy update-trainee-model` against project `hqjgrlzvrttnyfjqjewe`.
- Closes the half-deployed gap pattern from #143: two of the three 2026-05-12 Phase 2 gaps (#138 EF stub, #139 migration not applied) would have shipped automatically had this job existed. The third (#137 producer wiring) is an iOS-side concern unrelated to deploy.

## Defaults picked (from #143's five open questions)

1. **Auth**: `SUPABASE_ACCESS_TOKEN` + `SUPABASE_DB_PASSWORD` as GitHub Actions secrets. Project ref `hqjgrlzvrttnyfjqjewe` hardcoded (not sensitive — already in repo memory and visible in every deploy command).
2. **Migration safety**: forward-only. No dry-run gate. Bad migration → job fails → manual rollback via `docs/migrations/down/`. Same risk profile as today's all-manual flow.
3. **Ordering**: sequential — `db push` before `functions deploy`. Single job, three steps, so failure of an earlier step skips the later ones automatically.
4. **Partial failure**: if `db push` succeeds but `functions deploy` fails → schema ahead of EF. Operator re-runs deploy or rolls back manually. Documented in the workflow's header comment.
5. **Scope**: only `update-trainee-model` (the sole function besides `_shared`, which is a library). New functions will require explicit workflow updates — surfaced as a tradeoff, not silently auto-discovered.

## Required secrets (must be added before first merge to main)

\`\`\`
gh secret set SUPABASE_ACCESS_TOKEN --repo thearnavmenon/ProjectApex
gh secret set SUPABASE_DB_PASSWORD --repo thearnavmenon/ProjectApex
\`\`\`

The IDE's two yaml-context warnings on \`secrets.SUPABASE_*\` lines are expected and will resolve once these are added.

## Test plan

- [ ] Add the two secrets to GitHub Actions
- [ ] Merge this PR → confirm \`deploy\` job runs on the resulting push to main
- [ ] Confirm \`supabase db push --linked\` reports "Remote database is up to date" (no pending migrations beyond what's already applied)
- [ ] Confirm \`supabase functions deploy\` reports a new active version of \`update-trainee-model\`
- [ ] Next migration-bearing PR: confirm migration auto-applies on merge with no manual step
- [ ] Next EF-changing PR: confirm function auto-deploys on merge with no manual step

## Out of scope

- Detecting changed-only functions for deploy (deploy is unconditional for \`update-trainee-model\`).
- Concurrency group / merge serialization — low alpha-cohort merge velocity makes this premature.
- The iOS-side wiring audit that #135's shape implies — separate concern.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)