### PR TITLE
feat(#178): HEAVY REASSESSMENT block + delete vestigial reassessmentRecords

### DIFF
--- a/ProjectApex/Models/TraineeModel.swift
+++ b/ProjectApex/Models/TraineeModel.swift
@@ -28,7 +28,6 @@ struct TraineeModel: Codable, Sendable, Hashable {
     var transfers: [ExerciseTransfer]
     var bodyweight: BodyweightHistory
     var lifeContextEvents: [LifeContextEvent]
-    var reassessmentRecords: [ReassessmentRecord]
     /// Total completed sessions across the user's history. Drives the
     /// 6-session-window check for shouldFireGlobalPhaseAdvance.
     var totalSessionCount: Int
@@ -56,7 +55,6 @@ struct TraineeModel: Codable, Sendable, Hashable {
         transfers: [ExerciseTransfer] = [],
         bodyweight: BodyweightHistory = BodyweightHistory(),
         lifeContextEvents: [LifeContextEvent] = [],
-        reassessmentRecords: [ReassessmentRecord] = [],
         totalSessionCount: Int = 0,
         lastClassifiedNoteCreatedAt: Date? = nil,
         lastGlobalPhaseAdvanceFiredAtSessionCount: Int? = nil
@@ -75,7 +73,6 @@ struct TraineeModel: Codable, Sendable, Hashable {
         self.transfers = transfers
         self.bodyweight = bodyweight
         self.lifeContextEvents = lifeContextEvents
-        self.reassessmentRecords = reassessmentRecords
         self.totalSessionCount = totalSessionCount
         self.lastClassifiedNoteCreatedAt = lastClassifiedNoteCreatedAt
         self.lastGlobalPhaseAdvanceFiredAtSessionCount = lastGlobalPhaseAdvanceFiredAtSessionCount
@@ -109,7 +106,6 @@ struct TraineeModel: Codable, Sendable, Hashable {
         case transfers
         case bodyweight
         case lifeContextEvents
-        case reassessmentRecords
         case totalSessionCount
         case lastClassifiedNoteCreatedAt
         case lastGlobalPhaseAdvanceFiredAtSessionCount
@@ -177,9 +173,10 @@ struct TraineeModel: Codable, Sendable, Hashable {
         self.lifeContextEvents = try c.decodeIfPresent(
             [LifeContextEvent].self, forKey: .lifeContextEvents
         ) ?? []
-        self.reassessmentRecords = try c.decodeIfPresent(
-            [ReassessmentRecord].self, forKey: .reassessmentRecords
-        ) ?? []
+        // Legacy JSONB rows may carry a `reassessmentRecords` key from
+        // before #178 (the field was declared but never written by any
+        // production path). The key is intentionally absent from CodingKeys
+        // now, so the decoder silently ignores it.
         self.totalSessionCount = try c.decodeIfPresent(
             Int.self, forKey: .totalSessionCount
         ) ?? 0
@@ -218,7 +215,6 @@ struct TraineeModel: Codable, Sendable, Hashable {
         try c.encode(transfers, forKey: .transfers)
         try c.encode(bodyweight, forKey: .bodyweight)
         try c.encode(lifeContextEvents, forKey: .lifeContextEvents)
-        try c.encode(reassessmentRecords, forKey: .reassessmentRecords)
         try c.encode(totalSessionCount, forKey: .totalSessionCount)
         try c.encodeIfPresent(lastClassifiedNoteCreatedAt, forKey: .lastClassifiedNoteCreatedAt)
         try c.encodeIfPresent(lastGlobalPhaseAdvanceFiredAtSessionCount, forKey: .lastGlobalPhaseAdvanceFiredAtSessionCount)

--- a/ProjectApex/Models/TraineeModelDigest.swift
+++ b/ProjectApex/Models/TraineeModelDigest.swift
@@ -74,6 +74,13 @@ struct TraineeModelDigest: Codable, Sendable, Hashable {
     /// `WeekFatigueSignals` is substituted (both flags false → LLM falls
     /// through to normal behavior).
     var weeklyFatigue: WeekFatigueSignals
+    /// Present iff the global-phase-advance trigger fired within the
+    /// cooldown window per ADR-0005 / ADR-0012. When present, SessionPlan
+    /// prompts surface the HEAVY REASSESSMENT block. Nil otherwise. Trigger
+    /// detection is server-side (`lastGlobalPhaseAdvanceFiredAtSessionCount`);
+    /// this projection is derived at iOS digest-assembly time from that
+    /// persisted value plus the per-pattern transition log (#178).
+    var heavyReassessmentSignal: HeavyReassessmentSignal?
 
     /// Threshold below which a fatigue interaction is excluded from
     /// coaching prompts per ADR-0005.
@@ -85,6 +92,16 @@ struct TraineeModelDigest: Codable, Sendable, Hashable {
     /// Minimum paired-observation count (inclusive) for a transfer entry to
     /// surface (Q10 lock-in — guards against tiny-sample regressions).
     static let transferPairedObservationsThreshold: Int = 5
+
+    /// Sessions after `lastGlobalPhaseAdvanceFiredAtSessionCount` during
+    /// which the HEAVY REASSESSMENT block remains in the SessionPlan
+    /// prompt. Matches the server-side cooldown
+    /// (`GLOBAL_PHASE_ADVANCE_COOLDOWN_SESSIONS = 6` in
+    /// `supabase/functions/_shared/constants.ts`). #178 deliberately ships
+    /// without iOS-side acknowledgment state — the AI may mention
+    /// reassessment for up to this many consecutive sessions per fire event
+    /// until the UI screen + ack writer land in a follow-up.
+    static let heavyReassessmentCooldownWindow: Int = 6
 
     enum CodingKeys: String, CodingKey {
         case goal
@@ -100,6 +117,40 @@ struct TraineeModelDigest: Codable, Sendable, Hashable {
         case lastGlobalPhaseAdvanceFiredAtSessionCount = "last_global_phase_advance_fired_at_session_count"
         case perExerciseSummary        = "per_exercise_summary"
         case weeklyFatigue             = "weekly_fatigue"
+        case heavyReassessmentSignal   = "heavy_reassessment_signal"
+    }
+}
+
+// MARK: - HeavyReassessmentSignal
+
+/// Per ADR-0005: heavy reassessment is the UX event (UI screen + goal
+/// renegotiation) that fires when the global-phase-advance trigger predicate
+/// fires (ADR-0012: ≥4 of 6 major patterns transitioned phase within a
+/// trailing 6-session window; force-deload counts per ADR-0011 §(b)). Trigger
+/// detection and persistence happen server-side in the Edge Function
+/// orchestrator (`shouldFireGlobalPhaseAdvance` in `_shared/global-phase-
+/// advance.ts`); this digest projection is derived at iOS digest-assembly
+/// time from `TraineeModel.lastGlobalPhaseAdvanceFiredAtSessionCount` plus
+/// the per-pattern transition log, so SessionPlan can include the HEAVY
+/// REASSESSMENT prompt block during the cooldown window.
+struct HeavyReassessmentSignal: Codable, Sendable, Hashable {
+    /// Session-count at which the most recent global-phase-advance event
+    /// fired. Equal to `TraineeModel.lastGlobalPhaseAdvanceFiredAtSessionCount`.
+    var triggeringSessionCount: Int
+    /// Sessions elapsed since the trigger fired. 0 means GPA fired during
+    /// this digest's source session; 1 means one session has been logged
+    /// since. Always `< TraineeModelDigest.heavyReassessmentCooldownWindow`
+    /// when the signal is present.
+    var sessionsSinceTriggered: Int
+    /// Major patterns whose phase transitioned within the cooldown window
+    /// per ADR-0011 §(b) / ADR-0012 (force-deload counts as a transition).
+    /// Sorted by `rawValue` for deterministic JSON ordering.
+    var recentlyAdvancedPatterns: [MovementPattern]
+
+    enum CodingKeys: String, CodingKey {
+        case triggeringSessionCount   = "triggering_session_count"
+        case sessionsSinceTriggered   = "sessions_since_triggered"
+        case recentlyAdvancedPatterns = "recently_advanced_patterns"
     }
 }
 
@@ -155,6 +206,8 @@ extension TraineeModelDigest {
         let resolvedWeeklyFatigue = weeklyFatigue
             ?? WeekFatigueSignals.compute(from: [], sessionCount: 0)
 
+        let heavyReassessmentSignal = Self.deriveHeavyReassessmentSignal(from: model)
+
         self.init(
             goal: model.goal,
             projections: model.projections,
@@ -168,7 +221,37 @@ extension TraineeModelDigest {
             totalSessionCount: model.totalSessionCount,
             lastGlobalPhaseAdvanceFiredAtSessionCount: model.lastGlobalPhaseAdvanceFiredAtSessionCount,
             perExerciseSummary: perExerciseSummary,
-            weeklyFatigue: resolvedWeeklyFatigue
+            weeklyFatigue: resolvedWeeklyFatigue,
+            heavyReassessmentSignal: heavyReassessmentSignal
+        )
+    }
+
+    /// Returns a signal iff the server-side GPA trigger fired within the
+    /// cooldown window. Nil when GPA has never fired, when the cooldown has
+    /// elapsed since the last fire, or when (defensively) the persisted
+    /// fired-session-count is in the future relative to `totalSessionCount`.
+    static func deriveHeavyReassessmentSignal(
+        from model: TraineeModel
+    ) -> HeavyReassessmentSignal? {
+        guard let lastFired = model.lastGlobalPhaseAdvanceFiredAtSessionCount else {
+            return nil
+        }
+        let delta = model.totalSessionCount - lastFired
+        guard delta >= 0, delta < heavyReassessmentCooldownWindow else {
+            return nil
+        }
+        let recentPatterns = model.patterns
+            .filter { (pattern, profile) in
+                TraineeModel.majorPatterns.contains(pattern)
+                    && profile.lastPhaseTransitionAtSessionCount > 0
+                    && (model.totalSessionCount - profile.lastPhaseTransitionAtSessionCount) <= heavyReassessmentCooldownWindow
+            }
+            .map { $0.key }
+            .sorted { $0.rawValue < $1.rawValue }
+        return HeavyReassessmentSignal(
+            triggeringSessionCount: lastFired,
+            sessionsSinceTriggered: delta,
+            recentlyAdvancedPatterns: recentPatterns
         )
     }
 }

--- a/ProjectApex/Models/TraineeModelSnapshots.swift
+++ b/ProjectApex/Models/TraineeModelSnapshots.swift
@@ -123,22 +123,6 @@ struct LifeContextEvent: Codable, Sendable, Hashable {
     }
 }
 
-// MARK: - ReassessmentRecord
-
-/// Records a heavy reassessment firing — per ADR-0005, fires when ≥4 of
-/// 6 major patterns transition phase within a 6-session window.
-struct ReassessmentRecord: Codable, Sendable, Hashable {
-    var triggeredAt: Date
-    var triggeringSessionCount: Int
-    var advancedPatterns: [MovementPattern]
-
-    init(triggeredAt: Date, triggeringSessionCount: Int, advancedPatterns: [MovementPattern]) {
-        self.triggeredAt = triggeredAt
-        self.triggeringSessionCount = triggeringSessionCount
-        self.advancedPatterns = advancedPatterns
-    }
-}
-
 // MARK: - PatternProjection
 
 /// Per-pattern projection set at calibration review (or re-derived on

--- a/ProjectApex/Resources/Prompts/SystemPrompt_SessionPlan.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_SessionPlan.txt
@@ -294,6 +294,24 @@ cycled out of deload and into accumulation, expect lifted but restored capabilit
 prescribe at the lower end of accumulation rep ranges with moderate RIR, not the bottom
 of the deload prescription.
 
+HEAVY REASSESSMENT (ADR-0005 / ADR-0012):
+When trainee_model_digest.heavy_reassessment_signal is present, the user has recently
+triggered the global-phase-advance event: ≥4 of 6 major patterns transitioned phase
+within a trailing 6-session window (force-deload counts as a transition per ADR-0011
+§(b)). Per ADR-0005 this is the moment for goal renegotiation. In the session's
+coaching framing:
+• Acknowledge the milestone — name the recently_advanced_patterns specifically (e.g.
+  "Your squat, horizontal push, and hip hinge have all moved forward recently — your
+  training landscape has shifted.").
+• Suggest the user open the goal-review screen in the app to revisit targets. Do NOT
+  generate new numerical targets in this session's prescriptions — goal renegotiation
+  is a UI flow, not an inference output.
+• sessions_since_triggered tells you whether this is fresh (0–1) or has already been
+  surfaced for several sessions (2+). Calibrate emphasis: fresh → lead with the
+  framing; later → brief reminder, do not belabor.
+• Block absent → no reassessment commentary; do not invent the trigger. Absence means
+  either GPA has never fired or the cooldown window has elapsed since the last fire.
+
 ═══════════════════════════════════════════════════════════════
 PRESCRIPTION ACCURACY (AI self-correction)
 ═══════════════════════════════════════════════════════════════

--- a/ProjectApexTests/TraineeModelDigestTests.swift
+++ b/ProjectApexTests/TraineeModelDigestTests.swift
@@ -658,6 +658,23 @@ final class TraineeModelDigestTests: XCTestCase {
                        "Legacy stagnation_signals interpretation prose must not reappear")
     }
 
+    func test_sessionPlanPrompt_containsHeavyReassessmentBlock() throws {
+        let prompt = try loadSessionPlanPrompt()
+
+        XCTAssertTrue(prompt.contains("HEAVY REASSESSMENT (ADR-0005 / ADR-0012)"),
+                      "SessionPlan must include the HEAVY REASSESSMENT section header per #178")
+        XCTAssertTrue(prompt.contains("trainee_model_digest.heavy_reassessment_signal"),
+                      "SessionPlan must reference the heavy_reassessment_signal digest path so the LLM reads the correct field")
+        XCTAssertTrue(prompt.contains("recently_advanced_patterns"),
+                      "SessionPlan must direct the LLM to name the recently advanced patterns")
+        XCTAssertTrue(prompt.contains("sessions_since_triggered"),
+                      "SessionPlan must direct the LLM to calibrate emphasis from sessions_since_triggered")
+        XCTAssertTrue(prompt.contains("Do NOT\ngenerate new numerical targets"),
+                      "SessionPlan must explicitly prohibit inventing numerical goal targets — goal renegotiation is a UI flow per ADR-0005")
+        XCTAssertTrue(prompt.contains("Block absent → no reassessment commentary"),
+                      "SessionPlan must include the absent-block negative anchor — the LLM should not invent the trigger when the signal is missing")
+    }
+
     func test_inferencePrompt_containsPerPatternTrendBlock() {
         // Production Inference reads AIInferenceService.systemPrompt — now a
         // computed accessor backed by SystemPrompt_Inference.txt loaded from

--- a/ProjectApexTests/TraineeModelSnapshotsTests.swift
+++ b/ProjectApexTests/TraineeModelSnapshotsTests.swift
@@ -104,22 +104,6 @@ struct LifeContextEventTests {
     }
 }
 
-@Suite("ReassessmentRecord")
-struct ReassessmentRecordTests {
-    @Test("Round-trip preserves advanced-patterns list order")
-    func roundTrip() throws {
-        let original = ReassessmentRecord(
-            triggeredAt: Date(timeIntervalSince1970: 1_750_000_000),
-            triggeringSessionCount: 24,
-            advancedPatterns: [.horizontalPush, .squat, .verticalPull, .hipHinge]
-        )
-        let data = try JSONEncoder().encode(original)
-        let decoded = try JSONDecoder().decode(ReassessmentRecord.self, from: data)
-        #expect(decoded == original)
-        #expect(decoded.advancedPatterns == [.horizontalPush, .squat, .verticalPull, .hipHinge])
-    }
-}
-
 @Suite("PatternProjection")
 struct PatternProjectionTests {
     @Test("Round-trip preserves floor/stretch/progress")

--- a/ProjectApexTests/TraineeModelTests.swift
+++ b/ProjectApexTests/TraineeModelTests.swift
@@ -213,11 +213,6 @@ struct TraineeModelCodableTests {
         model.lifeContextEvents.append(LifeContextEvent(
             localDate: "2026-04-15", kind: "travel", notes: "10 days abroad"
         ))
-        model.reassessmentRecords.append(ReassessmentRecord(
-            triggeredAt: isoDate("2026-04-20"),
-            triggeringSessionCount: 18,
-            advancedPatterns: [.horizontalPush, .squat, .verticalPull, .hipHinge]
-        ))
         model.projections = ProjectionState(
             patternProjections: [
                 PatternProjection(pattern: .squat, floor: 140, stretch: 165, progress: .onTrack),

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -1014,7 +1014,6 @@ orchestratorTest(
       transfers: [],
       bodyweight: { entries: [] },
       lifeContextEvents: [],
-      reassessmentRecords: [],
       totalSessionCount: 0,
       // Phase 2 additions missing on purpose.
     };


### PR DESCRIPTION
## Summary

- Closes #178. Adds the HEAVY REASSESSMENT block to SessionPlan and the iOS-side digest projection that drives it. Deletes the vestigial `TraineeModel.reassessmentRecords` field (write-orphan; never written by production).
- **Pre-flight discovery (changes the architecture story)**: the global-phase-advance trigger predicate is already fully implemented server-side (`shouldFireGlobalPhaseAdvance` in `_shared/global-phase-advance.ts`), called from the EF orchestrator, and the fire event is persisted on `TraineeModel.lastGlobalPhaseAdvanceFiredAtSessionCount`. iOS digest already surfaced the field. So #178's scope shrunk dramatically: the iOS-side derived signal + the prompt block + the vestigial deletion. No new EF code paths.

## Grilling-locked resolutions (parent-resolved before dispatch)

- **Q1 (signal source) = (a) digest-derive.** The trigger predicate is already server-side; the iOS digest projection just surfaces the derived signal. The ADR-0005 framing of `shouldFireGlobalPhaseAdvance` as a "derived computed property" was load-bearing — the prep prompt's recommendation of (b) (EF writes a stateful record) would have re-storing what the spec explicitly derives.
- **Q2 (transition type) = (a) count all transition types.** **Flipped from prep prompt's recommendation of (c).** Second-opinion's "perverse incentive" framing was right: excluding force-deloads means the more stuck the user gets, the LESS likely the app intervenes — exactly the failure mode heavy reassessment exists to catch. Force-deload IS the loudest "current plan is mis-specified" signal. Also matches the existing EF code (explicit comment: "Force-deload counts as a phase transition (per ADR-0011 §(b) — feature, not bug)") and the literal ADR-0005 reading.
- **Q3 (window anchor) = (a) trailing 6 sessions.** Phase-shift artifacts (same behavior, different trigger outcome depending on epoch) disqualify aligned blocks. Matches the existing EF code (`currentSessionCount - lastPhaseTransitionAtSessionCount <= 6`).
- **Q4 (ack state) = N/A.** Q1's resolution renders it moot. **Ack state is deliberately out of scope for this PR** — no iOS UI writer exists yet, so adding the field would be dead code per Karpathy. The AI may mention reassessment for up to 6 consecutive sessions per fire event (matching the server-side cooldown), until the UI screen + ack writer land in a follow-up.

## Logical units

- **LU#1 (`6108920`) — `HeavyReassessmentSignal` digest projection.** New struct + new field on `TraineeModelDigest` + assembly logic (`deriveHeavyReassessmentSignal(from:)`). Filters to major patterns via `TraineeModel.majorPatterns`. Cooldown window constant (6 sessions) matches the EF's `GLOBAL_PHASE_ADVANCE_COOLDOWN_SESSIONS`.
- **LU#2 (`d9939f7`) — HEAVY REASSESSMENT block in `SystemPrompt_SessionPlan.txt` + β anchor test.** Block inserted after PHASE-CYCLING; same per-pattern-section neighborhood. Tells the AI to name the recently-advanced patterns specifically, calibrate emphasis from `sessions_since_triggered`, and explicitly forbids inventing new numerical goal targets (goal renegotiation is a UI flow, not an inference output). Negative anchor: "Block absent → no reassessment commentary."
- **LU#3 (`438ff72`) — delete vestigial `reassessmentRecords` field + `ReassessmentRecord` struct.** Pre-flight grep confirmed zero production writers. Legacy JSONB rows that carry the key have it silently dropped by the Swift decoder (unknown key, default behavior); one comment in `TraineeModel.init(from:)` documents this.
- **LU#4 (`73ebcbd`) — drop `reassessmentRecords` from EF orchestrator_test fixture.** The EF doesn't define a strict TS interface for the trainee model — the only EF reference was the stale fixture line. Cross-cutting grep for the symbol now returns zero hits across `supabase/`.

## Pre-deploy reminders

- **No new EF code paths.** This PR ships entirely on iOS + the .txt prompt + the test fixture. CI-auto-deploy of the EF is not affected by anything in this PR.
- **No DB migration in this PR.** Production rows that carry the legacy `reassessmentRecords` key in JSONB sit as harmless dead-key drift. Recommended follow-up: file a one-shot migration to `UPDATE ... SET model_json = model_json - 'reassessmentRecords'` once #178 has shipped long enough that no client expects to round-trip the key. Not load-bearing.
- **Cache invalidation:** SystemPrompt_SessionPlan.txt body changed — the `PromptCachingProvider` cache key derives from the prompt body, so next `SessionPlan` call invalidates the cache automatically. No manual action.

## Spinoffs to file (follow-up issues)

1. **iOS UI for heavy-reassessment screen + ack-set writer.** Adds an in-app surface for the user to dismiss the reassessment (renegotiate goals via existing onboarding-style flow, or skip). The writer adds `acknowledgedTriggeringSessionCounts: Set<Int>` to `TraineeModel` and gates the digest signal's `triggered` clause on `!acknowledged`. Until this ships, the AI mentions reassessment for ~6 consecutive sessions per fire event.
2. **One-shot DB migration to strip legacy `reassessmentRecords` JSONB key.** Cleans up dead data on existing alpha-cohort rows.

## Test plan

- [ ] `test_sessionPlanPrompt_containsHeavyReassessmentBlock` passes (β anchor test added in LU#2).
- [ ] Existing `test_sessionPlanPrompt_containsPerPatternTrendBlock_andLacksLegacyStagnationPhrases` still passes (block insertion was additive; existing anchors unchanged).
- [ ] `TraineeModelTests.bigRoundTrip` (test_basicRoundTrip in TraineeModelTests.swift) round-trips cleanly without the deleted `reassessmentRecords` append.
- [ ] `TraineeModelSnapshotsTests` suite passes without `ReassessmentRecordTests` (deleted in LU#3).
- [ ] EF `orchestrator_test.ts` compiles and runs without the deleted fixture field.
- [ ] Full `xcodebuild test` clean (not run in this dispatch env; CI to confirm).