### PR TITLE
fix(tests/#39): remove wall-clock assertion from live API test — wrong for retry paths

### DIFF
--- a/ProjectApexTests/AIInferenceServiceTests.swift
+++ b/ProjectApexTests/AIInferenceServiceTests.swift
@@ -178,9 +178,7 @@ final class AIInferenceServiceTests: XCTestCase {
         )
         let context = WorkoutContext.mockContext()
 
-        let start = Date()
         let result = await service.prescribe(context: context)
-        let elapsed = Date().timeIntervalSince(start)
 
         switch result {
         case .success(let prescription):
@@ -198,9 +196,6 @@ final class AIInferenceServiceTests: XCTestCase {
             // (c) reps in valid range
             XCTAssertTrue((1...30).contains(prescription.reps),
                           "Reps must be in 1–30.")
-            // (d) round-trip completed within 8 seconds (wall clock)
-            XCTAssertLessThan(elapsed, 8.0,
-                              "Live API round-trip must complete in under 8 seconds.")
 
         case .fallback(let reason):
             XCTFail("Expected .success from live API, got fallback: \(reason)")


### PR DESCRIPTION
## Summary

- `XCTAssertLessThan(elapsed, 8.0)` in `test_liveAPI_mockContext_returnsValidPrescription` was structurally wrong: `withTimeout(seconds: 8.0)` is per-attempt, not per-call. With `maxRetries: 2` (3 total attempts), the call can legitimately take ~24s while behaving correctly. Observed failure was 10.35s on a 3-attempt path.
- Fix: delete the assertion (not soften it — any wall-clock assertion on a live API test is a flake source).
- Orphan cleanup: deleted `let start = Date()`, `let elapsed = ...`, and comment `// (d) round-trip...` which were created unused by the deletion (per CLAUDE.md surgical-changes rule).
- Q1 (orphan lines): chose option (a) — delete orphans created by this change.
- No new latency-regression test added — issue body's "if desired" is conditional; out of scope.

## Cross-cutting grep results

`grep -rn 'XCTAssertLessThan.*elapsed|withTimeout.*8' ProjectApexTests/ ProjectApex/`

| Site | Verdict |
|------|---------|
| `AIInferenceServiceTests.swift` — deleted assertion | FIXED |
| `AIInferenceService.swift` — `withTimeout(seconds: 8.0)` production sites | UNCHANGED — correct per-attempt enforcement |
| No other `XCTAssertLessThan(elapsed, ...)` in live API tests | — |

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)