### PR TITLE
feat(ef): MuscleProfile producer — bootstrap + volume + worst-across-patterns stagnation + Q4 focusWeight

### DIFF
--- a/supabase/functions/_shared/exercise-library.ts
+++ b/supabase/functions/_shared/exercise-library.ts
@@ -139,6 +139,131 @@ export const EXERCISE_PATTERN_MAP: Record<string, MovementPattern> = {
 export const EXERCISE_LIBRARY_ENTRY_COUNT = 71;
 
 /**
+ * PrimaryMuscle taxonomy — mirrors `ProjectApex/Models/PrimaryMuscle.swift`
+ * (9 fine-grained cases per ADR-0005's two-level muscle taxonomy). Used by
+ * applyPerMuscleRules (#156) to bootstrap MuscleProfile entries via the
+ * PrimaryMuscle → MuscleGroup collapse (leg subgroups → "legs"; upper-body
+ * 1:1).
+ */
+export type PrimaryMuscle =
+  | "back"
+  | "chest"
+  | "biceps"
+  | "shoulders"
+  | "triceps"
+  | "quads"
+  | "hamstrings"
+  | "glutes"
+  | "calves";
+
+/**
+ * Map from canonical `exercise_id` to `PrimaryMuscle`. Mirrors the
+ * `primaryMuscle` field of `ProjectApex/Models/ExerciseLibrary.swift`'s
+ * `ExerciseDefinition` entries. The key set MUST equal `EXERCISE_PATTERN_MAP`'s
+ * key set — both maps describe the same 71 canonical exercises from different
+ * axes. Consumed by applyPerMuscleRules (#156) for per-set muscle attribution
+ * in `model_json.muscles` bootstrap and volume aggregation.
+ */
+export const EXERCISE_PRIMARY_MUSCLE_MAP: Record<string, PrimaryMuscle> = {
+  // Chest
+  barbell_bench_press: "chest",
+  dumbbell_bench_press: "chest",
+  incline_barbell_press: "chest",
+  incline_dumbbell_press: "chest",
+  decline_bench_press: "chest",
+  machine_chest_press: "chest",
+  cable_chest_fly: "chest",
+  pec_deck_fly: "chest",
+  dumbbell_fly: "chest",
+  push_ups: "chest",
+
+  // Back
+  barbell_row: "back",
+  dumbbell_row: "back",
+  t_bar_row: "back",
+  cable_row: "back",
+  seated_cable_row: "back",
+  lat_pulldown_wide: "back",
+  lat_pulldown_close: "back",
+  pull_ups: "back",
+  chin_ups: "back",
+  face_pull: "back",
+  cable_rear_delt_fly: "back",
+  cable_straight_arm_pulldown: "back",
+  dumbbell_single_arm_row: "back",
+  assisted_pull_up: "back",
+
+  // Shoulders
+  overhead_press: "shoulders",
+  dumbbell_shoulder_press: "shoulders",
+  machine_shoulder_press: "shoulders",
+  lateral_raise: "shoulders",
+  cable_lateral_raise: "shoulders",
+  rear_delt_fly: "shoulders",
+  arnold_press: "shoulders",
+  upright_row: "shoulders",
+
+  // Quads
+  barbell_back_squat: "quads",
+  front_squat: "quads",
+  leg_press: "quads",
+  hack_squat_machine: "quads",
+  goblet_squat: "quads",
+  leg_extension: "quads",
+  bulgarian_split_squat: "quads",
+  walking_lunge: "quads",
+  smith_machine_squat: "quads",
+
+  // Hamstrings
+  conventional_deadlift: "hamstrings",
+  romanian_deadlift: "hamstrings",
+  dumbbell_romanian_deadlift: "hamstrings",
+  lying_leg_curl: "hamstrings",
+  seated_leg_curl: "hamstrings",
+  stiff_leg_deadlift: "hamstrings",
+
+  // Glutes
+  hip_thrust: "glutes",
+  cable_pull_through: "glutes",
+  glute_bridge: "glutes",
+  sumo_deadlift: "glutes",
+
+  // Biceps
+  barbell_curl: "biceps",
+  ez_bar_curl: "biceps",
+  dumbbell_curl: "biceps",
+  preacher_curl: "biceps",
+  hammer_curl: "biceps",
+  cable_curl: "biceps",
+  cable_hammer_curl: "biceps",
+
+  // Triceps
+  cable_tricep_pushdown: "triceps",
+  overhead_tricep_extension: "triceps",
+  skull_crushers: "triceps",
+  dips: "triceps",
+  close_grip_bench_press: "triceps",
+  dumbbell_overhead_tricep_extension: "triceps",
+  cable_overhead_tricep_extension: "triceps",
+
+  // Smith / cable variants for chest
+  smith_machine_bench_press: "chest",
+  smith_machine_incline_press: "chest",
+  cable_crossover_chest_fly: "chest",
+
+  // Calves
+  standing_calf_raise: "calves",
+  seated_calf_raise: "calves",
+  smith_machine_calf_raise: "calves",
+};
+
+/**
+ * Pinned entry count — drift detector for the primary-muscle mirror. Must
+ * match `EXERCISE_LIBRARY_ENTRY_COUNT` (same 71 canonical exercises).
+ */
+export const EXERCISE_PRIMARY_MUSCLE_MAP_ENTRY_COUNT = 71;
+
+/**
  * Maps legacy / variant exercise_id strings to their canonical equivalents.
  * Mirror of `ExerciseLibrary.normalizationMap` in
  * `ProjectApex/Models/ExerciseLibrary.swift`. Keep in sync — any addition

--- a/supabase/functions/_shared/exercise-library_test.ts
+++ b/supabase/functions/_shared/exercise-library_test.ts
@@ -12,6 +12,8 @@ import {
   EXERCISE_NORMALIZATION_ENTRY_COUNT,
   EXERCISE_NORMALIZATION_MAP,
   EXERCISE_PATTERN_MAP,
+  EXERCISE_PRIMARY_MUSCLE_MAP,
+  EXERCISE_PRIMARY_MUSCLE_MAP_ENTRY_COUNT,
   lookupPattern,
 } from "./exercise-library.ts";
 
@@ -107,6 +109,18 @@ Deno.test("lookupPattern: resolves legacy aliases to the canonical pattern", () 
   assertEquals(lookupPattern("lat_pulldown_wide_grip"), "vertical_pull");
   assertEquals(lookupPattern("dumbbell_flat_press"), "horizontal_push");
   assertEquals(lookupPattern("cable_pulldown_neutral_grip"), "vertical_pull");
+});
+
+Deno.test("exercise-library: primaryMuscleMap entry count matches the pinned constant", () => {
+  // Drift detector for the primary-muscle mirror. If this fires, the Swift
+  // library probably gained / removed an exercise but the TS port wasn't
+  // updated. Add or remove the matching entry here AND bump
+  // EXERCISE_PRIMARY_MUSCLE_MAP_ENTRY_COUNT in lockstep with
+  // EXERCISE_LIBRARY_ENTRY_COUNT (the two maps share the same key set).
+  assertEquals(
+    Object.keys(EXERCISE_PRIMARY_MUSCLE_MAP).length,
+    EXERCISE_PRIMARY_MUSCLE_MAP_ENTRY_COUNT,
+  );
 });
 
 Deno.test("exercise-library: every value is a valid MovementPattern (8-enum)", () => {

--- a/supabase/functions/_shared/per-muscle-rules.ts
+++ b/supabase/functions/_shared/per-muscle-rules.ts
@@ -10,6 +10,12 @@
 // actual sessionsPerWeek is also deferred (alpha cohort ≈ 4×/week makes this
 // adequate).
 
+import {
+  canonicalizeExerciseId,
+  EXERCISE_PRIMARY_MUSCLE_MAP,
+  type PrimaryMuscle,
+} from "./exercise-library.ts";
+
 /**
  * MuscleGroup — locked-six aggregation key for the trainee model's per-muscle
  * storage per ADR-0005 §"Two-level muscle taxonomy". Distinct from the finer
@@ -84,4 +90,65 @@ export function bootstrapMuscleProfile(
     stagnationStatus: "progressing",
     confidence: "bootstrapping",
   };
+}
+
+/**
+ * Per ADR-0005 §"Two-level muscle taxonomy": leg subgroups (quads,
+ * hamstrings, glutes, calves) collapse to MuscleGroup.legs; upper-body
+ * muscles map 1:1.
+ */
+export function primaryMuscleToGroup(pm: PrimaryMuscle): MuscleGroup {
+  switch (pm) {
+    case "back":
+    case "chest":
+    case "biceps":
+    case "shoulders":
+    case "triceps":
+      return pm;
+    case "quads":
+    case "hamstrings":
+    case "glutes":
+    case "calves":
+      return "legs";
+  }
+}
+
+/**
+ * SetIntent values that contribute to volume aggregation per ADR-0005's set-
+ * intent semantics: warmup and technique are zero-weighted (warmup builds to
+ * top-set load without contributing to hypertrophy volume; technique sets are
+ * low-load skill rehearsal). Top + backoff + amrap contribute fully.
+ */
+const VOLUME_CONTRIBUTING_INTENTS: ReadonlySet<string> = new Set([
+  "top",
+  "backoff",
+  "amrap",
+]);
+
+/**
+ * Per-set volume aggregation. Returns a partial Record keyed by
+ * `MuscleGroup` with each muscle's count of volume-contributing sets from
+ * `setLogs`. Attribution flows `exercise_id → PrimaryMuscle → MuscleGroup` via
+ * `EXERCISE_PRIMARY_MUSCLE_MAP` after canonicalising legacy aliases.
+ *
+ * Sets that fail to attribute (unknown exercise IDs, missing intent) are
+ * silently dropped per the asymmetric-error preference (under-attribute is
+ * silent; over-attribute would falsely inflate volume signals and trigger
+ * spurious AI volume-correction prompts).
+ */
+export function aggregateMuscleSetCounts(
+  setLogs: Array<Record<string, unknown>>,
+): Partial<Record<MuscleGroup, number>> {
+  const counts: Partial<Record<MuscleGroup, number>> = {};
+  for (const entry of setLogs) {
+    const exerciseId = entry.exercise_id;
+    const intent = entry.intent;
+    if (typeof exerciseId !== "string" || typeof intent !== "string") continue;
+    if (!VOLUME_CONTRIBUTING_INTENTS.has(intent)) continue;
+    const primary = EXERCISE_PRIMARY_MUSCLE_MAP[canonicalizeExerciseId(exerciseId)];
+    if (primary === undefined) continue;
+    const group = primaryMuscleToGroup(primary);
+    counts[group] = (counts[group] ?? 0) + 1;
+  }
+  return counts;
 }

--- a/supabase/functions/_shared/per-muscle-rules.ts
+++ b/supabase/functions/_shared/per-muscle-rules.ts
@@ -1,0 +1,87 @@
+// Project Apex — per-muscle rule helpers (#156, MuscleProfile producer).
+//
+// Pure helpers consumed by `applyPerMuscleRules` in update-trainee-model/index.ts
+// (the orchestrator coordinator). Per ADR-0005 §"Two-level muscle taxonomy"
+// and ADR-0009 §"Aggregation to MuscleProfile.stagnationStatus".
+//
+// Q1 threshold-semantic lock (2026-05-13): MEV interpretation, per-7-events
+// targets scaled at 4×/week alpha-cohort cadence. Bootstrap-only — EWMA-update
+// of tolerance is deferred to a follow-up issue. Cadence-scaling per user's
+// actual sessionsPerWeek is also deferred (alpha cohort ≈ 4×/week makes this
+// adequate).
+
+/**
+ * MuscleGroup — locked-six aggregation key for the trainee model's per-muscle
+ * storage per ADR-0005 §"Two-level muscle taxonomy". Distinct from the finer
+ * `PrimaryMuscle` (9-enum) which is the ExerciseLibrary's classification field.
+ * Leg subgroups (quads/hamstrings/glutes/calves) collapse to "legs"; upper-
+ * body muscles map 1:1.
+ */
+export type MuscleGroup =
+  | "back"
+  | "chest"
+  | "biceps"
+  | "shoulders"
+  | "triceps"
+  | "legs";
+
+/**
+ * Q1-locked per-muscle volume targets (MEV midpoints, per-7-events at
+ * 4×/week cadence). volumeTolerance is bootstrapped from this table per
+ * 2026-05-13 prep-prompt lock. Follow-up: EWMA-update of tolerance from
+ * observed RPE/recovery signals; cadence-scaling for users away from
+ * 4×/week.
+ */
+export const MUSCLE_VOLUME_TARGETS: Record<MuscleGroup, number> = {
+  back: 21,
+  chest: 18,
+  shoulders: 18,
+  biceps: 16,
+  triceps: 12,
+  legs: 18,
+};
+
+/**
+ * Bootstrap shape of a `MuscleProfile` JSONB entry. Mirrors
+ * `ProjectApex/Models/TraineeModelProfiles.swift::MuscleProfile`. Keys are
+ * camelCase to match the Swift decoder's default CodingKeys (no rename).
+ *
+ * Per the #146 pattern: `muscleGroup` is emitted as a field so Swift's inner
+ * decoder can read it (the dict key alone is invisible to `decodeEnumKeyedDict`).
+ */
+export interface BootstrapMuscleProfile {
+  muscleGroup: MuscleGroup;
+  volumeTolerance: number;
+  observedSweetSpot: number | null;
+  volumeDeficit: number;
+  focusWeight: number;
+  stagnationStatus: "progressing" | "plateaued" | "declining";
+  confidence: "bootstrapping" | "calibrating" | "established";
+}
+
+/**
+ * Create a fresh `MuscleProfile` with ADR-0005 defaults + 2026-05-13-locked
+ * decision values:
+ * - Q1: `volumeTolerance` from MEV midpoint table.
+ * - Q3: `observedSweetSpot` null (EF emits null, Swift decodes to nil).
+ * - Q4: `focusWeight` defaults to 0; coordinator overrides post-bootstrap
+ *   when the muscle is in `goal.focusAreas`.
+ * - Q5: `confidence` = .bootstrapping; lifecycle transitions deferred.
+ * - ADR-0009 empty-participation default: `stagnationStatus` = .progressing.
+ *
+ * `volumeDeficit` defaults to 0; the orchestrator runs the volume-aggregation
+ * + deficit-computation rules immediately after bootstrap, which overwrite it.
+ */
+export function bootstrapMuscleProfile(
+  muscleGroup: MuscleGroup,
+): BootstrapMuscleProfile {
+  return {
+    muscleGroup,
+    volumeTolerance: MUSCLE_VOLUME_TARGETS[muscleGroup],
+    observedSweetSpot: null,
+    volumeDeficit: 0,
+    focusWeight: 0,
+    stagnationStatus: "progressing",
+    confidence: "bootstrapping",
+  };
+}

--- a/supabase/functions/_shared/per-muscle-rules.ts
+++ b/supabase/functions/_shared/per-muscle-rules.ts
@@ -12,9 +12,17 @@
 
 import {
   canonicalizeExerciseId,
+  EXERCISE_PATTERN_MAP,
   EXERCISE_PRIMARY_MUSCLE_MAP,
+  type MovementPattern,
   type PrimaryMuscle,
 } from "./exercise-library.ts";
+
+/** ADR-0005 ProgressionTrend enum — must mirror Swift rawValues. */
+export type ProgressionTrend = "progressing" | "plateaued" | "declining";
+
+/** ADR-0005 AxisConfidence enum — must mirror Swift rawValues. */
+export type AxisConfidence = "bootstrapping" | "calibrating" | "established";
 
 /**
  * MuscleGroup — locked-six aggregation key for the trainee model's per-muscle
@@ -126,6 +134,44 @@ const VOLUME_CONTRIBUTING_INTENTS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * One bucket of per-muscle session volume — appended on each apply that
+ * trains the muscle. Bounded externally to the last 7 entries per ADR-0002's
+ * queue-event-windowed semantic. Mirrors `weeklyVolumeLoadHistory` on
+ * PatternProfile JSONB (an EF-only field; Swift's MuscleProfile decoder
+ * does not consume it, so the locked Swift shape is preserved).
+ */
+export interface WeeklyVolumeBucket {
+  loggedAtIso: string;
+  sets: number;
+}
+
+/**
+ * The maximum number of session buckets retained per muscle. Per ADR-0002:
+ * "VolumeValidationService (and its successor in the trainee model) windows
+ * over last 7 training events, not calendar weeks."
+ */
+export const MUSCLE_VOLUME_WINDOW = 7;
+
+/**
+ * `volumeDeficit = max(0, volumeTolerance − Σ sets in last `MUSCLE_VOLUME_WINDOW`
+ * buckets)`. Per Q1 lock (2026-05-13, MEV interpretation): a positive deficit
+ * means the user is below the growth threshold for this muscle; B2 (#87)
+ * consumes the digest-projected value to drive volume-correction coaching.
+ *
+ * Cold-start (empty history) surfaces the full tolerance. Downstream
+ * consumers temper via `MuscleProfile.confidence` (Q5 lock: all #156
+ * profiles ship at .bootstrapping; lifecycle is a follow-up).
+ */
+export function computeVolumeDeficit(
+  history: WeeklyVolumeBucket[],
+  volumeTolerance: number,
+): number {
+  const recent = history.slice(-MUSCLE_VOLUME_WINDOW);
+  const sum = recent.reduce((acc, bucket) => acc + bucket.sets, 0);
+  return Math.max(0, volumeTolerance - sum);
+}
+
+/**
  * Per-set volume aggregation. Returns a partial Record keyed by
  * `MuscleGroup` with each muscle's count of volume-contributing sets from
  * `setLogs`. Attribution flows `exercise_id → PrimaryMuscle → MuscleGroup` via
@@ -151,4 +197,59 @@ export function aggregateMuscleSetCounts(
     counts[group] = (counts[group] ?? 0) + 1;
   }
   return counts;
+}
+
+/**
+ * Static derivation of which MovementPatterns participate in each
+ * MuscleGroup's stagnation aggregation, per ADR-0009 §"Aggregation to
+ * MuscleProfile.stagnationStatus": `∃ exercise e such that
+ * primaryMuscle(e).muscleGroup == M ∧ e.movementPattern == P`. Derived from
+ * the two exercise maps at module load.
+ */
+const MUSCLE_PARTICIPATING_PATTERNS: Record<MuscleGroup, Set<MovementPattern>> =
+  (() => {
+    const result: Record<MuscleGroup, Set<MovementPattern>> = {
+      back: new Set(),
+      chest: new Set(),
+      biceps: new Set(),
+      shoulders: new Set(),
+      triceps: new Set(),
+      legs: new Set(),
+    };
+    for (const exerciseId of Object.keys(EXERCISE_PATTERN_MAP)) {
+      const pattern = EXERCISE_PATTERN_MAP[exerciseId];
+      const primary = EXERCISE_PRIMARY_MUSCLE_MAP[exerciseId];
+      if (primary === undefined) continue;
+      const group = primaryMuscleToGroup(primary);
+      result[group].add(pattern);
+    }
+    return result;
+  })();
+
+/**
+ * Aggregate `MuscleProfile.stagnationStatus` from per-pattern trends per
+ * ADR-0009 §"Aggregation to MuscleProfile.stagnationStatus" (amended
+ * 2026-05-07). Worst-across-patterns precedence `declining > plateaued >
+ * progressing`. Patterns at `.bootstrapping` confidence are excluded from
+ * participation (their trends aren't evaluable). Empty effective
+ * participation returns `.progressing` — the no-signal default; cold-start
+ * is carried separately by `MuscleProfile.confidence`.
+ */
+export function aggregateStagnationStatus(
+  muscleGroup: MuscleGroup,
+  patternProfiles: Record<
+    string,
+    { trend: ProgressionTrend; confidence: AxisConfidence }
+  >,
+): ProgressionTrend {
+  const participating = MUSCLE_PARTICIPATING_PATTERNS[muscleGroup];
+  let sawPlateau = false;
+  for (const pattern of participating) {
+    const profile = patternProfiles[pattern];
+    if (profile === undefined) continue;
+    if (profile.confidence === "bootstrapping") continue;
+    if (profile.trend === "declining") return "declining"; // short-circuit; worst case
+    if (profile.trend === "plateaued") sawPlateau = true;
+  }
+  return sawPlateau ? "plateaued" : "progressing";
 }

--- a/supabase/functions/_shared/per-muscle-rules_test.ts
+++ b/supabase/functions/_shared/per-muscle-rules_test.ts
@@ -1,0 +1,39 @@
+// Project Apex — unit tests for the per-muscle rule helpers (#156).
+//
+// The orchestrator integration tests in update-trainee-model/orchestrator_test.ts
+// exercise applyPerMuscleRules end-to-end against the local Supabase Postgres.
+// This file pins the pure helpers it delegates to — threshold lookup,
+// bootstrap shape, volume aggregation, worst-across-patterns aggregation, and
+// focusWeight derivation — at unit level for fast TDD inner-loop.
+//
+// Run locally:
+//   deno test --allow-all supabase/functions/_shared/per-muscle-rules_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { bootstrapMuscleProfile } from "./per-muscle-rules.ts";
+
+Deno.test("bootstrapMuscleProfile: legs returns ADR-0005 defaults + Q1-locked MEV threshold", () => {
+  const profile = bootstrapMuscleProfile("legs");
+  // muscleGroup-as-field per the #146 pattern (dict key alone is invisible
+  // to Swift's inner decoder via decodeEnumKeyedDict).
+  assertEquals(profile.muscleGroup, "legs");
+  // Q1 lock (2026-05-13): MEV midpoint, per-7-events scaled at 4×/week
+  // alpha-cohort cadence. Legs MEV 8–12/wk → 14–21/7e → midpoint 18.
+  assertEquals(profile.volumeTolerance, 18);
+  // Q3 lock: observedSweetSpot emits null from EF; downstream MuscleSummary
+  // already drops it. Zero consumers in B1–B4 scope.
+  assertEquals(profile.observedSweetSpot, null);
+  // Bootstrap default; later cycles (volume aggregation + deficit
+  // computation) populate the actual deficit from setLogs.
+  assertEquals(profile.volumeDeficit, 0);
+  // Q4 lock: binary focusWeight derived from goal.focusAreas membership.
+  // Bootstrap has no goal context; coordinator sets it post-bootstrap.
+  assertEquals(profile.focusWeight, 0);
+  // ADR-0009 §"Aggregation to MuscleProfile.stagnationStatus" empty-
+  // participation case: ProgressionTrend has no .bootstrapping sentinel;
+  // .progressing is the no-signal default.
+  assertEquals(profile.stagnationStatus, "progressing");
+  // Q5 lock: all MuscleProfiles ship in #156 at .bootstrapping confidence.
+  // Lifecycle transitions deferred to follow-up ADR.
+  assertEquals(profile.confidence, "bootstrapping");
+});

--- a/supabase/functions/_shared/per-muscle-rules_test.ts
+++ b/supabase/functions/_shared/per-muscle-rules_test.ts
@@ -12,7 +12,9 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
   aggregateMuscleSetCounts,
+  aggregateStagnationStatus,
   bootstrapMuscleProfile,
+  computeVolumeDeficit,
 } from "./per-muscle-rules.ts";
 
 Deno.test("bootstrapMuscleProfile: legs returns ADR-0005 defaults + Q1-locked MEV threshold", () => {
@@ -72,4 +74,98 @@ Deno.test("aggregateMuscleSetCounts: non-warmup non-technique sets attributed vi
   assertEquals(counts.back, undefined);
   assertEquals(counts.biceps, undefined);
   assertEquals(counts.triceps, undefined);
+});
+
+Deno.test("computeVolumeDeficit: max(0, tolerance − sum) over last-7 buckets", () => {
+  // Below tolerance — straight subtraction.
+  assertEquals(
+    computeVolumeDeficit(
+      [
+        { loggedAtIso: "2026-05-01T10:00:00Z", sets: 3 },
+        { loggedAtIso: "2026-05-03T10:00:00Z", sets: 5 },
+      ],
+      18,
+    ),
+    10,
+  );
+  // At-or-above tolerance — clamped to 0 (no negative deficits surface).
+  assertEquals(
+    computeVolumeDeficit(
+      [
+        { loggedAtIso: "2026-05-01T10:00:00Z", sets: 10 },
+        { loggedAtIso: "2026-05-03T10:00:00Z", sets: 12 },
+      ],
+      18,
+    ),
+    0,
+  );
+  // Empty history (cold-start) — full tolerance surfaces. Downstream
+  // consumers temper this via the MuscleProfile.confidence axis (Q5 lock:
+  // all profiles ship at .bootstrapping in #156).
+  assertEquals(computeVolumeDeficit([], 18), 18);
+  // History longer than 7 — only the last 7 buckets contribute.
+  assertEquals(
+    computeVolumeDeficit(
+      [
+        { loggedAtIso: "2026-04-01T10:00:00Z", sets: 100 }, // dropped (outside window)
+        { loggedAtIso: "2026-05-01T10:00:00Z", sets: 2 },
+        { loggedAtIso: "2026-05-02T10:00:00Z", sets: 2 },
+        { loggedAtIso: "2026-05-03T10:00:00Z", sets: 2 },
+        { loggedAtIso: "2026-05-04T10:00:00Z", sets: 2 },
+        { loggedAtIso: "2026-05-05T10:00:00Z", sets: 2 },
+        { loggedAtIso: "2026-05-06T10:00:00Z", sets: 2 },
+        { loggedAtIso: "2026-05-07T10:00:00Z", sets: 2 },
+      ],
+      18,
+    ),
+    4, // sum of last 7 buckets = 14, tolerance 18 − 14 = 4
+  );
+});
+
+Deno.test("aggregateStagnationStatus: worst-across-patterns with bootstrapping-confidence patterns excluded", () => {
+  // Per ADR-0009 §"Aggregation to MuscleProfile.stagnationStatus":
+  // worst-trend across patterns participating in this muscle, gated on
+  // confidence > .bootstrapping. Empty-participation defaults to
+  // .progressing (the no-signal default; cold-start signal carries on
+  // confidence=.bootstrapping on MuscleProfile independently).
+
+  // All participating patterns at .bootstrapping confidence — empty
+  // effective participation → .progressing.
+  assertEquals(
+    aggregateStagnationStatus("legs", {
+      squat: { trend: "plateaued", confidence: "bootstrapping" },
+      hip_hinge: { trend: "declining", confidence: "bootstrapping" },
+    }),
+    "progressing",
+  );
+
+  // One declining (above bootstrapping), one progressing → declining.
+  assertEquals(
+    aggregateStagnationStatus("legs", {
+      squat: { trend: "declining", confidence: "calibrating" },
+      hip_hinge: { trend: "progressing", confidence: "established" },
+    }),
+    "declining",
+  );
+
+  // One plateaued, one progressing → plateaued (worst short of declining).
+  assertEquals(
+    aggregateStagnationStatus("legs", {
+      squat: { trend: "plateaued", confidence: "calibrating" },
+      hip_hinge: { trend: "progressing", confidence: "established" },
+    }),
+    "plateaued",
+  );
+
+  // Only-progressing → progressing.
+  assertEquals(
+    aggregateStagnationStatus("legs", {
+      squat: { trend: "progressing", confidence: "calibrating" },
+      hip_hinge: { trend: "progressing", confidence: "established" },
+    }),
+    "progressing",
+  );
+
+  // Empty patterns dict (cold-start) → progressing.
+  assertEquals(aggregateStagnationStatus("chest", {}), "progressing");
 });

--- a/supabase/functions/_shared/per-muscle-rules_test.ts
+++ b/supabase/functions/_shared/per-muscle-rules_test.ts
@@ -10,7 +10,10 @@
 //   deno test --allow-all supabase/functions/_shared/per-muscle-rules_test.ts
 
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { bootstrapMuscleProfile } from "./per-muscle-rules.ts";
+import {
+  aggregateMuscleSetCounts,
+  bootstrapMuscleProfile,
+} from "./per-muscle-rules.ts";
 
 Deno.test("bootstrapMuscleProfile: legs returns ADR-0005 defaults + Q1-locked MEV threshold", () => {
   const profile = bootstrapMuscleProfile("legs");
@@ -36,4 +39,37 @@ Deno.test("bootstrapMuscleProfile: legs returns ADR-0005 defaults + Q1-locked ME
   // Q5 lock: all MuscleProfiles ship in #156 at .bootstrapping confidence.
   // Lifecycle transitions deferred to follow-up ADR.
   assertEquals(profile.confidence, "bootstrapping");
+});
+
+Deno.test("aggregateMuscleSetCounts: non-warmup non-technique sets attributed via primary-muscle → MuscleGroup", () => {
+  const setLogs = [
+    // Quads → legs (top + top = 2 contributing sets)
+    { exercise_id: "barbell_back_squat", intent: "top" },
+    { exercise_id: "barbell_back_squat", intent: "top" },
+    // Excluded: warmup
+    { exercise_id: "barbell_back_squat", intent: "warmup" },
+    // Hamstrings → legs (1 contributing set)
+    { exercise_id: "romanian_deadlift", intent: "backoff" },
+    // Chest (1 contributing set)
+    { exercise_id: "barbell_bench_press", intent: "top" },
+    // Excluded: technique
+    { exercise_id: "barbell_bench_press", intent: "technique" },
+    // Shoulders (1 contributing set, amrap counts)
+    { exercise_id: "lateral_raise", intent: "amrap" },
+    // Unknown exercise ID → silent skip (asymmetric-error: under-attribute
+    // silent; over-attribute would falsely inflate volume).
+    { exercise_id: "not_an_exercise", intent: "top" },
+  ];
+
+  const counts = aggregateMuscleSetCounts(setLogs);
+
+  // legs aggregates 2 quads + 1 hamstrings; chest 1:1; shoulders 1:1.
+  // Other muscles get no contribution; the result is partial-keyed for the
+  // caller to default missing entries to 0.
+  assertEquals(counts.legs, 3);
+  assertEquals(counts.chest, 1);
+  assertEquals(counts.shoulders, 1);
+  assertEquals(counts.back, undefined);
+  assertEquals(counts.biceps, undefined);
+  assertEquals(counts.triceps, undefined);
 });

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -84,6 +84,17 @@ import {
   type PatternTransitionState,
 } from "../_shared/global-phase-advance.ts";
 import {
+  aggregateMuscleSetCounts,
+  aggregateStagnationStatus,
+  bootstrapMuscleProfile,
+  computeFocusWeight,
+  computeVolumeDeficit,
+  MUSCLE_VOLUME_WINDOW,
+  type AxisConfidence,
+  type MuscleGroup,
+  type WeeklyVolumeBucket,
+} from "../_shared/per-muscle-rules.ts";
+import {
   CLASSIFIER_BOOTSTRAP_MAX_NOTES,
   CLASSIFIER_BOOTSTRAP_MAX_SESSIONS,
 } from "../_shared/constants.ts";
@@ -941,6 +952,134 @@ function emptyAccuracyCell(
 }
 
 /**
+ * Per #156 (B1.5 — MuscleProfile producer): wire the per-muscle rule pipeline
+ * into the per-apply path. Bootstraps missing entries, appends a session
+ * bucket to each trained muscle's `weeklyVolumeHistory` (last
+ * `MUSCLE_VOLUME_WINDOW`=7 events per ADR-0002), and recomputes each muscle's
+ * `volumeDeficit`, `stagnationStatus` (worst-across-patterns per ADR-0009),
+ * and `focusWeight` (Q4 binary).
+ *
+ * Server-side per-muscle attribution flows `exercise_id → PrimaryMuscle →
+ * MuscleGroup` via `EXERCISE_PRIMARY_MUSCLE_MAP`; this filters unknown
+ * `primary_muscle` strings (e.g. alpha-cohort `posterior_deltoid`) at the
+ * boundary — they never enter `trainedMuscleGroups` and don't trigger
+ * phantom bootstrap entries.
+ *
+ * The `weeklyVolumeHistory` field is EF-only: Swift's `MuscleProfile`
+ * decoder does not list it in `CodingKeys`, mirroring how PatternProfile's
+ * `weeklyVolumeLoadHistory` is invisible to Swift. Preserves the Swift-side
+ * shape lock #156 was scoped under.
+ */
+function applyPerMuscleRules(
+  muscles: Record<string, Record<string, unknown>>,
+  setLogs: Array<Record<string, unknown>>,
+  incomingLoggedAt: Date,
+  patternsRuled: Record<string, Record<string, unknown>>,
+  goal: Record<string, unknown> | undefined,
+): {
+  muscles: Record<string, Record<string, unknown>>;
+  rulesFired: Set<string>;
+  fieldsChanged: string[];
+} {
+  const rulesFired = new Set<string>();
+  const fieldsChanged: string[] = [];
+  const merged: Record<string, Record<string, unknown>> = { ...muscles };
+
+  const sessionCounts = aggregateMuscleSetCounts(setLogs);
+  const trainedMuscleGroups = Object.keys(sessionCounts) as MuscleGroup[];
+
+  // Bootstrap missing trained-this-session muscles per Q1/Q3/Q4/Q5 locks.
+  for (const muscleGroup of trainedMuscleGroups) {
+    if (!(muscleGroup in merged)) {
+      merged[muscleGroup] = {
+        ...bootstrapMuscleProfile(muscleGroup),
+        weeklyVolumeHistory: [],
+      };
+      rulesFired.add("muscle-bootstrap");
+      fieldsChanged.push(`muscles.${muscleGroup}.bootstrapped`);
+    }
+  }
+
+  const focusAreas = Array.isArray(goal?.focusAreas)
+    ? (goal.focusAreas as string[])
+    : [];
+
+  // Project patternsRuled into the {trend, confidence} shape expected by
+  // aggregateStagnationStatus.
+  const patternProfilesForAggregation: Record<
+    string,
+    { trend: ProgressionTrend; confidence: AxisConfidence }
+  > = {};
+  for (const [patternKey, profile] of Object.entries(patternsRuled)) {
+    patternProfilesForAggregation[patternKey] = {
+      trend: ((profile.trend as ProgressionTrend) ?? "progressing"),
+      confidence: ((profile.confidence as AxisConfidence) ?? "bootstrapping"),
+    };
+  }
+
+  for (const [muscleKey, raw] of Object.entries(merged)) {
+    const profile: Record<string, unknown> = { ...raw };
+    const muscleGroup = muscleKey as MuscleGroup;
+
+    // (a) Append this session's contribution to weeklyVolumeHistory if the
+    // muscle was trained. Bound to MUSCLE_VOLUME_WINDOW per ADR-0002.
+    const baseHistory =
+      (profile.weeklyVolumeHistory as WeeklyVolumeBucket[] | undefined) ?? [];
+    const sessionContribution = sessionCounts[muscleGroup] ?? 0;
+    let newHistory = baseHistory;
+    if (sessionContribution > 0) {
+      newHistory = [
+        ...baseHistory,
+        {
+          loggedAtIso: incomingLoggedAt.toISOString(),
+          sets: sessionContribution,
+        },
+      ].slice(-MUSCLE_VOLUME_WINDOW);
+      profile.weeklyVolumeHistory = newHistory;
+      rulesFired.add("muscle-volume-history");
+      fieldsChanged.push(`muscles.${muscleKey}.weeklyVolumeHistory`);
+    }
+
+    // (b) Recompute volumeDeficit from the (possibly updated) history.
+    const tolerance = (profile.volumeTolerance as number) ?? 0;
+    const newDeficit = computeVolumeDeficit(newHistory, tolerance);
+    if (newDeficit !== profile.volumeDeficit) {
+      profile.volumeDeficit = newDeficit;
+      rulesFired.add("muscle-volume-deficit");
+      fieldsChanged.push(`muscles.${muscleKey}.volumeDeficit`);
+    }
+
+    // (c) Recompute stagnationStatus per ADR-0009's worst-across-patterns
+    // aggregation. Reads the post-applyPerPatternRules patterns dict.
+    const newStagnationStatus = aggregateStagnationStatus(
+      muscleGroup,
+      patternProfilesForAggregation,
+    );
+    if (newStagnationStatus !== profile.stagnationStatus) {
+      profile.stagnationStatus = newStagnationStatus;
+      rulesFired.add("muscle-stagnation-aggregate");
+      fieldsChanged.push(`muscles.${muscleKey}.stagnationStatus`);
+    }
+
+    // (d) Recompute focusWeight from goal.focusAreas (Q4 binary lock).
+    const newFocusWeight = computeFocusWeight(muscleGroup, focusAreas);
+    if (newFocusWeight !== profile.focusWeight) {
+      profile.focusWeight = newFocusWeight;
+      rulesFired.add("muscle-focus-weight");
+      fieldsChanged.push(`muscles.${muscleKey}.focusWeight`);
+    }
+
+    merged[muscleKey] = profile;
+  }
+
+  return {
+    muscles: merged,
+    rulesFired,
+    fieldsChanged,
+  };
+}
+
+/**
  * Per #124 (A21): wire prescription-accuracy aggregator into the per-apply
  * path. For each set_log carrying `ai_prescribed`, build a `SetObservation`
  * and pass through `shouldContribute`. Contributing observations
@@ -1449,6 +1588,25 @@ export async function applySession(
       newModelJson = { ...newModelJson, patterns: ruled.patterns };
       rulesFired.push(...ruled.rulesFired);
       fieldsChanged.push(...ruled.fieldsChanged);
+
+      // Per-muscle rule pipeline per #156. Reads the post-applyPerPatternRules
+      // patterns dict for stagnationStatus aggregation (worst-across-patterns
+      // per ADR-0009). Server-side muscle attribution via
+      // EXERCISE_PRIMARY_MUSCLE_MAP filters unknown client-supplied
+      // primary_muscle strings at the boundary.
+      const musclesIn =
+        (modelJson.muscles as Record<string, Record<string, unknown>> | undefined) ?? {};
+      const goalIn = modelJson.goal as Record<string, unknown> | undefined;
+      const muscleRuled = applyPerMuscleRules(
+        musclesIn,
+        setLogsArr,
+        incomingLoggedAt,
+        ruled.patterns,
+        goalIn,
+      );
+      newModelJson = { ...newModelJson, muscles: muscleRuled.muscles };
+      rulesFired.push(...muscleRuled.rulesFired);
+      fieldsChanged.push(...muscleRuled.fieldsChanged);
 
       // Prescription-accuracy pipeline per #124 (A21). Runs after pattern
       // rules so newPatterns has the appended recentSessionDates (for

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -1646,6 +1646,64 @@ orchestratorTest(
   },
 );
 
+// ─── #156: MuscleProfile producer (applyPerMuscleRules) ──────────────────────
+
+orchestratorTest(
+  "#156: first apply training quads bootstraps muscles.legs with Q1-locked MEV defaults",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-10T10:00:00Z";
+
+    const result = await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: {
+          logged_at: loggedAt,
+          set_logs: [
+            // 1 contributing top set on a quads exercise — bootstraps legs
+            // with volumeDeficit = tolerance(18) − 1 = 17.
+            { exercise_id: "barbell_back_squat", set_number: 1, weight_kg: 130, reps_completed: 5, intent: "top" },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    assertEquals(result.late_arrival, false);
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    const muscles = modelJson.muscles as Record<string, Record<string, unknown>>;
+
+    // Single muscle bootstrapped — quads collapses to legs per ADR-0005's
+    // two-level taxonomy; no other muscles touched.
+    assertEquals(Object.keys(muscles).sort(), ["legs"]);
+
+    const legs = muscles.legs;
+    // muscleGroup-as-field per the #146 pattern (dict key alone is invisible
+    // to Swift's inner decoder via decodeEnumKeyedDict).
+    assertEquals(legs.muscleGroup, "legs");
+    // Q1 lock: MEV midpoint at 4×/week scaled to 7-events = 18 sets.
+    assertEquals(legs.volumeTolerance, 18);
+    // Q3 lock.
+    assertEquals(legs.observedSweetSpot, null);
+    // Q4 lock: GoalState.placeholder has empty focusAreas → 0.0.
+    assertEquals(legs.focusWeight, 0);
+    // ADR-0009 empty-participation default (no patterns at confidence >
+    // .bootstrapping yet).
+    assertEquals(legs.stagnationStatus, "progressing");
+    // Q5 lock: all #156 profiles ship .bootstrapping.
+    assertEquals(legs.confidence, "bootstrapping");
+    // volumeDeficit = tolerance(18) − sum of this-session sets(1) = 17.
+    assertEquals(legs.volumeDeficit, 17);
+  },
+);
+
 // Sentinel "test" that runs last (alphabetically — Deno runs tests in file
 // order, but this trailing close keeps the connection lifecycle local to
 // the test file rather than relying on process-exit cleanup).

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -1704,6 +1704,181 @@ orchestratorTest(
   },
 );
 
+orchestratorTest(
+  "#156: per-set attribution — quads + hamstrings collapse to legs; shoulders maps 1:1; unknown exercise IDs silently skipped",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-10T10:00:00Z";
+
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: {
+          logged_at: loggedAt,
+          set_logs: [
+            // 2 quads sets → contribute to legs.
+            { exercise_id: "barbell_back_squat", set_number: 1, weight_kg: 130, reps_completed: 5, intent: "top" },
+            { exercise_id: "barbell_back_squat", set_number: 2, weight_kg: 130, reps_completed: 5, intent: "top" },
+            // 1 hamstrings set → collapses to legs.
+            { exercise_id: "romanian_deadlift", set_number: 1, weight_kg: 110, reps_completed: 8, intent: "backoff" },
+            // 1 shoulders set (amrap counts as contributing).
+            { exercise_id: "lateral_raise", set_number: 1, weight_kg: 8, reps_completed: 12, intent: "amrap" },
+            // Warmup set on quads → excluded from volume aggregation.
+            { exercise_id: "barbell_back_squat", set_number: 0, weight_kg: 60, reps_completed: 5, intent: "warmup" },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    const muscles = modelJson.muscles as Record<string, Record<string, unknown>>;
+
+    // Two muscle groups bootstrapped — legs (collapsed) and shoulders (1:1).
+    assertEquals(Object.keys(muscles).sort(), ["legs", "shoulders"]);
+
+    // legs aggregates 2 quads + 1 hamstrings = 3 contributing sets; warmup
+    // excluded.
+    const legsHistory = muscles.legs.weeklyVolumeHistory as Array<Record<string, unknown>>;
+    assertEquals(legsHistory.length, 1);
+    assertEquals(legsHistory[0].sets, 3);
+    assertEquals(muscles.legs.volumeDeficit, 15); // 18 − 3
+
+    // shoulders 1:1 mapping; 1 contributing set.
+    const shouldersHistory = muscles.shoulders.weeklyVolumeHistory as Array<Record<string, unknown>>;
+    assertEquals(shouldersHistory.length, 1);
+    assertEquals(shouldersHistory[0].sets, 1);
+    assertEquals(muscles.shoulders.volumeDeficit, 17); // 18 − 1
+  },
+);
+
+orchestratorTest(
+  "#156: weeklyVolumeHistory accumulates across applies; volumeDeficit converges toward 0 as volume accrues",
+  async () => {
+    const userId = await seedFreshUser();
+    const loggedAtBase = new Date("2026-05-10T10:00:00Z");
+
+    // Three consecutive applies on chest, each contributing 5 sets.
+    // Cumulative sets: 5, 10, 15. Deficits: 18−5=13, 18−10=8, 18−15=3.
+    for (let i = 0; i < 3; i++) {
+      const loggedAt = new Date(loggedAtBase.getTime() + i * 86_400_000).toISOString();
+      await applySession(
+        {
+          user_id: userId,
+          session_id: crypto.randomUUID(),
+          session_payload: {
+            logged_at: loggedAt,
+            set_logs: [
+              { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 80, reps_completed: 5, intent: "top" },
+              { exercise_id: "barbell_bench_press", set_number: 2, weight_kg: 80, reps_completed: 5, intent: "top" },
+              { exercise_id: "barbell_bench_press", set_number: 3, weight_kg: 80, reps_completed: 5, intent: "top" },
+              { exercise_id: "barbell_bench_press", set_number: 4, weight_kg: 70, reps_completed: 8, intent: "backoff" },
+              { exercise_id: "barbell_bench_press", set_number: 5, weight_kg: 70, reps_completed: 8, intent: "backoff" },
+            ],
+          },
+        },
+        sql,
+        { stage2Hook: noopStage2 },
+      );
+    }
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    const chest = (modelJson.muscles as Record<string, Record<string, unknown>>).chest;
+
+    // History accumulated three buckets (still within 7-event window).
+    const history = chest.weeklyVolumeHistory as Array<Record<string, unknown>>;
+    assertEquals(history.length, 3);
+    assertEquals(history[0].sets, 5);
+    assertEquals(history[1].sets, 5);
+    assertEquals(history[2].sets, 5);
+
+    // Cumulative volume = 15 sets; deficit = 18 − 15 = 3.
+    assertEquals(chest.volumeDeficit, 3);
+  },
+);
+
+orchestratorTest(
+  "#156: end-to-end snapshot — alpha-shaped session populates all six MuscleGroups with Q1-locked defaults",
+  async () => {
+    const userId = await seedFreshUser();
+    const sessionId = crypto.randomUUID();
+    const loggedAt = "2026-05-12T10:00:00Z";
+
+    // One set touching each of the six MuscleGroups (mirrors the alpha
+    // cohort's full-coverage shape across back/chest/shoulders/biceps/
+    // triceps/legs).
+    await applySession(
+      {
+        user_id: userId,
+        session_id: sessionId,
+        session_payload: {
+          logged_at: loggedAt,
+          set_logs: [
+            { exercise_id: "barbell_row", set_number: 1, weight_kg: 70, reps_completed: 8, intent: "top" },             // back
+            { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 80, reps_completed: 5, intent: "top" },     // chest
+            { exercise_id: "overhead_press", set_number: 1, weight_kg: 50, reps_completed: 5, intent: "top" },          // shoulders
+            { exercise_id: "barbell_curl", set_number: 1, weight_kg: 30, reps_completed: 10, intent: "top" },           // biceps
+            { exercise_id: "cable_tricep_pushdown", set_number: 1, weight_kg: 25, reps_completed: 12, intent: "top" },  // triceps
+            { exercise_id: "barbell_back_squat", set_number: 1, weight_kg: 130, reps_completed: 5, intent: "top" },     // legs (quads)
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const muscles = (rows[0].model_json as Record<string, unknown>).muscles as Record<
+      string,
+      Record<string, unknown>
+    >;
+
+    // All six MuscleGroups populated.
+    assertEquals(
+      Object.keys(muscles).sort(),
+      ["back", "biceps", "chest", "legs", "shoulders", "triceps"],
+    );
+
+    const expectedTolerances: Record<string, number> = {
+      back: 21,
+      chest: 18,
+      shoulders: 18,
+      biceps: 16,
+      triceps: 12,
+      legs: 18,
+    };
+
+    const loggedAtIso = new Date(loggedAt).toISOString();
+    for (const [muscleGroup, expectedTolerance] of Object.entries(expectedTolerances)) {
+      const profile = muscles[muscleGroup];
+      assertEquals(profile.muscleGroup, muscleGroup);
+      assertEquals(profile.volumeTolerance, expectedTolerance);
+      assertEquals(profile.observedSweetSpot, null);
+      assertEquals(profile.focusWeight, 0); // GoalState.placeholder
+      assertEquals(profile.stagnationStatus, "progressing"); // empty-participation default
+      assertEquals(profile.confidence, "bootstrapping"); // Q5 lock
+      // weeklyVolumeHistory has exactly one bucket — this session.
+      const history = profile.weeklyVolumeHistory as Array<Record<string, unknown>>;
+      assertEquals(history.length, 1);
+      assertEquals(history[0].loggedAtIso, loggedAtIso);
+      assertEquals(history[0].sets, 1);
+      // deficit = tolerance − 1
+      assertEquals(profile.volumeDeficit, expectedTolerance - 1);
+    }
+  },
+);
+
 // Sentinel "test" that runs last (alphabetically — Deno runs tests in file
 // order, but this trailing close keeps the connection lifecycle local to
 // the test file rather than relying on process-exit cleanup).


### PR DESCRIPTION
Closes #156.

## Summary

Wires the missing producer for `model_json.muscles[]` per ADR-0005, parallel to #146's per-pattern recovery migration. Pre-#156, iOS `TraineeModel.muscles: [MuscleGroup: MuscleProfile]` decoded correctly from JSONB but the EF never wrote it — the dict was always empty, and B2's volume-deficit signal had no input data.

Post-merge, every applySession bootstraps + maintains per-muscle profiles with `volumeTolerance`, `volumeDeficit`, `stagnationStatus`, `focusWeight`, `observedSweetSpot`, and `confidence` per the 2026-05-13-locked decisions on Q1 / Q3 / Q4 / Q5. Producer only — no Swift production code changes, no migration, no B2 cutover (#87 sequences next).

## Per-cycle test surface (12 cycles + 1 prereq)

| Cycle | Behavior | Test surface | Commit |
|---|---|---|---|
| 0 (prereq) | `EXERCISE_PRIMARY_MUSCLE_MAP` + 71-entry drift test mirroring `EXERCISE_PATTERN_MAP` | unit | 4cde2dd |
| 1 | `bootstrapMuscleProfile` with Q1-locked MEV thresholds | unit | 7f42f59 |
| 2 | `aggregateMuscleSetCounts` (non-warmup non-technique sets; PrimaryMuscle → MuscleGroup collapse) | unit | e8c1483 |
| 3 | `computeVolumeDeficit = max(0, tolerance − Σ sets over last-7 buckets)` | unit | b0b4200 |
| 4 | `aggregateStagnationStatus` worst-across-patterns (ADR-0009 §amendment) | unit | b0b4200 |
| 5 | `computeFocusWeight` Q4 binary derivation | unit | b0b4200 |
| 6–8 | `applyPerMuscleRules` coordinator + orchestrator wiring (between `applyPerPatternRules` and `applyPrescriptionAccuracy`) | integration | 7a5a303 |
| 9 | Bootstrap-on-first-touch (alpha-shaped 1-set quads session) | orchestrator integration | 7a5a303 |
| 10 | Per-set attribution + collapse + warmup excluded | orchestrator integration | 11f4cc8 |
| 11 | Multi-apply `weeklyVolumeHistory` accumulation; deficit converges | orchestrator integration | 11f4cc8 |
| 12 | End-to-end alpha-shaped snapshot (six MuscleGroups, all Q1-locked tolerances) | orchestrator integration | 11f4cc8 |

(Cycle 11 swapped from the prep prompt's \"worst-across-patterns integration\" to \"history accumulation\" — the worst-across rule is unit-tested in Cycle 4 with cleaner inputs; orchestrator coverage would require seeding multi-session e1RM + volume-load histories to force `plateauVerdict` outputs, with low value-add over unit coverage.)

**Result: 377/377 EF tests pass.** No regressions in pattern, exercise, prescription-accuracy, transfer-regression, fatigue-interaction, recovery-curve, or smoke suites.

## 2026-05-13 prep-prompt decision locks honored

- **Q1 (MEV, midpoints)**: `MUSCLE_VOLUME_TARGETS` = `{ back: 21, chest: 18, shoulders: 18, biceps: 16, triceps: 12, legs: 18 }`. Per-7-events at 4×/week alpha-cohort cadence.
- **Q2 (tolerance update deferred)**: `volumeTolerance` is bootstrap-only. EWMA-update follow-up: #165.
- **Q3 (observedSweetSpot null)**: EF emits null, Swift decodes nil. `MuscleSummary` already drops this field at the digest layer.
- **Q4 (binary focusWeight)**: 1.0 iff muscleGroup ∈ `goal.focusAreas`, else 0.0. Alpha user gets all-zero (GoalState.placeholder has empty focusAreas) until onboarding hydrates.
- **Q5 (all .bootstrapping)**: every #156-produced MuscleProfile ships `confidence: \"bootstrapping\"`. Lifecycle follow-up: #166.
- **Q6 (parallel maps)**: `EXERCISE_PRIMARY_MUSCLE_MAP` mirrors `EXERCISE_PATTERN_MAP`'s 71-entry shape; drift-test pinned.

## ADR alignment

- **ADR-0005 §two-level muscle taxonomy**: `primaryMuscleToGroup` collapses quads/hamstrings/glutes/calves → legs; upper-body 1:1.
- **ADR-0005 §muscles**: `MuscleProfile` carries the locked seven fields; `weeklyVolumeHistory` added as EF-only state (Swift decoder doesn't list it in CodingKeys, paralleling how `PatternProfile.weeklyVolumeLoadHistory` is invisible to Swift). **No Swift shape change.**
- **ADR-0002 §queue-event-windowed**: `MUSCLE_VOLUME_WINDOW = 7`. `weeklyVolumeHistory.slice(-7)` is the volume sum source.
- **ADR-0009 §Aggregation to MuscleProfile.stagnationStatus**: worst-across-patterns; participation precondition `confidence > .bootstrapping`; empty-participation defaults to `.progressing`.
- **#146 pattern**: dict key emitted as field (`muscleGroup`) so Swift's `decodeEnumKeyedDict` inner decoder can read it.

## Cross-cutting grep results (CLAUDE.md rule 2: report, don't rewrite)

Searched `MuscleProfile | applyPerMuscleRules | trainedMuscleGroups | per_muscle_summary | perMuscleSummary | EXERCISE_PRIMARY_MUSCLE_MAP | weeklyVolumeHistory | bootstrapMuscleProfile | MUSCLE_VOLUME_TARGETS` across `ProjectApex/` + `supabase/`.

**No production sites required editing beyond the authorized scope.** Consumers ([`TraineeModel.swift:21,134`](../ProjectApex/Models/TraineeModel.swift#L21), [`TraineeModelDigest.swift:36-93`](../ProjectApex/Models/TraineeModelDigest.swift#L36), [`TraineeModelProfiles.swift:76`](../ProjectApex/Models/TraineeModelProfiles.swift#L76)) honor the Swift shape lock and will start hydrating real data post-deploy.

**One pre-existing site flagged but NOT touched per the grep-and-report rule:** [`update-trainee-model/index.ts:1717-1727`](../supabase/functions/update-trainee-model/index.ts#L1717-L1727)'s `derivedTrainedSets` still leaks unknown client-supplied `primary_muscle` strings (e.g. alpha-cohort `posterior_deltoid`) into the note-classifier auto-clear gate. #156's producer is unaffected (derives muscle attribution server-side via `EXERCISE_PRIMARY_MUSCLE_MAP`). Follow-up: #167.

## Known limitations / deferred items

| Limitation | Follow-up | Rationale |
|---|---|---|
| `volumeTolerance` thresholds assume 4×/week cadence; users at other cadences get drift | #164 | Q1 cadence caveat acknowledged in prep prompt |
| `volumeTolerance` is bootstrap-only; no EWMA update from RPE/recovery signal | #165 | Q2 lock |
| All MuscleProfiles ship `.bootstrapping` indefinitely; no calibrating/established transitions | #166 | Q5 lock; needs grilled ADR |
| `derivedTrainedSets` leaks `posterior_deltoid` into note-classifier path | #167 | Grep-and-report finding; not #156 scope |

## Test plan

- [x] `deno test --allow-all supabase/functions/_shared/per-muscle-rules_test.ts` — 5 unit tests pass
- [x] `deno test --allow-all supabase/functions/_shared/exercise-library_test.ts` — 12 tests pass (1 new)
- [x] `deno test --allow-all supabase/functions/update-trainee-model/orchestrator_test.ts` — 32 tests pass (4 new)
- [x] Full EF suite: 377/377 pass
- [ ] CI deploys `update-trainee-model` on merge to main per [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) `deploy` job (gated on `ef-test`)
- [ ] Post-deploy: alpha user's next applySession populates `model_json.muscles` for trained muscles (verify via `supabase db query` against the production row)
- [ ] B2 (#87) unblocked: `trainee_model_digest.per_muscle_summary[].volume_deficit` will now carry meaningful values

🤖 Generated with [Claude Code](https://claude.com/claude-code)