### PR TITLE
fix: #146 unblock trainee-model decoder (per-pattern recovery + missing bootstrap fields + defensive goal decode)

### DIFF
--- a/ProjectApex/Models/TraineeModel.swift
+++ b/ProjectApex/Models/TraineeModel.swift
@@ -118,7 +118,14 @@ struct TraineeModel: Codable, Sendable, Hashable {
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.activeProgramId = try c.decodeIfPresent(UUID.self, forKey: .activeProgramId)
-        self.goal = try c.decode(GoalState.self, forKey: .goal)
+        // Defensive decode per #146 — Edge Function's applySession has no
+        // write path for `goal` (onboarding owns hydration via a separate
+        // flow not yet wired). Decode-if-present + `.placeholder` sentinel
+        // unblocks the rest of the model rather than throwing keyNotFound
+        // and silently dropping the whole TraineeModel via the parseResponse
+        // `try?` at TraineeModelUpdateJob:188.
+        self.goal = try c.decodeIfPresent(GoalState.self, forKey: .goal)
+            ?? GoalState.placeholder
         self.projections = try c.decodeIfPresent(ProjectionState.self, forKey: .projections)
         self.patterns = try c.decodeEnumKeyedDictIfPresent(
             PatternProfile.self, forKey: .patterns

--- a/ProjectApex/Models/TraineeModelSnapshots.swift
+++ b/ProjectApex/Models/TraineeModelSnapshots.swift
@@ -197,4 +197,16 @@ struct GoalState: Codable, Sendable, Hashable {
         self.focusAreas = focusAreas
         self.updatedAt = updatedAt
     }
+
+    /// Sentinel used by TraineeModel's defensive decode when the server's
+    /// model_json lacks a `goal` field per #146. The Edge Function's
+    /// applySession has no write path for `goal` (onboarding owns goal
+    /// hydration in a separate flow that isn't wired yet — see spinoff).
+    /// Detect downstream via `statement.isEmpty`; digest assembly should
+    /// fall back to cold-start coaching when goal has not been hydrated.
+    static let placeholder = GoalState(
+        statement: "",
+        focusAreas: [],
+        updatedAt: .distantPast
+    )
 }

--- a/docs/migrations/down/20260512055424_drop_orphan_top_level_recovery.sql
+++ b/docs/migrations/down/20260512055424_drop_orphan_top_level_recovery.sql
@@ -1,0 +1,24 @@
+-- Reverse migration for: supabase/migrations/20260512055424_drop_orphan_top_level_recovery.sql
+-- Documentation only — manual operator use (`psql -f`); not auto-applied
+-- by `supabase db push`.
+--
+-- Restores a synthetic top-level `recovery` field on every trainee_models
+-- row using ADR-0005 defaults (null timestamps + 1.0 readinesses). The
+-- pre-#146 EF code wrote real values into this field via the global
+-- stimulus-classifier + readiness-curve pipelines, but those pipelines
+-- moved to per-pattern recovery in the same PR — there is no way to
+-- reconstruct the prior per-row values from per-pattern state at rollback
+-- time. The reverse therefore restores the SHAPE (so pre-#146 EF code
+-- that reads `model_json.recovery` won't crash on missing-key) without
+-- claiming to restore the data.
+--
+-- Use only when rolling back the #146 EF deploy.
+
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{recovery}',
+  '{"lastNeuromuscularStimulusAt": null, "lastMetabolicStimulusAt": null, "neuromuscularReadiness": 1.0, "metabolicReadiness": 1.0}'::jsonb,
+  true
+)
+WHERE NOT (model_json ? 'recovery');

--- a/docs/phase-2-cleanup-plan-2026-05-12.md
+++ b/docs/phase-2-cleanup-plan-2026-05-12.md
@@ -86,15 +86,25 @@ ORDER BY ws.session_date DESC;
 
 If `appeared_in_applied_sessions` is `true` within ~5 minutes of session completion, the producer wiring works in production. If `false`, the WAQ retry / Edge Function pipeline has a remaining gap and this becomes the next investigation.
 
-### 6. Investigate `confidence: null` on all 5 patterns
+### 6. [#146](https://github.com/thearnavmenon/ProjectApex/issues/146) — contract-drift between EF emit and Swift decode
 
-After backfill, `trainee_models.model_json.patterns[*].confidence` is `null` for every pattern despite 19 sessions of data. Possible causes:
-- Confidence field is populated by a rule module not in the current backfill data path (e.g., needs cross-session aggregates that 19 sessions doesn't trigger).
-- Or it's actually a fifth gap — another half-wired field.
+**Originally framed as a 15-minute `confidence: null` check; investigation revealed five separate decoder-killer schema gaps.** The `confidence: null` observation was the tip — `JSONDecoder.decode(TraineeModel.self, ...)` was throwing `keyNotFound` on the FIRST missing field (`goal`) and never reaching `patterns[*].confidence`. The `try?` at `TraineeModelUpdateJob.parseResponse:188` silently swallowed every failure, so the iOS local store never hydrated. Net effect: `TraineeModelService.digest()` returned nil for every iOS call, blocking B1–B4 entirely.
 
-15-minute check: read the confidence-population path in `supabase/functions/update-trainee-model/index.ts`, find the trigger condition, see if our user's data should have hit it. If yes → file as a bug. If no → expected behaviour, document the threshold.
+Missing fields per server-emitted `model_json` for the alpha user:
 
-This matters because the digest is about to become a load-bearing input for B1–B4 cutover prompts, and confidence-gated logic (e.g., per ADR-0005's `.established`/`.calibrating` semantics) needs reliable confidence values.
+| Field | Status |
+|---|---|
+| Top-level `goal` | Swift defensive decode + `GoalState.placeholder` sentinel; spinoff issue for the real onboarding write path |
+| Per-PatternProfile `pattern` | EF bootstrap now emits as field |
+| Per-PatternProfile `rpeOffset` | EF bootstrap now emits with default `0` |
+| Per-PatternProfile `recovery` | EF migrated from top-level `model_json.recovery` to per-pattern per ADR-0005 + cross-platform fixture contract. `applyPerSetStimulusRules` + `applyRecoveryReadiness` now operate per-pattern; orphan top-level field stripped via SQL migration |
+| Per-PatternProfile `confidence` | EF bootstrap now emits `"bootstrapping"` default |
+
+This was the **fifth deployment-shape gap** in the same family as #135/#138/#139 (wiring/deploy/migration); #146 was at the contract layer: code emits one shape, code consumes a different shape, the integration point silently absorbs the mismatch.
+
+Sixth gap surfaced during #146 implementation: EF emits camelCase pattern keys (`horizontalPush`), Swift's `MovementPattern.rawValue` uses snake_case (`horizontal_push`). `decodeEnumKeyedDict` silently drops mismatched keys. Filed as separate spinoff — out of #146's scope.
+
+#146's coordinated PR ships this all in one batch with TS test updates, the recovery migration, and the docs update. After it merges, B1–B4 unblock for the 3 keys whose casing happens to match (squat/lunge/isolation); full 8-pattern unblock requires the casing spinoff to merge.
 
 ---
 
@@ -161,7 +171,7 @@ Working top-down, the highest-value sequencing is:
 1. **#1 (file CI auto-deploy issue)** — prevents the next gap of the same shape. Do this first.
 2. **#7 (unpause #132)** — small, safe, ships actual user value (equipment safety on per-day generation). Half-day.
 3. **#5 (live-session smoke check)** — after the next workout, one SQL query. Confirms the producer wiring works in the wild.
-4. **#6 (`confidence: null` investigation)** — 15 minutes. Either rules out a fifth gap or files it.
+4. **#6 ([#146](https://github.com/thearnavmenon/ProjectApex/issues/146))** — coordinated PR resolving 5 contract-drift gaps. ~3h of work; bundles EF + Swift + migration + tests.
 5. **#4 (deepLiftHistory fix per #141)** — likely a one-line WHERE clause fix.
 6. **#8 (resume B1, then B2/B3/B4)** — multi-PR cutover work. Largest scope but everything else has cleared the runway.
 7. **#2 + #3 (audit doc + G1 report corrections)** — can interleave anywhere. Honest accounting, no code risk.

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -432,14 +432,17 @@ function applyPerExerciseRules(
 }
 
 /**
- * Per-set stimulus pipeline per #118 (A18). Each set's (intent, reps, rpeFelt)
- * triple maps to a `StimulusDimension | null` via `classifyStimulus`; sets
- * that drive a dimension bump the corresponding `last*StimulusAt` timestamp
- * to the session's `incomingLoggedAt`.
+ * Per-set stimulus pipeline per #118 (A18), migrated to per-pattern recovery
+ * per #146. Each set's (intent, reps, rpeFelt) triple maps to a
+ * `StimulusDimension | null` via `classifyStimulus`; sets that drive a
+ * dimension bump the corresponding `last*StimulusAt` timestamp on the
+ * pattern resolved via `lookupPattern(set.exercise_id)`. Sets whose
+ * exercise has no pattern mapping (or whose intent contributes no
+ * stimulus) are skipped.
  *
- * Bootstrap: missing `model_json.recovery` gets ADR-0005 defaults — null
- * timestamps + 1.0 readinesses. Readiness scalars are owned by A19; this
- * slice only updates the timestamps.
+ * Defense-in-depth: per-pattern bootstrap with full `recovery` shape lives
+ * in `applyPerPatternRules`. If a pattern still lacks a `recovery` field at
+ * this stage, fill ADR-0005 defaults rather than throwing.
  *
  * Monotonicity: the orchestrator's watermark check rejects late arrivals
  * before this helper runs, so `incomingLoggedAt >= last_applied_logged_at >=
@@ -447,37 +450,27 @@ function applyPerExerciseRules(
  * `max()` guard needed.
  */
 function applyPerSetStimulusRules(
-  recovery: Record<string, unknown> | undefined,
+  patterns: Record<string, Record<string, unknown>>,
   setLogs: Array<Record<string, unknown>>,
   incomingLoggedAt: Date,
 ): {
-  recovery: Record<string, unknown>;
+  patterns: Record<string, Record<string, unknown>>;
   rulesFired: Set<string>;
   fieldsChanged: string[];
 } {
   const rulesFired = new Set<string>();
   const fieldsChanged: string[] = [];
-  const wasBootstrapped = recovery === undefined;
-  const newRecovery: Record<string, unknown> = wasBootstrapped
-    ? {
-        lastNeuromuscularStimulusAt: null,
-        lastMetabolicStimulusAt: null,
-        neuromuscularReadiness: 1.0,
-        metabolicReadiness: 1.0,
-      }
-    : { ...recovery };
-  if (wasBootstrapped) {
-    fieldsChanged.push("recovery.bootstrapped");
-  }
-
   const loggedAtIso = incomingLoggedAt.toISOString();
-  let bumpedNm = false;
-  let bumpedMet = false;
 
+  const bumps: Record<string, { nm: boolean; met: boolean }> = {};
   for (const set of setLogs) {
     const intent = set.intent;
     if (typeof intent !== "string") continue;
     if (typeof set.reps_completed !== "number") continue;
+    const exerciseId = set.exercise_id;
+    if (typeof exerciseId !== "string") continue;
+    const patternKey = lookupPattern(exerciseId);
+    if (!patternKey) continue;
     const rpeFelt = typeof set.rpe_felt === "number" ? set.rpe_felt : null;
     const dim = classifyStimulus(
       intent as SetIntent,
@@ -485,28 +478,49 @@ function applyPerSetStimulusRules(
       rpeFelt,
     );
     if (dim === null) continue;
-    if (dim === "neuromuscular" || dim === "both") bumpedNm = true;
-    if (dim === "metabolic" || dim === "both") bumpedMet = true;
+    const entry = bumps[patternKey] ?? { nm: false, met: false };
+    if (dim === "neuromuscular" || dim === "both") entry.nm = true;
+    if (dim === "metabolic" || dim === "both") entry.met = true;
+    bumps[patternKey] = entry;
   }
 
-  if (bumpedNm) {
-    newRecovery.lastNeuromuscularStimulusAt = loggedAtIso;
-    rulesFired.add("stimulus-classifier");
-    fieldsChanged.push("recovery.lastNeuromuscularStimulusAt");
-  }
-  if (bumpedMet) {
-    newRecovery.lastMetabolicStimulusAt = loggedAtIso;
-    rulesFired.add("stimulus-classifier");
-    fieldsChanged.push("recovery.lastMetabolicStimulusAt");
+  const newPatterns: Record<string, Record<string, unknown>> = { ...patterns };
+  for (const [patternKey, flags] of Object.entries(bumps)) {
+    const profile = newPatterns[patternKey];
+    if (!profile) continue; // pattern not in dict — orchestrator owns bootstrap
+    const priorRecovery =
+      (profile.recovery as Record<string, unknown> | undefined) ?? {
+        lastNeuromuscularStimulusAt: null,
+        lastMetabolicStimulusAt: null,
+        neuromuscularReadiness: 1.0,
+        metabolicReadiness: 1.0,
+      };
+    const newRecovery: Record<string, unknown> = { ...priorRecovery };
+    if (flags.nm) {
+      newRecovery.lastNeuromuscularStimulusAt = loggedAtIso;
+      rulesFired.add("stimulus-classifier");
+      fieldsChanged.push(
+        `patterns.${patternKey}.recovery.lastNeuromuscularStimulusAt`,
+      );
+    }
+    if (flags.met) {
+      newRecovery.lastMetabolicStimulusAt = loggedAtIso;
+      rulesFired.add("stimulus-classifier");
+      fieldsChanged.push(
+        `patterns.${patternKey}.recovery.lastMetabolicStimulusAt`,
+      );
+    }
+    newPatterns[patternKey] = { ...profile, recovery: newRecovery };
   }
 
-  return { recovery: newRecovery, rulesFired, fieldsChanged };
+  return { patterns: newPatterns, rulesFired, fieldsChanged };
 }
 
 /**
- * Recovery readiness pipeline per #120 (A19). Reads the just-bumped
- * `last*StimulusAt` timestamps from `recovery` and computes the per-axis
- * readiness scalars via ADR-0010's curve:
+ * Recovery readiness pipeline per #120 (A19), migrated to per-pattern
+ * recovery per #146. For each pattern, reads its `recovery.last*StimulusAt`
+ * timestamps and computes the per-axis readiness scalars via ADR-0010's
+ * curve:
  *
  *   readiness(t) = clamp(0, 1, 0.3 + 0.7 × (1 - exp(-t / tau)))
  *
@@ -523,38 +537,51 @@ function applyPerSetStimulusRules(
  * in-depth catches any path that bypasses the watermark.
  */
 function applyRecoveryReadiness(
-  recovery: Record<string, unknown>,
+  patterns: Record<string, Record<string, unknown>>,
   incomingLoggedAt: Date,
   userId: string,
 ): {
-  recovery: Record<string, unknown>;
+  patterns: Record<string, Record<string, unknown>>;
   rulesFired: Set<string>;
   fieldsChanged: string[];
 } {
   const rulesFired = new Set<string>();
   const fieldsChanged: string[] = [];
-
-  const nmRaw = recovery.lastNeuromuscularStimulusAt;
-  const metRaw = recovery.lastMetabolicStimulusAt;
-  const lastNm = typeof nmRaw === "string" ? new Date(nmRaw) : null;
-  const lastMet = typeof metRaw === "string" ? new Date(metRaw) : null;
-
   const ctx = { userId };
-  const newNmReadiness = readiness("neuromuscular", lastNm, incomingLoggedAt, ctx);
-  const newMetReadiness = readiness("metabolic", lastMet, incomingLoggedAt, ctx);
 
-  const newRecovery = { ...recovery };
-  if (newRecovery.neuromuscularReadiness !== newNmReadiness) {
-    newRecovery.neuromuscularReadiness = newNmReadiness;
-    fieldsChanged.push("recovery.neuromuscularReadiness");
-  }
-  if (newRecovery.metabolicReadiness !== newMetReadiness) {
-    newRecovery.metabolicReadiness = newMetReadiness;
-    fieldsChanged.push("recovery.metabolicReadiness");
-  }
-  rulesFired.add("recovery-curve");
+  const newPatterns: Record<string, Record<string, unknown>> = {};
+  for (const [patternKey, profile] of Object.entries(patterns)) {
+    const recovery =
+      (profile.recovery as Record<string, unknown> | undefined) ?? {
+        lastNeuromuscularStimulusAt: null,
+        lastMetabolicStimulusAt: null,
+        neuromuscularReadiness: 1.0,
+        metabolicReadiness: 1.0,
+      };
+    const nmRaw = recovery.lastNeuromuscularStimulusAt;
+    const metRaw = recovery.lastMetabolicStimulusAt;
+    const lastNm = typeof nmRaw === "string" ? new Date(nmRaw) : null;
+    const lastMet = typeof metRaw === "string" ? new Date(metRaw) : null;
 
-  return { recovery: newRecovery, rulesFired, fieldsChanged };
+    const newNmReadiness = readiness("neuromuscular", lastNm, incomingLoggedAt, ctx);
+    const newMetReadiness = readiness("metabolic", lastMet, incomingLoggedAt, ctx);
+
+    const newRecovery = { ...recovery };
+    if (newRecovery.neuromuscularReadiness !== newNmReadiness) {
+      newRecovery.neuromuscularReadiness = newNmReadiness;
+      fieldsChanged.push(`patterns.${patternKey}.recovery.neuromuscularReadiness`);
+    }
+    if (newRecovery.metabolicReadiness !== newMetReadiness) {
+      newRecovery.metabolicReadiness = newMetReadiness;
+      fieldsChanged.push(`patterns.${patternKey}.recovery.metabolicReadiness`);
+    }
+    newPatterns[patternKey] = { ...profile, recovery: newRecovery };
+  }
+  if (Object.keys(patterns).length > 0) {
+    rulesFired.add("recovery-curve");
+  }
+
+  return { patterns: newPatterns, rulesFired, fieldsChanged };
 }
 
 /**
@@ -736,6 +763,10 @@ function applyPerPatternRules(
   for (const pattern of trainedPatterns) {
     if (!(pattern in merged)) {
       merged[pattern] = {
+        // #146: emit `pattern` as a field so Swift's PatternProfile.init
+        // can decode it (the dict key alone is invisible to the inner
+        // decoder via decodeEnumKeyedDict).
+        pattern,
         currentPhase: "accumulation",
         sessionsInPhase: 0,
         consecutiveForceDeloadsOnPattern: 0,
@@ -743,6 +774,19 @@ function applyPerPatternRules(
         recentSessionDates: [],
         transitionModeUntil: null,
         trend: "progressing",
+        // #146: fields required by Swift PatternProfile decoder. rpeOffset
+        // and confidence default per ADR-0005 (bootstrapping); real calibration
+        // logic flips confidence in later slices. recovery moved from
+        // top-level model_json.recovery to per-pattern per ADR-0005 §"recovery
+        // (two-dimensional NM + metabolic) is locked as per-pattern".
+        rpeOffset: 0,
+        confidence: "bootstrapping",
+        recovery: {
+          lastNeuromuscularStimulusAt: null,
+          lastMetabolicStimulusAt: null,
+          neuromuscularReadiness: 1.0,
+          metabolicReadiness: 1.0,
+        },
         // A20 (#122): persisted track input for plateau-verdict's volume-load
         // dimension. Each entry buckets a session's pattern volume-load
         // (Σ weight × reps over non-warmup sets) by ISO week.
@@ -1470,29 +1514,37 @@ export async function applySession(
       rulesFired.push(...fatigueRuled.rulesFired);
       fieldsChanged.push(...fatigueRuled.fieldsChanged);
 
-      // Per-set stimulus pipeline per #118 (A18). Wires stimulus-classifier
-      // into RecoveryProfile.last*StimulusAt. Readiness scalars wire in A19.
-      const recoveryIn = modelJson.recovery as
-        | Record<string, unknown>
-        | undefined;
+      // Per-set stimulus pipeline per #118 (A18), migrated to per-pattern
+      // recovery per #146. Each set's stimulus dimension attributes to its
+      // exercise's pattern (via lookupPattern); the matching pattern's
+      // recovery.last*StimulusAt timestamps update accordingly. Reads the
+      // post-applyPerPatternRules patterns dict so newly-bootstrapped
+      // patterns from this session have their recovery field present.
+      const patternsAfterPatternRules = newModelJson.patterns as Record<
+        string,
+        Record<string, unknown>
+      >;
       const stimulusRuled = applyPerSetStimulusRules(
-        recoveryIn,
+        patternsAfterPatternRules,
         setLogsArr,
         incomingLoggedAt,
       );
-      newModelJson = { ...newModelJson, recovery: stimulusRuled.recovery };
+      newModelJson = { ...newModelJson, patterns: stimulusRuled.patterns };
       rulesFired.push(...stimulusRuled.rulesFired);
       fieldsChanged.push(...stimulusRuled.fieldsChanged);
 
-      // Recovery readiness compute per #120 (A19). Reads the just-bumped
-      // last*StimulusAt timestamps from stimulusRuled.recovery and writes
-      // *Readiness scalars per ADR-0010's curve.
+      // Recovery readiness compute per #120 (A19), per-pattern per #146.
+      // For each pattern, reads its recovery.last*StimulusAt timestamps
+      // (just bumped above) and writes *Readiness scalars per ADR-0010's
+      // curve. Untrained-this-session patterns also recompute readiness
+      // against the new incomingLoggedAt — recovery decays for everyone
+      // every apply, not just trained patterns.
       const readinessRuled = applyRecoveryReadiness(
-        stimulusRuled.recovery,
+        stimulusRuled.patterns,
         incomingLoggedAt,
         req.user_id,
       );
-      newModelJson = { ...newModelJson, recovery: readinessRuled.recovery };
+      newModelJson = { ...newModelJson, patterns: readinessRuled.patterns };
       rulesFired.push(...readinessRuled.rulesFired);
       fieldsChanged.push(...readinessRuled.fieldsChanged);
 

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -190,7 +190,7 @@ orchestratorTest(
 );
 
 orchestratorTest(
-  "A18 / #118: stimulus-classifier wired — first apply with mixed-intent sets bootstraps RecoveryProfile + bumps last*StimulusAt per Q3 mapping",
+  "A18 / #118 (per-pattern recovery per #146): stimulus-classifier wired — bench top×5 bumps horizontalPush NM; row top×8 bumps horizontalPull NM+metabolic (top×8 classifies as 'both')",
   async () => {
     const userId = await seedFreshUser();
     const sessionId = crypto.randomUUID();
@@ -205,9 +205,9 @@ orchestratorTest(
           set_logs: [
             // warmup → null dim, no timestamp bump
             { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 60, reps_completed: 5, intent: "warmup" },
-            // top reps=5 → "neuromuscular" (BACKOFF_NM_REP_MAX is 5)
+            // top reps=5 → "neuromuscular" → horizontalPush NM only
             { exercise_id: "barbell_bench_press", set_number: 2, weight_kg: 100, reps_completed: 5, intent: "top", rpe_felt: 8 },
-            // top reps=8 RPE=8 → "metabolic" (no RPE bump under threshold)
+            // top reps=8 → "both" (BACKOFF_BOTH_REP_MAX=8) → horizontalPull NM + metabolic
             { exercise_id: "barbell_row", set_number: 1, weight_kg: 70, reps_completed: 8, intent: "top", rpe_felt: 8 },
           ],
         },
@@ -222,22 +222,25 @@ orchestratorTest(
       SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
     `;
     const modelJson = rows[0].model_json as Record<string, unknown>;
-    const recovery = modelJson.recovery as Record<string, unknown>;
-
-    // Both timestamps bumped to loggedAt: NM (top×5) + metabolic (top×8).
+    const patterns = modelJson.patterns as Record<string, Record<string, unknown>>;
     const expectedIso = new Date(loggedAt).toISOString();
-    assertEquals(recovery.lastNeuromuscularStimulusAt, expectedIso);
-    assertEquals(recovery.lastMetabolicStimulusAt, expectedIso);
 
-    // Readinesses computed via A19's recovery-curve at t=0 → residual floor 0.3.
-    assertEquals(
-      Number((recovery.neuromuscularReadiness as number).toFixed(4)),
-      0.3,
-    );
-    assertEquals(
-      Number((recovery.metabolicReadiness as number).toFixed(4)),
-      0.3,
-    );
+    // horizontalPush: NM only (bench top×5). metabolic axis untouched.
+    const pushRec = patterns.horizontalPush.recovery as Record<string, unknown>;
+    assertEquals(pushRec.lastNeuromuscularStimulusAt, expectedIso);
+    assertEquals(pushRec.lastMetabolicStimulusAt, null);
+    assertEquals(Number((pushRec.neuromuscularReadiness as number).toFixed(4)), 0.3);
+    assertEquals(pushRec.metabolicReadiness, 1.0);
+
+    // horizontalPull: both axes (row top×8 = "both"). NM and metabolic bumped.
+    const pullRec = patterns.horizontalPull.recovery as Record<string, unknown>;
+    assertEquals(pullRec.lastNeuromuscularStimulusAt, expectedIso);
+    assertEquals(pullRec.lastMetabolicStimulusAt, expectedIso);
+    assertEquals(Number((pullRec.neuromuscularReadiness as number).toFixed(4)), 0.3);
+    assertEquals(Number((pullRec.metabolicReadiness as number).toFixed(4)), 0.3);
+
+    // No orphan top-level recovery write per #146.
+    assertEquals(modelJson.recovery, undefined);
   },
 );
 
@@ -578,7 +581,7 @@ orchestratorTest(
 );
 
 orchestratorTest(
-  "A19 / #120: recovery-curve wired — same-instant stimulus (lastStimulusAt === loggedAt) sets bumped axes to residual floor 0.3; null-timestamp axis stays at 1.0",
+  "A19 / #120 (per-pattern recovery per #146): recovery-curve wired — same-instant stimulus on squat NM axis sets squat NM readiness to floor 0.3; squat metabolic axis stays at 1.0 (null timestamp)",
   async () => {
     const userId = await seedFreshUser();
     const sessionId = crypto.randomUUID();
@@ -603,7 +606,8 @@ orchestratorTest(
     const rows = await sql`
       SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
     `;
-    const recovery = (rows[0].model_json as Record<string, unknown>).recovery as Record<string, unknown>;
+    const patterns = (rows[0].model_json as Record<string, unknown>).patterns as Record<string, Record<string, unknown>>;
+    const recovery = patterns.squat.recovery as Record<string, unknown>;
 
     // NM stimulus at loggedAt, computed at loggedAt → t=0 → readiness = floor 0.3
     assertEquals(
@@ -617,7 +621,7 @@ orchestratorTest(
 );
 
 orchestratorTest(
-  "A19 / #120: recovery-curve wired — second session 24h after stimulus produces partially-recovered readiness per ADR-0010 curve (NM ~0.78, metabolic ~0.69 if re-stimulated then 0.3)",
+  "A19 / #120 (per-pattern recovery per #146): second session 24h after horizontalPush stimulus produces partially-recovered NM readiness per ADR-0010 curve (~0.7853); metabolic untouched stays 1.0",
   async () => {
     const userId = await seedFreshUser();
     const sessionId1 = crypto.randomUUID();
@@ -625,7 +629,7 @@ orchestratorTest(
     const loggedAt1 = "2026-05-08T10:00:00Z";
     const loggedAt2 = "2026-05-09T10:00:00Z"; // exactly 24h later
 
-    // Session 1: heavy bench top×5 (NM only)
+    // Session 1: heavy bench top×5 (NM only) → bootstraps horizontalPush
     await applySession(
       {
         user_id: userId,
@@ -642,7 +646,8 @@ orchestratorTest(
     );
 
     // Session 2: empty (no stimulus). Tests "readiness recomputes from now-loggedAt
-    // even when no new stimulus arrives."
+    // even when no new stimulus arrives" — readiness decay applies even for
+    // patterns not trained this session.
     await applySession(
       {
         user_id: userId,
@@ -656,7 +661,8 @@ orchestratorTest(
     const rows = await sql`
       SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
     `;
-    const recovery = (rows[0].model_json as Record<string, unknown>).recovery as Record<string, unknown>;
+    const patterns = (rows[0].model_json as Record<string, unknown>).patterns as Record<string, Record<string, unknown>>;
+    const recovery = patterns.horizontalPush.recovery as Record<string, unknown>;
 
     // NM: 24h since stimulus, tau=30h → 0.3 + 0.7 × (1 - exp(-24/30)) ≈ 0.7853
     const expectedNm = 0.3 + 0.7 * (1 - Math.exp(-24 / 30));
@@ -670,7 +676,7 @@ orchestratorTest(
 );
 
 orchestratorTest(
-  "A18 / #118: warmup-only session leaves RecoveryProfile bootstrapped with null timestamps (no stimulus bump from low-stimulus sets)",
+  "A18 / #118 (per-pattern recovery per #146): warmup-only session bootstraps horizontalPush pattern with default recovery shape — null timestamps + 1.0 readinesses (no stimulus bump from low-stimulus sets)",
   async () => {
     const userId = await seedFreshUser();
     const sessionId = crypto.randomUUID();
@@ -696,7 +702,8 @@ orchestratorTest(
     const rows = await sql`
       SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
     `;
-    const recovery = (rows[0].model_json as Record<string, unknown>).recovery as Record<string, unknown>;
+    const patterns = (rows[0].model_json as Record<string, unknown>).patterns as Record<string, Record<string, unknown>>;
+    const recovery = patterns.horizontalPush.recovery as Record<string, unknown>;
 
     // Bootstrapped (the field exists)...
     assertEquals(recovery.neuromuscularReadiness, 1.0);

--- a/supabase/functions/update-trainee-model/smoke_test.ts
+++ b/supabase/functions/update-trainee-model/smoke_test.ts
@@ -188,23 +188,36 @@ smokeTest(
       assertEquals(profile.sessionCount, 1);
     }
 
-    // RecoveryProfile.last*StimulusAt populated (A18 / #118). The synthetic
-    // fixture has top sets at reps 5 (NM) and reps 8 with RPE 8 (metabolic),
-    // plus a backoff at reps 8 RPE 7 (metabolic) — so both timestamps must
-    // bump to loggedAt. Readinesses computed via ADR-0010 curve at t=0 →
-    // residual floor 0.3 (A19 / #120).
-    const recovery = modelJson.recovery as Record<string, unknown>;
-    assertEquals(recovery.lastNeuromuscularStimulusAt, expectedLoggedAtIso);
-    assertEquals(recovery.lastMetabolicStimulusAt, expectedLoggedAtIso);
-    // Readiness curve: 0.3 + 0.7 × (1 - exp(-0/tau)) = 0.3
-    assertEquals(
-      Number((recovery.neuromuscularReadiness as number).toFixed(4)),
-      0.3,
-    );
-    assertEquals(
-      Number((recovery.metabolicReadiness as number).toFixed(4)),
-      0.3,
-    );
+    // RecoveryProfile.last*StimulusAt populated per-pattern (A18 / #118,
+    // migrated to per-pattern recovery per #146). Per stimulus-classifier:
+    //   - bench top×5 RPE 8 → NM; backoff×8 RPE 7 → "both" (reps ≤ 8)
+    //     → horizontalPush: NM + met both bumped
+    //   - squat top×5 RPE 8 → NM only
+    //     → squat: NM bumped, met null
+    //   - row top×8 RPE 8 → "both"
+    //     → horizontalPull: NM + met both bumped
+    // Readinesses computed via ADR-0010 curve at t=0 → residual floor 0.3
+    // (A19 / #120) on bumped axes; null-timestamp axes stay at 1.0.
+    const pushRec = patterns.horizontalPush.recovery as Record<string, unknown>;
+    assertEquals(pushRec.lastNeuromuscularStimulusAt, expectedLoggedAtIso);
+    assertEquals(pushRec.lastMetabolicStimulusAt, expectedLoggedAtIso);
+    assertEquals(Number((pushRec.neuromuscularReadiness as number).toFixed(4)), 0.3);
+    assertEquals(Number((pushRec.metabolicReadiness as number).toFixed(4)), 0.3);
+
+    const squatRec = patterns.squat.recovery as Record<string, unknown>;
+    assertEquals(squatRec.lastNeuromuscularStimulusAt, expectedLoggedAtIso);
+    assertEquals(squatRec.lastMetabolicStimulusAt, null);
+    assertEquals(Number((squatRec.neuromuscularReadiness as number).toFixed(4)), 0.3);
+    assertEquals(squatRec.metabolicReadiness, 1.0);
+
+    const pullRec = patterns.horizontalPull.recovery as Record<string, unknown>;
+    assertEquals(pullRec.lastNeuromuscularStimulusAt, expectedLoggedAtIso);
+    assertEquals(pullRec.lastMetabolicStimulusAt, expectedLoggedAtIso);
+    assertEquals(Number((pullRec.neuromuscularReadiness as number).toFixed(4)), 0.3);
+    assertEquals(Number((pullRec.metabolicReadiness as number).toFixed(4)), 0.3);
+
+    // No orphan top-level recovery write per #146.
+    assertEquals(modelJson.recovery, undefined);
 
     // A21 / #124: prescription-accuracy bootstrapped to {} (synthetic
     // fixture has no ai_prescribed → no contributions accumulate).

--- a/supabase/migrations/20260512055424_drop_orphan_top_level_recovery.sql
+++ b/supabase/migrations/20260512055424_drop_orphan_top_level_recovery.sql
@@ -1,0 +1,21 @@
+-- Reverse migration: docs/migrations/down/20260512055424_drop_orphan_top_level_recovery.sql
+-- (documentation only; not auto-applied by `supabase db push`)
+--
+-- #146: drop orphan top-level `model_json.recovery` field on trainee_models.
+--
+-- Per ADR-0005, recovery is two-dimensional NM + metabolic per movement
+-- pattern (stored at `model_json.patterns[<key>].recovery`). The Edge
+-- Function previously wrote a top-level `model_json.recovery` alongside —
+-- a schema drift the Swift PatternProfile decoder never read. The EF code
+-- in this same PR migrates stimulus-classifier and readiness-curve rules
+-- to per-pattern recovery and stops writing the top-level field; this
+-- migration strips the orphan from existing alpha rows so the JSONB
+-- column reflects only the canonical shape.
+--
+-- The `-` operator on jsonb is idempotent: rows without the `recovery`
+-- key are unaffected, so the migration is order-safe relative to the
+-- Edge Function deploy. Forward-only per the migrations workflow.
+
+UPDATE public.trainee_models
+SET model_json = model_json - 'recovery'
+WHERE model_json ? 'recovery';


### PR DESCRIPTION
## Summary

Closes #146. Coordinated PR resolving five of the six contract-drift gaps between the Edge Function's `model_json` emit and Swift's `TraineeModel` decoder. The sixth (pattern key casing — EF camelCase vs Swift snake_case) discovered during implementation is deferred to #148.

- **EF bootstrap** now emits `pattern`, `rpeOffset`, `confidence`, and per-pattern `recovery` — the four fields Swift's `PatternProfile` decoder required.
- **EF recovery rules** (`applyPerSetStimulusRules`, `applyRecoveryReadiness`) migrated from a single top-level `model_json.recovery` to per-pattern recovery per ADR-0005 + the locked cross-platform fixture contract. Sets attribute to their exercise's pattern via the existing `lookupPattern` helper.
- **Swift defensive `goal` decode** + `GoalState.placeholder` sentinel — the EF has no write path for `goal` (#147 spinoff for the real onboarding hydration), so `decodeIfPresent` + sentinel unblocks the rest of the model.
- **Migration** strips orphan top-level `model_json.recovery` from existing alpha rows.

## Why coordinated PR

Per #146 discovery: the JSONDecoder threw `keyNotFound` on the FIRST missing field (`goal`), caught silently by `try?` at `TraineeModelUpdateJob.parseResponse:188`. iOS local store never hydrated → `TraineeModelService.digest()` returned nil for every iOS call → B1–B4 blocked. Fixing fewer than the full set of decoder-killers leaves the decoder still rejecting every response.

Per-pattern recovery option (a) chosen over bootstrap-only (b) after design discussion: (b) would have left readiness scalars frozen at 1.0 forever (stimulus/readiness rules continued writing top-level dead field), feeding "fully recovered, push hard" to B1's prompt regardless of actual stimulus history. (a) finishes what ADR-0005 specified all along.

## Spinoffs

- #147 — onboarding write path for `model_json.goal`
- #148 — EF pattern key casing (snake_case migration to match cross-platform fixture)

## Files

- `supabase/functions/update-trainee-model/index.ts` — bootstrap fields + per-pattern stimulus/readiness pipelines
- `supabase/functions/update-trainee-model/orchestrator_test.ts`, `smoke_test.ts` — per-pattern assertions
- `ProjectApex/Models/TraineeModel.swift`, `TraineeModelSnapshots.swift` — defensive decode + `GoalState.placeholder`
- `supabase/migrations/20260512055424_drop_orphan_top_level_recovery.sql` + reverse doc
- `docs/phase-2-cleanup-plan-2026-05-12.md` — replaced 15-min `confidence: null` entry with actual #146 scope

## Test plan

- [x] `deno check` clean on `index.ts`, `orchestrator_test.ts`, `smoke_test.ts`
- [ ] CI: TS unit tests for orchestrator stimulus + readiness pass per-pattern assertions
- [ ] CI: Swift build + tests pass
- [ ] Post-merge: CI auto-deploys EF (per #143/#144) and applies migration; verify next alpha session apply produces `model_json` with no top-level `recovery` and populated `patterns[<key>].recovery` per pattern trained
- [ ] Post-merge: iOS local-store hydrates (`TraineeModelService.digest()` returns non-nil) for the 3 patterns whose casing matches Swift rawValues (`squat`/`lunge`/`isolation`); remaining 5 patterns unblock when #148 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)