### PR TITLE
fix(#189): atomic deactivate-and-insert program RPC

### DIFF
--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -229,9 +229,11 @@ final class ProgramViewModel {
         let capturedUserId = userId
         let capturedMesocycle = mesocycle
         do {
-            try await capturedClient.deactivatePrograms(userId: capturedUserId)
-            let row = ProgramRow.forInsert(from: capturedMesocycle, userId: capturedUserId)
-            try await capturedClient.insert(row, table: "programs")
+            // Atomic server-side deactivate-old + upsert-new in one transaction
+            // (#189): replaces the non-transactional PATCH-then-POST whose partial
+            // failure could leave the user with zero active programs. Idempotent
+            // on retry (upsert on the client-generated program id).
+            try await capturedClient.deactivateAndInsertProgram(capturedMesocycle, userId: capturedUserId)
             // Success: clear any prior sync error.
             persistError = nil
             persistRetryAction = nil

--- a/ProjectApex/Services/SupabaseClient.swift
+++ b/ProjectApex/Services/SupabaseClient.swift
@@ -321,6 +321,50 @@ actor SupabaseClient {
         try await performExpectingRow(request, table: "programs", filter: "user_id=eq.\(userId.uuidString)")
     }
 
+    /// Atomically deactivates the user's existing program(s) and upserts
+    /// `mesocycle` as the new active program in a single server-side transaction
+    /// (#189), returning the persisted program id. Replaces the non-transactional
+    /// `deactivatePrograms()`-then-`insert()` sequence, whose partial failure
+    /// could leave the user with no active program at all. Idempotent on retry —
+    /// the server upserts on the client-generated program id.
+    ///
+    /// - Returns: The id of the persisted program (equals `mesocycle.id`).
+    /// - Throws: `SupabaseError` on HTTP/encoding/decoding failure.
+    @discardableResult
+    func deactivateAndInsertProgram(_ mesocycle: Mesocycle, userId: UUID) async throws -> UUID {
+        struct Params: Encodable {
+            let pUserId: UUID
+            let pProgramId: UUID
+            let pMesocycleJson: Mesocycle
+            let pWeeks: Int
+            enum CodingKeys: String, CodingKey {
+                case pUserId        = "p_user_id"
+                case pProgramId     = "p_program_id"
+                case pMesocycleJson = "p_mesocycle_json"
+                case pWeeks         = "p_weeks"
+            }
+        }
+        struct InsertedProgram: Decodable {
+            let programId: UUID
+            enum CodingKeys: String, CodingKey { case programId = "program_id" }
+        }
+        let params = Params(
+            pUserId: userId,
+            pProgramId: mesocycle.id,
+            pMesocycleJson: mesocycle,
+            pWeeks: mesocycle.totalWeeks
+        )
+        let rows = try await rpc(
+            "deactivate_and_insert_program",
+            params: params,
+            returning: [InsertedProgram].self
+        )
+        guard let id = rows.first?.programId else {
+            throw SupabaseError.decodingError("deactivate_and_insert_program returned no row")
+        }
+        return id
+    }
+
     /// Fetches the most recent `is_active = true` program row for `userId`.
     ///
     /// Returns `nil` when no active program exists (e.g. first-time user or

--- a/ProjectApexTests/ProgramPersistenceTests.swift
+++ b/ProjectApexTests/ProgramPersistenceTests.swift
@@ -231,6 +231,45 @@ final class ProgramPersistenceTests: XCTestCase {
                        "Deactivation body must set is_active = false.")
     }
 
+    // MARK: ─── 2b. SupabaseClient.deactivateAndInsertProgram() (#189) ─────────
+
+    /// #189: regen-persist must be ONE atomic server-side call (deactivate + new
+    /// program in a single transaction) — not a separate PATCH-then-POST whose
+    /// partial failure left the user with no active program. Verifies the client
+    /// routes through the `deactivate_and_insert_program` RPC with the right
+    /// params and surfaces the returned program id.
+    func test_deactivateAndInsertProgram_callsAtomicRPC_returningProgramId() async throws {
+        let mesocycle = Mesocycle.mockMesocycle()
+        // The RPC RETURNS TABLE(program_id uuid) → PostgREST replies with a JSON array.
+        ProgramStubURLProtocol.stubbedStatusCode = 200
+        ProgramStubURLProtocol.stubbedData =
+            #"[{"program_id":"\#(mesocycle.id.uuidString)"}]"#.data(using: .utf8)!
+
+        let client = makeProgramClient()
+        let returnedId = try await client.deactivateAndInsertProgram(mesocycle, userId: testUserId)
+
+        // 1. A single POST to the atomic RPC endpoint — not PATCH + POST.
+        let req = try XCTUnwrap(ProgramStubURLProtocol.lastRequest)
+        XCTAssertEqual(req.httpMethod, "POST")
+        XCTAssertTrue(
+            req.url?.absoluteString.contains("/rpc/deactivate_and_insert_program") == true,
+            "Persist must go through the atomic RPC, got \(req.url?.absoluteString ?? "nil")"
+        )
+
+        // 2. Params carry the user id, client program id, weeks, and mesocycle JSONB.
+        let bodyData = try XCTUnwrap(ProgramStubURLProtocol.requestBodies.last)
+        let body = try XCTUnwrap(try JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        XCTAssertEqual(body["p_user_id"] as? String, testUserId.uuidString)
+        XCTAssertEqual(body["p_program_id"] as? String, mesocycle.id.uuidString,
+                       "program id must be the client-generated mesocycle id (#181)")
+        XCTAssertEqual(body["p_weeks"] as? Int, mesocycle.totalWeeks)
+        XCTAssertNotNil(body["p_mesocycle_json"] as? [String: Any],
+                        "the full mesocycle must be sent as the jsonb param")
+
+        // 3. The persisted program id is returned (for #181 stale-id reconciliation).
+        XCTAssertEqual(returnedId, mesocycle.id)
+    }
+
     // MARK: ─── 3. SupabaseClient.fetchActiveProgram() ─────────────────────────
 
     func test_fetchActiveProgram_sendsGetToCorrectURL() async throws {

--- a/docs/migrations/down/20260604061428_add_deactivate_and_insert_program_rpc.sql
+++ b/docs/migrations/down/20260604061428_add_deactivate_and_insert_program_rpc.sql
@@ -1,0 +1,11 @@
+-- Reverse migration for: supabase/migrations/20260604061428_add_deactivate_and_insert_program_rpc.sql
+-- (documentation only; NOT auto-applied by `supabase db push`. Run manually with
+--  `psql -f` against the target database if the forward migration must be rolled back.)
+--
+-- #189: drops the atomic deactivate-and-insert RPC. The iOS client falls back to
+-- the prior non-transactional deactivatePrograms()-then-insert() path if this
+-- function is absent only when paired with a client build that still uses it —
+-- the forward migration is additive (a new function), so dropping it has no
+-- effect on existing rows or other functions.
+
+DROP FUNCTION IF EXISTS public.deactivate_and_insert_program(uuid, uuid, jsonb, integer);

--- a/supabase/migrations/20260604061428_add_deactivate_and_insert_program_rpc.sql
+++ b/supabase/migrations/20260604061428_add_deactivate_and_insert_program_rpc.sql
@@ -1,0 +1,69 @@
+-- Reverse migration: docs/migrations/down/20260604061428_add_deactivate_and_insert_program_rpc.sql
+-- (documentation only; not auto-applied by `supabase db push`)
+--
+-- #189: the iOS regen-persist sequence was a non-transactional client-side
+-- PATCH-then-POST — deactivatePrograms() (set every program is_active=false)
+-- followed by insert() of the new active program. If the PATCH succeeded but
+-- the POST failed (network blip, validation, FK), the user was left with zero
+-- active programs and fetchActiveProgram() returned nil: a hidden state-loss
+-- path (the historical run of inactive programs in the alpha user's DB is the
+-- footprint of this bug firing).
+--
+-- This adds a single server-side function that performs the deactivate + the
+-- new-program write in ONE transaction (a plpgsql function body is one
+-- transaction), so a partial failure can no longer strand the user with no
+-- active program. The write is an UPSERT on the client-generated primary key
+-- (programs.id = the local Mesocycle.id, per #181), which makes a client retry
+-- idempotent: re-running the call converges on exactly one active program
+-- regardless of how far a previous attempt got.
+--
+-- The function returns the persisted program id (needed for #181 stale-id
+-- reconciliation between the local mesocycle and the programs row).
+--
+-- SECURITY INVOKER (the default — stated explicitly here): the function runs as
+-- the calling user, so the existing "programs: owner access" RLS policy
+-- (user_id = auth.uid()) applies to both the UPDATE and the INSERT/UPSERT
+-- exactly as it does for the direct PATCH/POST this replaces. No privilege
+-- escalation; an authenticated user can still only touch their own rows.
+
+CREATE OR REPLACE FUNCTION public.deactivate_and_insert_program(
+    p_user_id uuid,
+    p_program_id uuid,
+    p_mesocycle_json jsonb,
+    p_weeks integer
+) RETURNS TABLE (program_id uuid)
+    LANGUAGE plpgsql
+    SECURITY INVOKER
+    SET search_path = ''
+    AS $$
+DECLARE
+    v_program_id uuid;
+BEGIN
+    -- 1. Deactivate the user's currently-active program(s).
+    UPDATE public.programs
+       SET is_active = false
+     WHERE user_id = p_user_id
+       AND is_active = true;
+
+    -- 2. Upsert the new program as active. ON CONFLICT (id) makes a retry
+    --    idempotent — if a prior attempt already inserted this id, re-running
+    --    just re-activates and refreshes it instead of erroring on the PK.
+    INSERT INTO public.programs (id, user_id, mesocycle_json, weeks, is_active)
+    VALUES (p_program_id, p_user_id, p_mesocycle_json, p_weeks, true)
+    ON CONFLICT (id) DO UPDATE
+        SET user_id        = excluded.user_id,
+            mesocycle_json = excluded.mesocycle_json,
+            weeks          = excluded.weeks,
+            is_active      = true
+    RETURNING id INTO v_program_id;
+
+    -- 3. Return the persisted id as a single-row result set (RETURNS TABLE).
+    RETURN QUERY SELECT v_program_id;
+END;
+$$;
+
+ALTER FUNCTION public.deactivate_and_insert_program(uuid, uuid, jsonb, integer) OWNER TO postgres;
+
+GRANT ALL ON FUNCTION public.deactivate_and_insert_program(uuid, uuid, jsonb, integer) TO anon;
+GRANT ALL ON FUNCTION public.deactivate_and_insert_program(uuid, uuid, jsonb, integer) TO authenticated;
+GRANT ALL ON FUNCTION public.deactivate_and_insert_program(uuid, uuid, jsonb, integer) TO service_role;


### PR DESCRIPTION
Closes #189

## Problem

Regen-persist (`ProgramViewModel.persistProgram`) was a **non-transactional** client-side sequence:

```swift
try await client.deactivatePrograms(userId:)        // PATCH all → is_active=false
try await client.insert(row, table: "programs")      // POST new active
```

If the PATCH succeeded but the POST failed (network blip, validation, FK), the user was left with **all programs `is_active=false` and no new active program** — `fetchActiveProgram()` returns `nil`, and the user appears to have no program. The historical run of inactive programs in the alpha user's DB is the footprint of this firing.

## Fix (locked decision — server-side atomic RPC)

**Migration** `supabase/migrations/20260604061428_add_deactivate_and_insert_program_rpc.sql` adds:

```sql
public.deactivate_and_insert_program(p_user_id uuid, p_program_id uuid,
                                     p_mesocycle_json jsonb, p_weeks integer)
  RETURNS TABLE (program_id uuid)
```

- **Atomic**: a plpgsql function body runs in a single transaction, so the deactivate and the new-program write either both land or neither does. The zero-active-program window is gone.
- **Idempotent on retry**: the write is an `INSERT … ON CONFLICT (id) DO UPDATE` on the client-generated PK (`programs.id` = local `Mesocycle.id`, per #181). A retry converges on exactly one active program regardless of how far a prior attempt got.
- **Returns the persisted id** (needed for #181 stale-id reconciliation).
- **`SECURITY INVOKER`**: runs as the calling user, so the existing `"programs: owner access"` RLS (`user_id = auth.uid()`) governs both writes exactly as it did the direct PATCH/POST. No privilege escalation.

> Why plpgsql and not a single multi-CTE statement: on the retry case, a `WITH deactivated AS (UPDATE …), upserted AS (INSERT … ON CONFLICT DO UPDATE …)` would modify the **same row twice in one statement**, which Postgres forbids. plpgsql's sequential UPDATE-then-INSERT sees the prior statement's effect and is correct.

**Reverse migration** (doc-only) at `docs/migrations/down/20260604061428_add_deactivate_and_insert_program_rpc.sql` drops the function.

**iOS**: `SupabaseClient.deactivateAndInsertProgram(_:userId:)` calls the RPC via the existing `rpc()` helper; `persistProgram` makes that one atomic call.

## Test

`test_deactivateAndInsertProgram_callsAtomicRPC_returningProgramId` (XCTest, `ProgramStubURLProtocol`): asserts persist routes through a single POST to `/rpc/deactivate_and_insert_program` with `p_user_id`/`p_program_id`/`p_weeks`/`p_mesocycle_json`, and surfaces the returned id. Full `ProgramPersistenceTests` suite green.

## Deploy note

Merging to `main` triggers the "Deploy to linked Supabase" job (`supabase db push` + `functions deploy`, gated on the Deno EF-tests job). This migration is **additive** (a new function — no table/data changes) and **reversible** (documented down migration). The iOS behavior change ships via an app build, **not** this deploy, so post-deploy the new function simply exists until a client build uses it.

## Surgical-change note

`SupabaseClient.deactivatePrograms(userId:)` is no longer called in production (its only caller, `persistProgram`, now uses the RPC). I **left it in place** — it's a public method with direct test coverage (`test_deactivatePrograms_*`) and a reasonable standalone primitive; removing it would mean deleting passing tests, which is out of scope for this fix. Flagging rather than deleting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)