### PR TITLE
chore(#67): drop set_logs.local_date DEFAULT '1970-01-01' sentinel

### DIFF
--- a/docs/migrations/down/20260606042014_drop_set_logs_local_date_default.sql
+++ b/docs/migrations/down/20260606042014_drop_set_logs_local_date_default.sql
@@ -1,0 +1,10 @@
+-- Reverse of 20260606042014_drop_set_logs_local_date_default.sql
+--
+-- supabase db push is forward-only; this file is for manual operator use
+-- (psql -f) when rolling back the DEFAULT drop on set_logs.local_date.
+--
+-- Restores the backfill-only sentinel DEFAULT '1970-01-01' that the forward
+-- migration dropped. The column was — and remains — NOT NULL; only the DEFAULT
+-- is being reinstated.
+
+ALTER TABLE "public"."set_logs" ALTER COLUMN "local_date" SET DEFAULT '1970-01-01'::text;

--- a/supabase/migrations/20260606042014_drop_set_logs_local_date_default.sql
+++ b/supabase/migrations/20260606042014_drop_set_logs_local_date_default.sql
@@ -1,0 +1,17 @@
+-- Reverse migration: docs/migrations/down/20260606042014_drop_set_logs_local_date_default.sql
+-- (documentation only; not auto-applied by `supabase db push`)
+--
+-- #67: drop the backfill-only sentinel DEFAULT '1970-01-01' on set_logs.local_date.
+--
+-- Defence-in-depth. The DEFAULT originated in the baseline dump
+-- (supabase/migrations/20260506091314_remote_schema.sql:169) as a backfill
+-- safety net. All three (and only three) set_logs insert paths now populate
+-- local_date explicitly via the non-optional SetLog.formatLocalDate
+-- (WorkoutSession.swift:209), which never yields the sentinel. Dropping the
+-- DEFAULT means any future omission surfaces as a loud 23502 NOT NULL violation
+-- rather than silently writing the 1970 sentinel — which is the point.
+--
+-- The column stays NOT NULL. Existing sentinel rows are untouched (backfill is
+-- out of scope, tracked in #63).
+
+ALTER TABLE "public"."set_logs" ALTER COLUMN "local_date" DROP DEFAULT;


### PR DESCRIPTION
Closes #67.

## What

Drops the backfill-only sentinel `DEFAULT '1970-01-01'` on `set_logs.local_date`. Defence-in-depth: all three (and only three) `set_logs` insert paths populate `local_date` explicitly via the non-optional `SetLog.formatLocalDate` (`WorkoutSession.swift:209`), which never yields the sentinel. Dropping the DEFAULT turns any future omission into a loud `23502` NOT NULL violation instead of a silent 1970 write — which is the point.

The DEFAULT originated in the baseline dump (`supabase/migrations/20260506091314_remote_schema.sql:169`).

## Files

- `supabase/migrations/20260606042014_drop_set_logs_local_date_default.sql` — forward: `ALTER COLUMN local_date DROP DEFAULT`
- `docs/migrations/down/20260606042014_drop_set_logs_local_date_default.sql` — doc-only reverse (byte-identical filename), restores the DEFAULT

## Notes

- **CI applies on merge** (#143) — this PR only authors the migration files. No `db push` / `db reset` was run; no database (local or linked) was mutated.
- **Column stays NOT NULL** — only the DEFAULT is dropped.
- **Existing sentinel rows untouched** — backfill is out of scope, tracked in #63.
- **Stale-COMMENT follow-up:** the column COMMENT at `20260506091314_remote_schema.sql:181` ("Default '1970-01-01' is a backfill-only sentinel — new writes populate explicitly") becomes stale once the DEFAULT is gone. It is **not** edited here because it lives in the baseline dump, not this migration. A follow-up should update it.
- **On-device smoke still owed by a human:** a real device write through the three insert paths should be verified post-merge to confirm no path was relying on the DEFAULT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)