### PR TITLE
fix(scheme/#38): make APEX_INTEGRATION_TESTS opt-in (isEnabled NO) + doc update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Stale references to a top-level `migrations/` directory should be removed if enc
 
 ### Integration test flag
 
-`APEX_INTEGRATION_TESTS=1` — environment variable that gates live-API tests requiring real credentials and network access. Set in the Xcode scheme's environment variables for local or CI runs. Tests gated by this flag:
+`APEX_INTEGRATION_TESTS=1` — environment variable that gates live-API tests requiring real credentials and network access. Default: `isEnabled = NO` in the shared scheme (PR #38). Opt-in: toggle via Scheme Editor or pass `xcodebuild -e APEX_INTEGRATION_TESTS=1`. CI omits the variable intentionally. Tests gated by this flag:
 - `AIInferenceServiceTests.test_liveAPI_*` — real Anthropic API round-trip
 - `AnthropicProviderCachingTests.test_smokeTest_cacheEffectiveness_*` — two identical Anthropic calls asserting `cache_read_input_tokens > 0` on the second call (verifies prompt-caching mechanism end-to-end; uses a padded system prompt to clear the 1,024-token cache minimum)
 

--- a/ProjectApex.xcodeproj/xcshareddata/xcschemes/ProjectApex.xcscheme
+++ b/ProjectApex.xcodeproj/xcshareddata/xcschemes/ProjectApex.xcscheme
@@ -45,7 +45,7 @@
          <EnvironmentVariable
             key = "APEX_INTEGRATION_TESTS"
             value = "1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
       <TestPlans>


### PR DESCRIPTION
## Summary

- Flips `APEX_INTEGRATION_TESTS` in the shared scheme from `isEnabled = "YES"` to `isEnabled = "NO"`. Variable remains defined (no deletion) so developers can re-enable via Scheme Editor without hunting for the name.
- Every `xcodebuild test` invocation previously ran live Anthropic API tests — non-deterministic based on network latency and key presence. This makes the local test suite deterministic by default.
- Updates CLAUDE.md "Integration test flag" section with a one-line corollary noting NO is the default and documenting the opt-in mechanism.

## Cross-cutting grep results

| Site | Verdict |
|------|---------|
| `.xcscheme` | FIXED — `isEnabled = "YES"` → `"NO"` |
| `AIInferenceServiceTests.swift` — `requireLiveAPI()` helper | UNCHANGED — reads env var; default NO makes tests SKIP correctly |
| `AnthropicProviderCachingTests.swift` | UNCHANGED — same gating pattern |
| `ProgramPersistenceTests.swift`, `ProgramGenerationServiceTests.swift`, `TraineeModelUpdateJobTests.swift` | UNCHANGED — all self-gate via `ProcessInfo` |
| `CLAUDE.md` "Integration test flag" section | UPDATED — one-line corollary added |
| `.github/workflows/ci.yml` | UNCHANGED — already omits `APEX_INTEGRATION_TESTS` intentionally (line ~54 comment) |

## Test plan

- [x] Pre-flight gate (a): confirmed `isEnabled = "YES"` before fix
- [x] Pre-flight gate (b): Xcode not running during edit
- [ ] Post-fix gate (c): `test_liveAPI_*` tests SKIP (not fail) when run without opt-in — verify on next local run

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)