### PR TITLE
fix(ios/#212): nonisolated deinit on LateArrivalNotificationQueue to prevent dealloc crash

### DIFF
--- a/ProjectApex/Services/LateArrivalNotificationQueue.swift
+++ b/ProjectApex/Services/LateArrivalNotificationQueue.swift
@@ -44,6 +44,8 @@ final class LateArrivalNotificationQueue {
         self.key      = key
     }
 
+    nonisolated deinit {}
+
     // MARK: - Factories
 
     /// Production queue persisted to `UserDefaults.standard`.


### PR DESCRIPTION
## Summary

- Adds `nonisolated deinit {}` to `LateArrivalNotificationQueue`, an `@MainActor final class` missing this guard.
- Matches the identical pattern landed in PRs #198 (4 view models), #208 (LiveSessionWatcher), #209 (AppDependencies).
- No behavior change; no new tests required (latent crash prevention, L4 LOCKED per issue #37 precedent).

## Cross-cutting grep

After the fix, grepped all `@MainActor final class` sites in the main source tree. Results:

| Class | nonisolated deinit {} | Notes |
|---|---|---|
| LiveSessionWatcher | present | PR #208 |
| AppDependencies | present | PR #209 |
| ProgressViewModel | present | PR #198 |
| ProgramViewModel | present | already in main (issue #210 may be stale) |
| ExerciseSwapViewModel | present | PR #198 |
| WorkoutViewModel | present | PR #198 |
| LateArrivalNotificationQueue | **added here** | this PR |
| TraineeModelLocalStore | absent | open issue #211 — not authorized for this dispatch |

`TraineeModelLocalStore` is reported-not-edited per grep-and-report rule. Issue #211 tracks it.

Closes #212