### PR TITLE
fix(ios/#37): nonisolated deinit on 4 @MainActor view models to prevent dealloc crash

### DIFF
--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -696,4 +696,9 @@ final class ProgramViewModel {
         }
         return nil
     }
+
+    // Prevents ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
+    // when @State releases this @MainActor class from a CFRunLoop layout-pass
+    // callback that is not inside a Swift Concurrency Task. See issue #37.
+    nonisolated deinit {}
 }

--- a/ProjectApex/Features/Workout/ExerciseSwapViewModel.swift
+++ b/ProjectApex/Features/Workout/ExerciseSwapViewModel.swift
@@ -104,4 +104,9 @@ final class ExerciseSwapViewModel {
         // Surface the latest assistant suggestion (if any)
         pendingSuggestion = msgs.last(where: { $0.role == .assistant })?.suggestion
     }
+
+    // Prevents ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
+    // when @State releases this @MainActor class from a CFRunLoop layout-pass
+    // callback that is not inside a Swift Concurrency Task. See issue #37.
+    nonisolated deinit {}
 }

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -675,4 +675,9 @@ private struct PreviewLLMProvider: LLMProvider {
         }
         """
     }
+
+    // Prevents ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
+    // when @State releases this @MainActor class from a CFRunLoop layout-pass
+    // callback that is not inside a Swift Concurrency Task. See issue #37.
+    nonisolated deinit {}
 }

--- a/ProjectApex/GymScanner/ScannerViewModel.swift
+++ b/ProjectApex/GymScanner/ScannerViewModel.swift
@@ -344,6 +344,11 @@ final class ScannerViewModel {
             nothingDetectedToast = false
         }
     }
+
+    // Prevents ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
+    // when @State releases this @MainActor class from a CFRunLoop layout-pass
+    // callback that is not inside a Swift Concurrency Task. See issue #37.
+    nonisolated deinit {}
 }
 
 


### PR DESCRIPTION
## Summary

- Adds `nonisolated deinit {}` to four `@MainActor final class` view models owned by `@State` in SwiftUI views. Mirrors the ProgressViewModel fix from #36.
- Crash path: `@State`-owned `@MainActor` class released from CFRunLoop layout-pass callback → not inside a Swift Concurrency Task → `swift_task_deinitOnExecutorImpl` → task-local storage lookup finds garbage → `___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED`.
- Bug is latent (no existing test crashes today); this is preventive.
- Q1 (one PR vs four): chose one PR — structurally identical edits, same issue, reviewable in single diff.

## Changes

| Class | File | Owner |
|-------|------|-------|
| `ProgramViewModel` | `Features/Program/ProgramViewModel.swift` | `@State var programViewModel: ProgramViewModel?` in ContentView |
| `WorkoutViewModel` | `Features/Workout/WorkoutViewModel.swift` | `@State private var viewModel: WorkoutViewModel?` in WorkoutView |
| `ExerciseSwapViewModel` | `Features/Workout/ExerciseSwapViewModel.swift` | `@State var viewModel: ExerciseSwapViewModel` in ExerciseSwapView + `@State private var swapViewModel: ExerciseSwapViewModel?` in ActiveSetView |
| `ScannerViewModel` | `GymScanner/ScannerViewModel.swift` | `@State private var viewModel = ScannerViewModel()` in ScannerView |

## Cross-cutting grep results (Q2)

Additional `@MainActor final class` types NOT in the issue body scope:

| Class | File | @State ownership | Verdict |
|-------|------|-----------------|---------|
| `AppDependencies` | `App/AppDependencies.swift` | `@State private var deps = AppDependencies()` in ProjectApexApp | REPORT-ONLY — spinoff issue recommended |
| `LiveSessionWatcher` | `App/LiveSessionWatcher.swift` | No `@State` ownership found | REPORT-ONLY — ownership model differs; lower-risk |

These are NOT edited in this PR per CLAUDE.md Process commitment rule 2 (grep-and-report). Recommend filing spinoff issue for AppDependencies at minimum.

ProgressViewModel (reference fix, #36): confirmed `nonisolated deinit {}` with empty body — pattern mirrored exactly.

## Test plan

- [x] Pre-flight gate (a): all four classes confirmed `@MainActor final class`, no existing `nonisolated deinit`
- [x] Pre-flight gate (b): all four confirmed with `@State` ownership
- [x] Pre-flight gate (c): ProgressViewModel reference pattern confirmed as empty body
- [ ] Full xcodebuild compile passes (CI)
- [ ] Existing test suite green (CI)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)