### PR TITLE
fix(#151): align PATTERN_TRAINS_JOINTS to snake_case lower_back

### DIFF
--- a/docs/migrations/down/20260601090000_rename_joint_keys_snake_case.sql
+++ b/docs/migrations/down/20260601090000_rename_joint_keys_snake_case.sql
@@ -1,0 +1,59 @@
+-- REVERSE of supabase/migrations/20260601090000_rename_joint_keys_snake_case.sql
+-- (documentation only; not auto-applied by `supabase db push` — run manually
+--  via `psql -f` if the forward #151 migration must be rolled back.)
+--
+-- Renames the snake_case joint key 'lower_back' back to camelCase 'lowerBack'
+-- in trainee_models.model_json limitation subjects where subject.kind='joint'.
+-- Only restore this alongside reverting the EF code change in the same PR —
+-- otherwise the auto-clear gate (which now expects snake_case) breaks again.
+--
+-- Idempotent (no-op when the value isn't 'lower_back'). Scoped to joint
+-- subjects only, so it will not touch the canonical 'lower_back' used by the
+-- note-classifier tissue-fallthrough path (that value is produced fresh, not
+-- stored as a joint subject this migration manages).
+
+CREATE OR REPLACE FUNCTION pg_temp.revert_joint_value(input jsonb)
+RETURNS jsonb LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE input #>> '{}'
+    WHEN 'lower_back' THEN '"lowerBack"'::jsonb
+    ELSE input
+  END
+$$;
+
+-- 1. activeLimitations[*].subject.value when subject.kind='joint'.
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{activeLimitations}',
+  (
+    SELECT COALESCE(jsonb_agg(
+      CASE
+        WHEN entry #>> '{subject,kind}' = 'joint' THEN
+          jsonb_set(entry, '{subject,value}', pg_temp.revert_joint_value(entry#>'{subject,value}'))
+        ELSE entry
+      END
+    ), '[]'::jsonb)
+    FROM jsonb_array_elements(model_json->'activeLimitations') AS e(entry)
+  )
+)
+WHERE model_json ? 'activeLimitations'
+  AND jsonb_typeof(model_json->'activeLimitations') = 'array';
+
+-- 2. clearedLimitations[*].subject.value when subject.kind='joint'.
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{clearedLimitations}',
+  (
+    SELECT COALESCE(jsonb_agg(
+      CASE
+        WHEN entry #>> '{subject,kind}' = 'joint' THEN
+          jsonb_set(entry, '{subject,value}', pg_temp.revert_joint_value(entry#>'{subject,value}'))
+        ELSE entry
+      END
+    ), '[]'::jsonb)
+    FROM jsonb_array_elements(model_json->'clearedLimitations') AS e(entry)
+  )
+)
+WHERE model_json ? 'clearedLimitations'
+  AND jsonb_typeof(model_json->'clearedLimitations') = 'array';

--- a/supabase/functions/_shared/note-classifier.ts
+++ b/supabase/functions/_shared/note-classifier.ts
@@ -201,18 +201,18 @@ export function selectBootstrapNotes(
 //
 // Map per Q9:
 //   - shoulder, elbow, wrist → all push + all pull (excluding isolation)
-//   - hip, knee, ankle, lowerBack → squat + hip_hinge + lunge
-//   - lowerBack also → vertical_push (per Q9 push extension; OHP loads lumbar
+//   - hip, knee, ankle, lower_back → squat + hip_hinge + lunge
+//   - lower_back also → vertical_push (per Q9 push extension; OHP loads lumbar
 //     through bracing chain)
 //   - neck → no patterns (rare in training)
 const PATTERN_TRAINS_JOINTS: Record<string, readonly string[]> = {
   horizontal_push: ["shoulder", "elbow", "wrist"],
-  vertical_push: ["shoulder", "elbow", "wrist", "lowerBack"],
+  vertical_push: ["shoulder", "elbow", "wrist", "lower_back"],
   horizontal_pull: ["shoulder", "elbow", "wrist"],
   vertical_pull: ["shoulder", "elbow", "wrist"],
-  squat: ["hip", "knee", "ankle", "lowerBack"],
-  hip_hinge: ["hip", "knee", "ankle", "lowerBack"],
-  lunge: ["hip", "knee", "ankle", "lowerBack"],
+  squat: ["hip", "knee", "ankle", "lower_back"],
+  hip_hinge: ["hip", "knee", "ankle", "lower_back"],
+  lunge: ["hip", "knee", "ankle", "lower_back"],
   isolation: [],
 };
 

--- a/supabase/functions/_shared/note-classifier_test.ts
+++ b/supabase/functions/_shared/note-classifier_test.ts
@@ -254,6 +254,44 @@ Deno.test(
 );
 
 Deno.test(
+  "Q9 #151 regression: AI-inferred lower_back joint limitation auto-clears when the session trains squat — gate must route through derivedTrainedJoints",
+  () => {
+    // Reproduces #151: PATTERN_TRAINS_JOINTS once stored "lowerBack" (camelCase)
+    // while a joint subject.value is the BodyJoint rawValue "lower_back"
+    // (snake_case), so trainedJoints.has(subject.value) silently missed and a
+    // lower_back limitation never auto-cleared. Unlike the shoulder test above,
+    // this drives the REAL production derivation (derivedTrainedJoints) instead
+    // of hand-constructing trainedJoints — that hand-construction is precisely
+    // why the existing tests masked the bug.
+    const preExisting: ActiveLimitation = {
+      subject: { kind: "joint", value: "lower_back" },
+      severity: "mild",
+      onsetDate: ANCHOR.toISOString(),
+      evidenceCount: 2,
+      userConfirmed: false,
+      notes: null,
+      sessionsWithoutReMention: 2,
+    };
+    const sessionDate = new Date(ANCHOR.getTime() + 7 * 86400 * 1000);
+    const trainedPatterns = new Set(["squat"]);
+    const result = updateLimitationLifecycle({
+      active: [preExisting],
+      cleared: [],
+      classifierMentions: [], // no re-mention this session
+      trainedPatterns,
+      trainedMuscleGroups: new Set(),
+      trainedJoints: derivedTrainedJoints(trainedPatterns), // production path, not hand-built
+      notesProcessed: true,
+      now: sessionDate,
+    });
+    assertEquals(result.active.length, 0, "lower_back limitation must auto-clear when squat trains it");
+    assertEquals(result.cleared.length, 1);
+    assertEquals(result.cleared[0].subject.kind, "joint");
+    assertEquals(result.cleared[0].subject.value, "lower_back");
+  },
+);
+
+Deno.test(
   "Q9: user-reported limitation never auto-clears — even 10 sessions of subject-trained + notes-processed + no-mention leave it in active",
   () => {
     // userConfirmed=true → never auto-clear regardless of counter. Cycle 13
@@ -434,21 +472,21 @@ Deno.test(
     const joints = derivedTrainedJoints(new Set(["squat"]));
     assertEquals(joints.has("shoulder"), false, "squat is a lower-body pattern; doesn't train shoulder per Q9");
     assertEquals(joints.has("elbow"), false);
-    assertEquals(joints.has("hip"), true, "squat trains hip/knee/ankle/lowerBack per Q9");
+    assertEquals(joints.has("hip"), true, "squat trains hip/knee/ankle/lower_back per Q9");
     assertEquals(joints.has("knee"), true);
     assertEquals(joints.has("ankle"), true);
-    assertEquals(joints.has("lowerBack"), true);
+    assertEquals(joints.has("lower_back"), true);
   },
 );
 
 Deno.test(
-  "Q9 joint→pattern map: lowerBack is trained on hip_hinge (per Q9 lowerBack ↔ squat+hip_hinge+lunge+vertical_push)",
+  "Q9 joint→pattern map: lower_back is trained on hip_hinge (per Q9 lower_back ↔ squat+hip_hinge+lunge+vertical_push)",
   () => {
     const joints = derivedTrainedJoints(new Set(["hip_hinge"]));
-    assertEquals(joints.has("lowerBack"), true);
-    // Cross-check vertical_push also trains lowerBack per Q9 push extension.
+    assertEquals(joints.has("lower_back"), true);
+    // Cross-check vertical_push also trains lower_back per Q9 push extension.
     const jointsVP = derivedTrainedJoints(new Set(["vertical_push"]));
-    assertEquals(jointsVP.has("lowerBack"), true, "vertical_push trains lowerBack per Q9 push extension (OHP loads lumbar through bracing chain)");
+    assertEquals(jointsVP.has("lower_back"), true, "vertical_push trains lower_back per Q9 push extension (OHP loads lumbar through bracing chain)");
   },
 );
 

--- a/supabase/migrations/20260601090000_rename_joint_keys_snake_case.sql
+++ b/supabase/migrations/20260601090000_rename_joint_keys_snake_case.sql
@@ -1,0 +1,74 @@
+-- Reverse migration: docs/migrations/down/20260601090000_rename_joint_keys_snake_case.sql
+-- (documentation only; not auto-applied by `supabase db push`)
+--
+-- #151: rename the camelCase joint key 'lowerBack' to snake_case 'lower_back'
+-- in trainee_models.model_json limitation subjects.
+--
+-- The Edge Function's PATTERN_TRAINS_JOINTS map (_shared/note-classifier.ts)
+-- previously stored the joint string "lowerBack" (camelCase), while a joint
+-- subject's value is the BodyJoint rawValue "lower_back" (snake_case) — locked
+-- by note-classifier-prompt.txt and Swift's BodyJoint.lowerBack = "lower_back".
+-- The auto-clear gate isSubjectTrained does trainedJoints.has(subject.value),
+-- so a lower_back-scoped limitation never matched the camelCase-derived set and
+-- never auto-cleared. EF code in this same PR fixes the map to snake_case; this
+-- migration renames the key in any existing alpha JSONB rows.
+--
+-- 'lowerBack' is the only multi-word joint, so it is the only joint affected
+-- (shoulder/elbow/wrist/hip/knee/ankle/neck have no casing distinction).
+--
+-- Joint-keyed locations migrated (joints are never pattern-keyed, so unlike
+-- #148 only the two limitation arrays need touching):
+--   1. model_json.activeLimitations[*].subject.value  when subject.kind='joint'
+--   2. model_json.clearedLimitations[*].subject.value when subject.kind='joint'
+--
+-- Each location is migrated independently with an idempotent transformation
+-- (no-op when the value isn't 'lowerBack') so the migration can re-run safely.
+-- Forward-only per the migrations workflow.
+
+-- Helper: rename the camelCase joint scalar 'lowerBack' to snake_case within a
+-- jsonb scalar. Returns the input unchanged for any non-matching value.
+CREATE OR REPLACE FUNCTION pg_temp.rename_joint_value(input jsonb)
+RETURNS jsonb LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE input #>> '{}'
+    WHEN 'lowerBack' THEN '"lower_back"'::jsonb
+    ELSE input
+  END
+$$;
+
+-- 1. activeLimitations[*].subject.value when subject.kind='joint'.
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{activeLimitations}',
+  (
+    SELECT COALESCE(jsonb_agg(
+      CASE
+        WHEN entry #>> '{subject,kind}' = 'joint' THEN
+          jsonb_set(entry, '{subject,value}', pg_temp.rename_joint_value(entry#>'{subject,value}'))
+        ELSE entry
+      END
+    ), '[]'::jsonb)
+    FROM jsonb_array_elements(model_json->'activeLimitations') AS e(entry)
+  )
+)
+WHERE model_json ? 'activeLimitations'
+  AND jsonb_typeof(model_json->'activeLimitations') = 'array';
+
+-- 2. clearedLimitations[*].subject.value when subject.kind='joint'.
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{clearedLimitations}',
+  (
+    SELECT COALESCE(jsonb_agg(
+      CASE
+        WHEN entry #>> '{subject,kind}' = 'joint' THEN
+          jsonb_set(entry, '{subject,value}', pg_temp.rename_joint_value(entry#>'{subject,value}'))
+        ELSE entry
+      END
+    ), '[]'::jsonb)
+    FROM jsonb_array_elements(model_json->'clearedLimitations') AS e(entry)
+  )
+)
+WHERE model_json ? 'clearedLimitations'
+  AND jsonb_typeof(model_json->'clearedLimitations') = 'array';


### PR DESCRIPTION
Closes #151

## Root cause
`PATTERN_TRAINS_JOINTS` in `note-classifier.ts` stored the joint string `"lowerBack"` (camelCase), but a joint subject's `value` is the `BodyJoint` rawValue `"lower_back"` (snake_case — locked by `note-classifier-prompt.txt` and Swift `BodyJoint.lowerBack = "lower_back"`). The auto-clear gate `isSubjectTrained` does `trainedJoints.has(subject.value)`, so a `lower_back` limitation never matched the camelCase-derived set and **never auto-cleared** — it persisted indefinitely.

## What shipped
- Flip the 4 `PATTERN_TRAINS_JOINTS` values `lowerBack` → `lower_back` (snake_case is the canonical contract).
- Correct the existing masking assertions in `note-classifier_test.ts` (they asserted the buggy camelCase value, so they passed while the gate was broken).
- **New regression test** that drives the *real* `derivedTrainedJoints` production path (the existing auto-clear test hand-builds `trainedJoints`, which is why it never caught this).
- **Data migration** `20260601090000_rename_joint_keys_snake_case.sql` (+ reverse under `docs/migrations/down/`) renaming `lowerBack`→`lower_back` in existing `model_json` joint subjects (activeLimitations + clearedLimitations). Idempotent, forward-only.

## Verification
`deno test note-classifier_test.ts`: **RED→GREEN proven** — reverting only the source map fix makes the new regression test + corrected assertions fail (3 failed); with the fix, **65 passed / 0 failed**.

## Blast radius (grep-and-report)
`lowerBack` is the only multi-word joint, so it is the only joint affected (shoulder/elbow/wrist/hip/knee/ankle/neck have no casing distinction). iOS `BodyJoint.lowerBack` rawValue is already `"lower_back"` and is **not** changed. Sibling vocabulary-drift bug #167 (muscle path) is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)