### PR TITLE
fix(ios/#188): surface program-persist failures via non-blocking sync-error banner

### DIFF
--- a/ProjectApex/Features/Program/ProgramOverviewView.swift
+++ b/ProjectApex/Features/Program/ProgramOverviewView.swift
@@ -70,6 +70,54 @@ struct ProgramOverviewView: View {
         // Live-session highlight + set-progress now come from
         // deps.liveSessionWatcher (a single 500ms poll owned by AppDependencies)
         // so this view no longer runs its own loop against the manager actor.
+        // #188: Non-blocking sync-error banner — shown while program remains usable.
+        .overlay(alignment: .top) {
+            if let message = viewModel.persistError {
+                syncErrorBanner(message: message)
+            }
+        }
+    }
+
+    // MARK: - Sync error banner (#188)
+
+    private func syncErrorBanner(message: String) -> some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Image(systemName: "exclamationmark.icloud")
+                    .foregroundStyle(Color(red: 0.91, green: 0.63, blue: 0.19))
+
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+
+                Spacer()
+
+                if viewModel.persistRetryAction != nil {
+                    Button("Retry") {
+                        Task { await viewModel.persistRetryAction?() }
+                    }
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(Color(red: 0.23, green: 0.56, blue: 1.00))
+                }
+
+                Button {
+                    viewModel.dismissPersistError()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.footnote)
+                        .foregroundStyle(.white.opacity(0.6))
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(Color(red: 0.12, green: 0.12, blue: 0.16).opacity(0.95))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+        }
+        .transition(.move(edge: .top).combined(with: .opacity))
+        .animation(.easeInOut(duration: 0.25), value: viewModel.persistError)
     }
 
     // MARK: - Loading

--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -73,6 +73,15 @@ final class ProgramViewModel {
     /// Incremented by ContentView to tell ProgramOverviewView to scroll to the current week.
     var scrollToCurrentWeekTrigger: Int = 0
 
+    // MARK: Sync-error state (#188)
+    /// Non-nil when a background Supabase persist failed. The view renders a
+    /// non-blocking banner so the user is aware the sync failed. Local-first
+    /// design: local state remains valid; sync is the failure, not the local write.
+    var persistError: String?
+    /// Retry action captured at the time of failure. Invoking it re-runs the
+    /// deactivate → insert flow. Set to nil on banner dismissal.
+    var persistRetryAction: (@MainActor @Sendable () async -> Void)?
+
     // MARK: Private
 
     private let supabaseClient: SupabaseClient
@@ -188,19 +197,9 @@ final class ProgramViewModel {
         currentMesocycle = mesocycle
         viewState = .loaded(mesocycle)
 
-        // Also update the Supabase row in the background.
-        let capturedUserId = userId
-        let capturedClient = supabaseClient
-        let capturedMesocycle = mesocycle
-        Task.detached {
-            do {
-                try await capturedClient.deactivatePrograms(userId: capturedUserId)
-                let row = ProgramRow.forInsert(from: capturedMesocycle, userId: capturedUserId)
-                try await capturedClient.insert(row, table: "programs")
-            } catch {
-                programPersistLogger.error("program insert failed (regenerateProgram): \(error.localizedDescription, privacy: .public) — user_id=\(capturedUserId.uuidString, privacy: .public), program_id=\(capturedMesocycle.id.uuidString, privacy: .public). Local cache preserved; row will not exist server-side until a successful retry.")
-            }
-        }
+        // Persist to Supabase in the background. Failure surfaces via persistError
+        // banner (#188) — local-first design; local state is already updated above.
+        Task { await self.persistProgram(mesocycle, context: "regenerateProgram") }
     }
 
     /// Returns a flat list of all terminal TrainingDays (`.completed` or `.skipped`) in the
@@ -212,6 +211,46 @@ final class ProgramViewModel {
         return mesocycle.weeks.flatMap { week in
             week.trainingDays.filter { $0.status == .completed || $0.status == .skipped }
         }
+    }
+
+    // MARK: - Sync helper (#188)
+
+    /// Deactivates existing programs and inserts a new row server-side.
+    /// On failure, surfaces the error via `persistError` + `persistRetryAction`
+    /// rather than swallowing it. Local state is unaffected (local-first design).
+    ///
+    /// - Parameters:
+    ///   - mesocycle: The mesocycle to persist.
+    ///   - context: A short label for the logger (e.g. "regenerateProgram").
+    private func persistProgram(_ mesocycle: Mesocycle, context: String) async {
+        let capturedClient = supabaseClient
+        let capturedUserId = userId
+        let capturedMesocycle = mesocycle
+        do {
+            try await capturedClient.deactivatePrograms(userId: capturedUserId)
+            let row = ProgramRow.forInsert(from: capturedMesocycle, userId: capturedUserId)
+            try await capturedClient.insert(row, table: "programs")
+            // Success: clear any prior sync error.
+            persistError = nil
+            persistRetryAction = nil
+        } catch {
+            programPersistLogger.error(
+                "program insert failed (\(context)): \(error.localizedDescription, privacy: .public)"
+                + " — user_id=\(capturedUserId.uuidString, privacy: .public)"
+                + ", program_id=\(capturedMesocycle.id.uuidString, privacy: .public)"
+                + ". Local cache preserved; row will not exist server-side until a successful retry."
+            )
+            persistError = "Couldn't sync your program. Tap to retry."
+            persistRetryAction = { [weak self] in
+                await self?.persistProgram(capturedMesocycle, context: context)
+            }
+        }
+    }
+
+    /// Dismisses the sync-error banner without retrying.
+    func dismissPersistError() {
+        persistError = nil
+        persistRetryAction = nil
     }
 
     // MARK: - Generate (legacy static path — ProgramGenerationService)
@@ -253,18 +292,9 @@ final class ProgramViewModel {
                 trainingDaysPerWeek: daysPerWeek
             )
             if persistToSupabase {
-                // Persist to Supabase (fire-and-forget for UX speed)
-                let capturedUserId = userId
-                let capturedClient = supabaseClient
-                Task.detached {
-                    do {
-                        try await capturedClient.deactivatePrograms(userId: capturedUserId)
-                        let row = ProgramRow.forInsert(from: mesocycle, userId: capturedUserId)
-                        try await capturedClient.insert(row, table: "programs")
-                    } catch {
-                        programPersistLogger.error("program insert failed (generateProgram): \(error.localizedDescription, privacy: .public) — user_id=\(capturedUserId.uuidString, privacy: .public), program_id=\(mesocycle.id.uuidString, privacy: .public). Local cache preserved; row will not exist server-side until a successful retry.")
-                    }
-                }
+                // Persist to Supabase in the background. Failure surfaces via
+                // persistError banner (#188) — local-first design.
+                Task { await self.persistProgram(mesocycle, context: "generateProgram") }
             }
             mesocycle.saveToUserDefaults()
             currentMesocycle = mesocycle
@@ -316,18 +346,9 @@ final class ProgramViewModel {
             let mesocycle = MacroPlanService.buildPendingMesocycle(from: skeleton, userId: userId)
 
             if persistToSupabase {
-                // Persist to Supabase (fire-and-forget)
-                let capturedUserId = userId
-                let capturedClient = supabaseClient
-                Task.detached {
-                    do {
-                        try await capturedClient.deactivatePrograms(userId: capturedUserId)
-                        let row = ProgramRow.forInsert(from: mesocycle, userId: capturedUserId)
-                        try await capturedClient.insert(row, table: "programs")
-                    } catch {
-                        programPersistLogger.error("program insert failed (generateMacroSkeleton): \(error.localizedDescription, privacy: .public) — user_id=\(capturedUserId.uuidString, privacy: .public), program_id=\(mesocycle.id.uuidString, privacy: .public). Local cache preserved; row will not exist server-side until a successful retry.")
-                    }
-                }
+                // Persist to Supabase in the background. Failure surfaces via
+                // persistError banner (#188) — local-first design.
+                Task { await self.persistProgram(mesocycle, context: "generateMacroSkeleton") }
             }
             mesocycle.saveToUserDefaults()
             currentMesocycle = mesocycle


### PR DESCRIPTION
## Summary

- Three `Task.detached` blocks in `ProgramViewModel` caught server-persist failures with `os.Logger` only. User had zero visibility into sync failures. This was how Bug #2 (#181) stayed invisible for weeks.
- Fix: extract `persistProgram(mesocycle:context:)` helper that sets `persistError` + `persistRetryAction` on failure. Add `syncErrorBanner` overlay in `ProgramOverviewView` that shows when `persistError != nil`.
- Non-blocking design: program remains usable (`.loaded` state unchanged), banner overlays at top.
- Local-first invariant preserved: local state is updated before the async task; failure never rolls back local `Mesocycle` or `viewState`.

## Open question resolutions

| Q | Recommendation chosen | Rationale |
|---|----------------------|-----------|
| Q1 (centralize) | (b) shared helper | Three identical catch blocks → single `persistProgram()` |
| Q2 (retry) | (a) manual retry only | Auto-retry without user awareness adjacent to silent-failure pattern being fixed |
| Q3 (banner copy) | (b) "Couldn't sync your program. Tap to retry." | Shorter, user-friendly vs technical "server sync failed" |
| Q4 (categorization) | (a) single error category | Simpler UX; all errors get same banner; categorization is follow-up |

## Relationship to #185

- #185: makes PATCH no-ops visible (server-side guard)
- #188: makes raised errors visible to the user (UI-side guard)
- Both safe to merge in any order.

## Cross-cutting grep — other Task.detached + fire-and-forget sites (REPORT-ONLY)

These are NOT edited in this PR (CLAUDE.md Process commitment rule 2):

| File | Location | Pattern |
|------|----------|---------|
| `ProgramDayDetailView.swift` | ~1069, ~1180 | `Task.detached { ... }` |
| `ManualSessionLogView.swift` | ~426 | `Task.detached { }` (RAG memory embed) |
| `WorkoutSessionManager.swift` | Multiple | Fire-and-forget memory embeds, gym streak, set writes |

Recommendation: file spinoff issues for the `WorkoutSessionManager` fire-and-forget writes (most critical for data integrity). ProgramDayDetailView and ManualSessionLogView are lower-risk (memory embed failures).

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)