### PR TITLE
test: green two pre-existing failing tests (#181 stale id, #178 brittle whitespace)

### DIFF
--- a/ProjectApexTests/ProgramPersistenceTests.swift
+++ b/ProjectApexTests/ProgramPersistenceTests.swift
@@ -115,11 +115,14 @@ final class ProgramPersistenceTests: XCTestCase {
 
     // MARK: ─── 1. ProgramRow Codable round-trip ───────────────────────────────
 
-    func test_programRow_forInsert_hasNilIdAndCreatedAt() {
+    func test_programRow_forInsert_usesMesocycleIdAndNilCreatedAt() {
         let mesocycle = Mesocycle.mockMesocycle()
         let row = ProgramRow.forInsert(from: mesocycle, userId: testUserId)
 
-        XCTAssertNil(row.id,        "Insert row must have nil id (server-generated).")
+        // #181: programs.id is set to the local mesocycle.id (not server-generated)
+        // so the local mesocycle ↔ programs row stay reconcilable. createdAt is
+        // still server-generated (nil on insert).
+        XCTAssertEqual(row.id, mesocycle.id, "Insert row id must equal the local mesocycle id (#181).")
         XCTAssertNil(row.createdAt, "Insert row must have nil createdAt (server-generated).")
         XCTAssertEqual(row.userId, testUserId)
         XCTAssertTrue(row.isActive)

--- a/ProjectApexTests/TraineeModelDigestTests.swift
+++ b/ProjectApexTests/TraineeModelDigestTests.swift
@@ -669,7 +669,12 @@ final class TraineeModelDigestTests: XCTestCase {
                       "SessionPlan must direct the LLM to name the recently advanced patterns")
         XCTAssertTrue(prompt.contains("sessions_since_triggered"),
                       "SessionPlan must direct the LLM to calibrate emphasis from sessions_since_triggered")
-        XCTAssertTrue(prompt.contains("Do NOT\ngenerate new numerical targets"),
+        // The prohibition wraps across a line in the prompt
+        // ("Do NOT\n  generate new numerical targets ..."), so match on
+        // whitespace-collapsed text rather than an exact newline/indent.
+        let collapsedWhitespace = prompt.replacingOccurrences(
+            of: "\\s+", with: " ", options: .regularExpression)
+        XCTAssertTrue(collapsedWhitespace.contains("Do NOT generate new numerical targets"),
                       "SessionPlan must explicitly prohibit inventing numerical goal targets — goal renegotiation is a UI flow per ADR-0005")
         XCTAssertTrue(prompt.contains("Block absent → no reassessment commentary"),
                       "SessionPlan must include the absent-block negative anchor — the LLM should not invent the trigger when the signal is missing")


### PR DESCRIPTION
Two **deterministic** test failures (not from the 12-bug sweep) kept the iOS suite red. Both are test-only fixes — the production code/prompt are correct.

- **#181** — `ProgramPersistenceTests` asserted `forInsert` yields a nil id, but #181 deliberately sets `programs.id = mesocycle.id` (local↔server reconciliation; #189's RPC relies on it). Updated the assertion + renamed the test.
- **#178** — `TraineeModelDigestTests` matched an exact `"Do NOT\ngenerate new numerical targets"`, but the prohibition wraps a line in the prompt (`"Do NOT\n  generate ..."`). The block is present (header + 4 other anchors pass); switched to a whitespace-collapsed match.

## After this
Full local suite: 425 tests, **only the known AIInference network-timeout flake** remains red (the documented "iOS Build & Test flake"). The compile break + both deterministic failures are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)