### PR TITLE
fix(#186): query set_logs by session_id, not user_id, in fetchWeeklyFatigue

### DIFF
--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -1336,21 +1336,43 @@ actor WorkoutSessionManager {
         let sevenDaysAgo = ISO8601DateFormatter().string(
             from: Date(timeIntervalSinceNow: -7 * 24 * 3600)
         )
-        let recentLogs: [SetLog]
         do {
-            recentLogs = try await supabase.fetch(
+            // set_logs has no user_id column — it is keyed by session_id
+            // (FK → workout_sessions). The prior single-query filter on
+            // set_logs.user_id returned HTTP 400 (#186), silently swallowed
+            // here so weekly fatigue was never populated. Two-query pattern
+            // (mirrors ProgressViewModel / ProgramViewModel): resolve the
+            // user's recent sessions, then fetch their set_logs by session_id.
+            // No `completed` filter — fatigue counts all recent logged work,
+            // matching the original logged_at-window semantics (and avoiding
+            // the #171 completion-drift undercount).
+            struct SessionIdRow: Decodable { let id: UUID }
+            let sessionRows: [SessionIdRow] = try await supabase.fetch(
+                SessionIdRow.self,
+                table: "workout_sessions",
+                filters: [
+                    Filter(column: "user_id",      op: .eq,  value: userId.uuidString),
+                    Filter(column: "session_date", op: .gte, value: sevenDaysAgo)
+                ],
+                select: "id"
+            )
+            guard !sessionRows.isEmpty else {
+                return WeekFatigueSignals.compute(from: [], sessionCount: 0)
+            }
+            let sessionIds = sessionRows.map { $0.id.uuidString }.joined(separator: ",")
+            let recentLogs: [SetLog] = try await supabase.fetch(
                 SetLog.self,
                 table: "set_logs",
                 filters: [
-                    Filter(column: "user_id",    op: .eq,  value: userId.uuidString),
+                    Filter(column: "session_id", op: .in,  value: "(\(sessionIds))"),
                     Filter(column: "logged_at",  op: .gte, value: sevenDaysAgo)
                 ]
             )
+            let sessionCount = Set(recentLogs.map(\.sessionId)).count
+            return WeekFatigueSignals.compute(from: recentLogs, sessionCount: sessionCount)
         } catch {
             return nil
         }
-        let sessionCount = Set(recentLogs.map(\.sessionId)).count
-        return WeekFatigueSignals.compute(from: recentLogs, sessionCount: sessionCount)
     }
 
     /// Fetches the top-K most relevant memory items for `exercise` via the

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -81,6 +81,69 @@ private func makeTestSupabase() -> SupabaseClient {
     )
 }
 
+// MARK: - Recording URLProtocol (#186 — captures request URLs to assert query shape)
+
+/// Records every request URL so a test can assert which columns a query filters
+/// on. Returns one workout_sessions row for GET session lookups (so the
+/// weekly-fatigue two-query path proceeds to query set_logs); everything else
+/// gets an empty array.
+private final class WSMRecordingURLProtocol: URLProtocol, @unchecked Sendable {
+    static let lock = NSLock()
+    nonisolated(unsafe) static var requestURLs: [URL] = []
+    static func reset() {
+        lock.lock(); requestURLs = []; lock.unlock()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        if let url = request.url {
+            Self.lock.lock(); Self.requestURLs.append(url); Self.lock.unlock()
+        }
+        let path = request.url?.path ?? ""
+        let isGet = (request.httpMethod ?? "GET") == "GET"
+        let body = (isGet && path.contains("workout_sessions"))
+            ? "[{\"id\":\"00000000-0000-4000-8000-000000000001\"}]"
+            : "[]"
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200,
+            httpVersion: nil, headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+private func makeRecordingManager() -> WorkoutSessionManager {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [WSMRecordingURLProtocol.self]
+    let supabase = SupabaseClient(
+        supabaseURL: URL(string: "https://test.supabase.co")!,
+        anonKey: "test-key",
+        urlSession: URLSession(configuration: config)
+    )
+    let inferenceService = AIInferenceService(
+        provider: MockLLMProvider(response: prescriptionJSON()),
+        gymProfile: nil,
+        maxRetries: 0
+    )
+    let memoryService = MemoryService(supabase: supabase, embeddingAPIKey: "")
+    let suiteName = "com.test.wsm.rec.\(UUID().uuidString)"
+    let testDefaults = UserDefaults(suiteName: suiteName)!
+    let gymFactStore = GymFactStore(userDefaults: testDefaults)
+    let waq = WriteAheadQueue(supabase: supabase, userDefaults: testDefaults)
+    return WorkoutSessionManager(
+        aiInference: inferenceService,
+        healthKit: HealthKitService(),
+        memoryService: memoryService,
+        supabase: supabase,
+        gymFactStore: gymFactStore,
+        writeAheadQueue: waq
+    )
+}
+
 // MARK: - JSON Fixture Builders
 
 /// Builds a valid set_prescription JSON response string.
@@ -403,5 +466,33 @@ final class WorkoutSessionManagerTests: XCTestCase {
         XCTAssertEqual(summary.setsCompleted, 1)
         // totalVolumeKg should be positive
         XCTAssertGreaterThan(summary.totalVolumeKg, 0)
+    }
+
+    // MARK: #186: weekly-fatigue fetch queries set_logs by session_id, not user_id
+
+    /// set_logs has no `user_id` column; the weekly-fatigue fetch must resolve
+    /// the user's sessions first and query set_logs by `session_id`. Pre-fix it
+    /// emitted `set_logs?user_id=eq...` → HTTP 400 (silently swallowed), so the
+    /// fatigue signal was never populated.
+    func testFetchWeeklyFatigue_queriesSetLogsBySessionId_notUserId() async throws {
+        WSMRecordingURLProtocol.reset()
+        let manager = makeRecordingManager()
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        // Let the parallel fatigue fetch (two awaited queries) complete.
+        try await Task.sleep(nanoseconds: 400_000_000) // 0.4s
+
+        let setLogsRequests = WSMRecordingURLProtocol.requestURLs.filter {
+            $0.path.contains("set_logs")
+        }
+        XCTAssertFalse(
+            setLogsRequests.contains { ($0.query ?? "").contains("user_id") },
+            "set_logs must never be queried by user_id (no such column) — #186"
+        )
+        XCTAssertTrue(
+            setLogsRequests.contains { ($0.query ?? "").contains("session_id") },
+            "weekly-fatigue fetch must query set_logs by session_id"
+        )
     }
 }


### PR DESCRIPTION
Closes #186

## Root cause
`WorkoutSessionManager.fetchWeeklyFatigue` issued `GET /rest/v1/set_logs?user_id=eq.<uuid>&logged_at=gte...`, but **set_logs has no `user_id` column** (keyed by `session_id`, FK → workout_sessions). PostgREST returned **400**, the `catch` swallowed it → `cachedWeeklyFatigue` was silently `nil` (weekly-fatigue signal never populated; noisy 400s in logs).

## What shipped
Rewrote to the **two-query pattern** used at 5 other sites: resolve the user's recent `workout_sessions` ids (`user_id` + a 7-day `session_date` window, mirroring `fetchCompletedSessionCount`), then fetch `set_logs` by `session_id.in.(...)` + the existing `logged_at` window. No `completed` filter — fatigue should count all recent logged work, which also avoids the #171 completion-drift undercount. `WeekFatigueSignals.compute` + the cache assignment are unchanged.

## Verification
Added `testFetchWeeklyFatigue_queriesSetLogsBySessionId_notUserId` — a request-recording `URLProtocol` driven through `startSession`, asserting no `set_logs` request carries `user_id` and at least one carries `session_id`. **I could not run the iOS suite locally (no sim/Xcode-26.3 here); relying on CI's Build & Test job** — will confirm the new test goes RED→GREEN there before merge.

## Blast radius (grep-and-report)
`fetchWeeklyFatigue` was the **only** `set_logs` query using `user_id`; all others already use `session_id` (ProgressViewModel:201, ProgramViewModel:427/481, ProgramDayDetailView:971, WorkoutViewModel:395). Single-site bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)