### PR TITLE
fix(ios): add nonisolated deinit {} to ProgramViewModel (#37 spinoff)

### DIFF
--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -107,6 +107,8 @@ final class ProgramViewModel {
         self.userId = userId
     }
 
+    nonisolated deinit {}
+
     // MARK: - Load
 
     /// Loads the active program: tries UserDefaults cache first, then Supabase.


### PR DESCRIPTION
## Summary

- Adds `nonisolated deinit {}` to `ProgramViewModel` (`@MainActor final class`) to prevent a potential dealloc crash if the instance is released off the main actor.
- Surgical 2-line insertion matching the pattern from PRs #198 / #208 / #209.
- No behavior change; no new tests (L4 LOCKED, same rationale as #37).

## Grep report (grep-and-report, not grep-and-rewrite)

Cross-cutting grep surfaced additional `@MainActor final class` sites still missing `nonisolated deinit {}`. Listed here for awareness — NOT edited in this PR (not authorized):

- `ProjectApex/Services/LateArrivalNotificationQueue.swift` — `final class LateArrivalNotificationQueue`
- `ProjectApex/Services/TraineeModelLocalStore.swift` — `final class TraineeModelLocalStore`
- `ProjectApex/Features/Workout/WorkoutViewModel.swift` — `final class WorkoutViewModel`
- `ProjectApex/Features/Progress/ProgressViewModel.swift` — `final class ProgressViewModel`
- `ProjectApex/GymScanner/ScannerViewModel.swift` — `final class ScannerViewModel`

Each is a candidate for a follow-up spinoff issue (same pattern as #203, #204, #205, #210).

## Test plan

- [ ] Build passes (no new tests required per acceptance criteria)
- [ ] Confirm `nonisolated deinit {}` present in `ProgramViewModel`

Closes #210