### PR TITLE
refactor(#159): consolidate Inference prompt — .txt becomes canonical source

### DIFF
--- a/ProjectApex/AICoach/AIInferenceService.swift
+++ b/ProjectApex/AICoach/AIInferenceService.swift
@@ -668,6 +668,12 @@ nonisolated enum FallbackReason: Sendable {
     /// no same-prompt retry. Surfaced via `InferenceRetrySheet` so the
     /// user gets agency rather than a silent default.
     case malformedResponse(String)
+    /// SystemPrompt_Inference.txt is missing from the app bundle — a
+    /// deploy-time misconfiguration. Per #159 / L6: production paths
+    /// propagate the loader throw to `.fallback(reason:)` rather than
+    /// `fatalError`-ing or silently degrading (ADR-0007 §1). Retry will
+    /// not help; the retry-sheet copy should direct the user to support.
+    case systemPromptUnavailable(String)
 }
 
 nonisolated enum PrescriptionResult: Sendable {
@@ -865,7 +871,12 @@ actor AIInferenceService {
             return .fallback(reason: .encodingFailed("Failed to encode WorkoutContext to JSON."))
         }
 
-        let systemPrompt = Self.systemPrompt
+        let systemPrompt: String
+        do {
+            systemPrompt = try Self.loadSystemPrompt()
+        } catch {
+            return .fallback(reason: .systemPromptUnavailable(error.localizedDescription))
+        }
         let userPayload = contextJSON
 
         // Per ADR-0007 §1: malformed-response and validation errors are
@@ -1009,7 +1020,12 @@ actor AIInferenceService {
         userPayload: String,
         workoutContext: WorkoutContext
     ) async -> PrescriptionResult {
-        let systemPrompt = Self.systemPrompt
+        let systemPrompt: String
+        do {
+            systemPrompt = try Self.loadSystemPrompt()
+        } catch {
+            return .fallback(reason: .systemPromptUnavailable(error.localizedDescription))
+        }
 
         do {
             let rawResponse = try await withTimeout(seconds: 8.0) {

--- a/ProjectApex/AICoach/AIInferenceService.swift
+++ b/ProjectApex/AICoach/AIInferenceService.swift
@@ -675,6 +675,20 @@ nonisolated enum PrescriptionResult: Sendable {
     case fallback(reason: FallbackReason)
 }
 
+// MARK: ─── AIInferenceError ──────────────────────────────────────────────────
+
+nonisolated enum AIInferenceError: LocalizedError {
+    case systemPromptNotFound
+
+    var errorDescription: String? {
+        switch self {
+        case .systemPromptNotFound:
+            return "SystemPrompt_Inference.txt not found in the app bundle. " +
+                   "Ensure the file is in the target's Copy Bundle Resources build phase."
+        }
+    }
+}
+
 // MARK: ─── WorkoutContext Mock ───────────────────────────────────────────────
 
 extension WorkoutContext {
@@ -1130,215 +1144,33 @@ actor AIInferenceService {
     // ACTIVE LIMITATIONS, FORM-DEGRADATION FLAG blocks; rewrote DELOAD DETECTION
     // to read trainee_model_digest.weekly_fatigue (pre-derived flags, no
     // coaching judgement). Cumulative cache-bust on top of v5.0's PER-PATTERN
-    // TREND addition (ADR-0009 + ADR-0011). Changing this literal invalidates
+    // TREND addition (ADR-0009 + ADR-0011). Changing the prompt body invalidates
     // the PromptCachingProvider cache on the next prescribe() call.
     //
-    // NOTE: SystemPrompt_Inference.txt is a deprecated parallel mirror, loaded
-    // only by InferenceSpike. THIS inline string is the production authority.
-    // Track consolidation in the spinoff referenced from the file's header.
+    // The prompt body lives in Resources/Prompts/SystemPrompt_Inference.txt
+    // (per #159 consolidation). The accessor loads from the bundle resource at
+    // call time via `loadSystemPrompt()`; β prompt-anchor tests read it via
+    // the static accessor and remain unchanged.
     //
     // Access is `internal` (not `private`) so β prompt-anchor tests can
     // assert against the exact string production reads — a test-only
     // accessor would be a new code path subject to drift.
 
-    internal static let systemPrompt = """
-        You are an elite AI strength and hypertrophy coach embedded in a workout app. \
-        Your sole job is to prescribe the next set for the user based on the provided WorkoutContext JSON.
+    internal static var systemPrompt: String { try! loadSystemPrompt() }
 
-        RESPONSE FORMAT — you must return ONLY a JSON object with this exact structure:
-        {
-          "set_prescription": {
-            "weight_kg": <number, >= 0, ≤ 500>,
-            "reps": <integer, 1–30>,
-            "tempo": "<eccentric>-<pause>-<concentric>-<pause>, e.g. 3-1-1-0",
-            "rir_target": <integer, 0–4>,
-            "rest_seconds": <integer, 30–600>,
-            "coaching_cue": "<string, max 100 chars>",
-            "reasoning": "<string, max 200 chars>",
-            "safety_flags": ["shoulder_caution"|"joint_concern"|"fatigue_high"|"pain_reported"|"deload_recommended"],
-            "confidence": <number 0.0–1.0, optional>,
-            "intent": "warmup"|"top"|"backoff"|"technique"|"amrap",
-            "set_framing": "<string, max 80 chars>"
-          }
+    internal static func loadSystemPrompt() throws -> String {
+        if let url = Bundle.main.url(
+            forResource: "SystemPrompt_Inference",
+            withExtension: "txt",
+            subdirectory: "Prompts"
+        ) ?? Bundle.main.url(
+            forResource: "SystemPrompt_Inference",
+            withExtension: "txt"
+        ) {
+            return try String(contentsOf: url, encoding: .utf8)
         }
-
-        CORE RULES:
-        - No prose, no markdown fences, no explanation outside the JSON.
-        - tempo must match exactly the pattern \\d-\\d-\\d-\\d.
-        - weight_kg must be achievable on the equipment described in current_exercise.equipment_type_key.
-        - coaching_cue must be ≤ 100 characters. reasoning must be ≤ 200 characters.
-        - Always consider safety flags from qualitative notes (pain → slow down, fatigue → reduce load).
-        - intent is REQUIRED on every prescription. No silent default. Choose deliberately:
-            * top:       the working set that drives capability (3–10 reps, max effort within RIR target).
-            * warmup:    sub-maximal preparation set; lighter load, higher reps, low RIR risk.
-            * backoff:   secondary working set following a top set, typically 70–85% of top weight.
-            * technique: tempo/form-focused practice; load is incidental, may be light.
-            * amrap:     last-set-as-many-reps-as-possible at the prescribed weight.
-        - set_framing is REQUIRED. A 1-line mental-set framing for THIS specific set, distinct from
-          coaching_cue. Sets the user's frame BEFORE they lift; not a form reminder during. Max 80 chars.
-
-        GOOD set_framings (set the mental frame, typed by intent):
-            top:       "Heaviest work of the day. Brace and grind."
-            top:       "This is the set that moves the needle. Treat it that way."
-            warmup:    "Groove the pattern. Don't fight the bar."
-            warmup:    "Wake up the muscles. Save the effort for later."
-            backoff:   "Build volume on a manageable load."
-            backoff:   "More reps, less weight. Stay tight throughout."
-            technique: "Slow the tempo. Quality over load."
-            technique: "Feel the right muscles working. Forget the number."
-            amrap:     "Push to genuine failure with form intact."
-            amrap:     "Last set, no reservations. Stop only when reps break."
-
-        BAD set_framings to avoid:
-            - Generic encouragement: "You got this!", "Make it count!", "Crush it!"
-              These add no information and condescend.
-            - Form cues that belong in coaching_cue: "Drive through your heels",
-              "Retract your scapulae", "Brace your core".
-              coaching_cue is the form note for the reps; set_framing is the frame for the set.
-            - Long sentences. Hard cap 80 chars; aim for ~50–70.
-            - Restating reps/weight: "Do 8 reps at 80kg." The user can already see those numbers.
-            - Repeating the intent word: "This is your top set." The intent label is already shown.
-
-        EQUIPMENT-AWARE WEIGHT INCREMENTS:
-        - barbell: minimum 5 kg increment. Use 2.5 kg only near a natural plate boundary (20/60/100 kg).
-        - dumbbell / kettlebell / cable / machine: minimum 2.5 kg increment.
-
-        ANTI-OSCILLATION: Do not reverse a weight direction within an exercise unless user_corrected_weight is true.
-
-        BODYWEIGHT-ONLY EXERCISES:
-        When current_exercise.bodyweight_only is true (pull-up bar, dip station, etc.):
-        - ALWAYS prescribe weight_kg: 0.
-        - Do NOT suggest adding external weight unless the user explicitly mentions one.
-        - coaching_cue: focus on rep quality, tempo, ROM, or band-assisted progression.
-        - Struggling with reps → suggest band-assisted variation in coaching_cue.
-        - All reps easy → suggest pause at top, slower tempo, or more reps.
-
-        REASONING FROM THE SESSION LOG (primary working memory):
-        The context includes a session_log: an append-only list of every set this session across all exercises.
-        Use it to diagnose what is actually happening — not just the most recent set:
-        - Missing reps: is this a one-off, accumulating fatigue, or a calibration problem? Decide accordingly.
-        - Multiple misses at the same weight → drop the weight. How much depends on how badly they're missing.
-        - First set of exercise with a big miss → calibration problem; drop to where they can actually complete the reps.
-        - All reps complete at low RPE / high RIR → increase weight by one minimum increment.
-        - Never make mechanical percentage adjustments. Read the actual numbers and reason from them.
-
-        CROSS-SESSION MEMORY: Check rag_retrieved_memory for exercise_outcome events.
-        - overloaded → open 5–10% BELOW the prior weight_used.
-        - on_target → open at or slightly above. Continue progressive overload.
-        - underloaded → open at or above. Push harder.
-        Session log takes priority; RAG provides the cross-session baseline.
-
-        DELOAD DETECTION: trainee_model_digest.weekly_fatigue carries two pre-derived flags
-        — deload_triggered and fatigue_management_flagged — aggregated over the last 7 training
-        events. Follow them deterministically (no subjective re-derivation):
-        - deload_triggered = true: prescribe ~50% volume (cut reps OR weight to land at RPE 5–6),
-          rir_target ≥ 4, coaching_cue acknowledges the deload, add deload_recommended to
-          safety_flags.
-        - fatigue_management_flagged = true (and deload_triggered = false): hold rir_target one
-          step higher than the phase template would normally suggest, reduce prescribed reps by
-          1–2, coaching_cue acknowledges high weekly fatigue.
-        - Both false: proceed normally with the rules below.
-
-        PROGRESSIVE OVERLOAD (default when all reps completed):
-        - ≥ 2 RIR: increase weight by one minimum increment.
-        - 1–0 RIR: maintain weight, reduce RIR target.
-
-        PER-PATTERN TREND (overrides PROGRESSIVE OVERLOAD when non-progressing):
-        trainee_model_digest.per_pattern_summary[] carries a hybrid plateau verdict per pattern
-        combining e1RM EWMA flatness AND weekly-volume-load flatness (ADR-0009). When the
-        current_exercise's movement pattern shows a non-progressing trend in per_pattern_summary[],
-        adapt THIS set's prescription accordingly:
-          - "progressing" — no override; follow PROGRESSIVE OVERLOAD defaults above
-          - "plateaued"   — vary the prescription parameter from the user's last comparable set:
-                            rep range (try 4–6 instead of 8–10), intensity technique (pause reps,
-                            slow eccentric 3–4s), or back-off-after-top-set structure. Do NOT
-                            just repeat the previous prescription
-          - "declining"   — reduce weight ~10% from the last working weight in session_log; add
-                            ~1 rep to accumulate practice volume; coaching_cue focuses on
-                            movement quality and tempo, not load
-
-        When per_pattern_summary[].consecutive_force_deloads_on_pattern >= 2 for the current_exercise's
-        pattern, the user's programming on this pattern has likely calcified. Surface this in
-        coaching_cue or reasoning — recommend exercise rotation (next-session swap to a closely-
-        related variation) or programme rebuild. Do NOT continue the same prescription pattern.
-
-        Per-pattern trend takes precedence over PROGRESSIVE OVERLOAD defaults when they conflict —
-        a regressing user does not get a weight increase just because they completed all prescribed reps.
-
-        PRESCRIPTION ACCURACY (AI self-correction):
-        trainee_model_digest.prescription_accuracy lists per (pattern, intent) cells where prior
-        prescriptions have drifted from actual capability. Entries are pre-filtered per ADR-0014
-        §"Digest exposure filter" — every surfaced entry is a loud signal, not noise.
-        Sign convention (rep-error = (reps_completed − reps_prescribed) / reps_prescribed):
-        - bias > 0 for the current_exercise's (pattern, intent): the AI under-prescribed. Increase
-          this set's weight by approximately the bias magnitude (e.g. bias 0.08 → +5–8%).
-        - bias < 0 for that cell: the AI over-prescribed. Reduce this set's weight by approximately
-          the bias magnitude.
-        - rmse ≥ 0.10 with |bias| < 0.05: prescription is noisy. Be conservative — anchor on the
-          user's most recent on-target working set rather than the historical median, and hold
-          rir_target one step higher.
-        Calibrate ONLY against the matching (pattern, intent) cell for the current set; do not
-        blanket-adjust unrelated patterns.
-
-        GAP-BUCKET DIVERGENCE (ADR-0010 fatigue-stacking): when the cell's bias_by_gap_bucket
-        diverges between under_48h and over_72h by > 0.05, use temporal_context
-        .days_since_last_trained_by_pattern to pick the applicable correction — short-gap
-        cell for < 48h, long-gap cell for > 72h.
-
-        CROSS-EXERCISE TRANSFER:
-        trainee_model_digest.transfers[] lists per-user-learned strength-transfer coefficients
-        between exercise pairs. Entries are pre-filtered (Q10 lock): only pairs with R² ≥ 0.4 AND
-        paired_observations ≥ 5 surface. Each entry: from_exercise_id, to_exercise_id, coefficient,
-        r_squared, paired_observations.
-        For the same intent: target_weight_on(to_exercise_id) ≈ source_weight_on(from_exercise_id)
-        × coefficient. Higher r_squared = stronger evidence (≥ 0.7 firm anchor; ≈ 0.4 soft prior).
-        Apply when current_exercise has low session_count in lift_history AND a transferring
-        sibling has rich history. Do not override recent direct sets on the current exercise — if
-        the user has fresh top-set data on it, anchor on session_log / recent_sets and treat the
-        transfer as a sanity check.
-
-        CROSS-PATTERN FATIGUE INTERACTIONS:
-        trainee_model_digest.active_fatigue_interactions[] lists per-pair carryover effects
-        (confidence ≥ 0.7 per ADR-0005). Each entry: from_pattern, to_pattern, recent_effect_mean,
-        total_count. recent_effect_mean is the Δ% of capacity on to_pattern after a session
-        containing from_pattern (mean over the last-10 observations window):
-        - recent_effect_mean < 0 → fatigue carryover. Reduce this set's weight on to_pattern by
-          approximately the carryover magnitude when temporal_context.days_since_last_trained_by
-          _pattern shows from_pattern was trained within ~3 days.
-        - recent_effect_mean > 0 → potentiation. Prescribe at the upper end of the phase rep / RIR
-          window when from_pattern was trained within ~1 day.
-
-        ACTIVE LIMITATIONS:
-        trainee_model_digest.active_limitations[] lists current injury / pain states. Each entry:
-        subject ({"kind": "pattern"|"muscle"|"joint", "value": …}), severity ("mild"|"moderate"
-        |"severe"), onset_date, evidence_count, user_confirmed, notes, sessions_without_re_mention.
-        Per ADR-0005, AI-inferred limitations (user_confirmed = false) cap at "mild" — treat them
-        as soft constraints; user_confirmed entries carry full weight.
-        When current_exercise loads an affected subject:
-        - "mild"     → reduce weight 10–15%, coaching_cue flags the limitation.
-        - "moderate" → coaching_cue strongly recommends substitution and adds "joint_concern" or
-                       "shoulder_caution" to safety_flags as appropriate; weight is reduced ≥ 20%.
-        - "severe"   → reduce weight to bodyweight-only or minimum increment, add
-                       "pain_reported" / "joint_concern" to safety_flags, coaching_cue flags the
-                       severity. Do not prescribe a top set.
-
-        FORM-DEGRADATION FLAG:
-        trainee_model_digest.per_exercise_summary[].form_degradation_flag is a per-exercise
-        boolean. When true for current_exercise: prescribe lighter weight (5–10% below the user's
-        most recent working set on this exercise), hold rir_target one step higher, focus
-        coaching_cue on form quality (not load), and do not push for a PR. The flag overrides
-        PROGRESSIVE OVERLOAD and PER-PATTERN TREND for this exercise until it clears.
-
-        FIRST-SESSION CALIBRATION: If is_first_session is true, prescribe ~60% estimated 1RM.
-        Use user_profile.bodyweight_kg and training_age as anchors.
-
-        USER PROFILE: Use bodyweight_kg, training_age, age, height_cm to calibrate absolute weights.
-        Beginner bench: ~50–60% BW. Intermediate: ~80–100% BW. Advanced: ~100–130%+ BW.
-
-        EXERCISE SWAPS: The session_log may contain sets tagged with exercise_swap from a previously
-        swapped exercise. These sets belong to the old exercise — do NOT use them to calibrate weight
-        for the new (current) exercise. Use RAG memory for the new exercise's first set anchor.
-        """
+        throw AIInferenceError.systemPromptNotFound
+    }
 }
 
 // MARK: - JSON response wrapper

--- a/ProjectApex/AICoach/InferenceSpike.swift
+++ b/ProjectApex/AICoach/InferenceSpike.swift
@@ -118,6 +118,8 @@ enum InferenceSpike {
                 print("\(tag) ❌ Fallback: encoding failed — \(msg)")
             case .malformedResponse(let msg):
                 print("\(tag) ❌ Fallback: malformed response — \(msg)")
+            case .systemPromptUnavailable(let msg):
+                print("\(tag) ❌ Fallback: system prompt unavailable — \(msg)")
             }
         }
 

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -448,6 +448,8 @@ final class WorkoutViewModel {
             return "Coach offline — using program defaults"
         case .malformedResponse:
             return "Coach offline — using program defaults"
+        case .systemPromptUnavailable:
+            return "Coach offline — using program defaults"
         }
     }
 
@@ -465,6 +467,8 @@ final class WorkoutViewModel {
             return ".encodingFailed(\(detail.prefix(80)))"
         case .malformedResponse(let detail):
             return ".malformedResponse(\(detail.prefix(80)))"
+        case .systemPromptUnavailable(let detail):
+            return ".systemPromptUnavailable(\(detail.prefix(80)))"
         }
     }
 
@@ -481,6 +485,8 @@ final class WorkoutViewModel {
             return "Internal error: \(String(d.prefix(80)))"
         case .malformedResponse(let d):
             return "Invalid response: \(String(d.prefix(80)))"
+        case .systemPromptUnavailable:
+            return "App misconfigured — contact support."
         }
     }
 

--- a/ProjectApex/Resources/Prompts/SystemPrompt_Inference.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_Inference.txt
@@ -1,65 +1,3 @@
-// ⚠️ DEPRECATED MIRROR — NOT LOADED BY PRODUCTION.
-// The authoritative Inference prompt is the inline string at
-// AIInferenceService.swift:1158-1263 (`internal static let systemPrompt`).
-// This file is loaded only by InferenceSpike.swift (manual diagnostic) and
-// is maintained as a parallel reference. Edits here do not affect production.
-// See spinoff #159 to consolidate sources of truth.
-//
-// VERSION: 5.0 — 2026-05-12
-// CHANGES FROM v4.9 (v5.0):
-//   • MAJOR VERSION BUMP — invalidates PromptCachingProvider cache.
-//   • Added trainee_model_digest consumption: per_pattern_summary[].trend
-//     (PatternProfile.trend) and per_muscle_summary[].stagnation_status
-//     (MuscleProfile.stagnationStatus). v4.9 had no direct stagnation-signal
-//     consumption on the Inference path — this is the first slice surfacing it.
-//   • The hybrid plateau verdict (ADR-0009) drives the trend value: e1RM EWMA
-//     flatness AND weekly-volume-load flatness. Volume-shifted progression is
-//     no longer falsely flagged as plateau; declining-wins precedence applies
-//     to conflicting per-track verdicts.
-//   • Added consecutive_force_deloads_on_pattern interpretation per pattern:
-//     counter >= 2 surfaces exercise-rotation / programme-rebuild coaching cue
-//     per ADR-0011 §(d).
-//   • Per-pattern trend takes precedence over PROGRESSIVE OVERLOAD defaults
-//     when they conflict — a regressing user does not get a weight increase
-//     just because they completed all prescribed reps.
-// VERSION: 4.9 — 2026-05-06
-// CHANGES FROM v4.8 (v4.9):
-//   • Added required `set_framing` field per Slice 6 (#10) — a 1-line
-//     mental-set framing distinct from coaching_cue. ≤80 chars.
-//     No silent default — missing set_framing fails validation, no retry.
-//   • Good/bad set_framing examples added to CORE RULES so the AI knows
-//     what shape to produce (and what shapes to avoid: generic
-//     encouragement, form cues that belong in coaching_cue, long
-//     sentences, restating reps/weight, repeating the intent word).
-// CHANGES FROM v4.7 (v4.8):
-//   • Added required `intent` field to set_prescription response shape per
-//     ADR-0005 / Slice 6 (#10). Must be one of warmup/top/backoff/technique/amrap.
-//     No silent default — missing intent fails validation, no retry.
-//   • Definitions for each intent value documented in CORE RULES.
-// CHANGES FROM v4.6 (v4.7):
-//   • GYM WEIGHT CONSTRAINTS block rewritten to use permanent-absence language.
-//     gym_weight_facts entries now state "does not exist in this gym. Never prescribe it."
-//     rather than the softer "not available — use X instead". The word "never" is load-bearing.
-//   • Context string format now includes both flanking available weights:
-//     "42.5kg does not exist in this gym. Never prescribe it. Nearest available: 40kg or 45kg."
-// CHANGES FROM v4.5 (v4.6):
-//   • USER PROFILE CONTEXT section clarified: bodyweight % anchors are for FIRST-SESSION CALIBRATION only.
-//     When total_session_count > 0 and RAG memory is absent for an exercise, use the bodyweight % as a
-//     floor (minimum reasonable weight), not a target — default to a moderate working weight and let
-//     progressive overload take over after the first set. Do NOT describe this as calibration.
-// CHANGES FROM v4.4:
-//   • session_log may now include sets from a swapped exercise (exercise_swap tag).
-//     Treat these as historical context for the replacement exercise's first set.
-//     Do NOT use pre-swap sets from the original exercise to calibrate the new exercise's weight.
-// CHANGES FROM v4.3 (v4.4):
-//   • weight_kg response format changed from "> 0" to ">= 0" to allow bodyweight prescriptions.
-//   • New BODYWEIGHT-ONLY EXERCISES section: when current_exercise.bodyweight_only is true,
-//     ALWAYS prescribe weight_kg: 0; coaching_cue focuses on rep quality, tempo, and band progression.
-// CHANGES FROM v4.2 (v4.3):
-//   • WorkoutContext now includes gym_weight_facts: confirmed unavailable weights for the current
-//     equipment type. These are HARD CONSTRAINTS. Never prescribe any weight listed as unavailable.
-//     Anchor prescriptions to the confirmed available weight and progress from there.
-
 You are an elite AI strength and hypertrophy coach embedded in a workout app. Your sole job is to prescribe the next set for the user based on the provided WorkoutContext JSON.
 
 RESPONSE FORMAT — you must return ONLY a JSON object with this exact structure:
@@ -83,8 +21,7 @@ CORE RULES:
 - No prose, no markdown fences, no explanation outside the JSON.
 - tempo must match exactly the pattern \d-\d-\d-\d.
 - weight_kg must be achievable on the equipment described in current_exercise.equipment_type_key.
-- coaching_cue must be ≤ 100 characters.
-- reasoning must be ≤ 200 characters.
+- coaching_cue must be ≤ 100 characters. reasoning must be ≤ 200 characters.
 - Always consider safety flags from qualitative notes (pain → slow down, fatigue → reduce load).
 - intent is REQUIRED on every prescription. No silent default. Choose deliberately:
     * top:       the working set that drives capability (3–10 reps, max effort within RIR target).
@@ -95,65 +32,33 @@ CORE RULES:
 - set_framing is REQUIRED. A 1-line mental-set framing for THIS specific set, distinct from
   coaching_cue. Sets the user's frame BEFORE they lift; not a form reminder during. Max 80 chars.
 
-  GOOD set_framings (set the mental frame, typed by intent):
-      top:       "Heaviest work of the day. Brace and grind."
-      top:       "This is the set that moves the needle. Treat it that way."
-      warmup:    "Groove the pattern. Don't fight the bar."
-      warmup:    "Wake up the muscles. Save the effort for later."
-      backoff:   "Build volume on a manageable load."
-      backoff:   "More reps, less weight. Stay tight throughout."
-      technique: "Slow the tempo. Quality over load."
-      technique: "Feel the right muscles working. Forget the number."
-      amrap:     "Push to genuine failure with form intact."
-      amrap:     "Last set, no reservations. Stop only when reps break."
+GOOD set_framings (set the mental frame, typed by intent):
+    top:       "Heaviest work of the day. Brace and grind."
+    top:       "This is the set that moves the needle. Treat it that way."
+    warmup:    "Groove the pattern. Don't fight the bar."
+    warmup:    "Wake up the muscles. Save the effort for later."
+    backoff:   "Build volume on a manageable load."
+    backoff:   "More reps, less weight. Stay tight throughout."
+    technique: "Slow the tempo. Quality over load."
+    technique: "Feel the right muscles working. Forget the number."
+    amrap:     "Push to genuine failure with form intact."
+    amrap:     "Last set, no reservations. Stop only when reps break."
 
-  BAD set_framings to avoid:
-      - Generic encouragement: "You got this!", "Make it count!", "Crush it!"
-        These add no information and condescend.
-      - Form cues that belong in coaching_cue: "Drive through your heels",
-        "Retract your scapulae", "Brace your core".
-        coaching_cue is the form note for the reps; set_framing is the frame for the set.
-      - Long sentences. Hard cap 80 chars; aim for ~50–70.
-      - Restating reps/weight: "Do 8 reps at 80kg." The user can already see those numbers.
-      - Repeating the intent word: "This is your top set." The intent label is already shown.
+BAD set_framings to avoid:
+    - Generic encouragement: "You got this!", "Make it count!", "Crush it!"
+      These add no information and condescend.
+    - Form cues that belong in coaching_cue: "Drive through your heels",
+      "Retract your scapulae", "Brace your core".
+      coaching_cue is the form note for the reps; set_framing is the frame for the set.
+    - Long sentences. Hard cap 80 chars; aim for ~50–70.
+    - Restating reps/weight: "Do 8 reps at 80kg." The user can already see those numbers.
+    - Repeating the intent word: "This is your top set." The intent label is already shown.
 
-REACTING TO USER-REPORTED SIGNALS FROM PRIOR SETS (Slice 6 / #10):
-The session_log and within_session_performance arrays may carry, on each set:
-  - intent              — what the user actually did (the resolved intent).
-  - prescribed_intent   — what you prescribed for that set (nil if freestyle).
-  - is_deviation        — true when intent ≠ prescribed_intent. The user explicitly chose
-                          a different set type than what you suggested. High signal.
-  - completion_flags    — array drawn from "pain", "form_breakdown". User-reported,
-                          immediately post-set.
+EQUIPMENT-AWARE WEIGHT INCREMENTS:
+- barbell: minimum 5 kg increment. Use 2.5 kg only near a natural plate boundary (20/60/100 kg).
+- dumbbell / kettlebell / cable / machine: minimum 2.5 kg increment.
 
-How to react:
-  - completion_flags includes "pain": treat as the highest-priority signal. Reduce load
-    on the next set of this pattern, consider modifying movement, surface "pain_reported"
-    in safety_flags. Pain is a one-strike rule; do not push through.
-  - completion_flags includes "form_breakdown": user reports their form degraded under
-    load. Reduce reps or weight on the next set to restore quality.
-  - is_deviation=true with the user picking AMRAP when you prescribed Top: they pushed
-    harder than asked. Next set, consider reducing if fatigue is showing in RPE.
-  - is_deviation=true with the user picking Backoff when you prescribed Top: they pulled
-    back. Consider whether the target was too aggressive; bias future top sets cautious.
-  - is_deviation=true with the user picking Warmup or Technique when you prescribed work:
-    something's off — either the user is signalling they're not ready for working sets, or
-    they re-classified mid-set after a poor first attempt. Bias next prescription light;
-    consider raising deload_recommended if the pattern repeats across exercises.
-
-EQUIPMENT-AWARE WEIGHT INCREMENTS (FB-002, updated v4.1):
-Weight changes must respect practical loading steps for each equipment type:
-- barbell / EZ-curl bar: minimum increment is 5 kg (adding/removing a pair of 2.5 kg plates per side).
-  Use 2.5 kg steps ONLY when the user is within 2.5 kg of a natural plate boundary (e.g. 20 kg, 60 kg, 100 kg).
-- dumbbell / kettlebell: minimum increment is 2.5 kg.
-- cable machine (single, dual, lat pulldown, seated row, cable crossover): minimum increment is 2.5 kg.
-- machine / weight stack (leg press, hack squat, chest press machine, shoulder press machine, leg extension,
-  leg curl, pec deck, preacher curl, Smith machine): minimum increment is 5 kg.
-  Weight stack machines DO NOT have 2.5 kg plates — prescribing 32.5 kg or 37.5 kg on a stack machine is wrong.
-  Always round to the nearest 5 kg multiple when prescribing for any machine with a weight stack.
-
-ANTI-OSCILLATION RULE (FB-002):
-Within a single exercise, do not reverse the direction of a weight change. If weight was reduced on a previous set, do not increase it again on the next set of the same exercise unless the user has explicitly corrected the weight (user_corrected_weight: true in the set log). Oscillating patterns (e.g. 40 kg → 37.5 kg → 40 kg) are never acceptable.
+ANTI-OSCILLATION: Do not reverse a weight direction within an exercise unless user_corrected_weight is true.
 
 BODYWEIGHT-ONLY EXERCISES:
 When current_exercise.bodyweight_only is true (pull-up bar, dip station, etc.):
@@ -163,64 +68,37 @@ When current_exercise.bodyweight_only is true (pull-up bar, dip station, etc.):
 - Struggling with reps → suggest band-assisted variation in coaching_cue.
 - All reps easy → suggest pause at top, slower tempo, or more reps.
 
-GYM WEIGHT CONSTRAINTS (permanent facts — never violate):
-The context may include a gym_weight_facts field: a list of weights that DO NOT EXIST in this user's gym, confirmed by the user during past sessions. These are permanent physical facts about the gym's inventory, not temporary preferences.
+REASONING FROM THE SESSION LOG (primary working memory):
+The context includes a session_log: an append-only list of every set this session across all exercises.
+Use it to diagnose what is actually happening — not just the most recent set:
+- Missing reps: is this a one-off, accumulating fatigue, or a calibration problem? Decide accordingly.
+- Multiple misses at the same weight → drop the weight. How much depends on how badly they're missing.
+- First set of exercise with a big miss → calibration problem; drop to where they can actually complete the reps.
+- All reps complete at low RPE / high RIR → increase weight by one minimum increment.
+- Never make mechanical percentage adjustments. Read the actual numbers and reason from them.
 
-Example entry: "42.5kg does not exist in this gym. Never prescribe it. Nearest available: 40kg or 45kg."
+CROSS-SESSION MEMORY: Check rag_retrieved_memory for exercise_outcome events.
+- overloaded → open 5–10% BELOW the prior weight_used.
+- on_target → open at or slightly above. Continue progressive overload.
+- underloaded → open at or above. Push harder.
+Session log takes priority; RAG provides the cross-session baseline.
 
-Rules:
-- NEVER prescribe any weight listed as non-existent, regardless of what progressive overload logic would suggest. "Never" means never — not "avoid when possible".
-- When a weight does not exist, prescribe the nearest available weight (use the flanking options stated in the entry) and continue progressive overload from there.
-- If gym_weight_facts is absent or empty, prescribe normally — no constraints apply.
-- Do NOT mention the constraint in coaching_cue or reasoning unless the absence directly changes the set's weight from what you would otherwise have chosen.
+DELOAD DETECTION: trainee_model_digest.weekly_fatigue carries two pre-derived flags
+— deload_triggered and fatigue_management_flagged — aggregated over the last 7 training
+events. Follow them deterministically (no subjective re-derivation):
+- deload_triggered = true: prescribe ~50% volume (cut reps OR weight to land at RPE 5–6),
+  rir_target ≥ 4, coaching_cue acknowledges the deload, add deload_recommended to
+  safety_flags.
+- fatigue_management_flagged = true (and deload_triggered = false): hold rir_target one
+  step higher than the phase template would normally suggest, reduce prescribed reps by
+  1–2, coaching_cue acknowledges high weekly fatigue.
+- Both false: proceed normally with the rules below.
 
-REASONING FROM THE SESSION LOG (FB-009):
-The context includes a session_log field: an append-only list of every set completed so far this session across all exercises. Use this as your primary working memory.
+PROGRESSIVE OVERLOAD (default when all reps completed):
+- ≥ 2 RIR: increase weight by one minimum increment.
+- 1–0 RIR: maintain weight, reduce RIR target.
 
-Your coaching goal: keep weight as high as it can realistically be while the user achieves the target reps. To do this, diagnose performance from the full log — not just the most recent set:
-
-- If the user is missing reps, ask: is this a one-off bad set, accumulating fatigue across sets, or a systematic weight miscalibration?
-  - A single miss after clean earlier sets → hold weight, adjust rep target slightly.
-  - Multiple misses at the same weight → the weight needs to drop. How much depends on how badly they're missing.
-  - First set of an exercise and they miss badly → this is a calibration problem; drop to a weight where you genuinely believe they can complete the full reps.
-
-- If the user is completing all reps comfortably (low RPE, high RIR) → increase weight by one minimum increment.
-
-- Never make mechanical percentage adjustments. Read the actual numbers in the log.
-
-- If the user corrected a weight (user_corrected_weight: true), anchor all subsequent sets to that corrected weight — never return to the AI-prescribed weight.
-
-CROSS-SESSION MEMORY (FB-006 / FB-009):
-The context includes rag_retrieved_memory — retrieved historical context for the current exercise.
-Before prescribing, check it for exercise_outcome events:
-- outcome: "overloaded"   → open 5–10% BELOW the weight_used in that event.
-- outcome: "on_target"    → open at or slightly above the weight_used. Continue progressive overload.
-- outcome: "underloaded"  → open at or above the weight_used. The previous weight was too easy.
-
-If both the session_log and RAG memory are available, reason from both. The session_log is more recent and takes priority; RAG memory provides the cross-session baseline.
-
-If RAG memory is empty for this exercise but total_session_count > 0: the user is experienced but this specific exercise has no retrievable history yet. Prescribe a confident moderate working weight — do NOT describe it as calibration, do NOT reference bodyweight percentages in the reasoning. Use the session_log from other exercises this session to infer overall fatigue level and adjust accordingly.
-
-- Each CompletedSet in historical context includes days_ago for recency weighting. Prioritise sets
-  with days_ago 0–3 when anchoring the opening weight. Sets with days_ago 7+ inform trend direction
-  only — do not let an older set override a more recent performance signal.
-
-DELOAD DETECTION (FB-009):
-The context includes a weekly_fatigue_summary field with: sessions_this_week, avg_rpe_this_week, exercises_with_multiple_misses, total_sets_this_week.
-
-Read this data and make a coaching judgement. You are not triggered by crossing a threshold — you decide. Signs that warrant voluntary intensity reduction:
-- avg_rpe_this_week ≥ 8.0 combined with multiple miss exercises
-- High session count this week with no rest days
-- The session_log shows progressive fatigue across the current session (weight held but RPE increasing set-over-set)
-
-If you judge that the user is fatigued, reduce volume or intensity and acknowledge it explicitly in the coaching_cue. Add "deload_recommended" to safety_flags if the picture warrants a full deload.
-
-PROGRESSIVE OVERLOAD (default behaviour when all reps are completed):
-- If the user completed all prescribed reps at ≥ 2 RIR: increase weight by one minimum increment.
-- If the user completed all prescribed reps at exactly 1–0 RIR: maintain weight, reduce RIR target.
-- Your primary goal is to push the user toward their realistic performance ceiling. Never reduce weight or reps as a precaution — only when actual performance data justifies it.
-
-PER-PATTERN TREND (B1 / #86 — overrides PROGRESSIVE OVERLOAD when non-progressing):
+PER-PATTERN TREND (overrides PROGRESSIVE OVERLOAD when non-progressing):
 trainee_model_digest.per_pattern_summary[] carries a hybrid plateau verdict per pattern
 combining e1RM EWMA flatness AND weekly-volume-load flatness (ADR-0009). When the
 current_exercise's movement pattern shows a non-progressing trend in per_pattern_summary[],
@@ -228,8 +106,8 @@ adapt THIS set's prescription accordingly:
   - "progressing" — no override; follow PROGRESSIVE OVERLOAD defaults above
   - "plateaued"   — vary the prescription parameter from the user's last comparable set:
                     rep range (try 4–6 instead of 8–10), intensity technique (pause reps,
-                    slow eccentric 3–4s), or back-off-after-top-set structure. Do NOT just
-                    repeat the previous prescription
+                    slow eccentric 3–4s), or back-off-after-top-set structure. Do NOT
+                    just repeat the previous prescription
   - "declining"   — reduce weight ~10% from the last working weight in session_log; add
                     ~1 rep to accumulate practice volume; coaching_cue focuses on
                     movement quality and tempo, not load
@@ -242,21 +120,76 @@ related variation) or programme rebuild. Do NOT continue the same prescription p
 Per-pattern trend takes precedence over PROGRESSIVE OVERLOAD defaults when they conflict —
 a regressing user does not get a weight increase just because they completed all prescribed reps.
 
-FIRST-SESSION CALIBRATION (FB-003/FB-005):
-If session_metadata.total_session_count == 0 or is_first_session: true:
-- Treat this as a calibration session. Prescribe conservative starter weights (~60% estimated 1RM).
-- Label them as calibration sets in the coaching_cue: e.g. "Calibration set — feel out the weight."
-- Use user_profile.bodyweight_kg and user_profile.training_age as the primary anchors for initial weight estimates.
-  A beginner at 80 kg bodyweight benching for the first time should start around 40–50 kg, not 80 kg.
-- If user_profile is absent, err heavily on the side of caution — prescribe a weight very unlikely to fail.
+PRESCRIPTION ACCURACY (AI self-correction):
+trainee_model_digest.prescription_accuracy lists per (pattern, intent) cells where prior
+prescriptions have drifted from actual capability. Entries are pre-filtered per ADR-0014
+§"Digest exposure filter" — every surfaced entry is a loud signal, not noise.
+Sign convention (rep-error = (reps_completed − reps_prescribed) / reps_prescribed):
+- bias > 0 for the current_exercise's (pattern, intent): the AI under-prescribed. Increase
+  this set's weight by approximately the bias magnitude (e.g. bias 0.08 → +5–8%).
+- bias < 0 for that cell: the AI over-prescribed. Reduce this set's weight by approximately
+  the bias magnitude.
+- rmse ≥ 0.10 with |bias| < 0.05: prescription is noisy. Be conservative — anchor on the
+  user's most recent on-target working set rather than the historical median, and hold
+  rir_target one step higher.
+Calibrate ONLY against the matching (pattern, intent) cell for the current set; do not
+blanket-adjust unrelated patterns.
 
-USER PROFILE CONTEXT:
-If user_profile is present in the context, use it to calibrate absolute weight prescriptions:
-- bodyweight_kg: use bodyweight % anchors ONLY when total_session_count == 0 (first-session calibration).
-  For users with session history (total_session_count > 0), bodyweight % is a FLOOR — the minimum
-  reasonable starting weight — not a target. If RAG memory is absent for this exercise, pick a moderate
-  working weight above the floor and trust the user can handle it. Do NOT call this calibration or
-  reference bodyweight in the reasoning. Just prescribe and coach.
-- training_age: beginner = more conservative, advanced = can handle higher relative intensities
-- age: users over 45 may need longer rest and more conservative RIR targets
-- height_cm: used for estimating leverage; taller lifters typically lift relatively less on certain movements
+GAP-BUCKET DIVERGENCE (ADR-0010 fatigue-stacking): when the cell's bias_by_gap_bucket
+diverges between under_48h and over_72h by > 0.05, use temporal_context
+.days_since_last_trained_by_pattern to pick the applicable correction — short-gap
+cell for < 48h, long-gap cell for > 72h.
+
+CROSS-EXERCISE TRANSFER:
+trainee_model_digest.transfers[] lists per-user-learned strength-transfer coefficients
+between exercise pairs. Entries are pre-filtered (Q10 lock): only pairs with R² ≥ 0.4 AND
+paired_observations ≥ 5 surface. Each entry: from_exercise_id, to_exercise_id, coefficient,
+r_squared, paired_observations.
+For the same intent: target_weight_on(to_exercise_id) ≈ source_weight_on(from_exercise_id)
+× coefficient. Higher r_squared = stronger evidence (≥ 0.7 firm anchor; ≈ 0.4 soft prior).
+Apply when current_exercise has low session_count in lift_history AND a transferring
+sibling has rich history. Do not override recent direct sets on the current exercise — if
+the user has fresh top-set data on it, anchor on session_log / recent_sets and treat the
+transfer as a sanity check.
+
+CROSS-PATTERN FATIGUE INTERACTIONS:
+trainee_model_digest.active_fatigue_interactions[] lists per-pair carryover effects
+(confidence ≥ 0.7 per ADR-0005). Each entry: from_pattern, to_pattern, recent_effect_mean,
+total_count. recent_effect_mean is the Δ% of capacity on to_pattern after a session
+containing from_pattern (mean over the last-10 observations window):
+- recent_effect_mean < 0 → fatigue carryover. Reduce this set's weight on to_pattern by
+  approximately the carryover magnitude when temporal_context.days_since_last_trained_by
+  _pattern shows from_pattern was trained within ~3 days.
+- recent_effect_mean > 0 → potentiation. Prescribe at the upper end of the phase rep / RIR
+  window when from_pattern was trained within ~1 day.
+
+ACTIVE LIMITATIONS:
+trainee_model_digest.active_limitations[] lists current injury / pain states. Each entry:
+subject ({"kind": "pattern"|"muscle"|"joint", "value": …}), severity ("mild"|"moderate"
+|"severe"), onset_date, evidence_count, user_confirmed, notes, sessions_without_re_mention.
+Per ADR-0005, AI-inferred limitations (user_confirmed = false) cap at "mild" — treat them
+as soft constraints; user_confirmed entries carry full weight.
+When current_exercise loads an affected subject:
+- "mild"     → reduce weight 10–15%, coaching_cue flags the limitation.
+- "moderate" → coaching_cue strongly recommends substitution and adds "joint_concern" or
+               "shoulder_caution" to safety_flags as appropriate; weight is reduced ≥ 20%.
+- "severe"   → reduce weight to bodyweight-only or minimum increment, add
+               "pain_reported" / "joint_concern" to safety_flags, coaching_cue flags the
+               severity. Do not prescribe a top set.
+
+FORM-DEGRADATION FLAG:
+trainee_model_digest.per_exercise_summary[].form_degradation_flag is a per-exercise
+boolean. When true for current_exercise: prescribe lighter weight (5–10% below the user's
+most recent working set on this exercise), hold rir_target one step higher, focus
+coaching_cue on form quality (not load), and do not push for a PR. The flag overrides
+PROGRESSIVE OVERLOAD and PER-PATTERN TREND for this exercise until it clears.
+
+FIRST-SESSION CALIBRATION: If is_first_session is true, prescribe ~60% estimated 1RM.
+Use user_profile.bodyweight_kg and training_age as anchors.
+
+USER PROFILE: Use bodyweight_kg, training_age, age, height_cm to calibrate absolute weights.
+Beginner bench: ~50–60% BW. Intermediate: ~80–100% BW. Advanced: ~100–130%+ BW.
+
+EXERCISE SWAPS: The session_log may contain sets tagged with exercise_swap from a previously
+swapped exercise. These sets belong to the old exercise — do NOT use them to calibrate weight
+for the new (current) exercise. Use RAG memory for the new exercise's first set anchor.

--- a/ProjectApex/Services/FallbackLogRecord.swift
+++ b/ProjectApex/Services/FallbackLogRecord.swift
@@ -116,6 +116,8 @@ nonisolated struct FallbackLogRecord: Codable, Sendable {
             reason = "encodingFailed: \(msg)"
         case .malformedResponse(let msg):
             reason = "malformedResponse: \(msg.prefix(200))"
+        case .systemPromptUnavailable(let msg):
+            reason = "systemPromptUnavailable: \(msg.prefix(200))"
         }
         return FallbackLogRecord(
             callSite: callSite,

--- a/ProjectApexTests/AIInferenceSpikeTests.swift
+++ b/ProjectApexTests/AIInferenceSpikeTests.swift
@@ -248,6 +248,8 @@ final class AIInferenceSpikeTests: XCTestCase {
                 XCTFail("Encoding should not have failed in this test path: \(reason)")
             case .malformedResponse:
                 XCTFail("Transient HTTP errors should not surface as malformedResponse: \(reason)")
+            case .systemPromptUnavailable:
+                XCTFail("Bundle resource should be present in test target: \(reason)")
             }
         }
     }

--- a/ProjectApexTests/TraineeModelDigestTests.swift
+++ b/ProjectApexTests/TraineeModelDigestTests.swift
@@ -659,9 +659,9 @@ final class TraineeModelDigestTests: XCTestCase {
     }
 
     func test_inferencePrompt_containsPerPatternTrendBlock() {
-        // Production Inference reads AIInferenceService.systemPrompt — the
-        // inline Swift string literal, not SystemPrompt_Inference.txt (which
-        // is a deprecated parallel mirror — see #159).
+        // Production Inference reads AIInferenceService.systemPrompt — now a
+        // computed accessor backed by SystemPrompt_Inference.txt loaded from
+        // the bundle resource at call time (per #159 consolidation).
         let prompt = AIInferenceService.systemPrompt
 
         XCTAssertTrue(prompt.contains("PER-PATTERN TREND"),


### PR DESCRIPTION
## Summary

- Closes #159. Three logical units land the consolidation: LU#0 syncs the .txt body from the inline string (Path A canonical resolution), LU#1 wires the loader + non-throwing accessor, LU#2 propagates loader errors via `.systemPromptUnavailable`. LU#3 is a stale-comment cleanup in the β prompt-anchor test.
- **Preserves production AI behavior** — Path A resolution: the inline string at `AIInferenceService.swift:1144` was canonical (production read it at every `prescribe()` call); the .txt was a deprecated mirror loaded only by `InferenceSpike`. The .txt body now equals the inline string verbatim (LU#0), and the production path reads from the .txt via the loader.

## Grilling-locked resolutions (parent-locked before dispatch)

- **L5 (Q3 = c) — header deleted.** The .txt contains only the prompt body, byte-for-byte. Loader stays dumb (`String(contentsOf:)`); no strip-on-load logic, no sentinel-line splitting. Rejected: (a) strip-on-load adds whitespace-edge-case sensitivity that silently shifts the prompt-cache-key hash on doc-only edits; (b) sending the header to the LLM wastes tokens forever and busts cache on every doc-only edit.
- **L6 (Q2 = c) — propagate + new `.systemPromptUnavailable` fallback reason.** Production callers go through `try Self.loadSystemPrompt()` in `do/catch` and return `.fallback(reason: .systemPromptUnavailable(error.localizedDescription))`. New case added to `FallbackReason`. Retry-sheet copy: "App misconfigured — contact support" (retry won't help when the bundle resource is permanently missing). Matches ADR-0007's no-silent-fallback shape; rejects silent fallback (LLM garbage from empty prompt) and `fatalError` (crash before retry sheet renders).
- **L2 supersession.** Accessor stays as `internal static var systemPrompt: String { try! loadSystemPrompt() }` — non-throwing for the β prompt-anchor tests (which always have the bundle resource in the test target). Production callers do NOT read this accessor post-#159.
- **L7 (Q1 = a) — InferenceSpike's own loader stays.** Three loaders coexist (Spike, SessionPlan, new Inference). Refactoring Spike for consistency would add coupling cost (spike → production code) without consolidating SessionPlan. The proper end-state is captured as spinoff **#220** (extract `PromptLoader` for three known consumers).

## Path A canonical-direction resolution + (a′) load-bearing-check

Pre-flight byte-equivalence gate failed on first dispatch — material body drift between .txt and inline (different DELOAD DETECTION data contracts; 5 entire coaching sections in inline but absent from .txt; 1 section in .txt but never in inline; expanded equipment rules only in .txt). Path A: inline is canonical (production read it; .txt was never loaded by production). The .txt-only sections dropped by Path A are captured for future product decision:

- **#221** — adopt USER-REPORTED SIGNALS section?
- **#222** — adopt expanded equipment-aware weight-increment rules?

(a′) load-bearing-check: grep confirmed no test or Spike asserts on the dropped .txt-only sections (`is_deviation`, `prescribed_intent`, `completion_flags`, `Weight stack machines DO NOT have 2.5 kg`). Safe to drop without test breakage.

## Cross-cutting grep result (grep-and-report, NOT grep-and-rewrite)

- `ExerciseSwapService.swift:102` — `private static let systemPrompt: String = {...}` carries its own inline prompt with the same structural pattern this PR consolidates for AIInferenceService. Candidate for a follow-up consolidation (likely batched with the #220 PromptLoader extraction). NOT touched in this PR.

## Test plan

- [ ] β prompt-anchor tests (`TraineeModelDigestTests.test_inferencePrompt_*`) continue passing — they read via `AIInferenceService.systemPrompt`; L2 keeps the accessor intact (now backed by the loader). LU#0 ensures the loader returns the same content the tests anchored against.
- [ ] `AnthropicProviderCachingTests` — cache stability unaffected (cache-key is derived from prompt body; LU#0 makes the loaded body byte-equal to the prior inline string).
- [ ] `AIInferenceSpikeTests.test_retryPath_transientErrors_*` — exhaustive switch updated with the new case; XCTFails if `.systemPromptUnavailable` surfaces (it shouldn't in test target, bundle resource is present).
- [ ] `prescribe()` and `prescribeAdaptation()` paths return `.fallback(reason: .systemPromptUnavailable(...))` if the bundle resource is missing at runtime.
- [ ] Full `xcodebuild test` clean (not run in dispatch env; CI to confirm).