### PR TITLE
fix(ef): collapse transferRegressions dict → transfers list — match cross-platform contract

### DIFF
--- a/ProjectApexTests/TraineeModelSnapshotsCrossValidationTests.swift
+++ b/ProjectApexTests/TraineeModelSnapshotsCrossValidationTests.swift
@@ -112,6 +112,23 @@ final class TraineeModelSnapshotsCrossValidationTests: XCTestCase {
         )
     }
 
+    /// Cross-exercise transfers are persisted as a JSON array under the
+    /// `transfers` top-level key (per cross-platform shape contract; see
+    /// docs/fixtures/trainee-model-snapshot.json). The EF writes the rich
+    /// shape (intercept, spearmanFlagged, seWidening, state, observations)
+    /// alongside the basic 5 fields Swift's ExerciseTransfer carries; Swift
+    /// Codable tolerates the extra keys by default and decodes the basic
+    /// fields.
+    func test_transfers_listShapeDecodesCorrectly() {
+        XCTAssertEqual(Self.model.transfers.count, 1)
+        let t0 = Self.model.transfers[0]
+        XCTAssertEqual(t0.fromExerciseId, "barbell_bench_press")
+        XCTAssertEqual(t0.toExerciseId, "overhead_press")
+        XCTAssertEqual(t0.coefficient, 0.83)
+        XCTAssertEqual(t0.rSquared, 0.62)
+        XCTAssertEqual(t0.pairedObservations, 8)
+    }
+
     /// PrescriptionAccuracy gained gap-bucket fields in slice A9 (#80) per
     /// ADR-0014. The fixture exercises the populated dictionaries; verify
     /// the Swift Codable's `decodeIfPresent` defaults to empty-dict on

--- a/docs/fixtures/trainee-model-snapshot.json
+++ b/docs/fixtures/trainee-model-snapshot.json
@@ -99,7 +99,23 @@
     }
   },
   "prescriptionIntentMismatches": [],
-  "transfers": [],
+  "transfers": [
+    {
+      "fromExerciseId": "barbell_bench_press",
+      "toExerciseId": "overhead_press",
+      "coefficient": 0.83,
+      "intercept": 12.4,
+      "rSquared": 0.62,
+      "pairedObservations": 8,
+      "spearmanFlagged": false,
+      "seWidening": 0.0,
+      "state": "published",
+      "observations": [
+        { "fromE1RM": 100.0, "toE1RM": 65.0, "observedAt": "2025-12-15T10:00:00.000Z" },
+        { "fromE1RM": 102.5, "toE1RM": 67.5, "observedAt": "2025-12-22T10:00:00.000Z" }
+      ]
+    }
+  ],
   "bodyweight": {
     "entries": []
   },

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -1209,6 +1209,90 @@ function applyPrescriptionAccuracy(
 }
 
 /**
+ * Internal apply-path representation of transfer state — dict-of-dict for
+ * O(1) cell lookup during the per-pair update loop. The JSONB write/read
+ * boundary uses the flat-list shape (`TransferEntry[]`) per the
+ * cross-platform contract; bridges at the caller convert between the two.
+ */
+type TransferDict = Record<string, Record<string, {
+  observations: PairedObservation[];
+  fit: TransferFit;
+}>>;
+
+/**
+ * Flat-list element for JSONB persistence under the `transfers` key.
+ * Matches Swift's `ExerciseTransfer` struct (basic fields decode); the
+ * EF-internal rich fields (intercept, spearmanFlagged, seWidening, state,
+ * observations) ride along and are tolerated by Swift Codable's default
+ * unknown-key behavior.
+ */
+interface TransferEntry {
+  fromExerciseId: string;
+  toExerciseId: string;
+  coefficient: number;
+  intercept: number;
+  rSquared: number;
+  pairedObservations: number;
+  spearmanFlagged: boolean;
+  seWidening: number;
+  state: TransferFit["state"];
+  observations: PairedObservation[];
+}
+
+/**
+ * Hydrate the internal dict from the JSONB-side list shape. Used at apply-
+ * path entry to round-trip an existing `transfers` array back into the
+ * O(1)-lookup structure the rule operates on.
+ */
+function hydrateTransferDictFromList(list: TransferEntry[]): TransferDict {
+  const dict: TransferDict = {};
+  for (const e of list) {
+    if (!dict[e.fromExerciseId]) dict[e.fromExerciseId] = {};
+    dict[e.fromExerciseId][e.toExerciseId] = {
+      observations: e.observations,
+      fit: {
+        coefficient: e.coefficient,
+        intercept: e.intercept,
+        rSquared: e.rSquared,
+        pairedObservations: e.pairedObservations,
+        spearmanFlagged: e.spearmanFlagged,
+        seWidening: e.seWidening,
+        state: e.state,
+      },
+    };
+  }
+  return dict;
+}
+
+/**
+ * Flatten the internal dict to the JSONB-side list shape. Used at apply-
+ * path exit before the UPSERT. Output ordering is deterministic
+ * (lexicographic by from then to) for stable JSONB diffs.
+ */
+function flattenTransferDictToList(dict: TransferDict): TransferEntry[] {
+  const list: TransferEntry[] = [];
+  for (const fromExerciseId of Object.keys(dict).sort()) {
+    const byTo = dict[fromExerciseId];
+    for (const toExerciseId of Object.keys(byTo).sort()) {
+      const cell = byTo[toExerciseId];
+      list.push({
+        fromExerciseId,
+        toExerciseId,
+        coefficient: cell.fit.coefficient,
+        intercept: cell.fit.intercept,
+        rSquared: cell.fit.rSquared,
+        pairedObservations: cell.fit.pairedObservations,
+        spearmanFlagged: cell.fit.spearmanFlagged,
+        seWidening: cell.fit.seWidening,
+        state: cell.fit.state,
+        observations: cell.observations,
+      });
+    }
+  }
+  return list;
+}
+
+/**
  * Per #126 (A22): wire transfer-regression. v1 alpha-cohort pair-detection
  * rule = "trained in the same session": for each pair of exercises with
  * top-intent sets in the current session, record a directional
@@ -1223,19 +1307,16 @@ function applyPrescriptionAccuracy(
  * sxx=0 → `coefficient = NaN`, which would break JSONB serialisation; the
  * placeholder fit (zeroed coefficients, state=candidate) keeps storage
  * clean while still tracking the observation.
+ *
+ * Operates on the internal dict-of-dict shape; the caller bridges to/from
+ * the JSONB list shape (`TransferEntry[]`) at the apply-path boundary.
  */
-function applyTransferRegressions(
-  transferRegressions: Record<string, Record<string, {
-    observations: PairedObservation[];
-    fit: TransferFit;
-  }>>,
+function applyTransfers(
+  transfers: TransferDict,
   setLogs: Array<Record<string, unknown>>,
   incomingLoggedAt: Date,
 ): {
-  transferRegressions: Record<string, Record<string, {
-    observations: PairedObservation[];
-    fit: TransferFit;
-  }>>;
+  transfers: TransferDict;
   rulesFired: Set<string>;
   fieldsChanged: string[];
 } {
@@ -1259,15 +1340,12 @@ function applyTransferRegressions(
   }
 
   if (sessionE1rmByExercise.size < 2) {
-    return { transferRegressions, rulesFired, fieldsChanged };
+    return { transfers, rulesFired, fieldsChanged };
   }
 
   // Clone storage shape so updates remain immutable from caller's POV.
-  const next: Record<string, Record<string, {
-    observations: PairedObservation[];
-    fit: TransferFit;
-  }>> = {};
-  for (const [from, m] of Object.entries(transferRegressions)) {
+  const next: TransferDict = {};
+  for (const [from, m] of Object.entries(transfers)) {
     next[from] = { ...m };
   }
 
@@ -1308,11 +1386,11 @@ function applyTransferRegressions(
       fromMap[toEx] = { observations: newObservations, fit: newFit };
       next[fromEx] = fromMap;
       rulesFired.add("transfer-regression");
-      fieldsChanged.push(`transferRegressions.${fromEx}.${toEx}`);
+      fieldsChanged.push(`transfers.${fromEx}.${toEx}`);
     }
   }
 
-  return { transferRegressions: next, rulesFired, fieldsChanged };
+  return { transfers: next, rulesFired, fieldsChanged };
 }
 
 /**
@@ -1634,21 +1712,29 @@ export async function applySession(
       // Transfer-regression pipeline per #126 (A22). Pair-detects within
       // the current session and recomputes the log-log fit per ordered
       // exercise pair.
-      const transferIn =
-        (modelJson.transferRegressions as
-          | Record<string, Record<string, {
-              observations: PairedObservation[];
-              fit: TransferFit;
-            }>>
-          | undefined) ?? {};
-      const transferRuled = applyTransferRegressions(
+      //
+      // JSONB shape contract: top-level key `transfers` carries a flat list
+      // of TransferEntry per the cross-platform fixture. Internal apply uses
+      // dict-of-dict for O(1) lookup; the bridges hydrate/flatten at the
+      // boundary. Legacy fallback: rows pre-dating the schema-drift fix
+      // store the same data under `transferRegressions` (dict-of-dict);
+      // when `transfers` is absent and the legacy key is present, hydrate
+      // from there. The legacy key is left in place on write (not actively
+      // cleaned up here) — a follow-up cleanup PR drops it after the
+      // migration is verified across the alpha cohort.
+      const transferList = modelJson.transfers as TransferEntry[] | undefined;
+      const legacyDict = modelJson.transferRegressions as TransferDict | undefined;
+      const transferIn: TransferDict = transferList !== undefined
+        ? hydrateTransferDictFromList(transferList)
+        : (legacyDict ?? {});
+      const transferRuled = applyTransfers(
         transferIn,
         setLogsArr,
         incomingLoggedAt,
       );
       newModelJson = {
         ...newModelJson,
-        transferRegressions: transferRuled.transferRegressions,
+        transfers: flattenTransferDictToList(transferRuled.transfers),
       };
       rulesFired.push(...transferRuled.rulesFired);
       fieldsChanged.push(...transferRuled.fieldsChanged);

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -19,7 +19,7 @@
 // Run locally:
 //   deno test --allow-net --allow-env supabase/functions/update-trainee-model/orchestrator_test.ts
 
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assertEquals, assertExists } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import postgres from "postgres";
 import { applySession } from "./index.ts";
 import type { ApplyCompleteEvent, LateArrivalEvent } from "../_shared/observability.ts";
@@ -416,17 +416,23 @@ orchestratorTest(
     const rows = await sql`
       SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
     `;
-    const tr = (rows[0].model_json as Record<string, unknown>).transferRegressions as Record<string, Record<string, Record<string, unknown>>>;
-    const benchToRow = tr["barbell_bench_press"]["barbell_row"];
-    const rowToBench = tr["barbell_row"]["barbell_bench_press"];
+    const transfers = (rows[0].model_json as Record<string, unknown>).transfers as Array<Record<string, unknown>>;
+    assertEquals(transfers.length, 2);
+    const benchToRow = transfers.find(
+      (t) => t.fromExerciseId === "barbell_bench_press" && t.toExerciseId === "barbell_row",
+    );
+    const rowToBench = transfers.find(
+      (t) => t.fromExerciseId === "barbell_row" && t.toExerciseId === "barbell_bench_press",
+    );
+    assertExists(benchToRow);
+    assertExists(rowToBench);
     assertEquals((benchToRow.observations as unknown[]).length, 1);
     assertEquals((rowToBench.observations as unknown[]).length, 1);
-    const benchToRowFit = benchToRow.fit as Record<string, unknown>;
-    assertEquals(benchToRowFit.state, "candidate");
+    assertEquals(benchToRow.state, "candidate");
     // Placeholder fit values — n<2 path returns zeroed coefficients (no NaN).
-    assertEquals(benchToRowFit.coefficient, 0);
-    assertEquals(benchToRowFit.rSquared, 0);
-    assertEquals(benchToRowFit.pairedObservations, 1);
+    assertEquals(benchToRow.coefficient, 0);
+    assertEquals(benchToRow.rSquared, 0);
+    assertEquals(benchToRow.pairedObservations, 1);
   },
 );
 
@@ -544,8 +550,88 @@ orchestratorTest(
     const rows = await sql`
       SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
     `;
-    const tr = (rows[0].model_json as Record<string, unknown>).transferRegressions as Record<string, unknown>;
-    assertEquals(Object.keys(tr).length, 0);
+    const transfers = (rows[0].model_json as Record<string, unknown>).transfers as Array<Record<string, unknown>>;
+    assertEquals(transfers.length, 0);
+  },
+);
+
+orchestratorTest(
+  "schema-drift-fix: row seeded with legacy transferRegressions dict (no transfers key) auto-migrates on first apply — all cells preserved as transfers list entries with new observation appended for the trained pair",
+  async () => {
+    // Simulates the prod migration: alpha row has model_json containing
+    // `transferRegressions` dict-of-dicts under the old key, no `transfers`
+    // key. First post-deploy apply must hydrate the legacy dict, process
+    // rule, and write the unified `transfers` list shape — preserving every
+    // existing cell.
+    const userId = crypto.randomUUID();
+    await sql`
+      INSERT INTO public.users (id, display_name)
+      VALUES (${userId}, ${"orchestrator-test-" + userId.slice(0, 8)})
+    `;
+    // Seed model_json with two pre-existing cells under the LEGACY key —
+    // bench↔squat pair (both directions). One observation each.
+    const legacyModel = {
+      transferRegressions: {
+        "barbell_bench_press": {
+          "barbell_back_squat": {
+            observations: [{ fromE1RM: 100, toE1RM: 130, observedAt: "2026-05-01T10:00:00Z" }],
+            fit: { coefficient: 0, intercept: 0, rSquared: 0, pairedObservations: 1, spearmanFlagged: false, seWidening: 0, state: "candidate" },
+          },
+        },
+        "barbell_back_squat": {
+          "barbell_bench_press": {
+            observations: [{ fromE1RM: 130, toE1RM: 100, observedAt: "2026-05-01T10:00:00Z" }],
+            fit: { coefficient: 0, intercept: 0, rSquared: 0, pairedObservations: 1, spearmanFlagged: false, seWidening: 0, state: "candidate" },
+          },
+        },
+      },
+    };
+    await sql`
+      INSERT INTO public.trainee_models (user_id, model_json)
+      VALUES (${userId}, ${sql.json(legacyModel)})
+    `;
+
+    // Apply a session that re-trains the same pair — adds one observation
+    // to each direction. Post-apply, total observations per cell = 2.
+    await applySession(
+      {
+        user_id: userId,
+        session_id: crypto.randomUUID(),
+        session_payload: {
+          logged_at: "2026-05-08T10:00:00Z",
+          set_logs: [
+            { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 102.5, reps_completed: 5, intent: "top", rpe_felt: 8 },
+            { exercise_id: "barbell_back_squat", set_number: 1, weight_kg: 132.5, reps_completed: 5, intent: "top", rpe_felt: 8 },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    const transfers = modelJson.transfers as Array<Record<string, unknown>>;
+    assertExists(transfers, "transfers list must be populated post-apply");
+    assertEquals(transfers.length, 2);
+
+    const benchToSquat = transfers.find(
+      (t) => t.fromExerciseId === "barbell_bench_press" && t.toExerciseId === "barbell_back_squat",
+    );
+    const squatToBench = transfers.find(
+      (t) => t.fromExerciseId === "barbell_back_squat" && t.toExerciseId === "barbell_bench_press",
+    );
+    assertExists(benchToSquat, "legacy bench→squat cell must migrate");
+    assertExists(squatToBench, "legacy squat→bench cell must migrate");
+
+    // Each cell now carries 2 observations (1 legacy + 1 from this session).
+    assertEquals((benchToSquat.observations as unknown[]).length, 2);
+    assertEquals((squatToBench.observations as unknown[]).length, 2);
+    // n=2 enables a real fit — no longer placeholder zeros.
+    assertEquals(benchToSquat.pairedObservations, 2);
+    assertEquals(benchToSquat.state, "candidate"); // <5 obs, stays candidate per Q10
   },
 );
 
@@ -1690,6 +1776,21 @@ orchestratorTest(
       "between_48_and_72h": 0.05,
       "over72h": 0.06,
     });
+    // transfers must be a JSON array (not the legacy `transferRegressions`
+    // dict-of-dicts shape). Element shape carries the basic 5 fields Swift's
+    // ExerciseTransfer struct decodes plus EF-internal rich fields (intercept,
+    // spearmanFlagged, seWidening, state, observations) that Swift Codable
+    // tolerates by default.
+    const transfers = returned.transfers as Array<Record<string, unknown>>;
+    assertEquals(Array.isArray(transfers), true, "transfers must be a JSON array, not a dict (cross-platform shape contract)");
+    assertEquals(transfers.length, 1);
+    const t0 = transfers[0];
+    assertEquals(t0.fromExerciseId, "barbell_bench_press");
+    assertEquals(t0.toExerciseId, "overhead_press");
+    assertEquals(t0.coefficient, 0.83);
+    assertEquals(t0.rSquared, 0.62);
+    assertEquals(t0.pairedObservations, 8);
+    assertEquals(t0.state, "published");
   },
 );
 

--- a/supabase/functions/update-trainee-model/smoke_test.ts
+++ b/supabase/functions/update-trainee-model/smoke_test.ts
@@ -228,17 +228,18 @@ smokeTest(
     // A22 / #126: transfer-regression — fixture has 3 top-intent exercises
     // (bench, squat, row) → 6 ordered pairs (3×2 = each pair recorded both
     // directions). Single session → n=1, candidate state, placeholder fit.
-    const transfers = modelJson.transferRegressions as Record<string, Record<string, Record<string, unknown>>>;
+    const transfers = modelJson.transfers as Array<Record<string, unknown>>;
     const expectedExercises = ["barbell_back_squat", "barbell_bench_press", "barbell_row"];
-    assertEquals(Object.keys(transfers).sort(), expectedExercises);
+    assertEquals(transfers.length, 6);
     for (const fromEx of expectedExercises) {
       for (const toEx of expectedExercises) {
         if (fromEx === toEx) continue;
-        const cell = transfers[fromEx][toEx];
-        assertExists(cell, `transferRegressions[${fromEx}][${toEx}] should exist`);
+        const cell = transfers.find(
+          (t) => t.fromExerciseId === fromEx && t.toExerciseId === toEx,
+        );
+        assertExists(cell, `transfers entry [${fromEx} → ${toEx}] should exist`);
         assertEquals((cell.observations as unknown[]).length, 1);
-        const fit = cell.fit as Record<string, unknown>;
-        assertEquals(fit.state, "candidate");
+        assertEquals(cell.state, "candidate");
       }
     }
 


### PR DESCRIPTION
## Summary

EF wrote transfer state under top-level JSONB key `transferRegressions` (nested dict), while the cross-platform fixture and Swift `TraineeModel.transfers: [ExerciseTransfer]` expected a flat list under key `transfers`. Swift decoded empty list on every prod assembly.

**Path A** per planning surface: EF refactors to write the list shape; legacy fallback read auto-migrates existing prod rows on first apply (no manual backfill); Swift requires no code change (Codable ignores extra rich fields).

**Coverage gap that let it land**: the cross-platform parity round-trip test asserted other top-level fields but never `transfers` shape; the fixture had `"transfers": []` so the empty-state case trivially passed for both sides.

## What landed

- **`update-trainee-model/index.ts`** —
  - New `TransferDict` (internal apply representation, dict-of-dict) + `TransferEntry` (JSONB list shape) types.
  - `applyTransferRegressions` → `applyTransfers`, internal logic unchanged; only param/return names + fieldsChanged label updated.
  - Caller-side bridges `hydrateTransferDictFromList` / `flattenTransferDictToList` at the apply-path boundary.
  - Legacy fallback: `transfers || hydrate(transferRegressions) || {}`.
  - Writes `transfers` list only; legacy key left as orphan (cleanup PR follows).
- **`docs/fixtures/trainee-model-snapshot.json`** — populated `transfers` entry (bench → ohp, state=published).
- **TS parity test** (`ADR-0006 …`) extended to assert array shape + element fields.
- **Swift parity test** (`TraineeModelSnapshotsCrossValidationTests`) extended to assert `model.transfers[0]` decodes basic 5 fields.
- **`orchestrator_test.ts`** — new `schema-drift-fix` test seeds legacy dict + asserts auto-migration to list with all cells preserved.
- **4 existing EF test sites** rewritten to assert list shape.

## Test plan

- [x] Local deno test on transfer + parity tests → all green
- [x] Local deno full ef-test regression → **456 passed | 0 failed** (up from 455 — added migration test)
- [ ] CI ef-test green
- [ ] **Post-merge alpha verification** (operator): a session-apply lands → check that the alpha row's `model_json.transfers` is a populated array (~70 entries from the legacy dict) and `transferRegressions` either stays as orphan or is auto-cleaned. Sample SQL:
  ```sql
  SELECT
    jsonb_typeof(model_json->'transfers')          AS transfers_type,
    jsonb_array_length(model_json->'transfers')    AS transfers_len,
    jsonb_typeof(model_json->'transferRegressions') AS legacy_type
  FROM public.trainee_models WHERE user_id = '6ce6c575-...';
  ```
- [ ] **Cleanup PR (followup)**: drop the legacy `transferRegressions` JSONB key from prod row + remove the fallback read from EF.

## Migration safety

The legacy fallback read is a one-cycle shim — it ensures existing rows with `transferRegressions` (the alpha row, ~70 cells) survive the cutover with all data preserved. The first session-apply post-deploy auto-migrates: reads legacy dict, processes rule, writes new list shape. The cleanup PR removes the shim after verification.

Closes part of the Phase 2 backend-fixes prerequisite for #89 (B4) — unblocks CROSS-EXERCISE TRANSFER prompt block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)