### PR TITLE
fix(#192): normalize day_type labels to snake_case

### DIFF
--- a/ProjectApex/Services/MacroPlanService.swift
+++ b/ProjectApex/Services/MacroPlanService.swift
@@ -298,7 +298,7 @@ actor MacroPlanService {
             let days: [TrainingDay] = intent.dayFocus.enumerated().map { dayIndex, focus in
                 // Assign standard ISO-weekday slots: Mon=1, Tue=2, Wed=3, Thu=4, ...
                 let dayOfWeek = standardDayOfWeek(for: dayIndex, daysPerWeek: skeleton.trainingDaysPerWeek)
-                let label = focus.replacingOccurrences(of: " ", with: "_")
+                let label = normalizeDayLabel(focus)
                 return TrainingDay(
                     id: UUID(),
                     dayOfWeek: dayOfWeek,
@@ -343,6 +343,21 @@ actor MacroPlanService {
         let slots = table[daysPerWeek] ?? slots4
         guard dayIndex < slots.count else { return dayIndex + 1 }
         return slots[dayIndex]
+    }
+
+    /// Normalize a free-text day-focus string into a clean snake_case
+    /// `day_type` label. The macro-skeleton prompt lets the LLM emit focus
+    /// strings with spaces, ampersands, slashes, etc. (e.g. "Arms & Shoulders",
+    /// "Chest/Shoulders/Triceps"); the prior space-only substitution left the
+    /// `&` and `/` intact, producing non-standard values like `Arms_&_Shoulders`
+    /// (#192). Collapse every run of non-alphanumeric characters to a single
+    /// underscore and trim, so the stored label always matches `^[A-Za-z0-9_]+$`.
+    /// Case is preserved (the convention is `Push_A`/`Upper_Push`, not lowercase).
+    static func normalizeDayLabel(_ focus: String) -> String {
+        return focus
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: "_")
     }
 
     // MARK: - Private: Helpers

--- a/ProjectApexTests/MacroPlanServiceDayCountTests.swift
+++ b/ProjectApexTests/MacroPlanServiceDayCountTests.swift
@@ -479,3 +479,53 @@ private let validOneDayTemplateJSON = """
   }
 }
 """
+
+// MARK: - #192 day_type normalization
+
+@Suite("MacroPlanService — day_type normalization (#192)")
+struct MacroPlanServiceDayLabelNormalizationTests {
+
+    @Test("buildPendingMesocycle normalizes free-text focus into snake_case day labels")
+    func normalizesDayFocusLabels() {
+        let userId = UUID()
+        let skeleton = MesocycleSkeleton(
+            id: UUID(),
+            userId: userId,
+            createdAt: Date(timeIntervalSince1970: 0),
+            isActive: false,
+            trainingDaysPerWeek: 3,
+            periodizationModel: "linear_periodization",
+            weekIntents: [
+                WeekIntent(
+                    weekLabel: "Week 1",
+                    dayFocus: ["Arms & Shoulders", "Chest/Back", "Legs"],
+                    volumeLandmark: 0.5
+                )
+            ]
+        )
+
+        let meso = MacroPlanService.buildPendingMesocycle(from: skeleton, userId: userId)
+        let labels = meso.weeks[0].trainingDays.map(\.dayLabel)
+
+        // Before #192 the space-only substitution produced "Arms_&_Shoulders"
+        // and left the "/" intact ("Chest/Back").
+        #expect(labels[0] == "Arms_Shoulders")
+        #expect(labels[1] == "Chest_Back")
+        #expect(labels[2] == "Legs")
+        for label in labels {
+            #expect(
+                label.range(of: "^[A-Za-z0-9_]+$", options: .regularExpression) != nil,
+                "day label must be snake_case-safe, got \(label)"
+            )
+        }
+    }
+
+    @Test("normalizeDayLabel collapses runs of non-alphanumerics and trims")
+    func normalizerEdgeCases() {
+        #expect(MacroPlanService.normalizeDayLabel("Arms & Shoulders") == "Arms_Shoulders")
+        #expect(MacroPlanService.normalizeDayLabel("Chest/Shoulders/Triceps") == "Chest_Shoulders_Triceps")
+        #expect(MacroPlanService.normalizeDayLabel("Upper Push") == "Upper_Push")
+        #expect(MacroPlanService.normalizeDayLabel("  Legs  ") == "Legs")
+        #expect(MacroPlanService.normalizeDayLabel("Push_A") == "Push_A")
+    }
+}


### PR DESCRIPTION
Closes #192

## Root cause
`MacroPlanService` minted `day_type` labels via `focus.replacingOccurrences(of: " ", with: "_")` — space-only. The macro-skeleton prompt lets the LLM emit free-text focus like `"Arms & Shoulders"`, so the `&` (and `/`) survived → `Arms_&_Shoulders`.

## What shipped
- New `MacroPlanService.normalizeDayLabel(_:)`: collapses every run of non-alphanumeric chars to a single `_` and trims → `Arms_Shoulders`. **Case preserved** (the convention is `Push_A`/`Upper_Push`, not lowercase).
- Applied at the single skeleton mint point (`buildPendingMesocycle`).
- Behavioral test through `buildPendingMesocycle` (`Arms & Shoulders`→`Arms_Shoulders`, `Chest/Back`→`Chest_Back`) + direct normalizer edge cases.

## Grep-and-report (NOT changed here — needs authorization)
A **second day_label mint point** exists: `ProgramGenerationService.swift` (`expandTemplate`) decodes `day_label` straight from the LLM with no normalization. Recommend it adopt the same helper. Left for #172, which extends this surface (regen label continuity) and overlaps this file.

## Note
This is the decision-free normalization base that **#172** (regen label continuity, strategy A) will build on — kept surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)