### PR TITLE
fix(#171): consistent early-exit status + feed early-exit sets to the model

### DIFF
--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -1444,7 +1444,13 @@ actor WorkoutSessionManager {
 
         // Blocking write: patch workout_sessions with status + completed + summary (P3-T06 AC)
         // Must complete before PostWorkoutSummaryView is shown.
-        let patch = WorkoutSessionSummaryPatch(status: "completed", completed: finalSession.completed, summary: summary)
+        // Keep (status, completed) internally consistent (#171): an early exit is
+        // NOT a full completion, so don't hardcode status="completed" alongside
+        // completed=false. Use "partial" — not "abandoned", since the deep
+        // lift-history fetch excludes 'abandoned' but a partial session carries
+        // real logged sets we want the model and history to see.
+        let status = finalSession.completed ? "completed" : "partial"
+        let patch = WorkoutSessionSummaryPatch(status: status, completed: finalSession.completed, summary: summary)
         let sessionId = finalSession.id
         print("[WorkoutSessionManager] Writing session completion — id: \(sessionId), completed: \(finalSession.completed), sets: \(completedSets.count)")
         do {
@@ -1456,12 +1462,15 @@ actor WorkoutSessionManager {
             try? await writeAheadQueue.enqueue(patch, table: "workout_sessions")
         }
 
-        // Producer side of the trainee-model update pipeline (#135). Only fire
-        // on real completion — early exit leaves completed=false, which the
-        // digest pipeline treats as a non-event. Must run AFTER the PATCH so
-        // the session row exists when the WAQ flush dispatches this item to
-        // the Edge Function.
-        if finalSession.completed, let traineeModelService {
+        // Producer side of the trainee-model update pipeline (#135). Fire for
+        // ANY saved session, including early exits (#171). We only reach this
+        // point when completedSets is non-empty (guard at the top of this
+        // method), so the model always has real logged sets to learn from. The
+        // Edge Function aggregates actual logged sets and never reads
+        // workout_sessions.status/completed, so a partial session contributes
+        // accurately instead of vanishing. Must run AFTER the PATCH so the
+        // session row exists when the WAQ flush dispatches this item to the EF.
+        if let traineeModelService {
             try? await traineeModelService.enqueueUpdate(forSession: finalSession, setLogs: completedSets)
         }
 

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -495,4 +495,101 @@ final class WorkoutSessionManagerTests: XCTestCase {
             "weekly-fatigue fetch must query set_logs by session_id"
         )
     }
+
+    // MARK: #171 — early-exit writes a consistent (status, completed) pair
+
+    /// Reproduces #171: finishSession hardcoded status="completed" while
+    /// completed=false on early exit. The pair must be internally consistent —
+    /// early exit writes status="partial" (not "completed").
+    func testFinishSession_earlyExit_writesPartialStatusConsistentWithCompletedFalse() async throws {
+        WSMBodyCaptureURLProtocol.reset()
+        let manager = makeBodyCaptureManager()
+        let day = makeTrainingDay(exerciseCount: 2, setsPerExercise: 3)
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 300_000_000)
+        await manager.completeSet(actualReps: 10, rpeFelt: 6, intent: .top)
+        await manager.endSessionEarly()
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        // The completion PATCH is the only one carrying a `summary` object.
+        let summaryPatch = WSMBodyCaptureURLProtocol.captured
+            .filter { $0.path.contains("workout_sessions") && $0.method == "PATCH" && !$0.body.isEmpty }
+            .compactMap { try? JSONSerialization.jsonObject(with: $0.body) as? [String: Any] }
+            .first { $0["summary"] != nil }
+        let patch = try XCTUnwrap(summaryPatch, "expected a workout_sessions completion PATCH")
+        XCTAssertEqual(patch["completed"] as? Bool, false, "early exit must not be completed=true")
+        XCTAssertEqual(
+            patch["status"] as? String, "partial",
+            "status must be consistent with completed=false, not the old hardcoded 'completed' (#171)"
+        )
+    }
+}
+
+// MARK: - Body-capturing URLProtocol (#171 — inspect the PATCH payload)
+
+private final class WSMBodyCaptureURLProtocol: URLProtocol, @unchecked Sendable {
+    static let lock = NSLock()
+    nonisolated(unsafe) static var captured: [(path: String, method: String, body: Data)] = []
+    static func reset() {
+        lock.lock(); captured = []; lock.unlock()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let path = request.url?.path ?? ""
+        let method = request.httpMethod ?? "GET"
+        var body = request.httpBody ?? Data()
+        if body.isEmpty, let stream = request.httpBodyStream {
+            stream.open()
+            defer { stream.close() }
+            let bufSize = 4096
+            let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: bufSize)
+            defer { buf.deallocate() }
+            while stream.hasBytesAvailable {
+                let n = stream.read(buf, maxLength: bufSize)
+                if n > 0 { body.append(buf, count: n) } else { break }
+            }
+        }
+        Self.lock.lock(); Self.captured.append((path, method, body)); Self.lock.unlock()
+
+        // Return one row for workout_sessions so the PATCH's performExpectingRow
+        // (return=representation) sees a match; empty array otherwise.
+        let respBody = path.contains("workout_sessions")
+            ? "[{\"id\":\"00000000-0000-4000-8000-000000000001\"}]"
+            : "[]"
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(respBody.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+private func makeBodyCaptureManager() -> WorkoutSessionManager {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [WSMBodyCaptureURLProtocol.self]
+    let supabase = SupabaseClient(
+        supabaseURL: URL(string: "https://test.supabase.co")!,
+        anonKey: "test-key",
+        urlSession: URLSession(configuration: config)
+    )
+    let inferenceService = AIInferenceService(
+        provider: MockLLMProvider(response: prescriptionJSON()),
+        gymProfile: nil,
+        maxRetries: 0
+    )
+    let memoryService = MemoryService(supabase: supabase, embeddingAPIKey: "")
+    let testDefaults = UserDefaults(suiteName: "com.test.wsm.body.\(UUID().uuidString)")!
+    let gymFactStore = GymFactStore(userDefaults: testDefaults)
+    let waq = WriteAheadQueue(supabase: supabase, userDefaults: testDefaults)
+    return WorkoutSessionManager(
+        aiInference: inferenceService,
+        healthKit: HealthKitService(),
+        memoryService: memoryService,
+        supabase: supabase,
+        gymFactStore: gymFactStore,
+        writeAheadQueue: waq
+    )
 }


### PR DESCRIPTION
Closes #171

## Root cause
`finishSession` hardcoded `status="completed"` while writing `completed=false` for early exits — an incoherent pair that read sites disagree on (most filter `completed=true`; `ProgramViewModel` uses `status != 'abandoned'`). And the trainee-model enqueue was gated on `completed`, so early-exit sets (real training data) were silently dropped.

## What shipped (your decision: learn from them + fix the contradiction)
- **Consistent write:** early exit now writes `status="partial"` (consistent with `completed=false`). Deliberately not `"abandoned"` — that's excluded from the deep lift-history fetch, but a partial session carries real sets we want kept.
- **Feed the model:** the trainee-model enqueue is decoupled from `completed`. We only reach `finishSession` with logged sets, and the EF aggregates *actual* sets (never reading `status`/`completed`), so a 3-set early exit contributes accurately instead of vanishing.

## Verification (local)
New body-capturing test asserts the completion PATCH is `(status='partial', completed=false)` on early exit. Full suite: 425 tests, only the 2 unrelated pre-existing failures (#181, #178) — no regressions.

## Note / deliberately left
`completed` stays `false` for early exit, so streak/progress counters (which filter `completed=true`) are **unchanged** — I did not expand early exits into "full completions" for those. Say the word if you want early exits to count toward streaks too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)