### PR TITLE
fix(#172,#141): macro-plan reuses the user's historical day_type labels on regen

### DIFF
--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -333,7 +333,12 @@ final class ProgramViewModel {
             return v > 0 ? v : 4
         }()
 
-        print("[ProgramViewModel] generateMacroSkeleton — training_days_per_week: \(daysPerWeek)")
+        // Carry the user's established day-label convention into generation so a
+        // regen reuses it instead of inventing a fresh one that detaches lift
+        // history (#172/#141). Empty for a first program — the LLM derives labels.
+        let historicalDayLabels = await fetchHistoricalDayLabels()
+
+        print("[ProgramViewModel] generateMacroSkeleton — training_days_per_week: \(daysPerWeek), historical_day_labels: \(historicalDayLabels)")
 
         do {
             let skeleton = try await macroPlanService.generateSkeleton(
@@ -344,7 +349,8 @@ final class ProgramViewModel {
                 bodyweightKg: bwKg,
                 ageYears: ageYears,
                 trainingAge: trainingAge,
-                trainingDaysPerWeek: daysPerWeek
+                trainingDaysPerWeek: daysPerWeek,
+                historicalDayLabels: historicalDayLabels
             )
 
             // Build pending mesocycle from skeleton
@@ -360,6 +366,35 @@ final class ProgramViewModel {
             viewState = .loaded(mesocycle)
         } catch {
             viewState = .error(error.localizedDescription)
+        }
+    }
+
+    /// Fetches the user's established day-label convention from past sessions so a
+    /// regenerated program reuses it instead of inventing a fresh convention (#172).
+    /// Returns the distinct `day_type` values from the user's recent sessions,
+    /// most-recent-first, or `[]` for a user with no history (first program).
+    /// Best-effort: a fetch failure just falls back to LLM-derived labels.
+    private func fetchHistoricalDayLabels() async -> [String] {
+        do {
+            let sessions = try await supabaseClient.fetch(
+                SessionMetaRow.self,
+                table: "workout_sessions",
+                filters: [
+                    Filter(column: "user_id", op: .eq,  value: userId.uuidString),
+                    Filter(column: "status",  op: .neq, value: "abandoned")
+                ],
+                order: "session_date.desc",
+                limit: 30
+            )
+            // Distinct labels, preserving most-recent-first order.
+            var seen = Set<String>()
+            var labels: [String] = []
+            for session in sessions where !session.dayType.isEmpty {
+                if seen.insert(session.dayType).inserted { labels.append(session.dayType) }
+            }
+            return labels
+        } catch {
+            return []
         }
     }
 

--- a/ProjectApex/Resources/Prompts/SystemPrompt_MacroPlan.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_MacroPlan.txt
@@ -75,6 +75,30 @@ DAY FOCUS (day_focus array)
   The session AI adapts exercise selection within each focus, not the structure.
 
 ═══════════════════════════════════════════════════════════════
+DAY-LABEL CONTINUITY (history.recent_day_labels)
+═══════════════════════════════════════════════════════════════
+When history.recent_day_labels is present, the user ALREADY has training history
+under an established day-label convention. Per-exercise progression is looked up
+by day label, so a fresh convention would silently detach all of that history.
+You MUST preserve the user's convention:
+
+• REUSE the exact strings in history.recent_day_labels as your day_focus values —
+  same spelling — for ALL 12 weeks. Arrange them into a sensible weekly order.
+• These historical labels TAKE PRECEDENCE over the "derive from first principles /
+  do not use named splits" rule above. If the user's convention is a named split
+  like "Push_A"/"Pull_A"/"Legs_A", reuse it verbatim.
+• Still honor the hard training_days_per_week count. Use exactly
+  training_days_per_week labels. If the user has FEWER distinct historical labels
+  than training_days_per_week, extend the convention in the SAME naming style
+  (e.g. add "Push_B"/"Pull_B"). If MORE, pick the training_days_per_week that best
+  cover the user's split.
+• When history.recent_day_labels is ABSENT, derive day_focus from first principles
+  exactly as described in the DAY FOCUS section above.
+
+This keeps one consistent label convention across the whole mesocycle and across
+regenerations, so the user's lift history stays attached to each day.
+
+═══════════════════════════════════════════════════════════════
 WEEK LABELS
 ═══════════════════════════════════════════════════════════════
 week_label must be concise (≤8 words) and descriptive, e.g.:

--- a/ProjectApex/Services/MacroPlanService.swift
+++ b/ProjectApex/Services/MacroPlanService.swift
@@ -48,11 +48,28 @@ nonisolated struct MacroPlanRequest: Codable, Sendable {
     let userProfile: MacroPlanUserProfile
     let gymProfile: MacroPlanGymProfile
     let constraints: MacroPlanConstraints
+    /// The user's established day-label convention, carried over so regen reuses
+    /// it instead of inventing a fresh one (#172). Optional → the key is omitted
+    /// (encodeIfPresent) for a user with no training history (first program).
+    let history: MacroPlanHistory?
 
     enum CodingKeys: String, CodingKey {
         case userProfile  = "user_profile"
         case gymProfile   = "gym_profile"
         case constraints
+        case history
+    }
+}
+
+/// Carries the user's existing day-label convention into the macro-plan prompt
+/// so a regenerated mesocycle preserves it across all weeks (#172). Without this,
+/// regen let the LLM invent a new convention (e.g. "Lower"/"Upper_Push") that no
+/// longer matched the user's history, detaching per-exercise lift history (#141).
+nonisolated struct MacroPlanHistory: Codable, Sendable {
+    let recentDayLabels: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case recentDayLabels = "recent_day_labels"
     }
 }
 
@@ -164,14 +181,15 @@ actor MacroPlanService {
         bodyweightKg: Double? = nil,
         ageYears: Int? = nil,
         trainingAge: String? = nil,
-        trainingDaysPerWeek: Int = 4
+        trainingDaysPerWeek: Int = 4,
+        historicalDayLabels: [String] = []
     ) async throws -> MesocycleSkeleton {
         isGenerating = true
         defer { isGenerating = false }
 
         let systemPrompt = try Self.loadSystemPrompt()
 
-        print("[MacroPlanService] Generating macro skeleton — training_days_per_week: \(trainingDaysPerWeek)")
+        print("[MacroPlanService] Generating macro skeleton — training_days_per_week: \(trainingDaysPerWeek), historical_day_labels: \(historicalDayLabels)")
 
         let request = MacroPlanRequest(
             userProfile: MacroPlanUserProfile(
@@ -186,7 +204,12 @@ actor MacroPlanService {
             constraints: MacroPlanConstraints(
                 trainingDaysPerWeek: trainingDaysPerWeek,
                 totalWeeks: 12
-            )
+            ),
+            // Pass the user's established labels so regen reuses their convention
+            // (#172); omit the block entirely for a user with no history.
+            history: historicalDayLabels.isEmpty
+                ? nil
+                : MacroPlanHistory(recentDayLabels: historicalDayLabels)
         )
 
         let encoder = JSONEncoder()

--- a/ProjectApexTests/MacroPlanServiceDayCountTests.swift
+++ b/ProjectApexTests/MacroPlanServiceDayCountTests.swift
@@ -529,3 +529,56 @@ struct MacroPlanServiceDayLabelNormalizationTests {
         #expect(MacroPlanService.normalizeDayLabel("Push_A") == "Push_A")
     }
 }
+
+// MARK: - Historical day-label continuity (#172)
+
+private func parseMacroPlanPayload(_ json: String) throws -> [String: Any] {
+    let data = try #require(json.data(using: .utf8))
+    return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+/// #172: a regen must carry the user's established day-label convention into the
+/// macro-plan LLM payload so it reuses those labels instead of inventing a fresh
+/// convention that detaches lift history (#141). The threading is asserted at the
+/// payload boundary (same altitude as the training_days_per_week tests above).
+@Suite("MacroPlanService — historical day-label continuity (#172)")
+struct MacroPlanServiceHistoricalLabelsTests {
+
+    @Test("generateSkeleton threads historicalDayLabels into history.recent_day_labels verbatim")
+    func threadsHistoricalLabels() async throws {
+        let provider = CapturingMockProvider(daysPerWeek: 4)
+        let service = MacroPlanService(provider: provider)
+        let historical = ["Push_A", "Pull_A", "Push_B", "Pull_B"]
+
+        _ = try await service.generateSkeleton(
+            userId: UUID(),
+            gymProfile: makeGymProfile(),
+            trainingDaysPerWeek: 4,
+            historicalDayLabels: historical
+        )
+
+        let root = try parseMacroPlanPayload(provider.lastUserPayload)
+        let history = try #require(root["history"] as? [String: Any],
+                                   "payload must include a history block when labels are supplied")
+        let labels = try #require(history["recent_day_labels"] as? [String])
+        #expect(labels == historical,
+                "history.recent_day_labels must carry the user's labels verbatim, got \(labels)")
+    }
+
+    @Test("generateSkeleton omits the history block for a user with no training history")
+    func omitsHistoryWhenEmpty() async throws {
+        let provider = CapturingMockProvider(daysPerWeek: 4)
+        let service = MacroPlanService(provider: provider)
+
+        _ = try await service.generateSkeleton(
+            userId: UUID(),
+            gymProfile: makeGymProfile(),
+            trainingDaysPerWeek: 4
+            // historicalDayLabels defaults to [] — first program, no history.
+        )
+
+        let root = try parseMacroPlanPayload(provider.lastUserPayload)
+        #expect(root["history"] == nil,
+                "history must be omitted (not null) when the user has no established labels")
+    }
+}


### PR DESCRIPTION
Closes #172
Closes #141

## Problem (#172)

On **regen**, the macro-plan LLM was given no knowledge of the day-label convention the user already trained under. It invented a fresh one (e.g. `Lower`/`Upper_Push`/`Upper_Pull`/`Full_Body`) while `regenerateProgram` grafted the previously-completed days back in carrying their **old** labels (`Push_A`/`Pull_A`/`Legs_A`). The result was a single `mesocycle_json` with two conventions concatenated — for the alpha user, 45 of 60 days had labels that matched none of their training history.

## Why it also closes #141

`ProgramViewModel.deepLiftHistory` looks up per-exercise history with `Filter(column: "day_type", op: .eq, value: day.dayLabel)`. For any new-convention day (`Lower`, etc.) that filter matched **zero** historical sessions, so the AI lost the user's lift history for ~75% of the program — the `deepLiftHistory: 0 set_log(s) across 0 exercise(s)` symptom reported in #141. #141 hypothesised `program_id` scoping; the real cause is this label drift. Closing #141 as a duplicate of #172.

## Fix (locked decision A — feed history + enforce continuity)

- **`MacroPlanRequest`** gains an optional `history.recent_day_labels` block. It's `Optional`, so the synthesized `encodeIfPresent` **omits the key entirely** for a user with no history — first-program payloads are byte-for-byte unchanged.
- **`MacroPlanService.generateSkeleton`** takes `historicalDayLabels: [String] = []` and builds the history block (nil when empty).
- **`ProgramViewModel.generateMacroSkeleton`** — the shared path `regenerateProgram` delegates to — fetches the user's distinct recent `day_type` labels (reusing the existing `SessionMetaRow` + `supabaseClient.fetch` pattern, most-recent-first, best-effort) and passes them in.
- **`SystemPrompt_MacroPlan.txt`** — new `DAY-LABEL CONTINUITY` section: when `history.recent_day_labels` is present, reuse those exact labels for all 12 weeks (this **takes precedence** over the existing "derive from first principles / no named splits" rule), while still honoring the hard `training_days_per_week` count. Absent history → derive fresh as before.

The fix lives in the shared `generateMacroSkeleton`, so `regenerateProgram` is covered without touching its graft logic — once the new weeks reuse the historical labels, they match the grafted completed days and the Frankenstein convention can't form.

## Tests

Swift Testing, mirroring the existing `training_days_per_week` threading tests (`CapturingMockProvider`):
- `generateSkeleton threads historicalDayLabels into history.recent_day_labels verbatim`
- `generateSkeleton omits the history block for a user with no training history`

Both pass; full test bundle green (no new failures).

## Cross-cutting grep (grep-and-report per CLAUDE.md)

`generateSkeleton` has a **second caller**: `OnboardingView.swift:874` (first-program generation). I did **not** edit it — onboarding is a brand-new user with no `workout_sessions`, so `historicalDayLabels` would resolve to `[]` and behavior is identical. The new parameter defaults to `[]`, so that call site compiles and behaves unchanged. **Recommendation:** leave as-is; optionally wire it later only if onboarding can re-run for a returning user (rare). Flagging for awareness, not editing without authorization.

## Out of scope (unchanged, per #172)

- Per-pending-day `exercises[]` backfill (PR #163).
- Existing-program backfill (operator action — regenerate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)