### PR TITLE
fix(ios/#203): nonisolated deinit on AppDependencies to prevent dealloc crash

### DIFF
--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -224,4 +224,8 @@ final class AppDependencies {
             traineeModelService: traineeModelService
         )
     }
+
+    // MARK: - Lifecycle
+
+    nonisolated deinit {}
 }


### PR DESCRIPTION
## Summary

- Adds `nonisolated deinit {}` to `AppDependencies` (`App/AppDependencies.swift`), matching the pattern landed for four view models in PR #198 (#37).
- `AppDependencies` is an `@Observable @MainActor final class` owned by `@State private var deps = AppDependencies()` in `ProjectApexApp` — the higher-risk site from the #198 grep because `@State`-owned objects are released by SwiftUI's layout machinery, which runs off the main actor.
- Crash path: `@State`-owned `@MainActor` class released from CFRunLoop layout-pass callback → not inside a Swift Concurrency Task → `swift_task_deinitOnExecutorImpl` → task-local storage lookup finds garbage → `___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED`.
- Bug is latent; no new tests required (same L4 LOCKED rationale as #37).

## Cross-cutting grep (CLAUDE.md compliance)

All `@MainActor final class` sites in the source tree were checked. Sites with `nonisolated deinit {}` coverage:

| Class | Status |
|---|---|
| `AppDependencies` | Fixed in this PR |
| `ProgressViewModel`, `ProgramViewModel`, `WorkoutViewModel`, `ExerciseSwapViewModel`, `ScannerViewModel` | Fixed in PR #198 |
| `LiveSessionWatcher` | Out of scope — separate spinoff per #203 issue body; lower-risk (no `@State` ownership found) |
| `LateArrivalNotificationQueue`, `TraineeModelLocalStore` | Not edited — out of scope for this PR; reported here per grep-and-report rule |

Closes #203