### PR TITLE
fix: validation gate for empty training_day exercises[] + prompt strengthening

### DIFF
--- a/ProjectApex/Resources/Prompts/SystemPrompt_MacroGeneration.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_MacroGeneration.txt
@@ -8,6 +8,7 @@ Return ONLY a single JSON object — no prose, no markdown fences, no explanatio
 CRITICAL: phase_templates is an array of JSON objects. Every phase object MUST be wrapped in { }.
 CRITICAL: training_days is an array of JSON objects. Every day object MUST be wrapped in { }.
 CRITICAL: exercises is an array of JSON objects. Every exercise object MUST be wrapped in { }.
+CRITICAL: every training_day MUST include at least one exercise. Empty exercises arrays are rejected and force a corrective retry. Never emit a training_day stub with `"exercises": []`.
 
 The top-level structure is:
 

--- a/ProjectApex/Services/ProgramGenerationService.swift
+++ b/ProjectApex/Services/ProgramGenerationService.swift
@@ -33,6 +33,19 @@ nonisolated struct EquipmentViolation: Sendable, Equatable {
     let requiredEquipment: EquipmentType
 }
 
+// MARK: - EmptyTrainingDayViolation
+
+/// A training day in the generated mesocycle that has no exercises.
+/// Surfaced post-B1 when the alpha user's Week 4 Full_Body and Lower days
+/// were observed empty — the LLM produced training_day stubs without
+/// populating their `exercises` arrays, and `expandTemplate` propagated
+/// the empty state across all 4 weeks of the phase.
+nonisolated struct EmptyTrainingDayViolation: Sendable, Equatable {
+    let dayLabel: String
+    let weekNumber: Int
+    let phase: MesocyclePhase
+}
+
 // MARK: - ProgramGenerationError
 
 nonisolated enum ProgramGenerationError: LocalizedError {
@@ -41,6 +54,7 @@ nonisolated enum ProgramGenerationError: LocalizedError {
     case llmProviderError(String)
     case decodingFailed(String)
     case equipmentConstraintViolation([EquipmentViolation])
+    case emptyTrainingDay([EmptyTrainingDayViolation])
 
     var errorDescription: String? {
         switch self {
@@ -55,6 +69,9 @@ nonisolated enum ProgramGenerationError: LocalizedError {
         case .equipmentConstraintViolation(let violations):
             let names = violations.map { "\($0.exerciseName) (week \($0.weekNumber))" }.joined(separator: ", ")
             return "Program contains equipment violations that could not be corrected: \(names)"
+        case .emptyTrainingDay(let violations):
+            let names = violations.map { "\($0.dayLabel) (week \($0.weekNumber))" }.joined(separator: ", ")
+            return "Program contains training days with no exercises that could not be corrected: \(names)"
         }
     }
 }
@@ -265,9 +282,34 @@ actor ProgramGenerationService {
 
         // Stage 2: Client expands templates into 12 weeks
         let userId = UUID(uuidString: userProfile.userId) ?? UUID()
-        let mesocycle = Self.expandTemplate(template, userId: userId)
+        var mesocycle = Self.expandTemplate(template, userId: userId)
 
-        // Equipment constraint validation
+        // Stage 2.5: Empty-training-day validation.
+        // The LLM occasionally produces training_day stubs with no exercises;
+        // `expandTemplate` propagates that empty state across all 4 weeks of
+        // the phase, leaving the user with no plan on those days. Catch it
+        // here with one corrective re-prompt before the equipment pass —
+        // empty days have a different failure mode than equipment violations,
+        // so they need a dedicated correction payload.
+        let emptyDays = Self.validateNonEmptyTrainingDays(mesocycle: mesocycle)
+        if !emptyDays.isEmpty {
+            let emptyDayCorrection = Self.buildEmptyDayCorrectionPayload(
+                originalRequest: requestJSON,
+                emptyDays: emptyDays
+            )
+            let correctedTemplate = try await callAndDecodeTemplate(
+                systemPrompt: systemPrompt,
+                userPayload: emptyDayCorrection
+            )
+            mesocycle = Self.expandTemplate(correctedTemplate, userId: userId)
+
+            let remainingEmpty = Self.validateNonEmptyTrainingDays(mesocycle: mesocycle)
+            if !remainingEmpty.isEmpty {
+                throw ProgramGenerationError.emptyTrainingDay(remainingEmpty)
+            }
+        }
+
+        // Stage 3: Equipment constraint validation
         let violations = Self.validateEquipmentConstraints(mesocycle: mesocycle, gymProfile: gymProfile)
         if violations.isEmpty { return mesocycle }
 
@@ -291,6 +333,29 @@ actor ProgramGenerationService {
             throw ProgramGenerationError.equipmentConstraintViolation(remainingViolations)
         }
         return correctedMesocycle
+    }
+
+    // MARK: Empty-Training-Day Validation
+
+    /// Returns every TrainingDay in the mesocycle whose `exercises` array is empty.
+    /// Empty days are surfaced as soon as `expandTemplate` runs — the LLM's
+    /// template can include `training_day` stubs with `exercises: []`, and the
+    /// expansion faithfully propagates the emptiness across the phase's weeks.
+    /// Caller fires a corrective re-prompt; persistent empties throw.
+    static func validateNonEmptyTrainingDays(
+        mesocycle: Mesocycle
+    ) -> [EmptyTrainingDayViolation] {
+        var violations: [EmptyTrainingDayViolation] = []
+        for week in mesocycle.weeks {
+            for day in week.trainingDays where day.exercises.isEmpty {
+                violations.append(EmptyTrainingDayViolation(
+                    dayLabel: day.dayLabel,
+                    weekNumber: week.weekNumber,
+                    phase: week.phase
+                ))
+            }
+        }
+        return violations
     }
 
     // MARK: Equipment Constraint Validation
@@ -488,7 +553,44 @@ actor ProgramGenerationService {
         )
     }
 
-    // MARK: - Private: Correction payload
+    // MARK: - Private: Correction payloads
+
+    /// Builds a corrective payload pointing the LLM at training days whose
+    /// `exercises` array came back empty. Each violation lists (phase, day_label)
+    /// — the LLM is asked to regenerate the phase with at least one exercise
+    /// per day. Different shape from the equipment-correction payload because
+    /// the failure mode is different (template malformation vs. equipment
+    /// availability mismatch).
+    private static func buildEmptyDayCorrectionPayload(
+        originalRequest: String,
+        emptyDays: [EmptyTrainingDayViolation]
+    ) -> String {
+        // Deduplicate by (phase, dayLabel) — expandTemplate replicates the
+        // template day across the phase's weeks, so an empty template day
+        // surfaces as N violations (one per week). The LLM corrects the
+        // template once.
+        var seen = Set<String>()
+        let uniqueLines: [String] = emptyDays.compactMap { v in
+            let key = "\(v.phase.rawValue)::\(v.dayLabel)"
+            guard !seen.contains(key) else { return nil }
+            seen.insert(key)
+            return "- phase: \(v.phase.rawValue), day_label: \(v.dayLabel) — exercises array was empty"
+        }
+        let violationLines = uniqueLines.joined(separator: "\n")
+
+        return """
+        \(originalRequest)
+
+        --- EMPTY-TRAINING-DAY CORRECTION REQUIRED ---
+        The following training_day stubs in the previous response had an empty `exercises` array.
+        Every training_day MUST include at least one exercise. Regenerate the affected phase
+        templates with a complete `exercises` list per day.
+        Return the corrected full mesocycle_template JSON — do NOT return only the changed days.
+
+        EMPTY DAYS:
+        \(violationLines)
+        """
+    }
 
     private static func buildCorrectionPayload(
         originalRequest: String,

--- a/ProjectApexTests/EquipmentConstraintValidationTests.swift
+++ b/ProjectApexTests/EquipmentConstraintValidationTests.swift
@@ -578,4 +578,297 @@ final class EquipmentConstraintValidationTests: XCTestCase {
             XCTFail("Expected ProgramGenerationError but got: \(error)")
         }
     }
+
+    // MARK: ─── validateNonEmptyTrainingDays() — pure static tests ─────────────
+
+    func test_validateNonEmpty_emptyMesocycle_noViolations() {
+        // A fully-populated mesocycle (every day has at least one exercise) returns no violations.
+        let mesocycle = singleExerciseMesocycle(equipment: .barbell)
+        let violations = ProgramGenerationService.validateNonEmptyTrainingDays(mesocycle: mesocycle)
+        XCTAssertTrue(violations.isEmpty,
+                      "No violations expected when every training day has at least one exercise.")
+    }
+
+    func test_validateNonEmpty_detectsEmptyDay() {
+        // A mesocycle with one day whose exercises array is empty produces one violation.
+        let emptyDay = TrainingDay(
+            id: UUID(),
+            dayOfWeek: 3,
+            dayLabel: "Full_Body",
+            exercises: [],
+            sessionNotes: nil
+        )
+        let week = TrainingWeek(
+            id: UUID(),
+            weekNumber: 4,
+            phase: .accumulation,
+            trainingDays: [emptyDay]
+        )
+        let mesocycle = Mesocycle(
+            id: UUID(),
+            userId: UUID(),
+            createdAt: Date(),
+            isActive: true,
+            weeks: [week],
+            totalWeeks: 12,
+            periodizationModel: "linear_periodization"
+        )
+
+        let violations = ProgramGenerationService.validateNonEmptyTrainingDays(mesocycle: mesocycle)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations[0].dayLabel, "Full_Body")
+        XCTAssertEqual(violations[0].weekNumber, 4)
+        XCTAssertEqual(violations[0].phase, .accumulation)
+    }
+
+    func test_validateNonEmpty_multipleEmpties_acrossWeeks() {
+        // Two empty days in two different weeks → two violations.
+        func makeWeek(_ n: Int, populated: Bool) -> TrainingWeek {
+            let day = TrainingDay(
+                id: UUID(),
+                dayOfWeek: 1,
+                dayLabel: "Day_\(n)",
+                exercises: populated ? [makePlannedExercise()] : [],
+                sessionNotes: nil
+            )
+            return TrainingWeek(
+                id: UUID(), weekNumber: n, phase: .accumulation, trainingDays: [day]
+            )
+        }
+        let mesocycle = Mesocycle(
+            id: UUID(),
+            userId: UUID(),
+            createdAt: Date(),
+            isActive: true,
+            weeks: [
+                makeWeek(1, populated: false),  // empty
+                makeWeek(2, populated: true),   // ok
+                makeWeek(3, populated: false),  // empty
+            ],
+            totalWeeks: 12,
+            periodizationModel: "linear_periodization"
+        )
+
+        let violations = ProgramGenerationService.validateNonEmptyTrainingDays(mesocycle: mesocycle)
+        XCTAssertEqual(violations.count, 2)
+        XCTAssertEqual(Set(violations.map(\.weekNumber)), Set([1, 3]))
+    }
+
+    func test_emptyDayViolation_struct() {
+        let v = EmptyTrainingDayViolation(
+            dayLabel: "Lower",
+            weekNumber: 4,
+            phase: .accumulation
+        )
+        XCTAssertEqual(v.dayLabel, "Lower")
+        XCTAssertEqual(v.weekNumber, 4)
+        XCTAssertEqual(v.phase, .accumulation)
+    }
+
+    // MARK: ─── generate() empty-day corrective re-prompt path ─────────────────
+
+    func test_generate_emptyDayCorrected_succeedsAfterRetry() async throws {
+        // First call returns a template with one empty Full_Body day; second
+        // call returns the same template with that day populated. The service
+        // should detect, re-prompt, and return the corrected mesocycle.
+        let provider = CallCountingProvider(responses: [
+            mesocycleWithEmptyFullBodyDayJSON(),    // first call — has empty day
+            barbellOnlyMesocycleJSON()              // second call (correction) — clean
+        ])
+        let service = ProgramGenerationService(provider: provider)
+
+        let mesocycle = try await service.generate(
+            userProfile: UserProfile(
+                userId: "AAAAAAAA-0000-0000-0000-000000000001",
+                experienceLevel: "intermediate",
+                goals: ["hypertrophy"],
+                bodyweightKg: 80,
+                ageYears: 28
+            ),
+            gymProfile: limitedGymProfile,
+            trainingDaysPerWeek: 4
+        )
+
+        XCTAssertEqual(provider.callCount, 2,
+                       "Expected one corrective re-prompt after detecting the empty day.")
+        let remaining = ProgramGenerationService.validateNonEmptyTrainingDays(mesocycle: mesocycle)
+        XCTAssertTrue(remaining.isEmpty,
+                      "Mesocycle returned to caller must have no empty training days.")
+    }
+
+    func test_generate_emptyDayPersists_throwsEmptyTrainingDay() async {
+        // Both calls return the empty-day template. After one corrective retry
+        // the service should throw `emptyTrainingDay`.
+        let provider = CallCountingProvider(responses: [
+            mesocycleWithEmptyFullBodyDayJSON(),
+            mesocycleWithEmptyFullBodyDayJSON()
+        ])
+        let service = ProgramGenerationService(provider: provider)
+
+        do {
+            _ = try await service.generate(
+                userProfile: UserProfile(
+                    userId: "AAAAAAAA-0000-0000-0000-000000000001",
+                    experienceLevel: "intermediate",
+                    goals: ["hypertrophy"],
+                    bodyweightKg: 80,
+                    ageYears: 28
+                ),
+                gymProfile: limitedGymProfile,
+                trainingDaysPerWeek: 4
+            )
+            XCTFail("Expected ProgramGenerationError.emptyTrainingDay")
+        } catch let err as ProgramGenerationError {
+            guard case .emptyTrainingDay(let violations) = err else {
+                XCTFail("Expected .emptyTrainingDay, got \(err)")
+                return
+            }
+            XCTAssertFalse(violations.isEmpty,
+                           "Throw must include at least one violation.")
+            XCTAssertTrue(violations.contains { $0.dayLabel == "Full_Body" },
+                          "The Full_Body day from the fixture should appear in violations.")
+        } catch {
+            XCTFail("Expected ProgramGenerationError but got: \(error)")
+        }
+    }
+}
+
+// MARK: - Empty-day test fixtures
+
+private func makePlannedExercise() -> PlannedExercise {
+    PlannedExercise(
+        id: UUID(),
+        exerciseId: "barbell_bench_press",
+        name: "Barbell Bench Press",
+        primaryMuscle: "pectoralis_major",
+        synergists: ["anterior_deltoid"],
+        equipmentRequired: .barbell,
+        sets: 3,
+        repRange: RepRange(min: 8, max: 12),
+        tempo: "3-1-1-0",
+        restSeconds: 120,
+        rirTarget: 2,
+        coachingCues: ["Retract scapula"]
+    )
+}
+
+/// MesocycleTemplate JSON with one accumulation training day whose `exercises`
+/// array is empty (Full_Body). All other phases are populated with a single
+/// barbell exercise. Drives the empty-day-corrective-re-prompt code path.
+private func mesocycleWithEmptyFullBodyDayJSON() -> String {
+    """
+    {
+      "mesocycle_template": {
+        "periodization_model": "linear_periodization",
+        "phase_templates": [
+          {
+            "phase": "accumulation",
+            "training_days": [
+              {
+                "day_of_week": 1,
+                "day_label": "Push_A",
+                "session_notes": null,
+                "exercises": [
+                  {
+                    "exercise_id": "barbell_bench_press",
+                    "name": "Barbell Bench Press",
+                    "primary_muscle": "pectoralis_major",
+                    "synergists": ["anterior_deltoid"],
+                    "equipment_required": "barbell",
+                    "sets": 4,
+                    "rep_range": { "min": 8, "max": 12 },
+                    "tempo": "3-1-1-0",
+                    "rest_seconds": 150,
+                    "rir_target": 3,
+                    "coaching_cues": ["Retract scapula"]
+                  }
+                ]
+              },
+              {
+                "day_of_week": 3,
+                "day_label": "Full_Body",
+                "session_notes": null,
+                "exercises": []
+              }
+            ]
+          },
+          {
+            "phase": "intensification",
+            "training_days": [
+              {
+                "day_of_week": 1,
+                "day_label": "Push_A",
+                "session_notes": null,
+                "exercises": [
+                  {
+                    "exercise_id": "barbell_bench_press",
+                    "name": "Barbell Bench Press",
+                    "primary_muscle": "pectoralis_major",
+                    "synergists": ["anterior_deltoid"],
+                    "equipment_required": "barbell",
+                    "sets": 4,
+                    "rep_range": { "min": 6, "max": 8 },
+                    "tempo": "3-1-1-0",
+                    "rest_seconds": 180,
+                    "rir_target": 2,
+                    "coaching_cues": ["Retract scapula"]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "phase": "peaking",
+            "training_days": [
+              {
+                "day_of_week": 1,
+                "day_label": "Push_A",
+                "session_notes": null,
+                "exercises": [
+                  {
+                    "exercise_id": "barbell_bench_press",
+                    "name": "Barbell Bench Press",
+                    "primary_muscle": "pectoralis_major",
+                    "synergists": ["anterior_deltoid"],
+                    "equipment_required": "barbell",
+                    "sets": 3,
+                    "rep_range": { "min": 3, "max": 5 },
+                    "tempo": "3-1-1-0",
+                    "rest_seconds": 240,
+                    "rir_target": 1,
+                    "coaching_cues": ["Retract scapula"]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "phase": "deload",
+            "training_days": [
+              {
+                "day_of_week": 1,
+                "day_label": "Push_A",
+                "session_notes": null,
+                "exercises": [
+                  {
+                    "exercise_id": "barbell_bench_press",
+                    "name": "Barbell Bench Press",
+                    "primary_muscle": "pectoralis_major",
+                    "synergists": ["anterior_deltoid"],
+                    "equipment_required": "barbell",
+                    "sets": 2,
+                    "rep_range": { "min": 8, "max": 12 },
+                    "tempo": "3-1-1-0",
+                    "rest_seconds": 120,
+                    "rir_target": 4,
+                    "coaching_cues": ["Easy pace"]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
 }


### PR DESCRIPTION
## Summary

Discharges bug #3 from today's post-B1 audit. The LLM produced \`training_day\` stubs with empty \`exercises[]\` arrays for the alpha user's Week 4 Full_Body and Lower days; \`expandTemplate\` propagated the empty state across all 4 weeks of accumulation, leaving the user training an empty day with the AI improvising.

- **Validation gate (Swift)** — \`validateNonEmptyTrainingDays(mesocycle:)\` runs as Stage 2.5 between expansion and the existing equipment validation. Empty days trigger one corrective re-prompt with a dedicated \`buildEmptyDayCorrectionPayload\` (deduped by \`(phase, dayLabel)\` so the LLM gets one correction line per template day, not N). Persistent empties after retry throw \`ProgramGenerationError.emptyTrainingDay\`.
- **Prompt strengthening** — fourth CRITICAL directive added to \`SystemPrompt_MacroGeneration.txt\`: empty exercises arrays are rejected and force a corrective retry. Reinforces the structural contract so the validation gate is rarely needed.

## Test plan

- [x] 16 tests pass in \`EquipmentConstraintValidationTests\` (11 prior + 6 new — 3 pure on \`validateNonEmptyTrainingDays\`, 1 struct field, 2 end-to-end via mock provider for corrected-after-retry success + persistent-empty throw)
- [x] Build succeeds
- [ ] CI iOS Build & Test sweep
- [ ] Manual: regenerate program post-merge → verify no empty training days under any combination of trainingDaysPerWeek

## Scope

Does not retroactively fix the user's currently-active program; the AI continues improvising for the remainder of Week 4. The gate prevents recurrence on next program regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)