### PR TITLE
fix(ios): use mesocycle.id as programs.id to prevent FK violations

### DIFF
--- a/ProjectApex/Extensions/Mesocycle+Persistence.swift
+++ b/ProjectApex/Extensions/Mesocycle+Persistence.swift
@@ -87,7 +87,7 @@ extension ProgramRow {
     ///   - userId:    The authenticated user's UUID.
     static func forInsert(from mesocycle: Mesocycle, userId: UUID) -> ProgramRow {
         ProgramRow(
-            id: nil,
+            id: mesocycle.id,
             userId: userId,
             mesocycleJson: mesocycle,
             weeks: mesocycle.totalWeeks,


### PR DESCRIPTION
## Summary

- One-line fix at [`Mesocycle+Persistence.swift:90`](ProjectApex/Extensions/Mesocycle+Persistence.swift#L90): `id: nil` → `id: mesocycle.id`.
- After this, PostgREST persists `programs.id` as the client-supplied UUID instead of auto-generating a fresh one, so the local `Mesocycle.id` and server `programs.id` are guaranteed to match.

## Why

`ProgramRow.forInsert` was sending `id: nil` to PostgREST, which triggered Postgres' `gen_random_uuid()` default for the `programs.id` column. The local `Mesocycle.id` and server `programs.id` never matched, and no reconciliation step (`insertReturning`) ever updated the local id from the response.

The mismatch was hidden for months because `workout_sessions.program_id` was always `NULL` for historic rows (the FK column was nullable). After #162 added the FK constraint and started populating `workout_sessions.program_id` from the local `mesocycle.id`, every session POST started returning **409** with `code: 23503` (FK violation). The `WriteAheadQueue` retried 5 times then silently dropped each item — user-visible effect was sessions completing in-app but never persisting server-side (data loss).

See #181 for the full root-cause investigation and evidence.

## Behavior change for the alpha user

The active server-side programs (created with auto-generated ids over multiple regen cycles) are now orphaned — no local `Mesocycle.id` will ever match them again. The user's *next* regen lands a new row with the local id, `deactivatePrograms` flips the old rows to `is_active=false`, and the system is in a coherent state from that point forward.

For the alpha user specifically, this already happened on 2026-05-15 — `programs.id=7d620ddf-...` was the first row to land with a client-supplied id. The 4 prior rows (`f2048a23`, `87f3a441`, `c7c1167e`, `8f85598a`) remain in the DB as inactive orphans. They're not actively referenced; they could be swept later but it's not blocking.

## Test plan

- [x] Manual: rebuild, regenerate program, verify new `programs.id` matches local `mesocycle.id`.
- [x] End-to-end: new session POSTed → 201 (was 409). Completed session reached `trainee_model_applied_sessions` at 2026-05-17 14:45 UTC. `trainee_models.transfers_len` advanced from `null` → `76`.
- [ ] Code review

## Out of scope (spinoffs filed under #181)

1. **Bug #6** — `WriteAheadQueue` silent-drop after 5 retries with no DLQ. The *real* data-loss path.
2. **Bug #5** — `PATCH 200` silent no-op on missing session_id masks failed writes.
3. **Bug #4** — `GET set_logs?user_id=eq.` returns 400 (column doesn't exist).
4. **`totalWeeks` JSONB key drift** — `mesocycle_json.totalWeeks` is null in the JSONB blob for all historic rows.
5. **Silent error UX** in regen path — fire-and-forget `Task.detached` swallows errors into `os.Logger`.
6. **`is_active=true` orphaning** — `deactivatePrograms` runs before insert without transactional rollback.
7. **`day_type=\"Arms_&_Shoulders\"`** — non-standard token (whitespace + `&`) from macro-skeleton service.

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)