### PR TITLE
fix(ef): add missing computeFocusWeight export — restores EF boot post-#156

### DIFF
--- a/supabase/functions/_shared/per-muscle-rules.ts
+++ b/supabase/functions/_shared/per-muscle-rules.ts
@@ -235,6 +235,19 @@ const MUSCLE_PARTICIPATING_PATTERNS: Record<MuscleGroup, Set<MovementPattern>> =
  * participation returns `.progressing` — the no-signal default; cold-start
  * is carried separately by `MuscleProfile.confidence`.
  */
+/**
+ * Per Q4 lock (2026-05-13): binary `focusWeight` derived from
+ * `GoalState.focusAreas` enum-membership. Returns 1.0 when the muscle is
+ * in the user's focus areas, 0.0 otherwise. Continuous-weight follow-up is
+ * scoped post-#156.
+ */
+export function computeFocusWeight(
+  muscleGroup: MuscleGroup,
+  focusAreas: readonly string[],
+): number {
+  return focusAreas.includes(muscleGroup) ? 1.0 : 0.0;
+}
+
 export function aggregateStagnationStatus(
   muscleGroup: MuscleGroup,
   patternProfiles: Record<

--- a/supabase/functions/_shared/per-muscle-rules_test.ts
+++ b/supabase/functions/_shared/per-muscle-rules_test.ts
@@ -14,6 +14,7 @@ import {
   aggregateMuscleSetCounts,
   aggregateStagnationStatus,
   bootstrapMuscleProfile,
+  computeFocusWeight,
   computeVolumeDeficit,
 } from "./per-muscle-rules.ts";
 
@@ -168,4 +169,14 @@ Deno.test("aggregateStagnationStatus: worst-across-patterns with bootstrapping-c
 
   // Empty patterns dict (cold-start) → progressing.
   assertEquals(aggregateStagnationStatus("chest", {}), "progressing");
+});
+
+Deno.test("computeFocusWeight: 1.0 iff muscleGroup ∈ goal.focusAreas (Q4 binary lock)", () => {
+  // Alpha-cohort baseline: GoalState.placeholder has empty focusAreas →
+  // every muscle gets 0.0 until onboarding hydrates focusAreas.
+  assertEquals(computeFocusWeight("legs", []), 0.0);
+  // Membership → 1.0.
+  assertEquals(computeFocusWeight("legs", ["legs", "back"]), 1.0);
+  // Non-membership → 0.0.
+  assertEquals(computeFocusWeight("chest", ["legs", "back"]), 0.0);
 });


### PR DESCRIPTION
## Cause

#156's orchestrator imports `computeFocusWeight` from `_shared/per-muscle-rules.ts` ([index.ts:90](../supabase/functions/update-trainee-model/index.ts#L90)) but the function itself was never committed to the producer branch — present in the working tree locally so the local `deno test` run was green (40/40 unit + 4/4 orchestrator integration), but the squash-merged commit d9b5545 ships an import that points at a non-existent export.

## Consequence

CI's `ef-test` job [worker-boots with](https://github.com/thearnavmenon/ProjectApex/actions/runs/25745465200):

```
Uncaught SyntaxError: The requested module '../_shared/per-muscle-rules.ts'
does not provide an export named 'computeFocusWeight'
```

The deploy job is gated on `ef-test`, so the EF on production is **still the pre-#156 version**. Alpha user's next apply runs against the old EF and `model_json.muscles` stays empty.

## Fix

Commit the missing `computeFocusWeight` + its unit test exactly as they existed in the working tree.

```
+export function computeFocusWeight(
+  muscleGroup: MuscleGroup,
+  focusAreas: readonly string[],
+): number {
+  return focusAreas.includes(muscleGroup) ? 1.0 : 0.0;
+}
```

Verified: 40/40 unit + 32/32 orchestrator integration tests pass post-fix.

## Test plan

- [x] `deno test --allow-all supabase/functions/_shared/per-muscle-rules_test.ts` — 5/5
- [x] `deno test --allow-all supabase/functions/update-trainee-model/orchestrator_test.ts` — 32/32 (the 4 new #156 tests still pass; they exercise the focusWeight path via the orchestrator)
- [ ] CI `ef-test` boot succeeds
- [ ] CI `deploy` runs and ships the new `update-trainee-model` revision
- [ ] Post-deploy: alpha user's next applySession populates `model_json.muscles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)