### PR TITLE
fix(#239): validate client e.pattern against canonical MovementPattern in derivedTrainedSets (#167 sibling)

### DIFF
--- a/supabase/functions/_shared/exercise-library.ts
+++ b/supabase/functions/_shared/exercise-library.ts
@@ -36,6 +36,24 @@ export type MovementPattern =
   | "isolation";
 
 /**
+ * Runtime single-source-of-truth for the `MovementPattern` vocabulary. The
+ * type above is compile-time only, so a client-supplied `pattern` string can't
+ * be validated against it at runtime (#228's lesson, mirrored from #167's
+ * MUSCLE_GROUPS set). Consumed by `derivedTrainedSets` to reject non-canonical
+ * client patterns before they leak into `trainedPatterns` (#239).
+ */
+export const MOVEMENT_PATTERNS: ReadonlySet<MovementPattern> = new Set<MovementPattern>([
+  "horizontal_push",
+  "vertical_push",
+  "horizontal_pull",
+  "vertical_pull",
+  "squat",
+  "hip_hinge",
+  "lunge",
+  "isolation",
+]);
+
+/**
  * Map from `exercise_id` (snake_case canonical IDs from `set_logs.exercise_id`)
  * to `MovementPattern`. Pinned at 71 entries as of 2026-05-10. Bumping this
  * map MUST also bump `EXERCISE_LIBRARY_ENTRY_COUNT` and the corresponding

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -30,7 +30,11 @@
 //   - docs/agents/edge-functions.md (secrets, deploy, local dev)
 
 import postgres from "postgres";
-import { canonicalizeExerciseId, lookupPattern } from "../_shared/exercise-library.ts";
+import {
+  canonicalizeExerciseId,
+  lookupPattern,
+  MOVEMENT_PATTERNS,
+} from "../_shared/exercise-library.ts";
 import {
   computeE1RM,
   type TopSet as EwmaTopSet,
@@ -1966,12 +1970,17 @@ export function derivedTrainedSets(
         // preference (under-bootstrap silent; over-bootstrap creates
         // phantom profiles).
         const fromExercise = lookupPattern(e.exercise_id);
-        if (typeof e.pattern === "string") {
+        // A non-canonical client pattern falls through to the trustworthy
+        // ExerciseLibrary lookup rather than leaking verbatim — a bogus
+        // client value can't leak into trainedPatterns / derivedTrainedJoints
+        // and falsely satisfy the auto-clear gate, nor suppress the real
+        // pattern (#239, mirroring #167's reject-unknown for primary_muscle).
+        if (typeof e.pattern === "string" && (MOVEMENT_PATTERNS as ReadonlySet<string>).has(e.pattern)) {
           patterns.add(e.pattern);
         } else if (fromExercise) {
           patterns.add(fromExercise);
         }
-      } else if (typeof e.pattern === "string") {
+      } else if (typeof e.pattern === "string" && (MOVEMENT_PATTERNS as ReadonlySet<string>).has(e.pattern)) {
         patterns.add(e.pattern);
       }
       if (typeof e.primary_muscle === "string") {

--- a/supabase/functions/update-trainee-model/index_test.ts
+++ b/supabase/functions/update-trainee-model/index_test.ts
@@ -51,6 +51,59 @@ Deno.test("derivedTrainedSets_keeps_canonical_primary_muscle", () => {
   assertEquals(trained.muscleGroups.has("legs"), true, "leg subgroup collapses to legs");
 });
 
+// ─── #239 (#167 sibling): derivedTrainedSets rejects non-canonical e.pattern ──
+// "bench" is not a canonical MovementPattern; before the fix the client-string
+// branch added it verbatim, leaking it into trainedPatterns where it could
+// falsely satisfy the note-classifier auto-clear gate. With no exercise_id
+// there is no library fallback, so a rejected pattern leaves patterns empty.
+Deno.test("derivedTrainedSets_rejects_unknown_pattern", () => {
+  const trained = derivedTrainedSets({
+    set_logs: [
+      { pattern: "bench", intent: "top" },
+    ],
+  });
+  assertEquals(
+    trained.patterns.has("bench"),
+    false,
+    "unknown pattern must not leak into patterns",
+  );
+  assertEquals(trained.patterns.size, 0, "no library fallback without exercise_id");
+});
+
+// A canonical client pattern still flows through unchanged.
+Deno.test("derivedTrainedSets_keeps_canonical_pattern", () => {
+  const trained = derivedTrainedSets({
+    set_logs: [
+      { pattern: "horizontal_push", intent: "top" },
+    ],
+  });
+  assertEquals(
+    trained.patterns.has("horizontal_push"),
+    true,
+    "canonical pattern retained",
+  );
+});
+
+// Highest-value assertion: a bogus client pattern must neither leak nor suppress
+// the real pattern — it falls through to the trustworthy ExerciseLibrary lookup.
+Deno.test("derivedTrainedSets_falls_through_to_library_on_unknown_pattern", () => {
+  const trained = derivedTrainedSets({
+    set_logs: [
+      { exercise_id: "barbell_bench_press", pattern: "bogus", intent: "top" },
+    ],
+  });
+  assertEquals(
+    trained.patterns.has("horizontal_push"),
+    true,
+    "bogus client pattern falls through to lookupPattern",
+  );
+  assertEquals(
+    trained.patterns.has("bogus"),
+    false,
+    "bogus client pattern must not leak into patterns",
+  );
+});
+
 // ─── D1: no set_logs key — passes ────────────────────────────────────────────
 Deno.test("validateRequest_no_set_logs_field_returns_ok", () => {
   const result = validateRequest(baseRequest({}));


### PR DESCRIPTION
Closes #239.

## What

`derivedTrainedSets` (`supabase/functions/update-trainee-model/index.ts`) added the client-supplied `e.pattern` string **verbatim** at both add sites, so a non-canonical client pattern (e.g. `"bench"`) leaked into `trainedPatterns` and could falsely satisfy the note-classifier auto-clear gate (`isSubjectTrained`, pattern branch). This is the sibling leak **one field over** from the `primary_muscle` leak that PR #228 fixed for #167 and explicitly left as grep-and-report.

This closes the sibling, mirroring #228's **option (a) reject-unknown** decision exactly (locked precedent — not re-decided).

## How

1. **Runtime vocabulary set.** Added `MOVEMENT_PATTERNS: ReadonlySet<MovementPattern>` next to the `MovementPattern` type in `_shared/exercise-library.ts` — the type alone is compile-time only, so it can't validate a runtime client string (the explicit #228 lesson, mirroring #167's `MUSCLE_GROUPS` set).
2. **Guarded both `e.pattern` add sites** against `MOVEMENT_PATTERNS`. A non-canonical client pattern **falls through** to the trustworthy `lookupPattern()` (when an `exercise_id` is present) rather than leaking verbatim — so a bogus client value can neither leak into `trainedPatterns`/`derivedTrainedJoints` nor *suppress* the real pattern. The `fromExercise` path was already safe (`lookupPattern` returns typed `MovementPattern | undefined`).

## TDD

Three tests added to `index_test.ts`, modeled on the existing `_rejects_unknown_primary_muscle` / `_keeps_canonical_primary_muscle` pair:
- `derivedTrainedSets_rejects_unknown_pattern` — `{ pattern: "bench" }` (no `exercise_id`) → `patterns` does not contain `"bench"` and is empty. **Failed before the fix** (leaked `true`).
- `derivedTrainedSets_keeps_canonical_pattern` — `{ pattern: "horizontal_push" }` → retained.
- `derivedTrainedSets_falls_through_to_library_on_unknown_pattern` — `{ exercise_id: "barbell_bench_press", pattern: "bogus" }` → `patterns` contains `"horizontal_push"` (from `lookupPattern`), not `"bogus"`. **Failed before the fix** (bogus suppressed the real pattern; `horizontal_push` absent).

RED→GREEN confirmed in TDD order: both leak-assertion tests fail without the guard, pass with it.

## Verify (local — source of truth; CI iOS Build & Test is known-flaky and gates nothing)

`deno test --allow-net --allow-env --allow-read --no-check` from `supabase/functions/`:
- Target suites `index_test.ts` + `note-classifier_test.ts` + `exercise-library_test.ts`: **91 passed | 0 failed**.
- Full `supabase/functions/` suite: **389 passed | 2 failed** — the 2 failures are the pre-existing `smoke_test.ts` HTTP integration tests (expect 200, get 503; they POST to a local Supabase runtime at `127.0.0.1:54321` that isn't running). Identical failures on the clean `main` baseline before this change; **zero new failures introduced**.

## Cross-cutting grep (grep-and-report only — per CLAUDE.md Process commitment 2; no edits beyond the two sites above)

Grepped `update-trainee-model/index.ts` and `_shared/*.ts` for other places a client string is added verbatim to a derived patterns/joints/muscle set:

| Site | Verdict |
|------|---------|
| `patterns.add(e.pattern)` ×2 (index.ts:1979,1984) | **Fixed by this PR.** |
| `exercises.add(e.exercise_id)` (index.ts:1964) | **Not the same class — no fix recommended.** `exercise_id` is an *open* vocabulary by design (`canonicalizeExerciseId`/`lookupPattern` pass unknown IDs through unchanged per the asymmetric-error preference); there is no closed canonical set to gate against. It also does **not** feed the `isSubjectTrained` pattern/muscle/joint gate (`subject.kind` switch has no `exercise` case). Its only consumer is the form-degradation `isCleanSession` check (`trainedExercises.has(exId)`, keyed by server-built `model_json.exercises` IDs); rejecting unknowns there would wrongly suppress real training. |
| `muscleGroups` adds (index.ts:1992,1994) | Already guarded by #167/#228. |
| `derivedTrainedJoints(trainedPatterns)` (note-classifier.ts:224) | **Not a leak.** Derives joints from a closed `PATTERN_TRAINS_JOINTS` table keyed by canonical patterns (`?? []` for unknowns); only ever emits hardcoded joint strings, never client data. Transitively *tightened* by this PR — a bogus pattern can no longer reach the joint derivation. |

No sites fixed beyond the two `e.pattern` adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)