### PR TITLE
arch(#191): remove SupabaseClient.serviceKey — service-role JWT cannot exist in client

### DIFF
--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -94,11 +94,7 @@ final class AppDependencies {
 
         // 2. Supabase — needs its anon key from Keychain; URL comes from Config
         let supabaseAnonKey = (try? keychain.retrieve(.supabaseAnonKey)) ?? ""
-        let supabaseServiceKey = (try? keychain.retrieve(.supabaseServiceKey)) ?? ""
         let client = SupabaseClient(supabaseURL: Config.supabaseURL, anonKey: supabaseAnonKey)
-        if !supabaseServiceKey.isEmpty {
-            Task { await client.set(serviceKey: supabaseServiceKey) }
-        }
         self.supabaseClient = client
 
         // 3. HealthKit — no dependencies

--- a/ProjectApex/Security/KeychainService.swift
+++ b/ProjectApex/Security/KeychainService.swift
@@ -38,9 +38,6 @@ enum KeychainKey: String, CaseIterable {
     case supabaseAnonKey  = "com.projectapex.keychain.supabaseAnonKey"
     /// Stable user identifier (UUID string) persisted between app reinstalls.
     case userId           = "com.projectapex.keychain.userId"
-    /// Supabase service role key (JWT). Bypasses RLS — used for MVP writes
-    /// until real Supabase Auth is wired. Never expose this to end users.
-    case supabaseServiceKey = "com.projectapex.keychain.supabaseServiceKey"
 }
 
 // MARK: - KeychainError

--- a/ProjectApex/Services/SupabaseClient.swift
+++ b/ProjectApex/Services/SupabaseClient.swift
@@ -98,10 +98,6 @@ actor SupabaseClient {
     /// request instead of (not in addition to) the anon key.
     var authToken: String?
 
-    /// Supabase service role key. When set, used as the bearer token on all
-    /// requests, bypassing RLS. For MVP use only — remove once real auth lands.
-    var serviceKey: String?
-
     // MARK: - Private helpers
 
     private let session: URLSession
@@ -122,12 +118,6 @@ actor SupabaseClient {
         let dec = JSONDecoder()
         dec.dateDecodingStrategy = .iso8601
         self.decoder = dec
-    }
-
-    // MARK: - Setters (actor-isolated for external callers)
-
-    func set(serviceKey: String?) {
-        self.serviceKey = serviceKey
     }
 
     // MARK: - Public API
@@ -439,10 +429,8 @@ actor SupabaseClient {
         request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        // Bearer priority: service key > user auth token > anon key.
-        if let key = serviceKey, !key.isEmpty {
-            request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-        } else if let token = authToken {
+        // Bearer priority: user auth token > anon key.
+        if let token = authToken {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         } else {
             request.setValue("Bearer \(anonKey)", forHTTPHeaderField: "Authorization")

--- a/ProjectApex/Settings/DeveloperSettingsView.swift
+++ b/ProjectApex/Settings/DeveloperSettingsView.swift
@@ -48,19 +48,16 @@ struct DeveloperSettingsView: View {
     @State private var anthropicKey: String    = ""
     @State private var openAIKey: String       = ""
     @State private var supabaseKey: String     = ""
-    @State private var supabaseServiceKey: String = ""
 
     /// Tracks which fields are revealing plain text.
     @State private var showAnthropic: Bool     = false
     @State private var showOpenAI: Bool        = false
     @State private var showSupabase: Bool      = false
-    @State private var showServiceKey: Bool    = false
 
     /// Keychain presence status loaded on appear / after save.
     @State private var anthropicStored: Bool      = false
     @State private var openAIStored: Bool         = false
     @State private var supabaseStored: Bool       = false
-    @State private var supabaseServiceStored: Bool = false
     @State private var supabaseAnonKeyValue: String? = nil
 
     /// Banner shown after a save attempt.
@@ -104,7 +101,6 @@ struct DeveloperSettingsView: View {
             anthropicSection
             openAISection
             supabaseSection
-            supabaseServiceSection
             saveSection
             developerToolsSection
         }
@@ -210,34 +206,6 @@ struct DeveloperSettingsView: View {
                     .foregroundStyle(.secondary)
                     .textSelection(.enabled)
             }
-            HStack {
-                statusRow(label: "Supabase Service Key", isPresent: supabaseServiceStored)
-                if supabaseServiceStored {
-                    Button(role: .destructive) {
-                        Task { await clearSupabaseServiceKey() }
-                    } label: {
-                        Image(systemName: "trash")
-                            .foregroundStyle(.red)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Delete Supabase service key from Keychain")
-                }
-            }
-        }
-    }
-
-    /// Deletes the stored Supabase service-role key from the Keychain and clears
-    /// it from the live `SupabaseClient` so subsequent requests fall back to the
-    /// anon key as the bearer.
-    @MainActor
-    private func clearSupabaseServiceKey() async {
-        do {
-            try keychain.delete(.supabaseServiceKey)
-            await deps.supabaseClient.set(serviceKey: nil)
-            refreshStoredStatus()
-            showBanner("Supabase service key cleared.", isError: false)
-        } catch {
-            showBanner("Failed to clear service key: \(error.localizedDescription)", isError: true)
         }
     }
 
@@ -338,23 +306,6 @@ struct DeveloperSettingsView: View {
             Text("Supabase")
         } footer: {
             Text("Anonymous key for database reads and RAG memory retrieval.")
-                .font(.caption)
-        }
-    }
-
-    private var supabaseServiceSection: some View {
-        Section {
-            apiKeyField(
-                label: "Supabase Service Key",
-                hint: "eyJ...",
-                text: $supabaseServiceKey,
-                showPlainText: $showServiceKey
-            )
-            formatHint("JWT — begins with \"eyJ\". Bypasses RLS for MVP writes.")
-        } header: {
-            Text("Supabase Service Role (MVP)")
-        } footer: {
-            Text("Required until Supabase Auth is wired. Allows the app to write embeddings and session data. Keep secret — never share publicly.")
                 .font(.caption)
         }
     }
@@ -564,30 +515,12 @@ struct DeveloperSettingsView: View {
             }
         }
 
-        // Supabase service role key (JWT)
-        if !supabaseServiceKey.isEmpty {
-            if !supabaseServiceKey.hasPrefix("eyJ") {
-                errors.append("Supabase service key must start with \"eyJ\" (JWT)")
-            } else {
-                do {
-                    try keychain.store(supabaseServiceKey, for: .supabaseServiceKey)
-                    savedCount += 1
-                    // Apply immediately to the live SupabaseClient so current session benefits.
-                    let key = supabaseServiceKey
-                    Task { await deps.supabaseClient.set(serviceKey: key) }
-                } catch {
-                    errors.append("Supabase Service: \(error.localizedDescription)")
-                }
-            }
-        }
-
         // Refresh stored-status indicators.
         refreshStoredStatus()
         // Clear text fields so the saved values are no longer visible.
         anthropicKey      = ""
         openAIKey         = ""
         supabaseKey       = ""
-        supabaseServiceKey = ""
 
         // Show banner.
         if errors.isEmpty {
@@ -607,7 +540,6 @@ struct DeveloperSettingsView: View {
         openAIStored         = (try? keychain.retrieve(.openAIAPIKey))       != nil
         supabaseAnonKeyValue  = try? keychain.retrieve(.supabaseAnonKey)
         supabaseStored       = supabaseAnonKeyValue != nil
-        supabaseServiceStored = (try? keychain.retrieve(.supabaseServiceKey)) != nil
     }
 
     /// Displays the banner for 3 seconds then hides it.


### PR DESCRIPTION
## Summary

Structural removal of the service-role bypass path from the iOS client. Closes #191.

The `serviceKey` property on `SupabaseClient` existed "for MVP use only — remove once real auth lands." MVP is over; real auth and RLS are the path forward. A stale service-role JWT in keychain caused the #180 EF 401 cascade. PR #182 shipped a defensive Clear button; this PR removes the architectural capability entirely.

**What was removed (5 layers, 4 commits):**

1. `SupabaseClient.serviceKey` property, `set(serviceKey:)` setter, and the `if let key = serviceKey` Bearer-priority branch in `baseRequest()`. Bearer priority is now: `authToken > anonKey`.
2. `AppDependencies` lines that read `.supabaseServiceKey` from the Keychain at startup and applied it to the live actor.
3. All service-key UI in `DeveloperSettingsView`: the `supabaseServiceSection` (input field, header/footer), the HStack status row + Clear button (PR #182), the `clearSupabaseServiceKey()` function, the service-key validation + store + live-actor-apply block in `saveKeys()`, and the `supabaseServiceStored` refresh line. Surgical — adjacent anonKey/authToken/anthropic/openAI paths untouched.
4. `KeychainKey.supabaseServiceKey` enum case. Direct removal per Q1 recommendation; no exhaustive switch sites existed outside the already-removed call sites — compiler verified clean.

**What was kept:** `anonKey`, `authToken`, all other Keychain cases, all other DeveloperSettingsView sections.

**Tests:** 0 test sites exercised the service-key path (pre-flight grep confirmed). 231 tests run; 231 pass. 2 pre-existing failures (`test_networkFailure_urlError_returnsFallbackLLMProviderError`, `test_programRow_forInsert_hasNilIdAndCreatedAt`) are unrelated to this change and existed on `main` before these commits.

## Open questions resolved (per prep prompt)

- **Q1 (enum removal):** Direct removal (a). Compiler surfaced no exhaustive-switch orphans beyond already-removed call sites.
- **Q2 (DeveloperSettingsView shape):** Surgical (a). Only service-key elements removed; view compiles and renders cleanly.
- **Q3 (migration):** Dead data (a). Keychain entry for any user who had the key will persist but is never read — harmless at alpha scale. **Pre-merge operator step: clear your keychain via `security delete-generic-password -s com.projectapex.keychain.supabaseServiceKey` or Keychain Access before merging, if any service key was previously stored.**
- **Q4 (CLAUDE.md edge-functions doc):** No update needed (a). `docs/agents/edge-functions.md` covers EF-side secrets (Supabase platform-injected `SUPABASE_SERVICE_ROLE_KEY`, rotation policy, password manager storage) — it does not describe client-side service-key injection. Correct as-is.

## Cross-cutting grep report (CLAUDE.md rule 2)

Final grep for `serviceKey|supabaseServiceKey|service.role|bypass.RLS` found only expected EF-side documentation hits:

- `docs/agents/edge-functions.md` — 15 hits, all describing EF-side `SUPABASE_SERVICE_ROLE_KEY` (platform-injected, rotation policy, password manager). No change needed; this is correct EF infrastructure documentation.
- `docs/phase-2-cleanup-plan-2026-05-12.md:69` — historical reference to a one-off CLI backfill script that used a service-role key for a past operation. Documentation of a completed event; no code change needed.
- `CLAUDE.md` — references `docs/agents/edge-functions.md` as authoritative for EF secrets. Correctly scoped to EF-side; no change needed.

No additional iOS code sites found.

## Pre-deploy / pre-merge reminders

- **Operator keychain cleanup (Q3):** If you have a stale `.supabaseServiceKey` entry in your keychain from prior MVP-era usage, clear it before or after merge — it becomes dead data but is harmless. Command: `security delete-generic-password -s com.projectapex.keychain.supabaseServiceKey -a ProjectApex` (adjust account name as needed), or use the Clear button in Developer Settings while the old build is still installed.
- **Post-merge spinoff:** Consider filing a short ADR codifying the "client cannot bypass RLS" invariant — the architectural posture is now structural (deleted), not convention-based. Not required by this PR.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)