### PR TITLE
ci: decouple Supabase deploy from iOS Build & Test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,15 @@ jobs:
   deploy:
     name: Deploy to linked Supabase
     runs-on: ubuntu-latest
-    needs: [test, ef-test]
+    # Intentionally NOT gated on the iOS `test` job. iOS Build & Test is known-flaky
+    # (standing admin-merge permission documented in auto-memory: "don't block on
+    # the iOS Build & Test flake"). Gating deploy on it inherits the flake — a
+    # transient iOS failure would silently skip schema + EF deploy, reproducing
+    # the half-deployed shape this workflow exists to prevent (first observed when
+    # PR #144's own merge landed and the deploy was skipped on the same flake).
+    # iOS app code and Supabase artifacts are independent deploy targets; gating
+    # only on `ef-test` (Deno integration) is the correct correlation.
+    needs: [ef-test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

- Removes `test` (iOS Build & Test) from the `deploy` job's `needs:` list — keeps only `ef-test`.
- Adds an inline rationale comment so the next reader doesn't re-introduce the iOS gate.

## Why

PR [#144](https://github.com/thearnavmenon/ProjectApex/pull/144) added auto-deploy gated on both `test` and `ef-test`. On its own merge, the iOS `Build & Test` job flaked (known-flaky per standing admin-merge policy — auto-memory entry "Merge autonomy"), and the deploy job was therefore **skipped**:

```
✓ Edge Function Tests (Deno)   2m8s
✗ Build & Test                 8m13s  (iOS — flake)
- Deploy to linked Supabase    skipped
```

That's the exact half-deployed shape #143 was filed to prevent. The gate on a known-flaky job inherits the flake into the deploy pipeline.

iOS app code and Supabase artifacts (migrations + Edge Functions) are independent deploy targets — iOS test flaking doesn't tell us anything about whether the schema or EF are safe to ship. Gating deploy on `ef-test` (Deno integration suite + EF smoke) is the correct correlation.

## Test plan

- [ ] Merge → confirm CI run on main has a `deploy` job that runs (not skipped) even if `test` is still in progress / fails
- [ ] First migration-bearing PR after merge: confirm migration auto-applies on its push
- [ ] First EF-source-changing PR after merge: confirm `update-trainee-model` auto-deploys
- [ ] If iOS `test` flakes on this PR's own merge, `deploy` still runs — this merge becomes the validation case

## Out of scope

- Bigger-picture iOS test flake investigation. Separate concern; tracked implicitly by the standing admin-merge policy.
- Concurrency group / merge serialization — still not a problem at alpha-cohort merge velocity.

Follow-up to #143 / #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)