### PR TITLE
ci: auto-deploy update-trainee-goal Edge Function (follow-up to #147)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,3 +185,6 @@ jobs:
 
       - name: Deploy update-trainee-model Edge Function
         run: supabase functions deploy update-trainee-model --project-ref hqjgrlzvrttnyfjqjewe
+
+      - name: Deploy update-trainee-goal Edge Function
+        run: supabase functions deploy update-trainee-goal --project-ref hqjgrlzvrttnyfjqjewe


### PR DESCRIPTION
## Summary

Follow-up to #147 / PR #152. The existing CI deploy job only invoked \`supabase functions deploy update-trainee-model\`, so the new \`update-trainee-goal\` Edge Function would not auto-deploy. Adds a parallel deploy step.

Caught post-merge of #147 before the next push to main.

## Test plan

- [ ] Next merge to main runs both deploy steps successfully
- [ ] After deploy, \`update-trainee-goal\` is invocable at https://hqjgrlzvrttnyfjqjewe.supabase.co/functions/v1/update-trainee-goal
- [ ] iOS onboarding's goal-write call (best-effort \`try?\`) reaches the live EF on next onboarding run

🤖 Generated with [Claude Code](https://claude.com/claude-code)