### PR TITLE
fix(#167): reject non-canonical primary_muscle in derivedTrainedSets

### DIFF
--- a/supabase/functions/_shared/per-muscle-rules.ts
+++ b/supabase/functions/_shared/per-muscle-rules.ts
@@ -40,6 +40,21 @@ export type MuscleGroup =
   | "legs";
 
 /**
+ * Runtime set of the locked-six `MuscleGroup` values — single source of truth
+ * mirroring the type above (the type alone is compile-time only). Used to
+ * validate client-supplied muscle strings at trust boundaries so non-canonical
+ * tokens (e.g. "posterior_deltoid") cannot leak into model state (#167).
+ */
+export const MUSCLE_GROUPS: ReadonlySet<MuscleGroup> = new Set<MuscleGroup>([
+  "back",
+  "chest",
+  "biceps",
+  "shoulders",
+  "triceps",
+  "legs",
+]);
+
+/**
  * Q1-locked per-muscle volume targets (MEV midpoints, per-7-events at
  * 4×/week cadence). volumeTolerance is bootstrapped from this table per
  * 2026-05-13 prep-prompt lock. Follow-up: EWMA-update of tolerance from

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -89,6 +89,7 @@ import {
   bootstrapMuscleProfile,
   computeFocusWeight,
   computeVolumeDeficit,
+  MUSCLE_GROUPS,
   MUSCLE_VOLUME_WINDOW,
   type AxisConfidence,
   type MuscleGroup,
@@ -1940,7 +1941,7 @@ export async function applySession(
  * over-detect → premature clearing, also silent in the AI-inferred path
  * which caps at .mild).
  */
-function derivedTrainedSets(
+export function derivedTrainedSets(
   sessionPayload: Record<string, unknown>,
 ): {
   exercises: Set<string>;
@@ -1980,9 +1981,14 @@ function derivedTrainedSets(
         const m = e.primary_muscle;
         if (["quads", "hamstrings", "glutes", "calves"].includes(m)) {
           muscleGroups.add("legs");
-        } else {
+        } else if ((MUSCLE_GROUPS as ReadonlySet<string>).has(m)) {
           muscleGroups.add(m);
         }
+        // else: a non-canonical primary_muscle string (e.g. "posterior_deltoid")
+        // — rejected per #167 so it cannot leak into trainedMuscleGroups and
+        // falsely satisfy the note-classifier auto-clear gate. Option (a)
+        // reject-unknown; remapping unknowns to a canonical group via
+        // EXERCISE_PRIMARY_MUSCLE_MAP is a possible follow-up (not done here).
       }
     }
   }

--- a/supabase/functions/update-trainee-model/index_test.ts
+++ b/supabase/functions/update-trainee-model/index_test.ts
@@ -9,7 +9,7 @@
 //   deno test supabase/functions/update-trainee-model/index_test.ts
 
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { validateRequest } from "./index.ts";
+import { derivedTrainedSets, validateRequest } from "./index.ts";
 
 const VALID_USER_ID = "11111111-1111-4111-8111-111111111111";
 const VALID_SESSION_ID = "22222222-2222-4222-8222-222222222222";
@@ -21,6 +21,35 @@ function baseRequest(payloadOverrides: Record<string, unknown> = {}) {
     session_payload: payloadOverrides,
   };
 }
+
+// ─── #167: derivedTrainedSets rejects non-canonical primary_muscle strings ───
+// posterior_deltoid is not a canonical MuscleGroup; before the fix the else
+// branch added it verbatim, leaking it into trainedMuscleGroups where it could
+// falsely satisfy the note-classifier auto-clear gate.
+Deno.test("derivedTrainedSets_rejects_unknown_primary_muscle", () => {
+  const trained = derivedTrainedSets({
+    set_logs: [
+      { exercise_id: "ex-1", primary_muscle: "posterior_deltoid", intent: "top" },
+    ],
+  });
+  assertEquals(
+    trained.muscleGroups.has("posterior_deltoid"),
+    false,
+    "unknown primary_muscle must not leak into muscleGroups",
+  );
+});
+
+// And a canonical primary_muscle still flows through unchanged.
+Deno.test("derivedTrainedSets_keeps_canonical_primary_muscle", () => {
+  const trained = derivedTrainedSets({
+    set_logs: [
+      { exercise_id: "ex-1", primary_muscle: "chest", intent: "top" },
+      { exercise_id: "ex-2", primary_muscle: "quads", intent: "top" },
+    ],
+  });
+  assertEquals(trained.muscleGroups.has("chest"), true, "canonical group retained");
+  assertEquals(trained.muscleGroups.has("legs"), true, "leg subgroup collapses to legs");
+});
 
 // ─── D1: no set_logs key — passes ────────────────────────────────────────────
 Deno.test("validateRequest_no_set_logs_field_returns_ok", () => {


### PR DESCRIPTION
Closes #167

## Root cause
`derivedTrainedSets` (update-trainee-model/index.ts) added the client-supplied `primary_muscle` string **verbatim** in its else branch, so an unknown token like `posterior_deltoid` leaked into `trainedMuscleGroups`. That set feeds the note-classifier auto-clear gate `isSubjectTrained` — a limitation could then match on a non-canonical string.

## What shipped (option (a) — minimal reject-unknown)
- New runtime `MUSCLE_GROUPS` set in `per-muscle-rules.ts` (single source of truth mirroring the `MuscleGroup` type — the type alone is compile-time only).
- The else branch now only adds `m` if it is a canonical `MuscleGroup`; non-canonical strings are skipped.
- `derivedTrainedSets` exported; RED + canonical-still-passes tests added to `index_test.ts`.

## Decision note
This is the **conservative option (a)** (reject unknown). **Option (b)** — remapping unknowns to a canonical group via `EXERCISE_PRIMARY_MUSCLE_MAP` (so e.g. `posterior_deltoid` would *count* toward `shoulders`) — is a deliberate enhancement left as a possible follow-up, not done here.

## Verification
`deno test`: RED→GREEN proven (reverting the guard fails `derivedTrainedSets_rejects_unknown_primary_muscle` with the exact leak assertion). With the fix: **index_test 11/0**, note-classifier **65/0** (shares per-muscle-rules).

## Grep-and-report (NOT fixed here — needs authorization)
The **same function has a sibling leak**: the pattern derivation (`index.ts` ~1968–1974) adds the client-supplied `e.pattern` string verbatim with no validation against the `MovementPattern` vocabulary, feeding `trainedPatterns` and `derivedTrainedJoints`. Identical leak shape, one field over. Recommend a separate issue/PR to validate `e.pattern` against the canonical `MovementPattern` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)