### PR TITLE
fix(ef): mirror session_count → model_json.totalSessionCount JSONB key (#175)

### DIFF
--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -1740,6 +1740,17 @@ export async function applySession(
       }
     }
 
+    // Mirror the canonical session_count column into model_json so Swift's
+    // TraineeModel.totalSessionCount decode sees the value B4's HEAVY
+    // REASSESSMENT prompt rule needs per ADR-0012 (#175). Without this,
+    // totalSessionCount decodes to 0 and the digest's
+    // `total_session_count - last_global_phase_advance_fired_at_session_count`
+    // computation misfires.
+    newModelJson = {
+      ...newModelJson,
+      totalSessionCount: newSessionCount,
+    };
+
     // Step 5: write back + advance watermark (ADR-0008 §"In-order").
     // session_count drives ADR-0012's 6-session-window cooldown.
     //

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -117,6 +117,53 @@ orchestratorTest(
 );
 
 orchestratorTest(
+  "#175: model_json.totalSessionCount mirrors session_count column on every apply",
+  async () => {
+    const userId = await seedFreshUser();
+
+    await applySession(
+      {
+        user_id: userId,
+        session_id: crypto.randomUUID(),
+        session_payload: { logged_at: "2026-05-08T10:00:00Z", set_logs: [] },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    let rows = await sql`
+      SELECT model_json, session_count FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    assertEquals(rows[0].session_count, 1);
+    assertEquals(
+      (rows[0].model_json as Record<string, unknown>).totalSessionCount,
+      1,
+      "first apply must mirror session_count=1 into model_json.totalSessionCount",
+    );
+
+    await applySession(
+      {
+        user_id: userId,
+        session_id: crypto.randomUUID(),
+        session_payload: { logged_at: "2026-05-09T10:00:00Z", set_logs: [] },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    rows = await sql`
+      SELECT model_json, session_count FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    assertEquals(rows[0].session_count, 2);
+    assertEquals(
+      (rows[0].model_json as Record<string, unknown>).totalSessionCount,
+      2,
+      "second apply must mirror session_count=2 into model_json.totalSessionCount",
+    );
+  },
+);
+
+orchestratorTest(
   "A17 / #116: ewma-engine wired — first apply with valid top sets bootstraps ExerciseProfile + populates e1rmCurrent via Epley × EWMA",
   async () => {
     const userId = await seedFreshUser();


### PR DESCRIPTION
## Summary

- EF wrote `trainee_models.session_count` as a dedicated column but never mirrored it into the `model_json` JSONB. Swift `TraineeModel.totalSessionCount` decodes from JSONB → defaulted to `0` on every prod assembly.
- Fix: unconditional `newModelJson.totalSessionCount = newSessionCount` write after the rule pipeline, before the UPSERT in `update-trainee-model/index.ts`.
- Test: new orchestrator integration test asserts `model_json.totalSessionCount` matches the `session_count` column on first **and** second apply (every-apply contract, not just bootstrap).
- Unblocks #89 (B4) HEAVY REASSESSMENT prompt rule (per ADR-0012).

## Test plan

- [x] Local deno test on the new test alone: `deno test --allow-net --allow-env --allow-read --allow-write supabase/functions/update-trainee-model/orchestrator_test.ts --filter "#175"` → 1 passed
- [x] Full ef-test regression: `deno test --allow-net --allow-env --allow-read --no-check` → **455 passed | 0 failed**
- [ ] CI ef-test green
- [ ] Operator applies one-row backfill SQL post-merge:

```sql
UPDATE public.trainee_models
SET model_json = jsonb_set(model_json, '{totalSessionCount}', to_jsonb(session_count))
WHERE NOT (model_json ? 'totalSessionCount');
```

Idempotent — re-runs are no-ops. At alpha scale this affects 1 row (verified pre-merge via prod REST query).

- [ ] Post-backfill verification: `select model_json->>'totalSessionCount', session_count from trainee_models where user_id = '6ce6c575-…'` returns matching values (`"20", 20`).

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)