### PR TITLE
fix: add workout_sessions.program_id FK with ON DELETE SET NULL

### DIFF
--- a/docs/migrations/down/20260512134826_add_workout_sessions_program_id_fk.sql
+++ b/docs/migrations/down/20260512134826_add_workout_sessions_program_id_fk.sql
@@ -1,0 +1,27 @@
+-- Reverse migration documentation for 20260512134826_add_workout_sessions_program_id_fk.sql
+-- (documentation only; not auto-applied — operator runs manually if needed)
+--
+-- Rollback for the workout_sessions.program_id FK + orphan-null cleanup.
+--
+-- Step 1: Drop the FK constraint.
+--
+--   ALTER TABLE public.workout_sessions
+--     DROP CONSTRAINT IF EXISTS workout_sessions_program_id_fkey;
+--
+-- The forward migration was idempotent (CREATE-IF-NOT-EXISTS), so DROP-IF-
+-- EXISTS is the symmetric reverse.
+--
+-- Step 2: Restoring null'd orphan program_ids is NOT recoverable from the
+-- database alone. If a future operator wants the pre-migration state back
+-- with the original (dangling) program_ids in place, they need a backup of
+-- workout_sessions taken BEFORE the forward migration ran. Sketch:
+--
+--   UPDATE public.workout_sessions ws
+--   SET program_id = bk.program_id
+--   FROM <backup_table> bk
+--   WHERE ws.id = bk.id AND ws.program_id IS NULL AND bk.program_id IS NOT NULL;
+--
+-- In practice the orphan-null'ing is a forward-only safety improvement: the
+-- session row stays intact, only its dangling reference is cleared. Rolling
+-- the null'ing back would re-introduce the data-integrity gap that motivated
+-- this migration in the first place — not recommended.

--- a/supabase/migrations/20260512134826_add_workout_sessions_program_id_fk.sql
+++ b/supabase/migrations/20260512134826_add_workout_sessions_program_id_fk.sql
@@ -1,0 +1,50 @@
+-- Reverse migration: docs/migrations/down/20260512134826_add_workout_sessions_program_id_fk.sql
+-- (documentation only; not auto-applied by `supabase db push`)
+--
+-- Adds a FK constraint on workout_sessions.program_id with ON DELETE SET NULL.
+--
+-- Discovered post-B1 during a routine session audit: a workout_session row
+-- referenced a program_id that didn't exist in `programs`. The column was
+-- defined as plain uuid without a FK (per the original remote_schema baseline
+-- at supabase/migrations/20260506091314_remote_schema.sql:248), so manual
+-- operator deletes against `programs` left orphan references behind. The
+-- iOS code path has no DELETE FROM programs site (verified via grep), so the
+-- orphans came from out-of-band cleanup; the schema is what allows them.
+--
+-- Two changes:
+--   1. NULL out any existing orphan program_ids — required because ADD
+--      CONSTRAINT ... NOT VALID + VALIDATE would still reject the orphans,
+--      and ADD CONSTRAINT without NOT VALID rejects them at constraint-add
+--      time. Null'ing them is cosmetically lossless (the session row stays;
+--      its dangling program reference becomes an explicit unknown).
+--   2. ADD the FK with ON DELETE SET NULL so any future legitimate program
+--      deletion gracefully nulls the back-reference rather than leaving
+--      orphans (or cascading and losing the session row, which would be
+--      worse — session history is more durable than program identity).
+--
+-- Cleanup-plan reference: see `docs/phase-2-cleanup-plan-2026-05-12.md` Tier 6
+-- item #9. This migration discharges that backlog item.
+
+-- 1. NULL out orphans.
+UPDATE public.workout_sessions
+SET program_id = NULL
+WHERE program_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.programs p WHERE p.id = workout_sessions.program_id
+  );
+
+-- 2. Add the FK constraint with ON DELETE SET NULL.
+-- Skip if the constraint already exists (idempotent re-runs).
+DO $migration$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workout_sessions_program_id_fkey'
+      AND conrelid = 'public.workout_sessions'::regclass
+  ) THEN
+    ALTER TABLE public.workout_sessions
+      ADD CONSTRAINT workout_sessions_program_id_fkey
+      FOREIGN KEY (program_id) REFERENCES public.programs(id) ON DELETE SET NULL;
+  END IF;
+END
+$migration$;


### PR DESCRIPTION
## Summary

Discharges cleanup-plan item [§6/9](docs/phase-2-cleanup-plan-2026-05-12.md). The column was a plain uuid without a FK; out-of-band operator deletes against \`programs\` left orphan session references. Discovered post-B1.

- Migration nulls existing orphans, then adds the FK with \`ON DELETE SET NULL\`.
- Future operator deletes gracefully null the session's program_id rather than leaving orphans (or cascading and losing the session row).
- Idempotent — \`ADD CONSTRAINT\` wrapped in an \`IF NOT EXISTS\` guard.

## Smoke-test (local) confirmed

- FK exists post-migration with \`confdeltype=n\` (SET NULL)
- Insert with non-existent program_id is now rejected by the FK
- DELETE of a program with an active session correctly nulls the session's program_id (session row preserved)
- Re-running the migration is a no-op

## Test plan

- [x] Local migration apply + functional tests (above)
- [ ] CI applies the migration in its \`supabase db push\` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)