### PR TITLE
fix(ef/#173): backfill null-confidence PatternProfiles to bootstrapping

### DIFF
--- a/supabase/functions/_shared/pattern-confidence-backfill.ts
+++ b/supabase/functions/_shared/pattern-confidence-backfill.ts
@@ -1,0 +1,49 @@
+// Project Apex — PatternProfile confidence-backfill helper (#173).
+//
+// Pre-existing patterns (those that existed in model_json.patterns before
+// PR #149/#146 landed the bootstrap producer) carry `confidence: null`
+// because the bootstrap path only runs for newly-discovered patterns
+// (`if (!(pattern in merged))`). This pure function repairs that shape
+// by initializing null-confidence entries to "bootstrapping".
+//
+// Design decisions (locked per prep-prompt):
+// - Producer-side fix, not SQL backfill: survives future field additions
+//   and catches the same shape for any affected user.
+// - Idempotent by construction: writing "bootstrapping" when confidence
+//   is already "bootstrapping" or beyond is a no-op in practice (the
+//   guard checks === null, not a falsy check).
+// - Scope: confidence field only. Other potentially-missing fields
+//   (rpeOffset, recovery, weeklyVolumeLoadHistory) are out of scope
+//   for this issue — #173 explicitly limits to confidence.
+// - Audit: returns a count of patterns actually written so the caller
+//   can conditionally add "pattern-confidence-backfill" to rulesFired.
+
+/**
+ * Walks model_json.patterns entries. For each entry where `confidence`
+ * is exactly `null`, sets it to `"bootstrapping"`.
+ *
+ * @param patterns - The patterns dict from model_json (mutated in place
+ *   on a shallow copy; original is not mutated).
+ * @returns An object with the updated patterns dict and `backfilledCount`
+ *   (number of patterns whose confidence was written).
+ */
+export function backfillPatternConfidence(
+  patterns: Record<string, Record<string, unknown>>,
+): {
+  patterns: Record<string, Record<string, unknown>>;
+  backfilledCount: number;
+} {
+  const updated: Record<string, Record<string, unknown>> = {};
+  let backfilledCount = 0;
+
+  for (const [key, profile] of Object.entries(patterns)) {
+    if (profile.confidence === null) {
+      updated[key] = { ...profile, confidence: "bootstrapping" };
+      backfilledCount++;
+    } else {
+      updated[key] = profile;
+    }
+  }
+
+  return { patterns: updated, backfilledCount };
+}

--- a/supabase/functions/_shared/pattern-confidence-backfill_test.ts
+++ b/supabase/functions/_shared/pattern-confidence-backfill_test.ts
@@ -1,0 +1,105 @@
+// Project Apex — pattern-confidence-backfill unit tests (#173).
+//
+// Run locally:
+//   deno test supabase/functions/_shared/pattern-confidence-backfill_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { backfillPatternConfidence } from "./pattern-confidence-backfill.ts";
+
+// ─── 1: Null-confidence patterns get "bootstrapping" ─────────────────────────
+
+Deno.test(
+  "backfillPatternConfidence_null_confidence_becomes_bootstrapping",
+  () => {
+    const patterns = {
+      isolation: { pattern: "isolation", confidence: null, trend: "declining" },
+      vertical_pull: { pattern: "vertical_pull", confidence: null, trend: "declining" },
+    };
+    const { patterns: result, backfilledCount } = backfillPatternConfidence(patterns);
+    assertEquals(result.isolation.confidence, "bootstrapping");
+    assertEquals(result.vertical_pull.confidence, "bootstrapping");
+    assertEquals(backfilledCount, 2);
+  },
+);
+
+// ─── 2: Already-bootstrapped patterns are untouched ─────────────────────────
+
+Deno.test(
+  "backfillPatternConfidence_bootstrapping_confidence_untouched",
+  () => {
+    const patterns = {
+      squat: { pattern: "squat", confidence: "bootstrapping", trend: "progressing" },
+      hip_hinge: { pattern: "hip_hinge", confidence: "bootstrapping", trend: "progressing" },
+    };
+    const { patterns: result, backfilledCount } = backfillPatternConfidence(patterns);
+    assertEquals(result.squat.confidence, "bootstrapping");
+    assertEquals(result.hip_hinge.confidence, "bootstrapping");
+    assertEquals(backfilledCount, 0);
+  },
+);
+
+// ─── 3: Mixed — null and non-null — only null entries are written ─────────────
+
+Deno.test(
+  "backfillPatternConfidence_mixed_only_null_entries_written",
+  () => {
+    const patterns = {
+      squat: { pattern: "squat", confidence: "bootstrapping", trend: "progressing" },
+      isolation: { pattern: "isolation", confidence: null, trend: "declining" },
+      vertical_pull: { pattern: "vertical_pull", confidence: "calibrating", trend: "plateaued" },
+    };
+    const { patterns: result, backfilledCount } = backfillPatternConfidence(patterns);
+    assertEquals(result.squat.confidence, "bootstrapping");      // untouched
+    assertEquals(result.isolation.confidence, "bootstrapping");  // fixed
+    assertEquals(result.vertical_pull.confidence, "calibrating"); // untouched
+    assertEquals(backfilledCount, 1);
+  },
+);
+
+// ─── 4: Idempotency — running twice produces identical output ────────────────
+
+Deno.test(
+  "backfillPatternConfidence_idempotent_second_run_no_changes",
+  () => {
+    const patterns = {
+      isolation: { pattern: "isolation", confidence: null, trend: "declining" },
+    };
+    const { patterns: afterFirst } = backfillPatternConfidence(patterns);
+    const { patterns: afterSecond, backfilledCount } = backfillPatternConfidence(afterFirst);
+    assertEquals(afterSecond.isolation.confidence, "bootstrapping");
+    assertEquals(backfilledCount, 0, "second run must not re-backfill already-set entries");
+  },
+);
+
+// ─── 5: Empty patterns dict — no-op ─────────────────────────────────────────
+
+Deno.test(
+  "backfillPatternConfidence_empty_patterns_returns_empty",
+  () => {
+    const { patterns: result, backfilledCount } = backfillPatternConfidence({});
+    assertEquals(Object.keys(result).length, 0);
+    assertEquals(backfilledCount, 0);
+  },
+);
+
+// ─── 6: Other fields are preserved ───────────────────────────────────────────
+
+Deno.test(
+  "backfillPatternConfidence_other_fields_preserved_on_fixed_entry",
+  () => {
+    const patterns = {
+      isolation: {
+        pattern: "isolation",
+        confidence: null,
+        trend: "declining",
+        rpeOffset: 2,
+        currentPhase: "accumulation",
+      },
+    };
+    const { patterns: result } = backfillPatternConfidence(patterns);
+    assertEquals(result.isolation.confidence, "bootstrapping");
+    assertEquals(result.isolation.trend, "declining");
+    assertEquals(result.isolation.rpeOffset, 2);
+    assertEquals(result.isolation.currentPhase, "accumulation");
+  },
+);

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -110,6 +110,7 @@ import {
   type NoteToClassify,
 } from "../_shared/note-classifier.ts";
 import { LLMPermanentError, LLMTransientError } from "../_shared/llm-retry.ts";
+import { backfillPatternConfidence } from "../_shared/pattern-confidence-backfill.ts";
 
 export interface UpdateTraineeModelRequest {
   user_id: string;
@@ -1655,8 +1656,19 @@ export async function applySession(
       // Per-pattern rule pipeline. Reads the post-A17 exercises for
       // plateau-verdict's e1rm history derivation (#122 / A20).
       const patternsIn = (modelJson.patterns as Record<string, Record<string, unknown>> | undefined) ?? {};
+
+      // #173: Backfill null-confidence entries on pre-existing patterns.
+      // Patterns created before PR #149/#146 landed the bootstrap producer
+      // carry confidence: null; the bootstrap path only runs for new patterns.
+      // backfillPatternConfidence is idempotent: already-set entries are unchanged.
+      const backfilled = backfillPatternConfidence(patternsIn);
+      if (backfilled.backfilledCount > 0) {
+        rulesFired.push("pattern-confidence-backfill");
+        fieldsChanged.push(`patterns.confidence-backfill.count=${backfilled.backfilledCount}`);
+      }
+
       const ruled = applyPerPatternRules(
-        patternsIn,
+        backfilled.patterns,
         trainedSets.patterns,
         incomingLoggedAt,
         newSessionCount,


### PR DESCRIPTION
## Summary

- Pre-existing patterns (those present before PR #149/#146 landed the bootstrap producer) carry `confidence: null`. The new-pattern bootstrap path (`if (!(pattern in merged))`) never ran for them.
- Downstream: `aggregateStagnationStatus` uses `profile.confidence === "bootstrapping"` — null silently fails this gate, causing pre-existing patterns to be excluded from stagnation aggregation.
- Fix: pure `backfillPatternConfidence` function called once per session-apply before `applyPerPatternRules`. Idempotent by construction.
- Open question Q1 (placement): chose option (b) — pure function called before applyPerPatternRules. Conceptually separate from rule application; easier to test in isolation.
- Open question Q2 (audit log): chose option (a) — adds `"pattern-confidence-backfill"` to `rulesFired` when backfill actually writes ≥1 entry. Provides visibility for confirming the rollout worked; can be removed after alpha-cohort backfill verified.

## Cross-cutting grep results

`grep -rn 'confidence.*null|confidence.*"bootstrapping"|backfill.*pattern' supabase/functions/ ProjectApex/Models/`

| Site | Verdict |
|------|---------|
| `update-trainee-model/index.ts` ~388, ~801 | UNCHANGED — new-pattern bootstrap defaults |
| `per-muscle-rules.ts aggregateStagnationStatus` | UNCHANGED — gate now works correctly for pre-existing patterns |
| New `_shared/pattern-confidence-backfill.ts` | NEW — the fix |
| Orchestrator wiring (~line 1664) | NEW — 1 call site |
| iOS Swift `ProjectApex/Models/` | OUT OF SCOPE — PatternProfile.confidence AxisConfidence enum decode; null would fail Swift decode — separate concern |

## Other null fields on pre-existing patterns (pre-flight gate b findings)

Unable to run live SQL query against alpha row in this session. Per issue body, the fix is scoped to `confidence` only. Other potentially-null fields (`rpeOffset`, `recovery`, `weeklyVolumeLoadHistory`) are out of scope per `#173` out-of-scope clause. Recommend verifying the alpha row post-deploy and filing separate issues if other null fields are found.

## Test plan

- [x] 6 unit tests for `backfillPatternConfidence` — all green
- [x] 9 existing `index_test.ts` validator tests — all green (unaffected by orchestrator wiring)
- [ ] Orchestrator integration tests (require local Supabase) — skipped in this session; CI will run them

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)