### PR TITLE
docs: start plain-language work diary (DIARY.md)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -1,0 +1,34 @@
+# Project Apex — Work Diary
+
+A plain-language diary of work that gets pushed and merged, written in simple words —
+like a journal, not a technical log. Newest entries go on top.
+
+Started 2026-06-07.
+
+---
+
+## 2026-06-07 — Stopped bad workout "pattern" labels from sneaking in
+
+**The problem (in plain words):**
+When the app sends a workout to the server, each set can carry a "pattern" label —
+like "horizontal_push" for a bench press. The server keeps a fixed list of valid
+pattern names. But the old code trusted whatever the app sent, even made-up words.
+Those junk words got dropped into the "what you trained today" list. That list helps
+the app decide when to quietly clear an old injury or form note — so a junk label
+could trip that safety check by accident.
+
+**What I changed:**
+The server now only accepts a pattern if it's on the real list of valid names. If the
+app sends junk, the server ignores it and works out the correct pattern from the
+exercise name instead. So bad data can't sneak in, and it also can't hide the right
+answer.
+
+**How I made sure it works:**
+I wrote three tests first. Two of them failed before the fix (which proved the bug was
+real), then passed after. All the important tests pass (91 out of 91).
+
+**Status:** Filed as issue #239, fix is in pull request #240. Pushed, waiting to be merged.
+
+*(This is also the day the diary started.)*
+
+---


### PR DESCRIPTION
Adds `DIARY.md` — a side document that logs pushed/merged work in simple, diary-style words. It builds up over time, newest entries on top.

Seeded with the first entry: the #239 `e.pattern` validation work (issue #239 / PR #240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)