### PR TITLE
fix(tests/#158): update stale XCTAssertNil to assert placeholder semantics post-#149

### DIFF
--- a/ProjectApexTests/TraineeModelUpdateJobTests.swift
+++ b/ProjectApexTests/TraineeModelUpdateJobTests.swift
@@ -215,7 +215,14 @@ final class TraineeModelUpdateJobTests: XCTestCase {
         let outcome = await handler(item)
 
         XCTAssertEqual(outcome, .success, "Phase 1 no-op 200 must still be treated as success")
-        XCTAssertNil(store.load(), "Store must remain empty when server returns an empty model")
+        // Post-#149: empty {} body now decodes to a TraineeModel with placeholder
+        // fields (GoalState.placeholder sentinel, empty patterns/muscles/exercises,
+        // totalSessionCount=0). Verify those placeholder semantics rather than
+        // asserting nil — the production store-persist is correct.
+        let loaded = store.load()
+        XCTAssertEqual(loaded?.goal, .placeholder)
+        XCTAssertEqual(loaded?.totalSessionCount, 0)
+        XCTAssertTrue(loaded?.patterns.isEmpty ?? false)
     }
 
     // MARK: ─── Test 4: HTTP 200 + missing trainee_model key → permanentFailure


### PR DESCRIPTION
## Summary

- `test_flushHandler_on200WithPhase1Stub_returnsSuccess_withoutSavingStore` was asserting `XCTAssertNil(store.load())` but PR #149 made `{"trainee_model":{}}` decode successfully to a `TraineeModel` with `GoalState.placeholder` fields, so the store is no longer nil.
- Fix: replace the nil assertion with three placeholder-semantics assertions (`goal == .placeholder`, `totalSessionCount == 0`, `patterns.isEmpty`). Behavioral intent preserved — placeholder + zero-session is "nothing useful happened."
- Scope: one test, one file, zero production changes.

## Cross-cutting grep results

`grep -rn 'XCTAssertNil.*store.load|trainee_model.*{}' ProjectApexTests/`

| Site | File | Verdict |
|------|------|---------|
| ~218 | TraineeModelUpdateJobTests.swift | FIXED — Phase 1 stub path |
| ~233 | TraineeModelUpdateJobTests.swift | UNTOUCHED — `{"unexpected":"shape"}` malformed JSON; legitimately produces nil |
| ~379 | TraineeModelUpdateJobTests.swift | UNTOUCHED — `late_arrival:true` path; legitimately does not update snapshot |
| ~125, ~165 | TraineeModelLocalStoreTests.swift | UNTOUCHED — store-unit-level tests, different test subject |

No other Phase 1 stub + nil assertion pairs found outside this one test.

## Test plan

- [ ] `xcodebuild test -only-testing:ProjectApexTests/TraineeModelUpdateJobTests/test_flushHandler_on200WithPhase1Stub_returnsSuccess_withoutSavingStore` passes
- [ ] Full `TraineeModelUpdateJobTests` class passes with no regression

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)