### PR TITLE
fix: #148 rename pattern keys camelCase → snake_case (full B1–B4 decoder unblock)

### DIFF
--- a/docs/migrations/down/20260512061710_rename_pattern_keys_snake_case.sql
+++ b/docs/migrations/down/20260512061710_rename_pattern_keys_snake_case.sql
@@ -1,0 +1,141 @@
+-- Reverse migration for: supabase/migrations/20260512061710_rename_pattern_keys_snake_case.sql
+-- Documentation only — manual operator use (`psql -f`); not auto-applied
+-- by `supabase db push`.
+--
+-- Inverts the snake_case → camelCase rename across the same 8 pattern-keyed
+-- locations. Use only when rolling back the #148 EF deploy.
+
+CREATE OR REPLACE FUNCTION pg_temp.unrename_pattern_value(input jsonb)
+RETURNS jsonb LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE input #>> '{}'
+    WHEN 'horizontal_push' THEN '"horizontalPush"'::jsonb
+    WHEN 'horizontal_pull' THEN '"horizontalPull"'::jsonb
+    WHEN 'vertical_push'   THEN '"verticalPush"'::jsonb
+    WHEN 'vertical_pull'   THEN '"verticalPull"'::jsonb
+    WHEN 'hip_hinge'       THEN '"hipHinge"'::jsonb
+    ELSE input
+  END
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.unrename_pattern_keys(input jsonb)
+RETURNS jsonb LANGUAGE sql IMMUTABLE AS $$
+  SELECT COALESCE(
+    jsonb_object_agg(
+      CASE k
+        WHEN 'horizontal_push' THEN 'horizontalPush'
+        WHEN 'horizontal_pull' THEN 'horizontalPull'
+        WHEN 'vertical_push'   THEN 'verticalPush'
+        WHEN 'vertical_pull'   THEN 'verticalPull'
+        WHEN 'hip_hinge'       THEN 'hipHinge'
+        ELSE k
+      END,
+      v
+    ),
+    '{}'::jsonb
+  )
+  FROM jsonb_each(input) AS e(k, v)
+$$;
+
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{patterns}',
+  (
+    SELECT COALESCE(
+      jsonb_object_agg(
+        CASE k
+          WHEN 'horizontal_push' THEN 'horizontalPush'
+          WHEN 'horizontal_pull' THEN 'horizontalPull'
+          WHEN 'vertical_push'   THEN 'verticalPush'
+          WHEN 'vertical_pull'   THEN 'verticalPull'
+          WHEN 'hip_hinge'       THEN 'hipHinge'
+          ELSE k
+        END,
+        CASE WHEN v ? 'pattern'
+          THEN jsonb_set(v, '{pattern}', pg_temp.unrename_pattern_value(v->'pattern'))
+          ELSE v
+        END
+      ),
+      '{}'::jsonb
+    )
+    FROM jsonb_each(model_json->'patterns') AS e(k, v)
+  )
+)
+WHERE model_json ? 'patterns' AND jsonb_typeof(model_json->'patterns') = 'object';
+
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{prescriptionAccuracy}',
+  pg_temp.unrename_pattern_keys(model_json->'prescriptionAccuracy')
+)
+WHERE model_json ? 'prescriptionAccuracy' AND jsonb_typeof(model_json->'prescriptionAccuracy') = 'object';
+
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{fatigueInteractions}',
+  (
+    SELECT COALESCE(jsonb_agg(
+      CASE
+        WHEN entry ? 'fromPattern' OR entry ? 'toPattern' THEN
+          entry
+            || jsonb_build_object('fromPattern', pg_temp.unrename_pattern_value(entry->'fromPattern'))
+            || jsonb_build_object('toPattern',   pg_temp.unrename_pattern_value(entry->'toPattern'))
+        ELSE entry
+      END
+    ), '[]'::jsonb)
+    FROM jsonb_array_elements(model_json->'fatigueInteractions') AS e(entry)
+  )
+)
+WHERE model_json ? 'fatigueInteractions' AND jsonb_typeof(model_json->'fatigueInteractions') = 'array';
+
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{lastSessionPatternPerformance}',
+  (
+    SELECT COALESCE(jsonb_agg(
+      CASE WHEN entry ? 'pattern'
+        THEN jsonb_set(entry, '{pattern}', pg_temp.unrename_pattern_value(entry->'pattern'))
+        ELSE entry
+      END
+    ), '[]'::jsonb)
+    FROM jsonb_array_elements(model_json->'lastSessionPatternPerformance') AS e(entry)
+  )
+)
+WHERE model_json ? 'lastSessionPatternPerformance' AND jsonb_typeof(model_json->'lastSessionPatternPerformance') = 'array';
+
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{activeLimitations}',
+  (
+    SELECT COALESCE(jsonb_agg(
+      CASE
+        WHEN entry #>> '{subject,kind}' = 'pattern' THEN
+          jsonb_set(entry, '{subject,value}', pg_temp.unrename_pattern_value(entry#>'{subject,value}'))
+        ELSE entry
+      END
+    ), '[]'::jsonb)
+    FROM jsonb_array_elements(model_json->'activeLimitations') AS e(entry)
+  )
+)
+WHERE model_json ? 'activeLimitations' AND jsonb_typeof(model_json->'activeLimitations') = 'array';
+
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{clearedLimitations}',
+  (
+    SELECT COALESCE(jsonb_agg(
+      CASE
+        WHEN entry #>> '{subject,kind}' = 'pattern' THEN
+          jsonb_set(entry, '{subject,value}', pg_temp.unrename_pattern_value(entry#>'{subject,value}'))
+        ELSE entry
+      END
+    ), '[]'::jsonb)
+    FROM jsonb_array_elements(model_json->'clearedLimitations') AS e(entry)
+  )
+)
+WHERE model_json ? 'clearedLimitations' AND jsonb_typeof(model_json->'clearedLimitations') = 'array';

--- a/supabase/functions/_shared/constants.ts
+++ b/supabase/functions/_shared/constants.ts
@@ -136,12 +136,12 @@ export const GLOBAL_PHASE_ADVANCE_BOOTSTRAP_GUARD = 6;
  * (auxiliary patterns whose phase transitions don't reflect macro readiness).
  */
 export const MAJOR_PATTERNS = [
-  "horizontalPush",
-  "verticalPush",
-  "horizontalPull",
-  "verticalPull",
+  "horizontal_push",
+  "vertical_push",
+  "horizontal_pull",
+  "vertical_pull",
   "squat",
-  "hipHinge",
+  "hip_hinge",
 ] as const;
 
 // ─── Cadence-aware translation (ADR-0015, Q5) ────────────────────────────────

--- a/supabase/functions/_shared/constants_test.ts
+++ b/supabase/functions/_shared/constants_test.ts
@@ -192,12 +192,12 @@ Deno.test(
   "ADR-0012: major patterns are exactly the 6 push/pull/squat/hinge axes (lunge + isolation excluded)",
   () => {
     assertEquals(MAJOR_PATTERNS, [
-      "horizontalPush",
-      "verticalPush",
-      "horizontalPull",
-      "verticalPull",
+      "horizontal_push",
+      "vertical_push",
+      "horizontal_pull",
+      "vertical_pull",
       "squat",
-      "hipHinge",
+      "hip_hinge",
     ]);
   },
 );

--- a/supabase/functions/_shared/exercise-library.ts
+++ b/supabase/functions/_shared/exercise-library.ts
@@ -26,12 +26,12 @@
  * 8 values per ADR-0005's pattern taxonomy.
  */
 export type MovementPattern =
-  | "horizontalPush"
-  | "verticalPush"
-  | "horizontalPull"
-  | "verticalPull"
+  | "horizontal_push"
+  | "vertical_push"
+  | "horizontal_pull"
+  | "vertical_pull"
   | "squat"
-  | "hipHinge"
+  | "hip_hinge"
   | "lunge"
   | "isolation";
 
@@ -43,42 +43,42 @@ export type MovementPattern =
  */
 export const EXERCISE_PATTERN_MAP: Record<string, MovementPattern> = {
   // Chest
-  barbell_bench_press: "horizontalPush",
-  dumbbell_bench_press: "horizontalPush",
-  incline_barbell_press: "horizontalPush",
-  incline_dumbbell_press: "horizontalPush",
-  decline_bench_press: "horizontalPush",
-  machine_chest_press: "horizontalPush",
+  barbell_bench_press: "horizontal_push",
+  dumbbell_bench_press: "horizontal_push",
+  incline_barbell_press: "horizontal_push",
+  incline_dumbbell_press: "horizontal_push",
+  decline_bench_press: "horizontal_push",
+  machine_chest_press: "horizontal_push",
   cable_chest_fly: "isolation",
   pec_deck_fly: "isolation",
   dumbbell_fly: "isolation",
-  push_ups: "horizontalPush",
+  push_ups: "horizontal_push",
 
   // Back
-  barbell_row: "horizontalPull",
-  dumbbell_row: "horizontalPull",
-  t_bar_row: "horizontalPull",
-  cable_row: "horizontalPull",
-  seated_cable_row: "horizontalPull",
-  lat_pulldown_wide: "verticalPull",
-  lat_pulldown_close: "verticalPull",
-  pull_ups: "verticalPull",
-  chin_ups: "verticalPull",
-  face_pull: "horizontalPull",
+  barbell_row: "horizontal_pull",
+  dumbbell_row: "horizontal_pull",
+  t_bar_row: "horizontal_pull",
+  cable_row: "horizontal_pull",
+  seated_cable_row: "horizontal_pull",
+  lat_pulldown_wide: "vertical_pull",
+  lat_pulldown_close: "vertical_pull",
+  pull_ups: "vertical_pull",
+  chin_ups: "vertical_pull",
+  face_pull: "horizontal_pull",
   cable_rear_delt_fly: "isolation",
-  cable_straight_arm_pulldown: "verticalPull",
-  dumbbell_single_arm_row: "horizontalPull",
-  assisted_pull_up: "verticalPull",
+  cable_straight_arm_pulldown: "vertical_pull",
+  dumbbell_single_arm_row: "horizontal_pull",
+  assisted_pull_up: "vertical_pull",
 
   // Shoulders
-  overhead_press: "verticalPush",
-  dumbbell_shoulder_press: "verticalPush",
-  machine_shoulder_press: "verticalPush",
+  overhead_press: "vertical_push",
+  dumbbell_shoulder_press: "vertical_push",
+  machine_shoulder_press: "vertical_push",
   lateral_raise: "isolation",
   cable_lateral_raise: "isolation",
   rear_delt_fly: "isolation",
-  arnold_press: "verticalPush",
-  upright_row: "verticalPull",
+  arnold_press: "vertical_push",
+  upright_row: "vertical_pull",
 
   // Quads
   barbell_back_squat: "squat",
@@ -92,16 +92,16 @@ export const EXERCISE_PATTERN_MAP: Record<string, MovementPattern> = {
   smith_machine_squat: "squat",
 
   // Hamstrings / Glutes / Hips
-  conventional_deadlift: "hipHinge",
-  romanian_deadlift: "hipHinge",
-  dumbbell_romanian_deadlift: "hipHinge",
+  conventional_deadlift: "hip_hinge",
+  romanian_deadlift: "hip_hinge",
+  dumbbell_romanian_deadlift: "hip_hinge",
   lying_leg_curl: "isolation",
   seated_leg_curl: "isolation",
-  stiff_leg_deadlift: "hipHinge",
-  hip_thrust: "hipHinge",
-  cable_pull_through: "hipHinge",
-  glute_bridge: "hipHinge",
-  sumo_deadlift: "hipHinge",
+  stiff_leg_deadlift: "hip_hinge",
+  hip_thrust: "hip_hinge",
+  cable_pull_through: "hip_hinge",
+  glute_bridge: "hip_hinge",
+  sumo_deadlift: "hip_hinge",
 
   // Biceps
   barbell_curl: "isolation",
@@ -116,14 +116,14 @@ export const EXERCISE_PATTERN_MAP: Record<string, MovementPattern> = {
   cable_tricep_pushdown: "isolation",
   overhead_tricep_extension: "isolation",
   skull_crushers: "isolation",
-  dips: "verticalPush",
-  close_grip_bench_press: "horizontalPush",
+  dips: "vertical_push",
+  close_grip_bench_press: "horizontal_push",
   dumbbell_overhead_tricep_extension: "isolation",
   cable_overhead_tricep_extension: "isolation",
 
   // Smith / cable variants for chest
-  smith_machine_bench_press: "horizontalPush",
-  smith_machine_incline_press: "horizontalPush",
+  smith_machine_bench_press: "horizontal_push",
+  smith_machine_incline_press: "horizontal_push",
   cable_crossover_chest_fly: "isolation",
 
   // Calves

--- a/supabase/functions/_shared/exercise-library_test.ts
+++ b/supabase/functions/_shared/exercise-library_test.ts
@@ -27,9 +27,9 @@ Deno.test("exercise-library: load-bearing pattern resolutions for the smoke fixt
   // its synthetic session_payload. If a Swift renaming changes one of
   // these, the smoke's pattern-bootstrap assertion would silently fail
   // to map. Pinning here catches that drift loudly.
-  assertEquals(lookupPattern("barbell_bench_press"), "horizontalPush");
+  assertEquals(lookupPattern("barbell_bench_press"), "horizontal_push");
   assertEquals(lookupPattern("barbell_back_squat"), "squat");
-  assertEquals(lookupPattern("barbell_row"), "horizontalPull");
+  assertEquals(lookupPattern("barbell_row"), "horizontal_pull");
 });
 
 Deno.test("exercise-library: lookupPattern returns undefined for unknown IDs", () => {
@@ -43,12 +43,12 @@ Deno.test("exercise-library: every value is a valid MovementPattern (8-enum)", (
   // ADR-0005's pattern taxonomy is closed at 8. Catch any typo in the
   // map that would produce a string outside this set.
   const valid = new Set([
-    "horizontalPush",
-    "verticalPush",
-    "horizontalPull",
-    "verticalPull",
+    "horizontal_push",
+    "vertical_push",
+    "horizontal_pull",
+    "vertical_pull",
     "squat",
-    "hipHinge",
+    "hip_hinge",
     "lunge",
     "isolation",
   ]);

--- a/supabase/functions/_shared/fatigue-interaction_test.ts
+++ b/supabase/functions/_shared/fatigue-interaction_test.ts
@@ -82,48 +82,48 @@ Deno.test(
 Deno.test(
   "ADR-0005: pair detection — Cartesian product across distinct patterns (2×2 = 4 observations, no self-pairs)",
   () => {
-    // Yesterday: squat + horizontalPush. Today: verticalPush + hipHinge.
+    // Yesterday: squat + horizontal_push. Today: vertical_push + hip_hinge.
     // No pattern overlap → 4 observations:
-    //   {squat → verticalPush, squat → hipHinge,
-    //    horizontalPush → verticalPush, horizontalPush → hipHinge}
+    //   {squat → vertical_push, squat → hip_hinge,
+    //    horizontal_push → vertical_push, horizontal_push → hip_hinge}
     // delta on each obs = performanceDeltaPct of the *to* pattern in newSession.
     // observedAt on each obs = the new session's loggedAt.
     // Iteration order: priorSession.patterns then newSession.patterns, both
     // sorted by MovementPattern string value lexicographically (cycle 4 in
-    // the slice plan). Sorted prior: [horizontalPush, squat]. Sorted new:
-    // [hipHinge, verticalPush].
+    // the slice plan). Sorted prior: [horizontal_push, squat]. Sorted new:
+    // [hip_hinge, vertical_push].
     const prior: SessionPatternPerformance[] = [
       mkPerf("squat", -0.02, 0, "s-prior"),
-      mkPerf("horizontalPush", -0.01, 0, "s-prior"),
+      mkPerf("horizontal_push", -0.01, 0, "s-prior"),
     ];
     const today: SessionPatternPerformance[] = [
-      mkPerf("verticalPush", -0.07, 1, "s-today"),
-      mkPerf("hipHinge", -0.05, 1, "s-today"),
+      mkPerf("vertical_push", -0.07, 1, "s-today"),
+      mkPerf("hip_hinge", -0.05, 1, "s-today"),
     ];
     const result = detectFatigueObservations(today, prior);
     const todayLoggedAt = new Date(2026, 0, 2);
     assertEquals(result, [
       {
-        fromPattern: "horizontalPush",
-        toPattern: "hipHinge",
+        fromPattern: "horizontal_push",
+        toPattern: "hip_hinge",
         delta: -0.05,
         observedAt: todayLoggedAt,
       },
       {
-        fromPattern: "horizontalPush",
-        toPattern: "verticalPush",
+        fromPattern: "horizontal_push",
+        toPattern: "vertical_push",
         delta: -0.07,
         observedAt: todayLoggedAt,
       },
       {
         fromPattern: "squat",
-        toPattern: "hipHinge",
+        toPattern: "hip_hinge",
         delta: -0.05,
         observedAt: todayLoggedAt,
       },
       {
         fromPattern: "squat",
-        toPattern: "verticalPush",
+        toPattern: "vertical_push",
         delta: -0.07,
         observedAt: todayLoggedAt,
       },
@@ -137,10 +137,10 @@ Deno.test(
     // Tracer for appendObservations: starting with no per-pair state, the
     // first observation creates a new FatigueState entry keyed by
     // (fromPattern, toPattern) with the delta in observations and totalCount=1.
-    const result = appendObservations([], [mkObs("squat", "hipHinge", -0.05, 1)]);
+    const result = appendObservations([], [mkObs("squat", "hip_hinge", -0.05, 1)]);
     assertEquals(result.length, 1);
     assertEquals(result[0].fromPattern, "squat");
-    assertEquals(result[0].toPattern, "hipHinge");
+    assertEquals(result[0].toPattern, "hip_hinge");
     assertEquals(result[0].observations, [-0.05]);
     assertEquals(result[0].totalCount, 1);
   },
@@ -154,14 +154,14 @@ Deno.test(
     // new delta lands at the tail. observations.length stays at 10.
     const seedObs: FatigueObservation[] = [];
     for (let i = 1; i <= 10; i++) {
-      seedObs.push(mkObs("squat", "hipHinge", -0.01 * i, i));
+      seedObs.push(mkObs("squat", "hip_hinge", -0.01 * i, i));
     }
     const seeded = appendObservations([], seedObs);
     assertEquals(seeded[0].observations.length, 10);
     assertEquals(seeded[0].totalCount, 10);
 
     const after = appendObservations(seeded, [
-      mkObs("squat", "hipHinge", -0.11, 11),
+      mkObs("squat", "hip_hinge", -0.11, 11),
     ]);
     assertEquals(after[0].observations.length, 10);
     // Oldest (-0.01) evicted; tail is -0.11.
@@ -180,7 +180,7 @@ Deno.test(
     let state: FatigueState[] = [];
     for (let i = 1; i <= 20; i++) {
       state = appendObservations(state, [
-        mkObs("squat", "hipHinge", -0.001 * i, i),
+        mkObs("squat", "hip_hinge", -0.001 * i, i),
       ]);
     }
     assertEquals(state.length, 1);
@@ -197,7 +197,7 @@ Deno.test(
     // Swift implementation (TraineeModelInteractions.swift:100). Returns 0.
     const state: FatigueState = {
       fromPattern: "squat",
-      toPattern: "hipHinge",
+      toPattern: "hip_hinge",
       observations: [-0.05],
       totalCount: 1,
     };
@@ -214,7 +214,7 @@ Deno.test(
     // (TraineeModelInteractions.swift:106) snaps to exactly 1.0.
     const state: FatigueState = {
       fromPattern: "squat",
-      toPattern: "hipHinge",
+      toPattern: "hip_hinge",
       observations: [-0.05, -0.05],
       totalCount: 2,
     };
@@ -235,7 +235,7 @@ Deno.test(
     // 1 - 1e-4/1e-2 = 0.99 and break the test.
     const state: FatigueState = {
       fromPattern: "squat",
-      toPattern: "hipHinge",
+      toPattern: "hip_hinge",
       observations: [0.0001, -0.0001],
       totalCount: 2,
     };
@@ -257,7 +257,7 @@ Deno.test(
     // the guarded ratio's effect on consistencyFactor.
     const state: FatigueState = {
       fromPattern: "squat",
-      toPattern: "hipHinge",
+      toPattern: "hip_hinge",
       observations: [0.005, -0.005],
       totalCount: 2,
     };
@@ -273,7 +273,7 @@ Deno.test(
     // Inclusive at 15 (>=, not >). Below threshold → hard cap at 0.5.
     const below: FatigueState = {
       fromPattern: "squat",
-      toPattern: "hipHinge",
+      toPattern: "hip_hinge",
       observations: [-0.05, -0.05],
       totalCount: 14,
     };
@@ -281,7 +281,7 @@ Deno.test(
 
     const at: FatigueState = {
       fromPattern: "squat",
-      toPattern: "hipHinge",
+      toPattern: "hip_hinge",
       observations: [-0.05, -0.05],
       totalCount: 15,
     };
@@ -307,7 +307,7 @@ Deno.test(
     // degenerate — × 1.0 is identity — so wouldn't catch that regression.
     const state: FatigueState = {
       fromPattern: "squat",
-      toPattern: "hipHinge",
+      toPattern: "hip_hinge",
       observations: [0.1, 0.2],
       totalCount: 14,
     };
@@ -355,7 +355,7 @@ for (const row of fixtureFile.fixtures) {
     () => {
       const state: FatigueState = {
         fromPattern: "squat",
-        toPattern: "hipHinge",
+        toPattern: "hip_hinge",
         observations: row.observations,
         totalCount: row.totalCount,
       };

--- a/supabase/functions/_shared/global-phase-advance_test.ts
+++ b/supabase/functions/_shared/global-phase-advance_test.ts
@@ -18,12 +18,12 @@ import {
 
 // All 6 major patterns per ADR-0012 / MAJOR_PATTERNS in constants.ts.
 const ALL_SIX_MAJORS = [
-  "horizontalPush",
-  "verticalPush",
-  "horizontalPull",
-  "verticalPull",
+  "horizontal_push",
+  "vertical_push",
+  "horizontal_pull",
+  "vertical_pull",
   "squat",
-  "hipHinge",
+  "hip_hinge",
 ];
 
 // Build a state covering all 6 majors. Patterns with `lastAt=0` are treated
@@ -39,9 +39,9 @@ const allMajorsWithLastAt = (
 Deno.test("ADR-0012: 3 of 6 majors transitioned in last 6 sessions → does NOT fire (under threshold)", () => {
   // Threshold is 4 majors per ADR-0012; 3 is the under-threshold case.
   const states = allMajorsWithLastAt({
-    horizontalPush: 13,
-    verticalPush: 14,
-    horizontalPull: 15,
+    horizontal_push: 13,
+    vertical_push: 14,
+    horizontal_pull: 15,
     // remaining 3 majors: lastAt=0 (never transitioned)
   });
   assertEquals(
@@ -56,11 +56,11 @@ Deno.test("ADR-0012 §Edge cases: ≥4 majors transitioned but sessionCount=5 (u
   // training history. Constants: GLOBAL_PHASE_ADVANCE_BOOTSTRAP_GUARD=6, so
   // sessionCount<6 blocks. sessionCount=5 sits just under.
   const states = allMajorsWithLastAt({
-    horizontalPush: 1,
-    verticalPush: 2,
-    horizontalPull: 3,
-    verticalPull: 4,
-    // squat, hipHinge: lastAt=0 (never)
+    horizontal_push: 1,
+    vertical_push: 2,
+    horizontal_pull: 3,
+    vertical_pull: 4,
+    // squat, hip_hinge: lastAt=0 (never)
   });
   assertEquals(
     shouldFireGlobalPhaseAdvance(states, /* sessionCount */ 5, /* lastFired */ null),
@@ -74,11 +74,11 @@ Deno.test("ADR-0012 §Cooldown: ≥4 majors but cooldown active (lastFired=4, se
   // pattern threshold is met. Boundary-inclusive on the "fires" side: 6
   // fires (C18 below), 5 blocks (this test).
   const states = allMajorsWithLastAt({
-    horizontalPush: 5,
-    verticalPush: 6,
-    horizontalPull: 7,
-    verticalPull: 8,
-    // squat, hipHinge: lastAt=0
+    horizontal_push: 5,
+    vertical_push: 6,
+    horizontal_pull: 7,
+    vertical_pull: 8,
+    // squat, hip_hinge: lastAt=0
   });
   assertEquals(
     shouldFireGlobalPhaseAdvance(states, /* sessionCount */ 9, /* lastFired */ 4),
@@ -92,11 +92,11 @@ Deno.test("ADR-0012 §Cooldown: ≥4 majors with cooldown just expired (lastFire
   // so delta=6 fires. Boundary semantics consistent with the §"Window
   // semantics" `delta <= 6` — both inclusive on the firing side.
   const states = allMajorsWithLastAt({
-    horizontalPush: 5,
-    verticalPush: 6,
-    horizontalPull: 7,
-    verticalPull: 8,
-    // squat, hipHinge: lastAt=0
+    horizontal_push: 5,
+    vertical_push: 6,
+    horizontal_pull: 7,
+    vertical_pull: 8,
+    // squat, hip_hinge: lastAt=0
   });
   assertEquals(
     shouldFireGlobalPhaseAdvance(states, /* sessionCount */ 10, /* lastFired */ 4),
@@ -121,10 +121,10 @@ Deno.test("ADR-0012 §Edge cases: lastPhaseTransitionAtSessionCount=0 (never tra
   // `lastAt > 0` guard added; the ADR's natural-exclusion claim is taken
   // at face value.
   const states = allMajorsWithLastAt({
-    horizontalPush: 2, // delta=5
-    verticalPush: 3, //   delta=4
-    horizontalPull: 4, // delta=3
-    // verticalPull, squat, hipHinge: lastAt=0 (delta=7 → excluded by window)
+    horizontal_push: 2, // delta=5
+    vertical_push: 3, //   delta=4
+    horizontal_pull: 4, // delta=3
+    // vertical_pull, squat, hip_hinge: lastAt=0 (delta=7 → excluded by window)
   });
   assertEquals(
     shouldFireGlobalPhaseAdvance(states, /* sessionCount */ 7, /* lastFired */ null),
@@ -146,11 +146,11 @@ Deno.test("ADR-0012 §Consequences: force-deload-as-transition is a feature — 
   // deloaded; the rule is agnostic to the transition kind). 2 majors at
   // lastAt=0 are excluded by the window check at sessionCount=12.
   const states = allMajorsWithLastAt({
-    horizontalPush: 7, // delta=5 (recent force-deload)
-    verticalPush: 8, //   delta=4
-    horizontalPull: 9, // delta=3
-    verticalPull: 10, //  delta=2
-    // squat, hipHinge: lastAt=0 (delta=12 → excluded)
+    horizontal_push: 7, // delta=5 (recent force-deload)
+    vertical_push: 8, //   delta=4
+    horizontal_pull: 9, // delta=3
+    vertical_pull: 10, //  delta=2
+    // squat, hip_hinge: lastAt=0 (delta=12 → excluded)
   });
   assertEquals(
     shouldFireGlobalPhaseAdvance(states, /* sessionCount */ 12, /* lastFired */ null),
@@ -169,12 +169,12 @@ Deno.test("ADR-0012 §Major patterns: lunge and isolation transitions do NOT cou
   // Correct behaviour: only 3 majors in window → does NOT fire.
   // Buggy behaviour: 5 patterns in window ≥ 4 → would erroneously fire.
   const states: PatternTransitionState[] = [
-    { pattern: "horizontalPush", lastPhaseTransitionAtSessionCount: 12 },
-    { pattern: "verticalPush", lastPhaseTransitionAtSessionCount: 13 },
-    { pattern: "horizontalPull", lastPhaseTransitionAtSessionCount: 14 },
-    { pattern: "verticalPull", lastPhaseTransitionAtSessionCount: 0 },
+    { pattern: "horizontal_push", lastPhaseTransitionAtSessionCount: 12 },
+    { pattern: "vertical_push", lastPhaseTransitionAtSessionCount: 13 },
+    { pattern: "horizontal_pull", lastPhaseTransitionAtSessionCount: 14 },
+    { pattern: "vertical_pull", lastPhaseTransitionAtSessionCount: 0 },
     { pattern: "squat", lastPhaseTransitionAtSessionCount: 0 },
-    { pattern: "hipHinge", lastPhaseTransitionAtSessionCount: 0 },
+    { pattern: "hip_hinge", lastPhaseTransitionAtSessionCount: 0 },
     { pattern: "lunge", lastPhaseTransitionAtSessionCount: 15 }, // accessory
     { pattern: "isolation", lastPhaseTransitionAtSessionCount: 14 }, // accessory
   ];
@@ -190,11 +190,11 @@ Deno.test("ADR-0012: ≥4 of 6 majors transitioned in last 6 sessions, no prior 
   // No prior global fire → cooldown trivially satisfied.
   // currentSessionCount=18 >= 6 → bootstrap guard satisfied.
   const states = allMajorsWithLastAt({
-    horizontalPush: 12,
-    verticalPush: 13,
-    horizontalPull: 14,
-    verticalPull: 15,
-    // squat, hipHinge: lastAt=0 (never)
+    horizontal_push: 12,
+    vertical_push: 13,
+    horizontal_pull: 14,
+    vertical_pull: 15,
+    // squat, hip_hinge: lastAt=0 (never)
   });
   assertEquals(
     shouldFireGlobalPhaseAdvance(

--- a/supabase/functions/_shared/note-classifier-prompt.txt
+++ b/supabase/functions/_shared/note-classifier-prompt.txt
@@ -50,8 +50,8 @@ tissue language.
 # Subject value vocabulary
 
 For `pattern` subjects, use exactly one of:
-  hipHinge, horizontalPull, horizontalPush, isolation, lunge, squat,
-  verticalPull, verticalPush
+  hip_hinge, horizontal_pull, horizontal_push, isolation, lunge, squat,
+  vertical_pull, vertical_push
 
 For `muscle` subjects, use exactly one of:
   back, chest, biceps, shoulders, triceps, legs

--- a/supabase/functions/_shared/note-classifier.ts
+++ b/supabase/functions/_shared/note-classifier.ts
@@ -201,17 +201,17 @@ export function selectBootstrapNotes(
 //
 // Map per Q9:
 //   - shoulder, elbow, wrist → all push + all pull (excluding isolation)
-//   - hip, knee, ankle, lowerBack → squat + hipHinge + lunge
-//   - lowerBack also → verticalPush (per Q9 push extension; OHP loads lumbar
+//   - hip, knee, ankle, lowerBack → squat + hip_hinge + lunge
+//   - lowerBack also → vertical_push (per Q9 push extension; OHP loads lumbar
 //     through bracing chain)
 //   - neck → no patterns (rare in training)
 const PATTERN_TRAINS_JOINTS: Record<string, readonly string[]> = {
-  horizontalPush: ["shoulder", "elbow", "wrist"],
-  verticalPush: ["shoulder", "elbow", "wrist", "lowerBack"],
-  horizontalPull: ["shoulder", "elbow", "wrist"],
-  verticalPull: ["shoulder", "elbow", "wrist"],
+  horizontal_push: ["shoulder", "elbow", "wrist"],
+  vertical_push: ["shoulder", "elbow", "wrist", "lowerBack"],
+  horizontal_pull: ["shoulder", "elbow", "wrist"],
+  vertical_pull: ["shoulder", "elbow", "wrist"],
   squat: ["hip", "knee", "ankle", "lowerBack"],
-  hipHinge: ["hip", "knee", "ankle", "lowerBack"],
+  hip_hinge: ["hip", "knee", "ankle", "lowerBack"],
   lunge: ["hip", "knee", "ankle", "lowerBack"],
   isolation: [],
 };

--- a/supabase/functions/_shared/note-classifier_test.ts
+++ b/supabase/functions/_shared/note-classifier_test.ts
@@ -154,7 +154,7 @@ Deno.test(
       active: [],
       cleared: [],
       classifierMentions: [mkMention("joint", "shoulder", "n1", "mechanical")],
-      trainedPatterns: new Set(["horizontalPush"]),
+      trainedPatterns: new Set(["horizontal_push"]),
       trainedMuscleGroups: new Set(),
       trainedJoints: new Set(["shoulder"]),
       notesProcessed: true,
@@ -173,7 +173,7 @@ Deno.test(
       active: after1.active,
       cleared: [],
       classifierMentions: [mkMention("joint", "shoulder", "n2", "mechanical")],
-      trainedPatterns: new Set(["horizontalPush"]),
+      trainedPatterns: new Set(["horizontal_push"]),
       trainedMuscleGroups: new Set(),
       trainedJoints: new Set(["shoulder"]),
       notesProcessed: true,
@@ -238,7 +238,7 @@ Deno.test(
       active: [preExisting],
       cleared: [],
       classifierMentions: [], // no re-mention this session
-      trainedPatterns: new Set(["horizontalPush"]),
+      trainedPatterns: new Set(["horizontal_push"]),
       trainedMuscleGroups: new Set(),
       trainedJoints: new Set(["shoulder"]),
       notesProcessed: true, // classifier ran
@@ -274,7 +274,7 @@ Deno.test(
         active,
         cleared: [],
         classifierMentions: [],
-        trainedPatterns: new Set(["horizontalPush"]),
+        trainedPatterns: new Set(["horizontal_push"]),
         trainedMuscleGroups: new Set(),
         trainedJoints: new Set(["shoulder"]),
         notesProcessed: true,
@@ -308,7 +308,7 @@ Deno.test(
       active: [userReported],
       cleared: [],
       classifierMentions: [mkMention("joint", "shoulder", "n1", "mechanical")],
-      trainedPatterns: new Set(["horizontalPush"]),
+      trainedPatterns: new Set(["horizontal_push"]),
       trainedMuscleGroups: new Set(),
       trainedJoints: new Set(["shoulder"]),
       notesProcessed: true,
@@ -419,9 +419,9 @@ Deno.test(
 // post-merge Q9 lock-in amendment.
 
 Deno.test(
-  "Q9 joint→pattern map: shoulder is trained when horizontalPush is in the session's trained patterns",
+  "Q9 joint→pattern map: shoulder is trained when horizontal_push is in the session's trained patterns",
   () => {
-    const joints = derivedTrainedJoints(new Set(["horizontalPush"]));
+    const joints = derivedTrainedJoints(new Set(["horizontal_push"]));
     assertEquals(joints.has("shoulder"), true);
     assertEquals(joints.has("elbow"), true);
     assertEquals(joints.has("wrist"), true);
@@ -442,23 +442,23 @@ Deno.test(
 );
 
 Deno.test(
-  "Q9 joint→pattern map: lowerBack is trained on hipHinge (per Q9 lowerBack ↔ squat+hipHinge+lunge+verticalPush)",
+  "Q9 joint→pattern map: lowerBack is trained on hip_hinge (per Q9 lowerBack ↔ squat+hip_hinge+lunge+vertical_push)",
   () => {
-    const joints = derivedTrainedJoints(new Set(["hipHinge"]));
+    const joints = derivedTrainedJoints(new Set(["hip_hinge"]));
     assertEquals(joints.has("lowerBack"), true);
-    // Cross-check verticalPush also trains lowerBack per Q9 push extension.
-    const jointsVP = derivedTrainedJoints(new Set(["verticalPush"]));
-    assertEquals(jointsVP.has("lowerBack"), true, "verticalPush trains lowerBack per Q9 push extension (OHP loads lumbar through bracing chain)");
+    // Cross-check vertical_push also trains lowerBack per Q9 push extension.
+    const jointsVP = derivedTrainedJoints(new Set(["vertical_push"]));
+    assertEquals(jointsVP.has("lowerBack"), true, "vertical_push trains lowerBack per Q9 push extension (OHP loads lumbar through bracing chain)");
   },
 );
 
 Deno.test(
-  "Q9 joint→pattern map: wrist is trained on horizontalPull (per Q9 wrist ↔ all push AND all pull, extended for grip-loading)",
+  "Q9 joint→pattern map: wrist is trained on horizontal_pull (per Q9 wrist ↔ all push AND all pull, extended for grip-loading)",
   () => {
-    const joints = derivedTrainedJoints(new Set(["horizontalPull"]));
+    const joints = derivedTrainedJoints(new Set(["horizontal_pull"]));
     assertEquals(joints.has("wrist"), true, "wrist trains on all pulls per Q9 push extension");
     // And on push patterns:
-    const jointsHP = derivedTrainedJoints(new Set(["horizontalPush"]));
+    const jointsHP = derivedTrainedJoints(new Set(["horizontal_push"]));
     assertEquals(jointsHP.has("wrist"), true);
   },
 );

--- a/supabase/functions/_shared/plateau-verdict_test.ts
+++ b/supabase/functions/_shared/plateau-verdict_test.ts
@@ -230,22 +230,22 @@ Deno.test("ADR-0009 amendment: muscle aggregation — empty participation (no pa
   assertEquals(aggregateMuscleStagnationStatus([]), "progressing");
 });
 
-Deno.test("ADR-0009 amendment: muscle aggregation — single-pattern muscle (chest with horizontalPush declining) → muscle declining (trivial aggregation; chest/shoulders/biceps/triceps have ≤1 primary pattern)", () => {
+Deno.test("ADR-0009 amendment: muscle aggregation — single-pattern muscle (chest with horizontal_push declining) → muscle declining (trivial aggregation; chest/shoulders/biceps/triceps have ≤1 primary pattern)", () => {
   const chestPatterns: PatternTrendForMuscleAggregation[] = [
-    { pattern: "horizontalPush", trend: "declining", confidence: "established" },
+    { pattern: "horizontal_push", trend: "declining", confidence: "established" },
   ];
   assertEquals(aggregateMuscleStagnationStatus(chestPatterns), "declining");
 });
 
-Deno.test("ADR-0009 amendment: muscle aggregation — legs scenario (squat plateaued + hipHinge progressing + lunge progressing, all participating) → legs plateaued (the canonical aggregation-risk concentration cell — see v2.x watch-item #9)", () => {
+Deno.test("ADR-0009 amendment: muscle aggregation — legs scenario (squat plateaued + hip_hinge progressing + lunge progressing, all participating) → legs plateaued (the canonical aggregation-risk concentration cell — see v2.x watch-item #9)", () => {
   // The named scenario from ADR-0009 §"Concentration of aggregation risk".
   // Squat plateaus are common; under worst-across-patterns, one squat plateau
-  // forces legs.stagnationStatus = .plateaued even when hipHinge and lunge
+  // forces legs.stagnationStatus = .plateaued even when hip_hinge and lunge
   // are progressing. v2.x upgrade-path trigger if this fires >30% of the
   // time across alpha cohort.
   const legsPatterns: PatternTrendForMuscleAggregation[] = [
     { pattern: "squat", trend: "plateaued", confidence: "established" },
-    { pattern: "hipHinge", trend: "progressing", confidence: "established" },
+    { pattern: "hip_hinge", trend: "progressing", confidence: "established" },
     { pattern: "lunge", trend: "progressing", confidence: "calibrating" },
   ];
   assertEquals(aggregateMuscleStagnationStatus(legsPatterns), "plateaued");
@@ -256,7 +256,7 @@ Deno.test("ADR-0009 amendment: muscle aggregation — all patterns declining BUT
   // declining. With it, the participating set is empty → progressing.
   const patterns: PatternTrendForMuscleAggregation[] = [
     { pattern: "squat", trend: "declining", confidence: "bootstrapping" },
-    { pattern: "hipHinge", trend: "declining", confidence: "bootstrapping" },
+    { pattern: "hip_hinge", trend: "declining", confidence: "bootstrapping" },
     { pattern: "lunge", trend: "declining", confidence: "bootstrapping" },
   ];
   assertEquals(aggregateMuscleStagnationStatus(patterns), "progressing");
@@ -268,7 +268,7 @@ Deno.test("ADR-0009 amendment: muscle aggregation — bootstrapping pattern with
   // participation precondition. Remaining patterns are both progressing.
   const patterns: PatternTrendForMuscleAggregation[] = [
     { pattern: "squat", trend: "declining", confidence: "bootstrapping" },
-    { pattern: "hipHinge", trend: "progressing", confidence: "established" },
+    { pattern: "hip_hinge", trend: "progressing", confidence: "established" },
     { pattern: "lunge", trend: "progressing", confidence: "calibrating" },
   ];
   assertEquals(aggregateMuscleStagnationStatus(patterns), "progressing");
@@ -277,7 +277,7 @@ Deno.test("ADR-0009 amendment: muscle aggregation — bootstrapping pattern with
 Deno.test("ADR-0009 amendment: muscle aggregation — one declining + one plateaued + one progressing → muscle declining (declining > plateaued in worst-order)", () => {
   const patterns: PatternTrendForMuscleAggregation[] = [
     { pattern: "squat", trend: "declining", confidence: "established" },
-    { pattern: "hipHinge", trend: "plateaued", confidence: "established" },
+    { pattern: "hip_hinge", trend: "plateaued", confidence: "established" },
     { pattern: "lunge", trend: "progressing", confidence: "calibrating" },
   ];
   assertEquals(aggregateMuscleStagnationStatus(patterns), "declining");
@@ -286,7 +286,7 @@ Deno.test("ADR-0009 amendment: muscle aggregation — one declining + one platea
 Deno.test("ADR-0009 amendment: muscle aggregation — one pattern plateaued + rest progressing → muscle plateaued", () => {
   const patterns: PatternTrendForMuscleAggregation[] = [
     { pattern: "squat", trend: "plateaued", confidence: "established" },
-    { pattern: "hipHinge", trend: "progressing", confidence: "established" },
+    { pattern: "hip_hinge", trend: "progressing", confidence: "established" },
     { pattern: "lunge", trend: "progressing", confidence: "calibrating" },
   ];
   assertEquals(aggregateMuscleStagnationStatus(patterns), "plateaued");
@@ -295,7 +295,7 @@ Deno.test("ADR-0009 amendment: muscle aggregation — one pattern plateaued + re
 Deno.test("ADR-0009 amendment: muscle aggregation — one pattern declining + rest progressing → muscle declining (worst-across-patterns)", () => {
   const patterns: PatternTrendForMuscleAggregation[] = [
     { pattern: "squat", trend: "declining", confidence: "established" },
-    { pattern: "hipHinge", trend: "progressing", confidence: "established" },
+    { pattern: "hip_hinge", trend: "progressing", confidence: "established" },
     { pattern: "lunge", trend: "progressing", confidence: "calibrating" },
   ];
   assertEquals(aggregateMuscleStagnationStatus(patterns), "declining");
@@ -306,7 +306,7 @@ Deno.test("ADR-0009 amendment (2026-05-07): muscle aggregation — all participa
   // (none bootstrapping → all participate).
   const patterns: PatternTrendForMuscleAggregation[] = [
     { pattern: "squat", trend: "progressing", confidence: "established" },
-    { pattern: "hipHinge", trend: "progressing", confidence: "established" },
+    { pattern: "hip_hinge", trend: "progressing", confidence: "established" },
     { pattern: "lunge", trend: "progressing", confidence: "calibrating" },
   ];
   assertEquals(aggregateMuscleStagnationStatus(patterns), "progressing");

--- a/supabase/functions/_shared/prescription-accuracy_test.ts
+++ b/supabase/functions/_shared/prescription-accuracy_test.ts
@@ -25,7 +25,7 @@ import {
 // Base fixture — all 6 inclusion criteria pass. Each cycle overrides only
 // the field(s) under test, leaving the rest at "criteria-pass" defaults.
 const baseObs = (overrides: Partial<SetObservation> = {}): SetObservation => ({
-  pattern: "horizontalPush",
+  pattern: "horizontal_push",
   prescribedIntent: "top",
   loggedIntent: "top",
   prescribedReps: 5,
@@ -116,7 +116,7 @@ Deno.test("ADR-0014 §criterion 6: deload phase excluded — sets prescribed dur
 });
 
 const emptyCell = (
-  pattern = "horizontalPush",
+  pattern = "horizontal_push",
   intent = "top",
 ): PerCellAccumulator => ({
   pattern,
@@ -139,7 +139,7 @@ const ZERO_BUCKET_RECORD = (): Record<InterSessionGapBucket, number> => ({
 // Direct DigestableAccuracy fixture (skips the cell-aggregation path so
 // surfacing tests can isolate the rule from the aggregation pipeline).
 const mkDigest = (overrides: Partial<DigestableAccuracy> = {}): DigestableAccuracy => ({
-  pattern: "horizontalPush",
+  pattern: "horizontal_push",
   intent: "top",
   bias: 0,
   rmse: 0,

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -190,7 +190,7 @@ orchestratorTest(
 );
 
 orchestratorTest(
-  "A18 / #118 (per-pattern recovery per #146): stimulus-classifier wired — bench top×5 bumps horizontalPush NM; row top×8 bumps horizontalPull NM+metabolic (top×8 classifies as 'both')",
+  "A18 / #118 (per-pattern recovery per #146): stimulus-classifier wired — bench top×5 bumps horizontal_push NM; row top×8 bumps horizontal_pull NM+metabolic (top×8 classifies as 'both')",
   async () => {
     const userId = await seedFreshUser();
     const sessionId = crypto.randomUUID();
@@ -205,9 +205,9 @@ orchestratorTest(
           set_logs: [
             // warmup → null dim, no timestamp bump
             { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 60, reps_completed: 5, intent: "warmup" },
-            // top reps=5 → "neuromuscular" → horizontalPush NM only
+            // top reps=5 → "neuromuscular" → horizontal_push NM only
             { exercise_id: "barbell_bench_press", set_number: 2, weight_kg: 100, reps_completed: 5, intent: "top", rpe_felt: 8 },
-            // top reps=8 → "both" (BACKOFF_BOTH_REP_MAX=8) → horizontalPull NM + metabolic
+            // top reps=8 → "both" (BACKOFF_BOTH_REP_MAX=8) → horizontal_pull NM + metabolic
             { exercise_id: "barbell_row", set_number: 1, weight_kg: 70, reps_completed: 8, intent: "top", rpe_felt: 8 },
           ],
         },
@@ -225,15 +225,15 @@ orchestratorTest(
     const patterns = modelJson.patterns as Record<string, Record<string, unknown>>;
     const expectedIso = new Date(loggedAt).toISOString();
 
-    // horizontalPush: NM only (bench top×5). metabolic axis untouched.
-    const pushRec = patterns.horizontalPush.recovery as Record<string, unknown>;
+    // horizontal_push: NM only (bench top×5). metabolic axis untouched.
+    const pushRec = patterns.horizontal_push.recovery as Record<string, unknown>;
     assertEquals(pushRec.lastNeuromuscularStimulusAt, expectedIso);
     assertEquals(pushRec.lastMetabolicStimulusAt, null);
     assertEquals(Number((pushRec.neuromuscularReadiness as number).toFixed(4)), 0.3);
     assertEquals(pushRec.metabolicReadiness, 1.0);
 
-    // horizontalPull: both axes (row top×8 = "both"). NM and metabolic bumped.
-    const pullRec = patterns.horizontalPull.recovery as Record<string, unknown>;
+    // horizontal_pull: both axes (row top×8 = "both"). NM and metabolic bumped.
+    const pullRec = patterns.horizontal_pull.recovery as Record<string, unknown>;
     assertEquals(pullRec.lastNeuromuscularStimulusAt, expectedIso);
     assertEquals(pullRec.lastMetabolicStimulusAt, expectedIso);
     assertEquals(Number((pullRec.neuromuscularReadiness as number).toFixed(4)), 0.3);
@@ -413,7 +413,7 @@ orchestratorTest(
     const lastPerf = modelJson.lastSessionPatternPerformance as Array<Record<string, unknown>>;
     assertEquals(interactions.length, 0);
     assertEquals(lastPerf.length, 1);
-    assertEquals(lastPerf[0].pattern, "horizontalPush");
+    assertEquals(lastPerf[0].pattern, "horizontal_push");
     // First-ever pattern → priorEwma = 0 → performanceDeltaPct = 0
     assertEquals(lastPerf[0].performanceDeltaPct, 0);
   },
@@ -428,7 +428,7 @@ orchestratorTest(
     const loggedAt1 = "2026-05-09T10:00:00Z";
     const loggedAt2 = "2026-05-10T10:00:00Z";
 
-    // Session 1: bench (horizontalPush)
+    // Session 1: bench (horizontal_push)
     await applySession(
       {
         user_id: userId,
@@ -444,7 +444,7 @@ orchestratorTest(
       { stage2Hook: noopStage2 },
     );
 
-    // Session 2: row (horizontalPull)
+    // Session 2: row (horizontal_pull)
     await applySession(
       {
         user_id: userId,
@@ -465,8 +465,8 @@ orchestratorTest(
     `;
     const interactions = (rows[0].model_json as Record<string, unknown>).fatigueInteractions as Array<Record<string, unknown>>;
     assertEquals(interactions.length, 1);
-    assertEquals(interactions[0].fromPattern, "horizontalPush");
-    assertEquals(interactions[0].toPattern, "horizontalPull");
+    assertEquals(interactions[0].fromPattern, "horizontal_push");
+    assertEquals(interactions[0].toPattern, "horizontal_pull");
     assertEquals(interactions[0].totalCount, 1);
     assertEquals((interactions[0].observations as number[]).length, 1);
   },
@@ -574,7 +574,7 @@ orchestratorTest(
       SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
     `;
     const patterns = (rows[0].model_json as Record<string, unknown>).patterns as Record<string, Record<string, unknown>>;
-    const push = patterns["horizontalPush"];
+    const push = patterns["horizontal_push"];
     assertEquals((push.weeklyVolumeLoadHistory as unknown[]).length, 0);
     assertEquals(push.trend, "progressing");
   },
@@ -621,7 +621,7 @@ orchestratorTest(
 );
 
 orchestratorTest(
-  "A19 / #120 (per-pattern recovery per #146): second session 24h after horizontalPush stimulus produces partially-recovered NM readiness per ADR-0010 curve (~0.7853); metabolic untouched stays 1.0",
+  "A19 / #120 (per-pattern recovery per #146): second session 24h after horizontal_push stimulus produces partially-recovered NM readiness per ADR-0010 curve (~0.7853); metabolic untouched stays 1.0",
   async () => {
     const userId = await seedFreshUser();
     const sessionId1 = crypto.randomUUID();
@@ -629,7 +629,7 @@ orchestratorTest(
     const loggedAt1 = "2026-05-08T10:00:00Z";
     const loggedAt2 = "2026-05-09T10:00:00Z"; // exactly 24h later
 
-    // Session 1: heavy bench top×5 (NM only) → bootstraps horizontalPush
+    // Session 1: heavy bench top×5 (NM only) → bootstraps horizontal_push
     await applySession(
       {
         user_id: userId,
@@ -662,7 +662,7 @@ orchestratorTest(
       SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
     `;
     const patterns = (rows[0].model_json as Record<string, unknown>).patterns as Record<string, Record<string, unknown>>;
-    const recovery = patterns.horizontalPush.recovery as Record<string, unknown>;
+    const recovery = patterns.horizontal_push.recovery as Record<string, unknown>;
 
     // NM: 24h since stimulus, tau=30h → 0.3 + 0.7 × (1 - exp(-24/30)) ≈ 0.7853
     const expectedNm = 0.3 + 0.7 * (1 - Math.exp(-24 / 30));
@@ -676,7 +676,7 @@ orchestratorTest(
 );
 
 orchestratorTest(
-  "A18 / #118 (per-pattern recovery per #146): warmup-only session bootstraps horizontalPush pattern with default recovery shape — null timestamps + 1.0 readinesses (no stimulus bump from low-stimulus sets)",
+  "A18 / #118 (per-pattern recovery per #146): warmup-only session bootstraps horizontal_push pattern with default recovery shape — null timestamps + 1.0 readinesses (no stimulus bump from low-stimulus sets)",
   async () => {
     const userId = await seedFreshUser();
     const sessionId = crypto.randomUUID();
@@ -703,7 +703,7 @@ orchestratorTest(
       SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
     `;
     const patterns = (rows[0].model_json as Record<string, unknown>).patterns as Record<string, Record<string, unknown>>;
-    const recovery = patterns.horizontalPush.recovery as Record<string, unknown>;
+    const recovery = patterns.horizontal_push.recovery as Record<string, unknown>;
 
     // Bootstrapped (the field exists)...
     assertEquals(recovery.neuromuscularReadiness, 1.0);
@@ -749,12 +749,12 @@ orchestratorTest(
     // via the ExerciseLibrary port (#110 / A15).
     assertEquals(
       Object.keys(patterns).sort(),
-      ["horizontalPull", "horizontalPush", "squat"],
+      ["horizontal_pull", "horizontal_push", "squat"],
     );
 
     // Each profile carries ADR-0011 defaults + the just-trained-this-session state.
     const expectedLoggedAtIso = new Date(loggedAt).toISOString();
-    for (const patternKey of ["horizontalPush", "squat", "horizontalPull"]) {
+    for (const patternKey of ["horizontal_push", "squat", "horizontal_pull"]) {
       const profile = patterns[patternKey];
       assertEquals(profile.currentPhase, "accumulation");
       assertEquals(profile.sessionsInPhase, 1);
@@ -1507,8 +1507,8 @@ orchestratorTest(
   async () => {
     // Synthetic 4-of-6 major-pattern transitions fixture. Pre-set
     // lastPhaseTransitionAtSessionCount within the 6-session window for
-    // squat / hipHinge / horizontalPush / verticalPush; the remaining
-    // major patterns (horizontalPull / verticalPull) sit outside the
+    // squat / hip_hinge / horizontal_push / vertical_push; the remaining
+    // major patterns (horizontal_pull / vertical_pull) sit outside the
     // window. session_count post-increment = 7 (above the bootstrap guard
     // of 6). lastGlobalPhaseAdvanceFiredAtSessionCount starts null —
     // never-fired.
@@ -1538,10 +1538,10 @@ orchestratorTest(
     const seedModel = {
       patterns: {
         squat: inWindowProfile("squat"),
-        hipHinge: inWindowProfile("hipHinge"),
-        horizontalPush: inWindowProfile("horizontalPush"),
-        verticalPush: inWindowProfile("verticalPush"),
-        // horizontalPull / verticalPull intentionally absent — they do not
+        hip_hinge: inWindowProfile("hip_hinge"),
+        horizontal_push: inWindowProfile("horizontal_push"),
+        vertical_push: inWindowProfile("vertical_push"),
+        // horizontal_pull / vertical_pull intentionally absent — they do not
         // contribute to the count, leaving 4-of-6 satisfied.
       },
       lastGlobalPhaseAdvanceFiredAtSessionCount: null,

--- a/supabase/functions/update-trainee-model/smoke_test.ts
+++ b/supabase/functions/update-trainee-model/smoke_test.ts
@@ -76,7 +76,7 @@ function syntheticSessionPayload(loggedAt: string): Record<string, unknown> {
   return {
     logged_at: loggedAt,
     set_logs: [
-      // horizontalPush — bench press: warmup ramp + top sets + backoff
+      // horizontal_push — bench press: warmup ramp + top sets + backoff
       { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 60, reps_completed: 5, intent: "warmup" },
       { exercise_id: "barbell_bench_press", set_number: 2, weight_kg: 80, reps_completed: 5, intent: "warmup" },
       { exercise_id: "barbell_bench_press", set_number: 3, weight_kg: 100, reps_completed: 5, intent: "top", rpe_felt: 8 },
@@ -86,7 +86,7 @@ function syntheticSessionPayload(loggedAt: string): Record<string, unknown> {
       { exercise_id: "barbell_back_squat", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "warmup" },
       { exercise_id: "barbell_back_squat", set_number: 2, weight_kg: 130, reps_completed: 5, intent: "top", rpe_felt: 8 },
       { exercise_id: "barbell_back_squat", set_number: 3, weight_kg: 130, reps_completed: 5, intent: "top", rpe_felt: 8 },
-      // horizontalPull — barbell row top sets
+      // horizontal_pull — barbell row top sets
       { exercise_id: "barbell_row", set_number: 1, weight_kg: 70, reps_completed: 8, intent: "top", rpe_felt: 8 },
       { exercise_id: "barbell_row", set_number: 2, weight_kg: 70, reps_completed: 8, intent: "top", rpe_felt: 8 },
     ],
@@ -147,19 +147,19 @@ smokeTest(
 
     // model_json.patterns bootstrapped for all 3 trained movement patterns
     // (#110 / A15). The synthetic fixture's exercise IDs resolve to:
-    //   barbell_bench_press → horizontalPush
+    //   barbell_bench_press → horizontal_push
     //   barbell_back_squat  → squat
-    //   barbell_row         → horizontalPull
+    //   barbell_row         → horizontal_pull
     // Each PatternProfile starts at accumulation, sessionsInPhase=1
     // (this apply counted), trend=progressing, recentSessionDates=[loggedAt].
     const modelJson = (model[0].model_json as Record<string, unknown>);
     const patterns = modelJson.patterns as Record<string, Record<string, unknown>>;
     assertEquals(
       Object.keys(patterns).sort(),
-      ["horizontalPull", "horizontalPush", "squat"],
+      ["horizontal_pull", "horizontal_push", "squat"],
     );
     const expectedLoggedAtIso = new Date(loggedAt).toISOString();
-    for (const patternKey of ["horizontalPush", "squat", "horizontalPull"]) {
+    for (const patternKey of ["horizontal_push", "squat", "horizontal_pull"]) {
       const profile = patterns[patternKey];
       assertEquals(profile.currentPhase, "accumulation");
       assertEquals(profile.sessionsInPhase, 1);
@@ -191,14 +191,14 @@ smokeTest(
     // RecoveryProfile.last*StimulusAt populated per-pattern (A18 / #118,
     // migrated to per-pattern recovery per #146). Per stimulus-classifier:
     //   - bench top×5 RPE 8 → NM; backoff×8 RPE 7 → "both" (reps ≤ 8)
-    //     → horizontalPush: NM + met both bumped
+    //     → horizontal_push: NM + met both bumped
     //   - squat top×5 RPE 8 → NM only
     //     → squat: NM bumped, met null
     //   - row top×8 RPE 8 → "both"
-    //     → horizontalPull: NM + met both bumped
+    //     → horizontal_pull: NM + met both bumped
     // Readinesses computed via ADR-0010 curve at t=0 → residual floor 0.3
     // (A19 / #120) on bumped axes; null-timestamp axes stay at 1.0.
-    const pushRec = patterns.horizontalPush.recovery as Record<string, unknown>;
+    const pushRec = patterns.horizontal_push.recovery as Record<string, unknown>;
     assertEquals(pushRec.lastNeuromuscularStimulusAt, expectedLoggedAtIso);
     assertEquals(pushRec.lastMetabolicStimulusAt, expectedLoggedAtIso);
     assertEquals(Number((pushRec.neuromuscularReadiness as number).toFixed(4)), 0.3);
@@ -210,7 +210,7 @@ smokeTest(
     assertEquals(Number((squatRec.neuromuscularReadiness as number).toFixed(4)), 0.3);
     assertEquals(squatRec.metabolicReadiness, 1.0);
 
-    const pullRec = patterns.horizontalPull.recovery as Record<string, unknown>;
+    const pullRec = patterns.horizontal_pull.recovery as Record<string, unknown>;
     assertEquals(pullRec.lastNeuromuscularStimulusAt, expectedLoggedAtIso);
     assertEquals(pullRec.lastMetabolicStimulusAt, expectedLoggedAtIso);
     assertEquals(Number((pullRec.neuromuscularReadiness as number).toFixed(4)), 0.3);
@@ -251,7 +251,7 @@ smokeTest(
       modelJson.lastSessionPatternPerformance as Array<Record<string, unknown>>;
     assertEquals(lastSessionPerf.length, 3);
     const perfPatterns = lastSessionPerf.map((p) => p.pattern as string).sort();
-    assertEquals(perfPatterns, ["horizontalPull", "horizontalPush", "squat"]);
+    assertEquals(perfPatterns, ["horizontal_pull", "horizontal_push", "squat"]);
 
     // All 7 G1-audit unwired modules now have orchestrator-side wiring +
     // smoke coverage. Phase 4 (G1 redefinition) closes #85.

--- a/supabase/migrations/20260512061710_rename_pattern_keys_snake_case.sql
+++ b/supabase/migrations/20260512061710_rename_pattern_keys_snake_case.sql
@@ -1,0 +1,180 @@
+-- Reverse migration: docs/migrations/down/20260512061710_rename_pattern_keys_snake_case.sql
+-- (documentation only; not auto-applied by `supabase db push`)
+--
+-- #148: rename camelCase MovementPattern keys to snake_case across all
+-- pattern-keyed locations in trainee_models.model_json.
+--
+-- The Edge Function previously emitted camelCase pattern keys
+-- (horizontalPush, horizontalPull, hipHinge, verticalPush, verticalPull)
+-- via _shared/exercise-library.ts's MovementPattern type. Swift's
+-- MovementPattern.rawValue uses snake_case (horizontal_push, etc.) per
+-- the cross-platform fixture contract locked by ADR-0006. decodeEnumKeyedDict
+-- silently skipped mismatched keys → 5 of 8 patterns dropped on iOS
+-- decode. EF code in this same PR migrates to snake_case; this migration
+-- renames the keys in existing alpha JSONB rows.
+--
+-- Pattern-keyed locations migrated:
+--   1. model_json.patterns                       (outer dict keys)
+--   2. model_json.patterns.<k>.pattern           (per-PatternProfile field added in #146)
+--   3. model_json.prescriptionAccuracy           (outer dict keys per ADR-0014)
+--   4. model_json.fatigueInteractions[*].fromPattern (string value)
+--   5. model_json.fatigueInteractions[*].toPattern   (string value)
+--   6. model_json.lastSessionPatternPerformance[*].pattern (string value)
+--   7. model_json.activeLimitations[*].subject.value when subject.kind='pattern'
+--   8. model_json.clearedLimitations[*].subject.value when subject.kind='pattern'
+--
+-- Each location is migrated independently with an idempotent transformation
+-- (no-op when source key/value isn't camelCase) so the migration can re-run
+-- safely if interrupted. Forward-only per the migrations workflow.
+
+-- Helper function: rename camelCase MovementPattern strings to snake_case
+-- within a jsonb scalar. Returns the input unchanged for non-matching values.
+CREATE OR REPLACE FUNCTION pg_temp.rename_pattern_value(input jsonb)
+RETURNS jsonb LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE input #>> '{}'
+    WHEN 'horizontalPush' THEN '"horizontal_push"'::jsonb
+    WHEN 'horizontalPull' THEN '"horizontal_pull"'::jsonb
+    WHEN 'verticalPush'   THEN '"vertical_push"'::jsonb
+    WHEN 'verticalPull'   THEN '"vertical_pull"'::jsonb
+    WHEN 'hipHinge'       THEN '"hip_hinge"'::jsonb
+    ELSE input
+  END
+$$;
+
+-- Helper function: rename camelCase MovementPattern keys within a JSON
+-- object. Builds a new object reusing snake_case keys for the 5 camelCase
+-- variants; all other keys pass through unchanged.
+CREATE OR REPLACE FUNCTION pg_temp.rename_pattern_keys(input jsonb)
+RETURNS jsonb LANGUAGE sql IMMUTABLE AS $$
+  SELECT COALESCE(
+    jsonb_object_agg(
+      CASE k
+        WHEN 'horizontalPush' THEN 'horizontal_push'
+        WHEN 'horizontalPull' THEN 'horizontal_pull'
+        WHEN 'verticalPush'   THEN 'vertical_push'
+        WHEN 'verticalPull'   THEN 'vertical_pull'
+        WHEN 'hipHinge'       THEN 'hip_hinge'
+        ELSE k
+      END,
+      v
+    ),
+    '{}'::jsonb
+  )
+  FROM jsonb_each(input) AS e(k, v)
+$$;
+
+-- 1 + 2. model_json.patterns outer keys + per-PatternProfile `pattern` field.
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{patterns}',
+  (
+    SELECT COALESCE(
+      jsonb_object_agg(
+        CASE k
+          WHEN 'horizontalPush' THEN 'horizontal_push'
+          WHEN 'horizontalPull' THEN 'horizontal_pull'
+          WHEN 'verticalPush'   THEN 'vertical_push'
+          WHEN 'verticalPull'   THEN 'vertical_pull'
+          WHEN 'hipHinge'       THEN 'hip_hinge'
+          ELSE k
+        END,
+        CASE WHEN v ? 'pattern'
+          THEN jsonb_set(v, '{pattern}', pg_temp.rename_pattern_value(v->'pattern'))
+          ELSE v
+        END
+      ),
+      '{}'::jsonb
+    )
+    FROM jsonb_each(model_json->'patterns') AS e(k, v)
+  )
+)
+WHERE model_json ? 'patterns'
+  AND jsonb_typeof(model_json->'patterns') = 'object';
+
+-- 3. model_json.prescriptionAccuracy outer keys.
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{prescriptionAccuracy}',
+  pg_temp.rename_pattern_keys(model_json->'prescriptionAccuracy')
+)
+WHERE model_json ? 'prescriptionAccuracy'
+  AND jsonb_typeof(model_json->'prescriptionAccuracy') = 'object';
+
+-- 4 + 5. fatigueInteractions[*].fromPattern + .toPattern values.
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{fatigueInteractions}',
+  (
+    SELECT COALESCE(jsonb_agg(
+      CASE
+        WHEN entry ? 'fromPattern' OR entry ? 'toPattern' THEN
+          entry
+            || jsonb_build_object('fromPattern', pg_temp.rename_pattern_value(entry->'fromPattern'))
+            || jsonb_build_object('toPattern',   pg_temp.rename_pattern_value(entry->'toPattern'))
+        ELSE entry
+      END
+    ), '[]'::jsonb)
+    FROM jsonb_array_elements(model_json->'fatigueInteractions') AS e(entry)
+  )
+)
+WHERE model_json ? 'fatigueInteractions'
+  AND jsonb_typeof(model_json->'fatigueInteractions') = 'array';
+
+-- 6. lastSessionPatternPerformance[*].pattern values.
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{lastSessionPatternPerformance}',
+  (
+    SELECT COALESCE(jsonb_agg(
+      CASE WHEN entry ? 'pattern'
+        THEN jsonb_set(entry, '{pattern}', pg_temp.rename_pattern_value(entry->'pattern'))
+        ELSE entry
+      END
+    ), '[]'::jsonb)
+    FROM jsonb_array_elements(model_json->'lastSessionPatternPerformance') AS e(entry)
+  )
+)
+WHERE model_json ? 'lastSessionPatternPerformance'
+  AND jsonb_typeof(model_json->'lastSessionPatternPerformance') = 'array';
+
+-- 7. activeLimitations[*].subject.value when subject.kind='pattern'.
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{activeLimitations}',
+  (
+    SELECT COALESCE(jsonb_agg(
+      CASE
+        WHEN entry #>> '{subject,kind}' = 'pattern' THEN
+          jsonb_set(entry, '{subject,value}', pg_temp.rename_pattern_value(entry#>'{subject,value}'))
+        ELSE entry
+      END
+    ), '[]'::jsonb)
+    FROM jsonb_array_elements(model_json->'activeLimitations') AS e(entry)
+  )
+)
+WHERE model_json ? 'activeLimitations'
+  AND jsonb_typeof(model_json->'activeLimitations') = 'array';
+
+-- 8. clearedLimitations[*].subject.value when subject.kind='pattern'.
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{clearedLimitations}',
+  (
+    SELECT COALESCE(jsonb_agg(
+      CASE
+        WHEN entry #>> '{subject,kind}' = 'pattern' THEN
+          jsonb_set(entry, '{subject,value}', pg_temp.rename_pattern_value(entry#>'{subject,value}'))
+        ELSE entry
+      END
+    ), '[]'::jsonb)
+    FROM jsonb_array_elements(model_json->'clearedLimitations') AS e(entry)
+  )
+)
+WHERE model_json ? 'clearedLimitations'
+  AND jsonb_typeof(model_json->'clearedLimitations') = 'array';


### PR DESCRIPTION
## Summary

Closes #148. Completes the B1–B4 decoder unblock started in #146/#149. Renames the Edge Function's MovementPattern keys from camelCase (`horizontalPush`, `horizontalPull`, `hipHinge`, `verticalPush`, `verticalPull`) to snake_case (`horizontal_push`, etc.) to match Swift's `MovementPattern.rawValue` and the cross-platform fixture contract locked by ADR-0006.

After #149 merged, iOS decoded only 3 patterns (`squat`/`lunge`/`isolation` — the keys whose camelCase happens to equal snake_case). The 5 push/pull/hinge patterns were silently dropped by `decodeEnumKeyedDict`. This PR closes that.

## Scope

### EF source renames

- `_shared/exercise-library.ts` — `MovementPattern` type union (8 values) + `EXERCISE_PATTERN_MAP` values (~30 entries hit by the 5 multi-word patterns)
- `_shared/constants.ts` — `MAJOR_PATTERNS` list
- `_shared/note-classifier.ts` — `PATTERN_TRAINS_JOINTS` keys
- `_shared/note-classifier-prompt.txt` — LLM vocabulary instruction (`hipHinge, horizontalPull, ...` → `hip_hinge, horizontal_pull, ...`)

### Test updates

All 9 EF test files with hardcoded camelCase pattern references: `orchestrator_test.ts`, `smoke_test.ts`, `global-phase-advance_test.ts`, `plateau-verdict_test.ts`, `fatigue-interaction_test.ts`, `constants_test.ts`, `exercise-library_test.ts`, `prescription-accuracy_test.ts`, `note-classifier_test.ts`.

### Migration

8 pattern-keyed locations in `trainee_models.model_json` renamed to snake_case:
1. `patterns` outer keys
2. `patterns.<k>.pattern` (field added in #146)
3. `prescriptionAccuracy` outer keys
4–5. `fatigueInteractions[*].fromPattern` / `.toPattern`
6. `lastSessionPatternPerformance[*].pattern`
7–8. `activeLimitations[*]` / `clearedLimitations[*]` `subject.value` when `subject.kind = 'pattern'`

Each location uses an idempotent transformation (no-op on already-snake_case values or absent keys), so the migration is order-safe relative to the EF deploy and re-runnable if interrupted.

## Out of scope (filed but not fixed in this PR)

Discovered during #148 inventory: `_shared/note-classifier.ts:209-217` `PATTERN_TRAINS_JOINTS` arrays contain the joint string `"lowerBack"` (camelCase) but Swift's `BodyJoint.lowerBack` rawValue is `"lower_back"` and the classifier prompt's joint vocabulary at `note-classifier-prompt.txt:60` already emits `lower_back`. So `trainedJoints.has("lower_back")` returns false when the set was populated from `"lowerBack"`-keyed map values. Filing as a separate spinoff — different vocabulary (BodyJoint vs MovementPattern), different fix shape, and explicitly out of #148's stated scope per CLAUDE.md surgical-changes principle.

## Test plan

- [x] `deno check` clean on all modified EF source + test files
- [ ] CI: TS unit tests pass
- [ ] CI: Swift build + tests pass
- [ ] Post-merge: CI auto-deploys EF + applies migration (per #143/#144); verify next alpha session apply produces `model_json` with all 8 pattern keys in snake_case
- [ ] Post-merge: iOS `decodeEnumKeyedDict` hydrates all patterns the alpha user has trained; `TraineeModelService.digest()` returns full per-pattern coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)