### PR TITLE
fix(ios/#211): nonisolated deinit on TraineeModelLocalStore to prevent dealloc crash

### DIFF
--- a/ProjectApex/Services/TraineeModelLocalStore.swift
+++ b/ProjectApex/Services/TraineeModelLocalStore.swift
@@ -59,6 +59,11 @@ final class TraineeModelLocalStore {
         self.container = container
     }
 
+    // Prevents dealloc crash when the OS releases this object off the main
+    // actor (e.g. from CFRunLoop callbacks). Stored properties are all Swift
+    // value types — safe to release on any thread.
+    nonisolated deinit {}
+
     // MARK: Factories
 
     /// Production store — persisted to the app's default SwiftData location.


### PR DESCRIPTION
## Summary

Adds `nonisolated deinit {}` to `TraineeModelLocalStore` (an `@MainActor final class`) to prevent a latent dealloc crash when the OS releases the object off the main actor from a CFRunLoop callback.

Matches the identical pattern landed in:
- PR #198 (`ProgressViewModel`)
- PR #208 (`LiveSessionWatcher`, issue #204)
- PR #209 (`AppDependencies`, issue #203)

## Change

Single insertion in `TraineeModelLocalStore.swift` — 5 lines (comment + `nonisolated deinit {}`). No behaviour change. No tests required (L4 LOCKED, same rationale as #37).

## Cross-cutting grep results

All `@MainActor final class` sites checked:

| Class | Has `nonisolated deinit`? |
|---|---|
| `ProgressViewModel` | yes (PR #198) |
| `LiveSessionWatcher` | yes (PR #208) |
| `AppDependencies` | yes (PR #209) |
| `ProgramViewModel` | yes |
| `WorkoutViewModel` | yes |
| `ScannerViewModel` | yes |
| `TraineeModelLocalStore` | **yes (this PR)** |
| `LateArrivalNotificationQueue` | **no** — additional unpatched site; reported, not edited per grep-and-report rule. Recommend spinoff issue. |

`CameraManager` is `NSObject` subclass without `@MainActor` isolation — different pattern, not applicable.

## Pre-deploy reminders

None.

## Spinoff recommendation

`LateArrivalNotificationQueue` is an `@MainActor final class` with no `nonisolated deinit {}` — same risk profile. Recommend opening a follow-up issue.

Closes #211