### PR TITLE
docs: close out Phase 5 functional-defect bug sweep (ADR-0017/0018, BACKLOG §2E, CONTEXT)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -290,8 +290,8 @@ Captured here so the BACKLOG sweep on 2026-06-01 has a single landing surface. E
 - [ ] P5-D01: #220 — extract `PromptLoader` for three known consumers (Inference, SessionPlan, InferenceSpike). Deferred from #159 per L7 lock; surgical change once the right shape is agreed.
 - [ ] P5-D02: #221 — adopt `USER-REPORTED SIGNALS` section in production Inference prompt? Surfaced by #159 Path A as a .txt-only section that has never run in production. Needs product decision (is this a signal we want, and what's the input shape?).
 - [ ] P5-D03: #222 — adopt expanded equipment-aware weight-increment rules in production Inference prompt? Same shape as P5-D02 (.txt-only expansion surfaced by #159).
-- [ ] P5-D04: existing Tier 3 needs-triage spinoffs (`#184`, `#186`, `#187`, `#189`, `#190`, `#192`) — pre-existing from the 2026-05-31 operator audit; carry forward to Tier 3 expansion when user authorises.
-- [ ] P5-D05: existing Phase 2 follow-ups (`#164`, `#165`, `#166`, `#167`, `#151`) — pre-existing; same shape as P5-D04.
+- [x] P5-D04: Tier 3 needs-triage spinoffs (`#184`, `#186`, `#187`, `#189`, `#190`, `#192`) — all closed in the 2026-06-02 → 2026-06-04 functional-defect sweep (§2E).
+- [ ] P5-D05: Phase 2 follow-ups — `#167` and `#151` closed in the functional-defect sweep (§2E); `#164`, `#165`, `#166` (MuscleProfile `volumeTolerance` cadence-scaling / EWMA-update / `confidence` lifecycle) remain open.
 
 **Not yet filed — surfaced in 2026-06-01 dispatch, awaiting decision:**
 
@@ -302,3 +302,25 @@ Captured here so the BACKLOG sweep on 2026-06-01 has a single landing surface. E
 **Operator actions (not code changes):**
 
 - [ ] Keychain cleanup: if `.supabaseServiceKey` is present on a user's machine from pre-#191 days, clear via Developer Settings → Clear button or `security delete-generic-password -s com.projectapex.keychain.supabaseServiceKey`. Verified absent on Arnav's machine 2026-06-01 (exit 44 = not found).
+
+### 2E — Functional-defect bug sweep (2026-06-02 → 2026-06-04)
+
+The 12 functional-defect issues from the 2026-05-31 operator audit (carried in §2D as P5-D04/P5-D05), fixed branch-per-issue with PR-before-close. Local test suite is the source of truth — the CI iOS "Build & Test" job is known-flaky and gates nothing. Each issue closed via its PR's `Closes #N` keyword unless noted.
+
+- [x] P5-E01: #151 — EF `PATTERN_TRAINS_JOINTS` joint-key drift → snake_case `lower_back`. PR #227.
+- [x] P5-E02: #167 — `derivedTrainedSets` rejects non-canonical `primary_muscle`. PR #228. (Sibling leak ~`update-trainee-model/index.ts:1968` flagged grep-and-report, not fixed.)
+- [x] P5-E03: #192 — macro-skeleton `normalizeDayLabel` collapses non-alphanumerics to snake_case. PR #229. (Sibling day-label mint point in `ProgramGenerationService` flagged grep-and-report.)
+- [x] P5-E04: #186 — weekly-fatigue fetch queries `set_logs` by `session_id`, not `user_id` (no such column → had been a swallowed HTTP 400). PR #230.
+- [x] P5-E05: #55 + #184 — WAQ `clearAll()`/`flush()` mid-retry race + dead-letter store instead of silent drop after retry exhaustion. PR #232.
+- [x] P5-E06: #171 — early-exit writes a consistent `(status, completed)` pair (`partial`/`false`, not the hardcoded `completed`) + feeds early-exit sets to the model. PR #233.
+- [x] P5-E07: #190 — `pauseSession` is non-blocking: persist `PausedSessionState` first, fire the server sync (flush + status PATCH) in a detached Task, then reset to idle. Regression test proven to fail pre-fix (0.64 s) / pass post-fix. PR #235.
+- [x] P5-E08: #172 + #141 — regen feeds the user's historical `day_type` labels into the macro-plan prompt so it reuses their convention instead of inventing a fresh one that detaches lift history. **ADR-0017.** PR #236. (#141 closed as a duplicate — its real cause was this label drift, not `program_id` scoping.)
+- [x] P5-E09: #189 — atomic `deactivate_and_insert_program` `SECURITY INVOKER` RPC (one transaction; upsert-idempotent on retry; returns the program id) replaces the non-transactional deactivate-then-insert. Forward migration `20260604061428_…` + doc-only reverse migration; deployed to the linked Supabase (db push + EF tests green). **ADR-0018.** PR #237.
+- [x] P5-E10: #187 — closed as **not-a-bug** (wontfix): `mesocycle_json` stores `total_weeks` (snake_case, consistent with the whole blob); the report queried `'totalWeeks'` (camelCase). The model round-trips cleanly and `programs.weeks` is the source of truth. No code change.
+
+Supporting work in the same window:
+
+- [x] Build hotfix: removed 2 illegal `nonisolated deinit`s that had broken `main`. PR #231.
+- [x] Greened 2 pre-existing failing tests (#181 stale id, #178 brittle whitespace). PR #234.
+
+Cross-cutting sites surfaced but left **grep-and-report** (awaiting authorization, per CLAUDE.md Process commitment 2): #167 sibling `primary_muscle` leak in `update-trainee-model/index.ts`; #192 sibling day-label mint point in `ProgramGenerationService`; #172 second `generateSkeleton` caller in `OnboardingView` (safe as-is — no history at onboarding); #189 `SupabaseClient.deactivatePrograms` now production-unused but test-covered (retained, not deleted).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,10 @@ _Avoid_: programme phase, training block
 The current phase position for a single movement pattern within the mesocycle phase progression. Stored on `PatternProfile.currentPhase`.
 _Avoid_: phase (when ambiguous)
 
+**Day label**:
+The label identifying a kind of training day (e.g. `Push_A`, `Upper_Push`). One concept under three layer-specific names: `day_focus` (the free-text string the macro-plan LLM emits per day) → `dayLabel` (`TrainingDay.dayLabel`, snake_case-normalized via `MacroPlanService.normalizeDayLabel`) → `day_type` (`workout_sessions.day_type`, persisted per logged session). It is the join key for per-day lift history (`deepLiftHistory` filters `day_type = dayLabel`), so the convention is a stable per-user key preserved across regen — not free LLM output. See ADR-0017.
+_Avoid_: day name, split name (and don't use `day_focus`/`day_type` interchangeably without naming the layer)
+
 ### Trainee model
 
 **Trainee model**:
@@ -142,6 +146,7 @@ _Avoid_: feature, ticket, story, horizontal slice
 - A **Form degradation flag** widens **e1RM** SE; an **active limitation** gates exercises and prescription.
 - **Calibration review** sets **floor projection** and **stretch projection** using current **EWMA** capability.
 - **Movement pattern** and **muscle group** are independent taxonomies — a set is associated with both via its exercise.
+- A **Day label** is the join key between a planned training day and the user's historical sessions of that kind; program regeneration must preserve the user's existing labels so the join keeps resolving. See ADR-0017.
 
 ## Example dialogue
 

--- a/docs/adr/0017-day-label-convention-is-a-stable-per-user-key.md
+++ b/docs/adr/0017-day-label-convention-is-a-stable-per-user-key.md
@@ -1,0 +1,90 @@
+# Day-label convention is a stable per-user key, preserved across regen
+
+**Status**: accepted, 2026-06-04
+
+## Context
+
+A program's training days carry a **day label** — the same concept named three
+different things across the layers it passes through:
+
+- `day_focus` — the free-text muscle-group string the macro-plan LLM emits per day in the skeleton (e.g. `"Upper Push"`).
+- `dayLabel` — the Swift `TrainingDay.dayLabel`, derived from `day_focus` via `MacroPlanService.normalizeDayLabel` (snake_case, e.g. `Upper_Push`).
+- `day_type` — the `workout_sessions.day_type` column persisted per logged session, equal to the `dayLabel` of the day that was trained.
+
+The day label is not cosmetic. `ProgramViewModel.deepLiftHistory` looks up a
+day's per-exercise history with `Filter(column: "day_type", op: .eq, value: day.dayLabel)`.
+That is, **the day label is the join key between a planned day and the user's
+historical sets for that kind of day.** Progression context (recent loads, e1RM
+trend) flows to the session AI through this lookup.
+
+Issue #172 exposed the consequence of treating the label as disposable. On
+**program regeneration**, the macro-plan LLM was given no knowledge of the labels
+the user already trained under. It invented a fresh convention (`Lower`,
+`Upper_Push`, `Upper_Pull`, `Full_Body`) while `ProgramViewModel.regenerateProgram`
+grafted the previously-completed days back in carrying their *original* labels
+(`Push_A`, `Pull_A`, `Legs_A`). The result was a single `mesocycle_json` holding
+two label conventions concatenated — for the alpha user, 45 of 60 days had labels
+that matched no historical session. Because `deepLiftHistory` joins on the label,
+every new-convention day matched zero history: the AI lost the user's lift history
+for ~75% of the program and reset to "fresh user" progression. This is the actual
+root cause behind the `0 set_logs across 0 exercises after regen` symptom reported
+in #141 (which had hypothesised `program_id` scoping — the wrong cause).
+
+The pre-existing macro-plan prompt already said "All 12 weeks MUST use the SAME
+day_focus order" — but that only enforces *internal* consistency within one
+generation. It said nothing about consistency *across* generations, and in fact
+actively told the LLM to "derive the structure from first principles" and "DO NOT
+use named splits like 'Push A'" — directly at odds with reusing the user's
+established `Push_A`/`Pull_A` convention.
+
+## Decision
+
+**The day-label convention is a stable per-user key. Once a user has training
+history under a set of day labels, program regeneration MUST preserve that
+convention rather than mint a new one.**
+
+Concretely:
+
+1. The macro-plan request carries an optional `history.recent_day_labels` block —
+   the user's distinct `day_type` values from their recent `workout_sessions`,
+   fetched by `ProgramViewModel.generateMacroSkeleton` (the shared path
+   `regenerateProgram` delegates to) and threaded through
+   `MacroPlanService.generateSkeleton(historicalDayLabels:)`. The block is
+   **omitted entirely** (synthesized `encodeIfPresent`) for a user with no
+   history, so first-program generation is unchanged.
+2. When `history.recent_day_labels` is present, the macro-plan system prompt
+   instructs the LLM to **reuse those exact labels for all 12 weeks** — and this
+   instruction **takes precedence** over the first-principles / no-named-splits
+   guidance, while still honoring the hard `training_days_per_week` count.
+3. When the block is absent, the LLM derives labels from first principles as
+   before.
+
+The fix lives in the shared `generateMacroSkeleton`, so `regenerateProgram` is
+covered without changing its graft logic: once the newly generated weeks reuse
+the historical labels, they match the grafted completed days and the
+two-convention "Frankenstein" mesocycle can no longer form.
+
+## Consequences
+
+- Lift history stays attached to each planned day across regenerations.
+  `deepLiftHistory`'s `day_type = dayLabel` join keeps resolving after a regen.
+- The three names for the day label (`day_focus` → `dayLabel` → `day_type`) are
+  one concept across layers; see CONTEXT.md. Code that mints or transforms a day
+  label must keep the normalized form stable (`normalizeDayLabel` is idempotent
+  on already-normalized labels, so the LLM emitting the historical strings
+  verbatim survives normalization unchanged).
+- This is an LLM-prompt-enforced invariant, not a hard schema constraint: the
+  model is *instructed* to reuse labels. The deterministic guard is the test that
+  the labels reach the prompt (`MacroPlanServiceHistoricalLabelsTests`); whether
+  the LLM obeys is a prompt-quality concern, not unit-testable.
+- A second caller of `generateSkeleton` exists — `OnboardingView` (first-program
+  generation). It was intentionally left passing the default empty
+  `historicalDayLabels`: onboarding is a brand-new user with no sessions, so the
+  behavior is identical. If onboarding is ever made re-runnable for a returning
+  user, it should fetch and pass historical labels too.
+
+## Supersedes / supersedes-by
+
+Supersedes the pre-#172 behavior where program regeneration let the macro-plan
+LLM choose a fresh day-label convention with no knowledge of the user's history.
+Not yet superseded.

--- a/docs/adr/0018-atomic-program-persistence-via-security-invoker-rpc.md
+++ b/docs/adr/0018-atomic-program-persistence-via-security-invoker-rpc.md
@@ -1,0 +1,108 @@
+# Atomic program persistence via a SECURITY INVOKER RPC
+
+**Status**: accepted, 2026-06-04
+
+## Context
+
+Persisting a (re)generated program to Supabase was a two-step, non-transactional
+client-side sequence in `ProgramViewModel.persistProgram`:
+
+```swift
+try await client.deactivatePrograms(userId:)     // PATCH every program → is_active=false
+try await client.insert(row, table: "programs")   // POST the new active program
+```
+
+The two calls are independent network round-trips with no shared transaction. If
+the PATCH succeeded but the POST failed (network blip, validation, FK, app
+backgrounded mid-sequence), the user was left with **all programs `is_active=false`
+and no new active program**. `fetchActiveProgram()` then returns `nil` and the
+user appears, server-side, to have no program at all. The historical run of
+inactive-only program rows in the alpha user's DB is the footprint of this
+partial-failure path firing (#189).
+
+Issue #189 listed three candidate fixes: (1) reverse the order (insert first,
+deactivate after — leaves a transient two-active-programs window resolved
+client-side by `created_at`), (2) a server-side transactional RPC, (3) an atomic
+upsert. The reverse-order option still has a non-atomic window and needs an
+upsert anyway for retry idempotency. The decision was the RPC.
+
+This sits under ADR-0016 (client cannot bypass RLS): the operation must remain
+subject to Row Level Security, so the RPC is **not** a service-role escalation —
+it is a `SECURITY INVOKER` function that runs as the calling user.
+
+## Decision
+
+**Multi-step program persistence is performed by a single server-side
+`SECURITY INVOKER` RPC, `public.deactivate_and_insert_program`, that does the
+deactivate and the new-program write in one transaction and returns the persisted
+program id.**
+
+Migration `supabase/migrations/20260604061428_add_deactivate_and_insert_program_rpc.sql`:
+
+```sql
+public.deactivate_and_insert_program(p_user_id uuid, p_program_id uuid,
+                                     p_mesocycle_json jsonb, p_weeks integer)
+  RETURNS TABLE (program_id uuid)
+  LANGUAGE plpgsql SECURITY INVOKER SET search_path = ''
+```
+
+Key properties:
+
+- **Atomic.** A plpgsql function body executes in one transaction, so the
+  `UPDATE … SET is_active=false` and the new-program write either both commit or
+  neither does. The zero-active-program window is structurally impossible.
+- **Idempotent on retry.** The write is `INSERT … ON CONFLICT (id) DO UPDATE … SET
+  is_active=true` on the **client-generated** primary key (`programs.id` =
+  local `Mesocycle.id`, per ADR/issue #181/#183). A retry — even after a prior
+  attempt partially or fully succeeded — converges on exactly one active program.
+- **RLS-preserving.** `SECURITY INVOKER` means the function runs as the caller, so
+  the existing `"programs: owner access"` policy (`user_id = auth.uid()`) governs
+  both the UPDATE and the INSERT/UPSERT exactly as it did the direct PATCH/POST.
+  No privilege change; an authenticated user can still only touch their own rows.
+  Consistent with ADR-0016.
+- **Returns the id** for #181 stale-id reconciliation between the local mesocycle
+  and the `programs` row.
+
+`SupabaseClient.deactivateAndInsertProgram(_:userId:)` calls it via the existing
+`rpc()` helper; `persistProgram` makes that one call.
+
+### Why plpgsql, not a single multi-CTE statement
+
+A tempting one-statement form —
+`WITH deactivated AS (UPDATE …), upserted AS (INSERT … ON CONFLICT DO UPDATE …) SELECT …` —
+is **wrong** on the retry case: when the program id already exists and is active,
+the `deactivated` UPDATE and the `upserted` ON CONFLICT DO UPDATE both modify the
+same row in a single statement, which PostgreSQL forbids ("tuple already modified
+by an operation triggered by the current command"). plpgsql's sequential
+UPDATE-then-INSERT runs them as separate statements, so the INSERT sees the
+UPDATE's effect — correct and retry-safe.
+
+### When to reach for an RPC vs. a client-side sequence vs. an Edge Function
+
+- **Single-row, single-statement** writes stay on the client (anon-key,
+  RLS-subject) — the existing `insert`/`update`/`deactivatePrograms` primitives.
+- **Multi-step writes that must be atomic** and that the *user is allowed to
+  perform under RLS* use a `SECURITY INVOKER` RPC like this one.
+- **Operations that require privileges the user does not have under RLS** belong
+  in an Edge Function with `SUPABASE_SERVICE_ROLE_KEY` server-side (ADR-0016,
+  `docs/agents/edge-functions.md`) — never a client-side service-role path.
+
+## Consequences
+
+- The partial-failure state-loss path in regen-persist is eliminated.
+- A new server-side surface (a callable RPC) now exists. It deploys via
+  `supabase db push` on merge to `main` (the "Deploy to linked Supabase" job),
+  with a documentation-only reverse migration at
+  `docs/migrations/down/20260604061428_add_deactivate_and_insert_program_rpc.sql`.
+- `SupabaseClient.deactivatePrograms(userId:)` is no longer called in production
+  (its only caller now uses the RPC). It was retained — it has direct test
+  coverage and is a reasonable standalone primitive — rather than deleted, to
+  keep this change surgical.
+- The iOS behavior change ships via an app build, **decoupled** from the migration
+  deploy: after the deploy the function simply exists until a client build calls
+  it, so the migration is safe to land ahead of the client.
+
+## Supersedes / supersedes-by
+
+Supersedes the pre-#189 non-transactional client-side `deactivatePrograms()`-then-
+`insert()` program-persist sequence. Not yet superseded.


### PR DESCRIPTION
Sweep-cadence documentation for the 2026-06-02 → 2026-06-04 functional-defect sweep (all 12 issues — `#55 #141 #151 #167 #171 #172 #184 #186 #187 #189 #190 #192` — now closed). No code or schema changes.

## What's documented

- **ADR-0017** — *Day-label convention is a stable per-user key, preserved across regen.* The decision behind #172/#141: `day_focus` → `dayLabel` → `day_type` is one concept across layers, and `deepLiftHistory` joins on it, so regen must reuse the user's existing labels rather than mint a fresh convention.
- **ADR-0018** — *Atomic program persistence via a SECURITY INVOKER RPC.* The decision behind #189: one-transaction deactivate+upsert, RLS-preserving (consistent with ADR-0016), retry-idempotent. Includes the plpgsql-vs-multi-CTE rationale and when to use an RPC vs a client-side sequence vs an Edge Function.
- **BACKLOG.md §2E** — per-issue shipped log (P5-E01..E10 + the build/test supporting PRs), with the grep-and-report sibling sites recorded as left-unedited. §2D updated: P5-D04 marked resolved; P5-D05 reflects #167/#151 closed while #164/#165/#166 remain open.
- **CONTEXT.md** — new "Day label" glossary term + a Relationships bullet linking ADR-0017. Re-read end-to-end for the phase boundary; nothing else was stale.

## Doc map adherence

Each doc kept to its job per CLAUDE.md: decisions → `docs/adr/`, current-state language → `CONTEXT.md`, long-form work log → `BACKLOG.md`. `CLAUDE.md` (agent rules) and `ARCHITECTURE.md` (Phase 1 legacy) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)