### PR TITLE
feat: #147 onboarding goal write path via update-trainee-goal EF

### DIFF
--- a/ProjectApex/Features/Onboarding/OnboardingView.swift
+++ b/ProjectApex/Features/Onboarding/OnboardingView.swift
@@ -931,6 +931,27 @@ struct OnboardingView: View {
             trainingAge: profile.trainingAge.rawValue
         )
         try? await deps.supabaseClient.insert(userRow, table: "users")
+
+        // #147: hydrate trainee_models.model_json.goal via the
+        // update-trainee-goal Edge Function. Best-effort — failure leaves
+        // the iOS side reading GoalState.placeholder (cold-start fallback
+        // until the next onboarding retry or DeveloperSettingsView reset).
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let goalPayload = TraineeGoalUpsertPayload(
+            userId: userId,
+            goal: GoalUpsertBody(
+                statement: profile.primaryGoal.rawValue,
+                focusAreas: [],
+                updatedAt: isoFormatter.string(from: Date())
+            )
+        )
+        if let encoded = try? JSONEncoder().encode(goalPayload) {
+            _ = try? await deps.supabaseClient.invokeFunction(
+                "update-trainee-goal",
+                body: encoded
+            )
+        }
     }
 
     private func completeOnboarding() {
@@ -984,6 +1005,28 @@ private struct UserInsertRow: Codable, Sendable {
         case age
         case trainingAge  = "training_age"
     }
+}
+
+// MARK: - TraineeGoalUpsertPayload (#147: onboarding goal write)
+
+/// Request body for the `update-trainee-goal` Edge Function. Mirrors the
+/// validator contract in `supabase/functions/update-trainee-goal/index.ts`:
+/// top-level `user_id` (UUID string) and `goal` object carrying the
+/// GoalState shape (statement + focusAreas + ISO-8601 updatedAt).
+private struct TraineeGoalUpsertPayload: Codable, Sendable {
+    let userId: UUID
+    let goal: GoalUpsertBody
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case goal
+    }
+}
+
+private struct GoalUpsertBody: Codable, Sendable {
+    let statement: String
+    let focusAreas: [String]
+    let updatedAt: String
 }
 
 // MARK: - Preview

--- a/supabase/functions/update-trainee-goal/deno.json
+++ b/supabase/functions/update-trainee-goal/deno.json
@@ -1,0 +1,6 @@
+{
+  "nodeModulesDir": "auto",
+  "imports": {
+    "postgres": "npm:postgres@3.4.4"
+  }
+}

--- a/supabase/functions/update-trainee-goal/deno.lock
+++ b/supabase/functions/update-trainee-goal/deno.lock
@@ -1,0 +1,51 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:postgres@3.4.4": "3.4.4"
+  },
+  "npm": {
+    "postgres@3.4.4": {
+      "integrity": "sha512-IbyN+9KslkqcXa8AO9fxpk97PA4pzewvpi2B3Dwy9u4zpV32QicaEdgmF3eSQUzdRk7ttDHQejNgAEr4XoeH4A=="
+    }
+  },
+  "remote": {
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
+    "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
+    "https://deno.land/std@0.224.0/assert/assert_array_includes.ts": "14c5094471bc8e4a7895fc6aa5a184300d8a1879606574cb1cd715ef36a4a3c7",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_exists.ts": "43420cf7f956748ae6ed1230646567b3593cb7a36c5a5327269279c870c5ddfd",
+    "https://deno.land/std@0.224.0/assert/assert_false.ts": "3e9be8e33275db00d952e9acb0cd29481a44fa0a4af6d37239ff58d79e8edeff",
+    "https://deno.land/std@0.224.0/assert/assert_greater.ts": "5e57b201fd51b64ced36c828e3dfd773412c1a6120c1a5a99066c9b261974e46",
+    "https://deno.land/std@0.224.0/assert/assert_greater_or_equal.ts": "9870030f997a08361b6f63400273c2fb1856f5db86c0c3852aab2a002e425c5b",
+    "https://deno.land/std@0.224.0/assert/assert_instance_of.ts": "e22343c1fdcacfaea8f37784ad782683ec1cf599ae9b1b618954e9c22f376f2c",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_less.ts": "60b61e13a1982865a72726a5fa86c24fad7eb27c3c08b13883fb68882b307f68",
+    "https://deno.land/std@0.224.0/assert/assert_less_or_equal.ts": "d2c84e17faba4afe085e6c9123a63395accf4f9e00150db899c46e67420e0ec3",
+    "https://deno.land/std@0.224.0/assert/assert_match.ts": "ace1710dd3b2811c391946954234b5da910c5665aed817943d086d4d4871a8b7",
+    "https://deno.land/std@0.224.0/assert/assert_not_equals.ts": "78d45dd46133d76ce624b2c6c09392f6110f0df9b73f911d20208a68dee2ef29",
+    "https://deno.land/std@0.224.0/assert/assert_not_instance_of.ts": "3434a669b4d20cdcc5359779301a0588f941ffdc2ad68803c31eabdb4890cf7a",
+    "https://deno.land/std@0.224.0/assert/assert_not_match.ts": "df30417240aa2d35b1ea44df7e541991348a063d9ee823430e0b58079a72242a",
+    "https://deno.land/std@0.224.0/assert/assert_not_strict_equals.ts": "37f73880bd672709373d6dc2c5f148691119bed161f3020fff3548a0496f71b8",
+    "https://deno.land/std@0.224.0/assert/assert_object_match.ts": "411450fd194fdaabc0089ae68f916b545a49d7b7e6d0026e84a54c9e7eed2693",
+    "https://deno.land/std@0.224.0/assert/assert_rejects.ts": "4bee1d6d565a5b623146a14668da8f9eb1f026a4f338bbf92b37e43e0aa53c31",
+    "https://deno.land/std@0.224.0/assert/assert_strict_equals.ts": "b4f45f0fd2e54d9029171876bd0b42dd9ed0efd8f853ab92a3f50127acfa54f5",
+    "https://deno.land/std@0.224.0/assert/assert_string_includes.ts": "496b9ecad84deab72c8718735373feb6cdaa071eb91a98206f6f3cb4285e71b8",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/assert/fail.ts": "0eba674ffb47dff083f02ced76d5130460bff1a9a68c6514ebe0cdea4abadb68",
+    "https://deno.land/std@0.224.0/assert/mod.ts": "48b8cb8a619ea0b7958ad7ee9376500fe902284bb36f0e32c598c3dc34cbd6f3",
+    "https://deno.land/std@0.224.0/assert/unimplemented.ts": "8c55a5793e9147b4f1ef68cd66496b7d5ba7a9e7ca30c6da070c1a58da723d73",
+    "https://deno.land/std@0.224.0/assert/unreachable.ts": "5ae3dbf63ef988615b93eb08d395dda771c96546565f9e521ed86f6510c29e19",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:postgres@3.4.4"
+    ]
+  }
+}

--- a/supabase/functions/update-trainee-goal/index.ts
+++ b/supabase/functions/update-trainee-goal/index.ts
@@ -1,0 +1,191 @@
+// Project Apex — update-trainee-goal Edge Function.
+//
+// #147 (spinoff from #146): onboarding-side write path for
+// `trainee_models.model_json.goal`. The session-apply pipeline
+// (update-trainee-model) has no goal-setter — its rule modules only
+// mutate behavioural fields (patterns, exercises, recovery, etc.). This
+// function is the goal-only write channel called from iOS onboarding.
+//
+// Single-writer invariant preserved per ADR-0006: this function is a
+// server-side writer of model_json (not a client-side direct UPSERT),
+// matching the same writer-class contract as update-trainee-model.
+//
+// Permissive semantics: re-onboarding (DeveloperSettingsView "Reset
+// Onboarding") replays the write, overwriting any prior goal. Goal
+// renegotiation lifecycle (ADR-0005 §goalLastRenegotiatedAt) is a
+// separate future feature; this slice does not pre-build for it.
+//
+// Atomic merge: jsonb_set on the existing model_json so the EF
+// session-apply pipeline's writes are not stomped if a session has
+// already landed before onboarding completes. The COALESCE on the
+// ON CONFLICT side handles the (theoretically impossible but
+// defensively-safe) NULL-model_json case.
+//
+// See:
+//   - ADR-0005 §"goal" — GoalState shape
+//   - ADR-0006 §"writer/reader contract" — single-writer invariant
+//   - docs/agents/edge-functions.md — secrets, deploy, local dev
+
+import postgres from "postgres";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export interface UpdateTraineeGoalRequest {
+  user_id: string;
+  goal: {
+    statement: string;
+    focusAreas: string[];
+    updatedAt: string;
+  };
+}
+
+const ISO_DATE_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/;
+
+export function validateRequest(
+  body: unknown,
+): UpdateTraineeGoalRequest | { error: string } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { error: "request body must be a JSON object" };
+  }
+  const { user_id, goal } = body as Record<string, unknown>;
+  if (typeof user_id !== "string" || !UUID_RE.test(user_id)) {
+    return { error: "user_id must be a UUID string" };
+  }
+  if (typeof goal !== "object" || goal === null || Array.isArray(goal)) {
+    return { error: "goal must be a JSON object" };
+  }
+  const g = goal as Record<string, unknown>;
+  if (typeof g.statement !== "string") {
+    return { error: "goal.statement must be a string" };
+  }
+  if (!Array.isArray(g.focusAreas)) {
+    return { error: "goal.focusAreas must be an array of strings" };
+  }
+  for (let i = 0; i < g.focusAreas.length; i++) {
+    if (typeof g.focusAreas[i] !== "string") {
+      return {
+        error: `goal.focusAreas[${i}] must be a string`,
+      };
+    }
+  }
+  if (typeof g.updatedAt !== "string" || !ISO_DATE_RE.test(g.updatedAt)) {
+    return { error: "goal.updatedAt must be an ISO 8601 timestamp string" };
+  }
+  return {
+    user_id,
+    goal: {
+      statement: g.statement,
+      focusAreas: g.focusAreas as string[],
+      updatedAt: g.updatedAt,
+    },
+  };
+}
+
+// deno-lint-ignore no-explicit-any
+type Sql = any;
+
+export interface UpsertGoalResult {
+  ok: true;
+  goal: UpdateTraineeGoalRequest["goal"];
+}
+
+/**
+ * Upserts `model_json.goal` for the user. Idempotent: re-running with the
+ * same payload yields the same end state. Permissive: re-running with a
+ * different `goal` overwrites the prior value (renegotiation lifecycle is
+ * not enforced here per #147 scope).
+ *
+ * On the INSERT path (no existing trainee_models row), `model_json` is
+ * seeded with just `{ "goal": <goal> }`. The session-apply pipeline's
+ * rule modules tolerate a sparse model_json (every read falls back to
+ * `?? <default>` per A12 conventions), so the first applySession will
+ * spread over this minimal row and populate the remaining fields.
+ */
+export async function upsertGoal(
+  req: UpdateTraineeGoalRequest,
+  sql: Sql,
+): Promise<UpsertGoalResult> {
+  await sql`
+    INSERT INTO public.trainee_models (user_id, model_json, updated_at)
+    VALUES (
+      ${req.user_id},
+      ${sql.json({ goal: req.goal })},
+      NOW()
+    )
+    ON CONFLICT (user_id) DO UPDATE SET
+      model_json = jsonb_set(
+        COALESCE(public.trainee_models.model_json, '{}'::jsonb),
+        '{goal}',
+        ${sql.json(req.goal)},
+        true
+      ),
+      updated_at = NOW()
+  `;
+  return { ok: true, goal: req.goal };
+}
+
+let cachedSql: Sql | undefined;
+function getSql(): Sql {
+  if (cachedSql) return cachedSql;
+  const url = Deno.env.get("SUPABASE_DB_URL");
+  if (!url) {
+    throw new Error(
+      "SUPABASE_DB_URL env var must be set to invoke upsertGoal from " +
+        "the HTTP path (see docs/agents/edge-functions.md)",
+    );
+  }
+  cachedSql = postgres(url);
+  return cachedSql;
+}
+
+export async function handleRequest(req: Request): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "method not allowed" }, 405);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: "request body must be valid JSON" }, 400);
+  }
+
+  const validated = validateRequest(body);
+  if ("error" in validated) {
+    return jsonResponse({ error: validated.error }, 400);
+  }
+
+  let sql: Sql;
+  try {
+    sql = getSql();
+  } catch (e) {
+    return jsonResponse(
+      { error: e instanceof Error ? e.message : "DB unavailable" },
+      500,
+    );
+  }
+
+  try {
+    const result = await upsertGoal(validated, sql);
+    return jsonResponse(result, 200);
+  } catch (e) {
+    console.error("[update-trainee-goal] upsertGoal failed:", e);
+    return jsonResponse(
+      { error: e instanceof Error ? e.message : "internal error" },
+      500,
+    );
+  }
+}
+
+if (import.meta.main) {
+  Deno.serve(handleRequest);
+}

--- a/supabase/functions/update-trainee-goal/index_test.ts
+++ b/supabase/functions/update-trainee-goal/index_test.ts
@@ -1,0 +1,126 @@
+// Project Apex — update-trainee-goal Edge Function — validator tests.
+//
+// #147: validates the request shape before the SQL write runs. Integration
+// tests against a real DB are covered separately (the orchestrator_test.ts
+// pattern from update-trainee-model could be ported when needed); this
+// file exercises the validator in isolation.
+//
+// Run locally:
+//   deno test supabase/functions/update-trainee-goal/index_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { validateRequest } from "./index.ts";
+
+const VALID_USER_ID = "11111111-1111-4111-8111-111111111111";
+const VALID_GOAL = {
+  statement: "Hypertrophy (muscle size)",
+  focusAreas: [],
+  updatedAt: "2026-05-12T10:00:00.000Z",
+};
+
+function baseRequest(overrides: Record<string, unknown> = {}) {
+  return { user_id: VALID_USER_ID, goal: VALID_GOAL, ...overrides };
+}
+
+Deno.test("validateRequest_happy_path_returns_ok", () => {
+  const result = validateRequest(baseRequest());
+  assertEquals("error" in result, false);
+});
+
+Deno.test("validateRequest_non_object_body_returns_400", () => {
+  const r1 = validateRequest(null);
+  const r2 = validateRequest([1, 2, 3]);
+  const r3 = validateRequest("string");
+  assertEquals("error" in r1, true);
+  assertEquals("error" in r2, true);
+  assertEquals("error" in r3, true);
+});
+
+Deno.test("validateRequest_missing_user_id_returns_400", () => {
+  const result = validateRequest({ goal: VALID_GOAL });
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("user_id"), true);
+});
+
+Deno.test("validateRequest_invalid_user_id_uuid_returns_400", () => {
+  const result = validateRequest({ user_id: "not-a-uuid", goal: VALID_GOAL });
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("user_id"), true);
+});
+
+Deno.test("validateRequest_missing_goal_returns_400", () => {
+  const result = validateRequest({ user_id: VALID_USER_ID });
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("goal"), true);
+});
+
+Deno.test("validateRequest_goal_missing_statement_returns_400", () => {
+  const result = validateRequest({
+    user_id: VALID_USER_ID,
+    goal: { focusAreas: [], updatedAt: "2026-05-12T10:00:00Z" },
+  });
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("statement"), true);
+});
+
+Deno.test("validateRequest_goal_focusAreas_not_array_returns_400", () => {
+  const result = validateRequest({
+    user_id: VALID_USER_ID,
+    goal: {
+      statement: "x",
+      focusAreas: "not-an-array",
+      updatedAt: "2026-05-12T10:00:00Z",
+    },
+  });
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("focusAreas"), true);
+});
+
+Deno.test("validateRequest_goal_focusAreas_non_string_entry_returns_400", () => {
+  const result = validateRequest({
+    user_id: VALID_USER_ID,
+    goal: {
+      statement: "x",
+      focusAreas: ["legs", 42, "back"],
+      updatedAt: "2026-05-12T10:00:00Z",
+    },
+  });
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("focusAreas[1]"), true);
+});
+
+Deno.test("validateRequest_goal_updatedAt_not_iso_returns_400", () => {
+  const result = validateRequest({
+    user_id: VALID_USER_ID,
+    goal: {
+      statement: "x",
+      focusAreas: [],
+      updatedAt: "not-a-date",
+    },
+  });
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("updatedAt"), true);
+});
+
+Deno.test("validateRequest_empty_statement_accepted", () => {
+  // GoalState.placeholder shape — empty statement is valid input. The
+  // sentinel pattern is used by digest-side cold-start detection, not
+  // rejected at the write boundary.
+  const result = validateRequest({
+    user_id: VALID_USER_ID,
+    goal: { statement: "", focusAreas: [], updatedAt: "2026-05-12T10:00:00Z" },
+  });
+  assertEquals("error" in result, false);
+});
+
+Deno.test("validateRequest_focusAreas_with_muscle_groups_accepted", () => {
+  const result = validateRequest({
+    user_id: VALID_USER_ID,
+    goal: {
+      statement: "Build broad strength",
+      focusAreas: ["legs", "back"],
+      updatedAt: "2026-05-12T10:00:00Z",
+    },
+  });
+  assertEquals("error" in result, false);
+});


### PR DESCRIPTION
## Summary

Closes #147. Hydrates `trainee_models.model_json.goal` from iOS onboarding via a new `update-trainee-goal` Edge Function. After this PR + #149 + #150 land, the contract-drift family in `trainee_models.model_json` for the MovementPattern + GoalState axes is fully closed.

### Why a new EF (not direct UPSERT or RPC)

ADR-0006 line 68 explicitly: "the trainee-model JSONB column is a contract between **Edge Function (writer)** and client (reader for digest assembly)." A Postgres RPC the iOS client calls directly to mutate `model_json` would violate the single-writer invariant. The new EF preserves it.

Future goal-renegotiation work (ADR-0005 §`goalLastRenegotiatedAt`, possibly with LLM normalization or ProjectionState recomputation) has a natural home here. Auth, observability, and integration-test patterns inherit from the existing `update-trainee-model` scaffolding.

### Files

**New EF:**
- `supabase/functions/update-trainee-goal/index.ts` — POST endpoint; validates UUID user_id + GoalState shape; atomic `INSERT ... ON CONFLICT DO UPDATE SET model_json = jsonb_set(...)` so the EF session-apply pipeline's writes are not stomped if a session lands before onboarding completes.
- `supabase/functions/update-trainee-goal/index_test.ts` — 11 validator unit tests (happy path, malformed body, missing fields, non-UUID, focusAreas type errors, non-ISO updatedAt, empty-statement-accepted, focusAreas-with-muscle-groups-accepted).
- `deno.json` + `deno.lock` — matches the sibling EF's directory pattern.

**iOS wiring:**
- `OnboardingView.persistUserIfNeeded` calls the new EF after the existing `users` insert. Maps `OnboardingProfile.primaryGoal.rawValue` verbatim into `GoalState.statement`; `focusAreas: []` (no UI to collect); `updatedAt: Date.now`. Best-effort — onboarding completes regardless.

### Out of scope (deliberate)

- **Renegotiation lifecycle** (`goalLastRenegotiatedAt`): permissive semantics; this PR allows re-onboarding to overwrite. Renegotiation is a separate user-facing feature.
- **Focus-area collection UI**: existing onboarding doesn't collect muscle focus areas; adding it is feature creep beyond #147.
- **JWT verification of user_id**: matches the existing pattern in `update-trainee-model` (trusts body.user_id). Cross-EF auth hardening is a separate concern.

### Test plan

- [x] `deno test supabase/functions/update-trainee-goal/index_test.ts` — 11/11 pass
- [x] `deno check` clean
- [ ] CI: auto-deploys new EF (per #143/#144/#145 wiring); next alpha onboarding hydrates `model_json.goal`
- [ ] Post-merge: after the alpha user re-onboards (or the next net-new user), verify `SELECT model_json->'goal' FROM trainee_models WHERE user_id = <uuid>` returns the populated GoalState
- [ ] iOS `TraineeModelService.digest()` returns `goal.statement = <selected onboarding goal>` (not `GoalState.placeholder` sentinel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)