### PR TITLE
fix(#243): normalize day_label in ProgramGenerationService legacy path (#192 sibling)

### DIFF
--- a/ProjectApex/Services/ProgramGenerationService.swift
+++ b/ProjectApex/Services/ProgramGenerationService.swift
@@ -501,7 +501,10 @@ actor ProgramGenerationService {
         return TrainingDay(
             id: UUID(),
             dayOfWeek: template.dayOfWeek,
-            dayLabel: template.dayLabel,
+            // #192 sibling (#243): normalize the LLM's free-text day label into a
+            // snake_case-safe `day_type` so it stays attached to history (#172 /
+            // ADR-0017), mirroring the macro-skeleton path fixed in PR #229.
+            dayLabel: MacroPlanService.normalizeDayLabel(template.dayLabel),
             exercises: exercises,
             sessionNotes: template.sessionNotes
         )

--- a/ProjectApexTests/ProgramGenerationServiceTests.swift
+++ b/ProjectApexTests/ProgramGenerationServiceTests.swift
@@ -16,6 +16,7 @@
 //      f. isGenerating flag transitions correctly (false → true → false).
 
 import XCTest
+import Testing
 @testable import ProjectApex
 
 // MARK: - Mock providers
@@ -574,6 +575,195 @@ final class ProgramGenerationServiceTests: XCTestCase {
                 payload.availableEquipment.contains(item.equipmentType.typeKey),
                 "GymProfilePayload must contain type key '\(item.equipmentType.typeKey)'."
             )
+        }
+    }
+}
+
+// MARK: - #192 sibling: day_label normalization in the legacy static path
+
+/// Variant of `validMesocycleJSON` whose accumulation phase carries free-text
+/// day labels with special characters ("Arms & Shoulders", "Chest/Back"). The
+/// legacy static `generate()` path mints `TrainingDay.dayLabel` in
+/// `ProgramGenerationService.buildTrainingDay`; before the #192 sibling fix
+/// (issue #243) it passed `template.dayLabel` through unnormalized, detaching the
+/// day from history (the #172 / ADR-0017 concern) and reintroducing the exact
+/// drift #192 fixed in the macro-skeleton path (PR #229).
+private let specialCharDayLabelJSON = """
+{
+  "mesocycle_template": {
+    "periodization_model": "linear_periodization",
+    "phase_templates": [
+      {
+        "phase": "accumulation",
+        "training_days": [
+          {
+            "day_of_week": 1,
+            "day_label": "Arms & Shoulders",
+            "session_notes": null,
+            "exercises": [
+              {
+                "exercise_id": "dumbbell_bench_press",
+                "name": "Dumbbell Bench Press",
+                "primary_muscle": "pectoralis_major",
+                "synergists": ["anterior_deltoid", "triceps_brachii"],
+                "equipment_required": "dumbbell_set",
+                "sets": 3,
+                "rep_range": { "min": 8, "max": 12 },
+                "tempo": "3-1-2-0",
+                "rest_seconds": 90,
+                "rir_target": 3,
+                "coaching_cues": ["Retract scapula", "Control the descent"]
+              }
+            ]
+          },
+          {
+            "day_of_week": 2,
+            "day_label": "Chest/Back",
+            "session_notes": null,
+            "exercises": [
+              {
+                "exercise_id": "dumbbell_bench_press",
+                "name": "Dumbbell Bench Press",
+                "primary_muscle": "pectoralis_major",
+                "synergists": ["anterior_deltoid", "triceps_brachii"],
+                "equipment_required": "dumbbell_set",
+                "sets": 3,
+                "rep_range": { "min": 8, "max": 12 },
+                "tempo": "3-1-2-0",
+                "rest_seconds": 90,
+                "rir_target": 3,
+                "coaching_cues": ["Retract scapula", "Control the descent"]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "phase": "intensification",
+        "training_days": [
+          {
+            "day_of_week": 1,
+            "day_label": "Arms & Shoulders",
+            "session_notes": null,
+            "exercises": [
+              {
+                "exercise_id": "dumbbell_bench_press",
+                "name": "Dumbbell Bench Press",
+                "primary_muscle": "pectoralis_major",
+                "synergists": ["anterior_deltoid", "triceps_brachii"],
+                "equipment_required": "dumbbell_set",
+                "sets": 3,
+                "rep_range": { "min": 6, "max": 10 },
+                "tempo": "3-1-2-0",
+                "rest_seconds": 120,
+                "rir_target": 2,
+                "coaching_cues": ["Retract scapula", "Control the descent"]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "phase": "peaking",
+        "training_days": [
+          {
+            "day_of_week": 1,
+            "day_label": "Arms & Shoulders",
+            "session_notes": null,
+            "exercises": [
+              {
+                "exercise_id": "dumbbell_bench_press",
+                "name": "Dumbbell Bench Press",
+                "primary_muscle": "pectoralis_major",
+                "synergists": ["anterior_deltoid", "triceps_brachii"],
+                "equipment_required": "dumbbell_set",
+                "sets": 3,
+                "rep_range": { "min": 4, "max": 8 },
+                "tempo": "3-1-2-0",
+                "rest_seconds": 150,
+                "rir_target": 1,
+                "coaching_cues": ["Retract scapula", "Maximal intent"]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "phase": "deload",
+        "training_days": [
+          {
+            "day_of_week": 1,
+            "day_label": "Arms & Shoulders",
+            "session_notes": null,
+            "exercises": [
+              {
+                "exercise_id": "dumbbell_bench_press",
+                "name": "Dumbbell Bench Press",
+                "primary_muscle": "pectoralis_major",
+                "synergists": ["anterior_deltoid", "triceps_brachii"],
+                "equipment_required": "dumbbell_set",
+                "sets": 2,
+                "rep_range": { "min": 10, "max": 15 },
+                "tempo": "2-1-2-0",
+                "rest_seconds": 60,
+                "rir_target": 4,
+                "coaching_cues": ["Easy effort", "Focus on form"]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+"""
+
+/// Mirrors `MacroPlanServiceDayLabelNormalizationTests` for the sibling mint
+/// point in the legacy static `ProgramGenerationService.generate()` path
+/// (issue #243). Asserts PARITY with the canonical `MacroPlanService.normalizeDayLabel`
+/// rather than re-deriving the algorithm, plus one explicit literal example.
+@Suite("ProgramGenerationService — day_label normalization (#192 sibling, #243)")
+struct ProgramGenerationServiceDayLabelNormalizationTests {
+
+    private func makeUserProfile() -> UserProfile {
+        UserProfile(
+            userId: "test-user",
+            experienceLevel: "intermediate",
+            goals: ["hypertrophy"],
+            bodyweightKg: nil,
+            ageYears: nil
+        )
+    }
+
+    @Test("generate normalizes free-text day_label through the legacy static expansion path")
+    func normalizesDayLabelOnExpansion() async throws {
+        let service = ProgramGenerationService(
+            provider: MockLLMProvider(response: specialCharDayLabelJSON)
+        )
+
+        let meso = try await service.generate(
+            userProfile: makeUserProfile(),
+            gymProfile: GymProfile.mockProfile()
+        )
+
+        let labels = meso.weeks[0].trainingDays.map(\.dayLabel)
+        try #require(labels.count == 2, "accumulation week must expand to its two template days")
+
+        // Parity with the canonical normalizer — do not hardcode the algorithm here.
+        #expect(labels[0] == MacroPlanService.normalizeDayLabel("Arms & Shoulders"))
+        #expect(labels[1] == MacroPlanService.normalizeDayLabel("Chest/Back"))
+
+        // Plus one explicit literal example (before the fix this was "Arms & Shoulders").
+        #expect(labels[0] == "Arms_Shoulders")
+
+        // Every minted label must be snake_case-safe across all 12 expanded weeks.
+        for week in meso.weeks {
+            for label in week.trainingDays.map(\.dayLabel) {
+                #expect(
+                    label.range(of: "^[A-Za-z0-9_]+$", options: .regularExpression) != nil,
+                    "day label must be snake_case-safe, got \(label)"
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## What

Normalize the LLM's free-text `day_label` in the **legacy static `generate()` path** of `ProgramGenerationService`, the sibling mint point flagged grep-and-report in PR #229 (the #192 fix).

`ProgramGenerationService.swift:504` (in `buildTrainingDay(from:phase:weekInPhase:)`) minted `TrainingDay.dayLabel` straight from `template.dayLabel`:

```swift
dayLabel: template.dayLabel,   // LLM string passed through unnormalized
```

So a label like `"Arms & Shoulders"` reached `TrainingDay.dayLabel` non-snake_case, detaching the day from history (the #172 / ADR-0017 concern) and reintroducing the exact drift #192 fixed in the macro-skeleton path. This path is LIVE (wired through AppDependencies / ProgramViewModel).

## Fix (minimal, no refactor)

```swift
dayLabel: MacroPlanService.normalizeDayLabel(template.dayLabel),
```

`normalizeDayLabel` is `static` at `MacroPlanService.swift:379` — directly callable, no import, no new dependency. This makes the legacy path match the macro-skeleton path (`MacroPlanService.swift:328`, fixed in #229).

> **Deferred option (not done here, surgical scope):** both sites now call `MacroPlanService.normalizeDayLabel`. If a third mint point appears, extracting the normalizer to a shared `DayLabel` util would be worth considering. Left as a note rather than a change.

## TDD

- **RED:** new Swift Testing suite `ProgramGenerationServiceDayLabelNormalizationTests` drives `generate()` (mock provider) with a special-char fixture (`"Arms & Shoulders"`, `"Chest/Back"`) and asserts the resulting `TrainingDay.dayLabel` equals `MacroPlanService.normalizeDayLabel(...)` (parity), an explicit literal (`"Arms_Shoulders"`), and `^[A-Za-z0-9_]+$` across all 12 expanded weeks. Before the fix it failed with 19 issues (`got Arms & Shoulders`, `got Chest/Back`).
- **GREEN:** applied the one-line fix; the suite passes.

Mirrors `MacroPlanServiceDayLabelNormalizationTests` (the #192 canonical normalizer test).

## Local test results (source of truth; CI iOS is known-flaky)

- Focused RED (before fix): `normalizesDayLabelOnExpansion` **FAILED** with 19 issues.
- Focused GREEN (after fix): **1 test, 0 failures**.
- Regression set — `ProgramGenerationServiceTests` (XCTest) + both day-label suites: **9 XCTest (2 live-API skipped) + 3 Swift Testing = 0 failures**.

## Cross-cutting grep (report-only, per CLAUDE.md Process commitment 2)

Grepped `template.dayLabel`, `dayLabel:`, and all `dayLabel` reads across `ProjectApex/`. Classification of every hit:

| Site | Verdict |
|---|---|
| `ProgramGenerationService.swift:504` | **FIXED here** — the legacy static mint point. |
| `MacroPlanService.swift:328` (`dayLabel: label`, where `label = normalizeDayLabel(focus)`) | Already fixed in PR #229. |
| `SessionPlanService.swift:539` (`dayLabel: payload.dayLabel`) | **New hit worth flagging.** Mints `TrainingDay.dayLabel` from the session-plan LLM payload. Lower risk than line 504 because the request already passes the *normalized* `skeletonDay.dayLabel` in and the LLM is expected to echo it — but it is **not** defensively normalized. Recommend a follow-up issue; **not fixed here** (out of this slice's scope). |
| `SessionPlanService.swift:417` (`dayLabel: skeletonDay.dayLabel`) | Safe — propagates an already-normalized skeleton label into the request. |
| `ProgramGenerationService.swift:352` (`EmptyTrainingDayViolation`) | Safe — reads from an already-expanded day for a correction payload, not a `TrainingDay` mint. |
| `ContentView.swift:368`, `WorkoutSessionManager.swift:1026` | Safe — propagate existing in-model / persisted labels. |
| `AIInferenceService.swift:725`, `InferenceSpike.swift:168`, `PausedSessionBannerView.swift:63`, `WorkoutProgram.swift:364/376` | Safe — hardcoded test/mock/preview literals. |
| OnboardingView caller | Safe (per PR #229 — no history at onboarding). |

**Per Process commitment 2, nothing beyond line 504 was edited.** The one genuinely new finding (`SessionPlanService.swift:539`) is reported for a follow-up decision, not changed.

Closes #243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
