### PR TITLE
test(#66): regression tests for set_logs encoders (intent + local_date)

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		729D1F4ED6B5BD11AFD51058 /* MigrationDatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6BA9A7C15E3ED7575683DB /* MigrationDatesTests.swift */; };
 		73406DCD1E0EE68C2B81616E /* TraineeModelSnapshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993DDBFBA2750C9A2D659E12 /* TraineeModelSnapshotsTests.swift */; };
 		7D8C4E6ADC8DEDCA31B72B1D /* ManualLogIntentGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */; };
+		66C0DE0066C0DE0066C0DE02 /* SetLogPayloadEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66C0DE0066C0DE0066C0DE01 /* SetLogPayloadEncoderTests.swift */; };
 		81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */; };
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
 		8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */; };
@@ -112,6 +113,7 @@
 		E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelLocalStoreTests.swift; sourceTree = "<group>"; };
 		ED1E4BCA9CBB3EDBB8068E06 /* SetCompletionFormStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetCompletionFormStateTests.swift; sourceTree = "<group>"; };
 		ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualLogIntentGateTests.swift; sourceTree = "<group>"; };
+		66C0DE0066C0DE0066C0DE01 /* SetLogPayloadEncoderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetLogPayloadEncoderTests.swift; sourceTree = "<group>"; };
 		EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelEnumsTests.swift; sourceTree = "<group>"; };
 		EFB324F8EA1B317B0F90575B /* ProjectApexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProjectApexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MovementPatternTests.swift; sourceTree = "<group>"; };
@@ -241,6 +243,7 @@
 				ED1E4BCA9CBB3EDBB8068E06 /* SetCompletionFormStateTests.swift */,
 				DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */,
 				ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */,
+				66C0DE0066C0DE0066C0DE01 /* SetLogPayloadEncoderTests.swift */,
 				7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */,
 				6437BED8DCD7F98C80FF4377 /* TraineeModelServiceTests.swift */,
 				862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */,
@@ -387,6 +390,7 @@
 				0CFD5EC802FC7842DCAC24AE /* SetCompletionFormStateTests.swift in Sources */,
 				8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */,
 				7D8C4E6ADC8DEDCA31B72B1D /* ManualLogIntentGateTests.swift in Sources */,
+				66C0DE0066C0DE0066C0DE02 /* SetLogPayloadEncoderTests.swift in Sources */,
 				C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */,
 				6587F62EDC961A3C558A6226 /* TraineeModelServiceTests.swift in Sources */,
 				C88AB47564E9AD1E0A3C2197 /* TraineeModelUpdateJobTests.swift in Sources */,

--- a/ProjectApex/Features/Program/ProgramDayDetailView.swift
+++ b/ProjectApex/Features/Program/ProgramDayDetailView.swift
@@ -1099,23 +1099,6 @@ struct ProgramDayDetailView: View {
         let isoFormatter = ISO8601DateFormatter()
         isoFormatter.timeZone = TimeZone.current
 
-        struct NewSetLogPayload: Encodable {
-            let id, sessionId, exerciseId, loggedAt: String
-            let setNumber, repsCompleted: Int
-            let weightKg: Double
-            let rpeFelt, rirEstimated: Int?
-            let primaryMuscle: String?
-            let localDate: String
-            let intent: String
-            enum CodingKeys: String, CodingKey {
-                case id; case sessionId = "session_id"; case exerciseId = "exercise_id"
-                case setNumber = "set_number"; case weightKg = "weight_kg"
-                case repsCompleted = "reps_completed"; case rpeFelt = "rpe_felt"
-                case rirEstimated = "rir_estimated"; case loggedAt = "logged_at"
-                case primaryMuscle = "primary_muscle"
-                case localDate = "local_date"; case intent
-            }
-        }
         let exerciseForLog = currentDay.exercises.first(where: { $0.exerciseId == newLog.exerciseId })
         let payload = NewSetLogPayload(
             id: newLog.id.uuidString,
@@ -1576,6 +1559,27 @@ private struct SetLogEditPatch: Encodable {
         case repsCompleted  = "reps_completed"
         case rpeFelt        = "rpe_felt"
         case rirEstimated   = "rir_estimated"
+    }
+}
+
+/// set_logs row for a set added to an already-completed session (no ai_prescribed column).
+// internal (not private) and hoisted to file scope (was nested in `addNewSetLog`):
+// exposed for encoder regression tests (#66).
+struct NewSetLogPayload: Encodable {
+    let id, sessionId, exerciseId, loggedAt: String
+    let setNumber, repsCompleted: Int
+    let weightKg: Double
+    let rpeFelt, rirEstimated: Int?
+    let primaryMuscle: String?
+    let localDate: String
+    let intent: String
+    enum CodingKeys: String, CodingKey {
+        case id; case sessionId = "session_id"; case exerciseId = "exercise_id"
+        case setNumber = "set_number"; case weightKg = "weight_kg"
+        case repsCompleted = "reps_completed"; case rpeFelt = "rpe_felt"
+        case rirEstimated = "rir_estimated"; case loggedAt = "logged_at"
+        case primaryMuscle = "primary_muscle"
+        case localDate = "local_date"; case intent
     }
 }
 

--- a/ProjectApex/Features/Workout/ManualSessionLogView.swift
+++ b/ProjectApex/Features/Workout/ManualSessionLogView.swift
@@ -774,7 +774,8 @@ private struct ManualSessionPayload: Encodable {
 }
 
 /// set_logs row for manually entered sets (no ai_prescribed column).
-private struct ManualSetLogPayload: Encodable {
+// internal (not private): exposed for encoder regression tests (#66).
+struct ManualSetLogPayload: Encodable {
     let id: String
     let sessionId: String
     let exerciseId: String

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -1743,7 +1743,8 @@ nonisolated struct WorkoutSessionStatusPatch: Encodable {
     let completed: Bool
 }
 
-nonisolated private struct SetLogPayload: Encodable {
+// internal (not private): exposed for encoder regression tests (#66).
+nonisolated struct SetLogPayload: Encodable {
     let id: String
     let sessionId: String
     let exerciseId: String

--- a/ProjectApexTests/SetLogPayloadEncoderTests.swift
+++ b/ProjectApexTests/SetLogPayloadEncoderTests.swift
@@ -1,0 +1,193 @@
+// SetLogPayloadEncoderTests.swift
+// ProjectApexTests — regression tests for set_logs encoders (#66)
+//
+// PR #64 fixed a production data-loss bug: the three Encodable payloads that
+// INSERT into `set_logs` were silently dropping `intent` and `local_date`,
+// producing 23502 NOT NULL violations on the server. The fix shipped WITHOUT
+// regression tests; these are them.
+//
+// Every payload that writes a row into `set_logs` MUST serialise both
+// `intent` (SetIntent.rawValue) and `local_date` (yyyy-MM-dd via
+// SetLog.formatLocalDate). These tests encode each payload to JSON and assert
+// the full snake_case shape, the intent rawValue (two cases), the local_date
+// format, and the ABSENCE of `ai_prescribed` (which the schema for these
+// insert paths does not carry).
+//
+// Encoders under test (each maps intent→"intent", localDate→"local_date"):
+//   • SetLogPayload      — WorkoutSessionManager.swift  (workout-session flush)
+//   • ManualSetLogPayload — ManualSessionLogView.swift  (freestyle manual log)
+//   • NewSetLogPayload   — ProgramDayDetailView.swift   (add-set-to-completed)
+//
+// All three are reachable here because #66 relaxed their visibility to
+// internal (and hoisted NewSetLogPayload to file scope) purely for this test.
+
+import XCTest
+@testable import ProjectApex
+
+final class SetLogPayloadEncoderTests: XCTestCase {
+
+    // MARK: - Constants
+
+    /// Required snake_case keys every set_logs INSERT payload must serialise.
+    private let requiredKeys: Set<String> = [
+        "id", "session_id", "exercise_id", "set_number", "weight_kg",
+        "reps_completed", "logged_at", "primary_muscle", "local_date", "intent",
+    ]
+
+    /// yyyy-MM-dd, timezone-immune shape (the assertion that guards the bug).
+    private let localDatePattern = #"^\d{4}-\d{2}-\d{2}$"#
+
+    // MARK: - Helpers
+
+    private func encodeToDict<T: Encodable>(_ value: T) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(value)
+        return try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any],
+            "Encoded payload was not a JSON object"
+        )
+    }
+
+    private func makeSetLog(loggedAt: Date) -> SetLog {
+        // intent is NOT read off SetLog by the encoders — it is passed as a
+        // separate, required init parameter — so the value carried here is
+        // deliberately irrelevant to what the payload serialises.
+        SetLog(
+            id: UUID(),
+            sessionId: UUID(),
+            exerciseId: "barbell_bench_press",
+            setNumber: 2,
+            weightKg: 100.0,
+            repsCompleted: 5,
+            rpeFelt: 8,
+            rirEstimated: 2,
+            aiPrescribed: nil,
+            loggedAt: loggedAt,
+            primaryMuscle: "pectoralis_major",
+            intent: nil
+        )
+    }
+
+    /// Asserts the invariants shared by every set_logs INSERT payload.
+    private func assertSetLogRowShape(
+        _ dict: [String: Any],
+        expectedIntent: SetIntent,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        // 1. All required snake_case keys present (incl. local_date + intent).
+        for key in requiredKeys {
+            XCTAssertNotNil(dict[key], "missing key '\(key)'", file: file, line: line)
+        }
+
+        // 2. intent equals the SetIntent rawValue.
+        XCTAssertEqual(
+            dict["intent"] as? String, expectedIntent.rawValue,
+            "intent should be the SetIntent rawValue", file: file, line: line
+        )
+
+        // 3. local_date matches yyyy-MM-dd (timezone-immune shape check).
+        let localDate = dict["local_date"] as? String
+        XCTAssertNotNil(localDate, "local_date should be a string", file: file, line: line)
+        XCTAssertNotNil(
+            localDate?.range(of: localDatePattern, options: .regularExpression),
+            "local_date '\(localDate ?? "nil")' should match \(localDatePattern)",
+            file: file, line: line
+        )
+
+        // 4. ai_prescribed is ABSENT — these insert paths do not carry it.
+        XCTAssertNil(
+            dict["ai_prescribed"], "ai_prescribed must not be serialised on set_logs inserts",
+            file: file, line: line
+        )
+    }
+
+    // MARK: - SetLogPayload (workout-session flush)
+
+    func test_setLogPayload_topIntent_serialisesIntentAndLocalDate() throws {
+        let log = makeSetLog(loggedAt: Date(timeIntervalSince1970: 1_781_524_800))
+        let dict = try encodeToDict(SetLogPayload(from: log, intent: .top))
+        assertSetLogRowShape(dict, expectedIntent: .top)
+    }
+
+    func test_setLogPayload_backoffIntent_serialisesIntentAndLocalDate() throws {
+        let log = makeSetLog(loggedAt: Date(timeIntervalSince1970: 1_781_524_800))
+        let dict = try encodeToDict(SetLogPayload(from: log, intent: .backoff))
+        assertSetLogRowShape(dict, expectedIntent: .backoff)
+    }
+
+    // MARK: - ManualSetLogPayload (freestyle manual log)
+
+    func test_manualSetLogPayload_topIntent_serialisesIntentAndLocalDate() throws {
+        let log = makeSetLog(loggedAt: Date(timeIntervalSince1970: 1_781_524_800))
+        let dict = try encodeToDict(ManualSetLogPayload(from: log, intent: .top))
+        assertSetLogRowShape(dict, expectedIntent: .top)
+    }
+
+    func test_manualSetLogPayload_backoffIntent_serialisesIntentAndLocalDate() throws {
+        let log = makeSetLog(loggedAt: Date(timeIntervalSince1970: 1_781_524_800))
+        let dict = try encodeToDict(ManualSetLogPayload(from: log, intent: .backoff))
+        assertSetLogRowShape(dict, expectedIntent: .backoff)
+    }
+
+    // MARK: - NewSetLogPayload (add-set-to-completed)
+
+    /// NewSetLogPayload takes local_date as a constructed argument (unlike the
+    /// two `from:` encoders, which compute it internally with the host TZ), so
+    /// we build it with an EXPLICIT timezone — no CI-machine TZ flake.
+    private func makeNewSetLogPayload(intent: SetIntent) -> NewSetLogPayload {
+        let loggedAt = Date(timeIntervalSince1970: 1_781_524_800)
+        let tz = TimeZone(identifier: "America/New_York")!
+        return NewSetLogPayload(
+            id: UUID().uuidString,
+            sessionId: UUID().uuidString,
+            exerciseId: "barbell_bench_press",
+            loggedAt: ISO8601DateFormatter().string(from: loggedAt),
+            setNumber: 3,
+            repsCompleted: 5,
+            weightKg: 100.0,
+            rpeFelt: 8,
+            rirEstimated: 2,
+            primaryMuscle: "pectoralis_major",
+            localDate: SetLog.formatLocalDate(loggedAt, in: tz),
+            intent: intent.rawValue
+        )
+    }
+
+    func test_newSetLogPayload_topIntent_serialisesIntentAndLocalDate() throws {
+        let dict = try encodeToDict(makeNewSetLogPayload(intent: .top))
+        assertSetLogRowShape(dict, expectedIntent: .top)
+    }
+
+    func test_newSetLogPayload_backoffIntent_serialisesIntentAndLocalDate() throws {
+        let dict = try encodeToDict(makeNewSetLogPayload(intent: .backoff))
+        assertSetLogRowShape(dict, expectedIntent: .backoff)
+    }
+
+    // MARK: - SetLog.formatLocalDate (explicit timezone → deterministic)
+
+    /// The local_date producer must yield a yyyy-MM-dd string interpreted in the
+    /// timezone it is given, regardless of host locale/TZ — the property the
+    /// shape checks above rely on. Pinning an explicit TZ makes the exact value
+    /// deterministic on any CI machine.
+    func test_formatLocalDate_explicitTimeZone_isDeterministic() {
+        // 2026-06-15T03:00:00Z — chosen so two zones straddle the day boundary.
+        let instant = Date(timeIntervalSince1970: 1_781_492_400)
+
+        // New York (UTC-4 in June) → still the 14th locally.
+        XCTAssertEqual(
+            SetLog.formatLocalDate(instant, in: TimeZone(identifier: "America/New_York")!),
+            "2026-06-14"
+        )
+        // Tokyo (UTC+9) → already the 15th locally.
+        XCTAssertEqual(
+            SetLog.formatLocalDate(instant, in: TimeZone(identifier: "Asia/Tokyo")!),
+            "2026-06-15"
+        )
+        // UTC at noon → unambiguously the 15th, and matches the yyyy-MM-dd shape.
+        let noon = Date(timeIntervalSince1970: 1_781_524_800)
+        XCTAssertEqual(
+            SetLog.formatLocalDate(noon, in: TimeZone(identifier: "UTC")!),
+            "2026-06-15"
+        )
+    }
+}


### PR DESCRIPTION
## What

Regression tests for the three `Encodable` payloads that INSERT into `set_logs`. PR #64 fixed a production data-loss bug — the encoders silently dropped `intent` and `local_date`, producing `23502` NOT NULL violations — but shipped **without** regression tests. This adds them.

New file `ProjectApexTests/SetLogPayloadEncoderTests.swift` encodes each payload to JSON (`JSONEncoder` → `JSONSerialization` dict) and, per encoder, asserts:
1. All snake_case keys present — incl. `local_date`, `intent`, `session_id`, `exercise_id`, `set_number`, `weight_kg`, `reps_completed`, `logged_at`, `primary_muscle`.
2. `intent` equals the `SetIntent` rawValue — two cases (`.top`→`"top"`, `.backoff`→`"backoff"`).
3. `local_date` matches `^\d{4}-\d{2}-\d{2}$` (timezone-immune shape).
4. `ai_prescribed` is **absent** from the JSON.

A dedicated `formatLocalDate` test passes an **explicit** `TimeZone` (New York / Tokyo / UTC) so the exact `yyyy-MM-dd` value is deterministic on any CI machine — no host-TZ flake.

## Production edits (Option A — relax visibility for direct unit testing)

The only production changes, each annotated with a one-line `#66` comment:
- `SetLogPayload` (WorkoutSessionManager.swift): `private` → `internal` (keeps `nonisolated`).
- `ManualSetLogPayload` (ManualSessionLogView.swift): `private` → `internal`.
- `NewSetLogPayload` (ProgramDayDetailView.swift): hoisted out of `addNewSetLog()` to file scope (`internal`), unchanged otherwise; call site still compiles against the memberwise init.

No other code touched.

## Guard proven

Temporarily dropping the `local_date` CodingKey case from `SetLogPayload` made **both** `SetLogPayload` tests fail (`** TEST FAILED ** — Executed 2 tests, with 6 failures`, assertion `missing key 'local_date'`). Restored immediately.

## Verification

- Focused run: `SetLogPayloadEncoderTests` — **7 tests, 0 failures**.
- Broader target (`ProjectApexTests`, live-API suites skipped): **411 tests, 0 failures** (5 integration-gated skips). `** TEST SUCCEEDED **`.

## Cross-cutting grep (report-only)

All `set_logs` references swept. Encodables **writing** to `set_logs`:
- `SetLogPayload`, `ManualSetLogPayload`, `NewSetLogPayload` — the three INSERT payloads carrying `intent`/`local_date` (under test). ✅
- `SetLogEditPatch` (ProgramDayDetailView.swift) — an **UPDATE** patch carrying only `weight_kg`/`reps_completed`/`rpe_felt`/`rir_estimated`; does **not** carry `intent`/`local_date`, so it is not subject to the NOT-NULL insert bug. Out of scope.
- All remaining references (ProgressViewModel, ProgramViewModel ×2, ProgramDayDetailView, WorkoutSessionManager, WorkoutViewModel) are `fetch` reads decoding `SetLog`.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)