### PR TITLE
fix(tests): wrap integration teardown deactivatePrograms in try? (#205)

### DIFF
--- a/ProjectApexTests/ProgramPersistenceTests.swift
+++ b/ProjectApexTests/ProgramPersistenceTests.swift
@@ -378,8 +378,9 @@ final class ProgramPersistenceTests: XCTestCase {
         // Use a stable test user ID that exists in the test project
         let testUser = UUID(uuidString: "00000000-0000-0000-0000-000000000099") ?? UUID()
 
-        // Deactivate any existing programs for this test user
-        try await client.deactivatePrograms(userId: testUser)
+        // Deactivate any existing programs for this test user.
+        // try? — patchNoMatch is expected when the test user has no programs yet.
+        try? await client.deactivatePrograms(userId: testUser)
 
         // Insert a mock mesocycle
         var mesocycle = Mesocycle.mockMesocycle()
@@ -406,7 +407,8 @@ final class ProgramPersistenceTests: XCTestCase {
         XCTAssertEqual(decoded.weeks.count, mesocycle.weeks.count)
         XCTAssertTrue(fetchedRow.isActive)
 
-        // Cleanup: deactivate the test row
-        try await client.deactivatePrograms(userId: testUser)
+        // Cleanup: deactivate the test row.
+        // try? — patchNoMatch is swallowed; we only care that nothing remains.
+        try? await client.deactivatePrograms(userId: testUser)
     }
 }


### PR DESCRIPTION
## Summary

- Wraps the pre-test setup `deactivatePrograms` call in `try?` so a `patchNoMatch` error is swallowed when the integration test user has no programs yet.
- Wraps the post-test cleanup `deactivatePrograms` call in `try?` for the same reason — teardown should succeed regardless of whether any rows were deactivated.
- Zero production code changes; test file only.

## Context

Spinoff from PR #201 / issue #185. `performExpectingRow` now throws `SupabaseError.patchNoMatch` when a PATCH returns 200 with zero matched rows. Running the integration suite (`APEX_INTEGRATION_TESTS=1`) against a fresh test user with no prior programs caused noisy teardown failures. `try?` is the correct form for deactivation guards in test teardown — we care only that nothing remains, not whether there was anything to remove.

## Test plan

- [ ] Default CI (no `APEX_INTEGRATION_TESTS=1`): no change to existing unit test outcomes — stub tests at lines 195–227 unaffected.
- [ ] Integration run (`APEX_INTEGRATION_TESTS=1`) against a fresh test user: teardown is clean, no `patchNoMatch` thrown.
- [ ] Integration run against a test user with existing programs: behavior unchanged (deactivation still runs, `try?` discards the non-error return).

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)