### PR TITLE
fix(ios/#204): nonisolated deinit on LiveSessionWatcher to prevent dealloc crash

### DIFF
--- a/ProjectApex/App/LiveSessionWatcher.swift
+++ b/ProjectApex/App/LiveSessionWatcher.swift
@@ -69,4 +69,9 @@ final class LiveSessionWatcher {
         pausedSessionExists = UserDefaults.standard.data(forKey: PausedSessionState.v2PersistenceKey) != nil
             || UserDefaults.standard.data(forKey: PausedSessionState.legacyPersistenceKey) != nil
     }
+
+    // Prevents ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
+    // when @State releases this @MainActor class from a CFRunLoop layout-pass
+    // callback that is not inside a Swift Concurrency Task. See issue #37.
+    nonisolated deinit {}
 }


### PR DESCRIPTION
## Summary

- Adds `nonisolated deinit {}` to `LiveSessionWatcher` (`App/LiveSessionWatcher.swift`), matching the pattern landed in PR #198 (#37) for 4 `@MainActor` view models.
- Prevents `___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED` when `@State` releases this class from a CFRunLoop layout-pass callback outside a Swift Concurrency Task.
- No behaviour change; latent-bug defence in depth. No new tests (L4 LOCKED, same rationale as #37).

## Cross-cutting grep report

Other `@MainActor final class` sites without `nonisolated deinit` (not authorized by this issue — grep-and-report per CLAUDE.md):
- `App/AppDependencies.swift` — flagged in #198 as higher-risk (no confirmed `@State` owner); tracked separately as #38 spinoff.
- `Features/Program/ProgramViewModel.swift` — not yet assessed.
- `Services/TraineeModelLocalStore.swift` — not yet assessed.
- `Services/LateArrivalNotificationQueue.swift` — not yet assessed.

Sites already covered: `ProgressViewModel`, `ExerciseSwapViewModel`, `WorkoutViewModel`, `ScannerViewModel` (all via PR #198).

Closes #204