### PR TITLE
test(#154): lock onboarding goal payload ↔ update-trainee-goal EF contract

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		A12FA719C0DE0001CAFE0001 /* TraineeModelSnapshotsCrossValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12FA719C0DE0002CAFE0002 /* TraineeModelSnapshotsCrossValidationTests.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */; };
 		A3741A0001CAFE0001CAFE01 /* LateArrivalNotificationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */; };
+		A1540154CAFE0154CAFE0001 /* OnboardingGoalPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1540154CAFE0154CAFE0002 /* OnboardingGoalPayloadTests.swift */; };
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
 		C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */; };
@@ -105,6 +106,7 @@
 		A11FA719C0DE0002CAFE0002 /* FatigueInteractionCrossValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FatigueInteractionCrossValidationTests.swift; sourceTree = "<group>"; };
 		A12FA719C0DE0002CAFE0002 /* TraineeModelSnapshotsCrossValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelSnapshotsCrossValidationTests.swift; sourceTree = "<group>"; };
 		A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LateArrivalNotificationQueueTests.swift; sourceTree = "<group>"; };
+		A1540154CAFE0154CAFE0002 /* OnboardingGoalPayloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingGoalPayloadTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
 		DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetPrescriptionIntentValidationTests.swift; sourceTree = "<group>"; };
 		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
@@ -245,6 +247,7 @@
 				6437BED8DCD7F98C80FF4377 /* TraineeModelServiceTests.swift */,
 				862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */,
 				A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */,
+				A1540154CAFE0154CAFE0002 /* OnboardingGoalPayloadTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -391,6 +394,7 @@
 				6587F62EDC961A3C558A6226 /* TraineeModelServiceTests.swift in Sources */,
 				C88AB47564E9AD1E0A3C2197 /* TraineeModelUpdateJobTests.swift in Sources */,
 				A3741A0001CAFE0001CAFE01 /* LateArrivalNotificationQueueTests.swift in Sources */,
+				A1540154CAFE0154CAFE0001 /* OnboardingGoalPayloadTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/Features/Onboarding/OnboardingView.swift
+++ b/ProjectApex/Features/Onboarding/OnboardingView.swift
@@ -1013,7 +1013,10 @@ private struct UserInsertRow: Codable, Sendable {
 /// validator contract in `supabase/functions/update-trainee-goal/index.ts`:
 /// top-level `user_id` (UUID string) and `goal` object carrying the
 /// GoalState shape (statement + focusAreas + ISO-8601 updatedAt).
-private struct TraineeGoalUpsertPayload: Codable, Sendable {
+///
+/// `internal` (not `private`) so the EF-contract parity test can encode it
+/// directly and assert the wire shape the validator accepts (#154).
+struct TraineeGoalUpsertPayload: Codable, Sendable {
     let userId: UUID
     let goal: GoalUpsertBody
 
@@ -1023,7 +1026,10 @@ private struct TraineeGoalUpsertPayload: Codable, Sendable {
     }
 }
 
-private struct GoalUpsertBody: Codable, Sendable {
+/// `internal` (not `private`) so the EF-contract parity test can assert the
+/// camelCase wire shape (`statement`/`focusAreas`/`updatedAt`) the validator
+/// requires — adding snake_case CodingKeys here would BREAK the EF (#154).
+struct GoalUpsertBody: Codable, Sendable {
     let statement: String
     let focusAreas: [String]
     let updatedAt: String

--- a/ProjectApexTests/OnboardingGoalPayloadTests.swift
+++ b/ProjectApexTests/OnboardingGoalPayloadTests.swift
@@ -1,0 +1,169 @@
+// OnboardingGoalPayloadTests.swift
+// ProjectApexTests
+//
+// Contract parity test (#154): the onboarding goal write
+// (`OnboardingView.swift` ~:941) builds a `TraineeGoalUpsertPayload`,
+// encodes it with a bare `JSONEncoder()`, and POSTs it to the
+// `update-trainee-goal` Edge Function. The EF validator
+// (`supabase/functions/update-trainee-goal/index.ts`, `validateRequest`)
+// enforces an EXACT shape. Nothing currently proves the client payload
+// encodes to a shape the validator accepts — a silent client/server schema
+// drift here breaks onboarding goal hydration (the iOS side then reads
+// `GoalState.placeholder`, the cold-start fallback).
+//
+// KEY SUBTLETY this test locks: the top-level key is snake_case (`user_id`)
+// but the `goal` sub-object keys are CAMEL-CASE (`statement`/`focusAreas`/
+// `updatedAt`). A well-meaning "consistency" refactor that snake-cases
+// `GoalUpsertBody` (e.g. adding `focusAreas = "focus_areas"` CodingKeys)
+// would silently break the EF — these assertions are the drift guard.
+//
+// The two payload structs are `internal` (not `private`) specifically so
+// this test can encode them directly and assert the wire shape.
+
+import XCTest
+@testable import ProjectApex
+
+final class OnboardingGoalPayloadTests: XCTestCase {
+
+    // Replicated literally from `supabase/functions/update-trainee-goal/index.ts`.
+    // If either regex changes there, this test must change in lockstep — that is
+    // the whole point of the parity lock.
+    //
+    //   UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    private static let efUUIDRegex =
+        "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    //   ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/
+    private static let efISODateRegex =
+        "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:?\\d{2})$"
+
+    /// Builds the payload EXACTLY the way the onboarding call site does
+    /// (`OnboardingView.swift` ~:939-948): `updatedAt` via `ISO8601DateFormatter`
+    /// with `[.withInternetDateTime, .withFractionalSeconds]`, encoded with a
+    /// bare `JSONEncoder()` (no key strategy). The only departure is a fixed
+    /// `Date` for determinism.
+    private func encodeCallSitePayload(
+        userId: UUID,
+        at date: Date
+    ) throws -> [String: Any] {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload = TraineeGoalUpsertPayload(
+            userId: userId,
+            goal: GoalUpsertBody(
+                statement: "Hypertrophy",
+                focusAreas: ["legs", "back"],
+                updatedAt: isoFormatter.string(from: date)
+            )
+        )
+        let data = try JSONEncoder().encode(payload)
+        return try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            "encoded payload must deserialize to a JSON object"
+        )
+    }
+
+    // MARK: ─── Top-level shape: snake_case `user_id`, no camelCase leak ────────
+
+    func test_payload_topLevelKeys_areExactlyUserIdAndGoal() throws {
+        let userId = UUID()
+        let json = try encodeCallSitePayload(
+            userId: userId,
+            at: Date(timeIntervalSinceReferenceDate: 800_000_000)
+        )
+
+        XCTAssertEqual(
+            Set(json.keys), ["user_id", "goal"],
+            "EF reads top-level `user_id` (snake_case) + `goal`; a camelCase " +
+            "`userId` leak or any extra key would be rejected by validateRequest"
+        )
+        XCTAssertNil(json["userId"], "no camelCase `userId` may leak to the wire")
+    }
+
+    func test_payload_userId_matchesEFUUIDRegex() throws {
+        let userId = UUID()
+        let json = try encodeCallSitePayload(
+            userId: userId,
+            at: Date(timeIntervalSinceReferenceDate: 800_000_000)
+        )
+
+        let userIdString = try XCTUnwrap(json["user_id"] as? String,
+            "user_id must encode as a String")
+        // EF gate: `typeof user_id === "string" && UUID_RE.test(user_id)`.
+        // UUID_RE carries the /i flag, so UUID().uuidString (uppercase) matches.
+        XCTAssertNotNil(
+            userIdString.range(
+                of: Self.efUUIDRegex,
+                options: [.regularExpression, .caseInsensitive]
+            ),
+            "user_id '\(userIdString)' must match the EF UUID_RE"
+        )
+    }
+
+    // MARK: ─── Goal sub-object: CAMEL-case keys (the drift guard) ──────────────
+
+    func test_goal_subObjectKeys_areExactlyCamelCase() throws {
+        let json = try encodeCallSitePayload(
+            userId: UUID(),
+            at: Date(timeIntervalSinceReferenceDate: 800_000_000)
+        )
+        let goal = try XCTUnwrap(json["goal"] as? [String: Any],
+            "goal must encode as a JSON object")
+
+        // Exact key set — present in camelCase, nothing extra.
+        XCTAssertEqual(
+            Set(goal.keys), ["statement", "focusAreas", "updatedAt"],
+            "EF reads goal.statement / goal.focusAreas / goal.updatedAt verbatim"
+        )
+
+        // Explicit camelCase presence + snake_case absence == the drift guard.
+        XCTAssertNotNil(goal["focusAreas"], "goal.focusAreas must be camelCase")
+        XCTAssertNotNil(goal["updatedAt"], "goal.updatedAt must be camelCase")
+        XCTAssertNil(
+            goal["focus_areas"],
+            "snake_case goal.focus_areas would be invisible to the EF validator"
+        )
+        XCTAssertNil(
+            goal["updated_at"],
+            "snake_case goal.updated_at would be invisible to the EF validator"
+        )
+    }
+
+    func test_goal_statementAndFocusAreas_haveExpectedTypes() throws {
+        let json = try encodeCallSitePayload(
+            userId: UUID(),
+            at: Date(timeIntervalSinceReferenceDate: 800_000_000)
+        )
+        let goal = try XCTUnwrap(json["goal"] as? [String: Any])
+
+        XCTAssertTrue(goal["statement"] is String,
+            "EF gate: typeof g.statement === 'string'")
+        XCTAssertTrue(goal["focusAreas"] is [Any],
+            "EF gate: Array.isArray(g.focusAreas)")
+        let focusAreas = try XCTUnwrap(goal["focusAreas"] as? [Any])
+        for element in focusAreas {
+            XCTAssertTrue(element is String,
+                "EF gate: each goal.focusAreas[i] must be a string")
+        }
+    }
+
+    // MARK: ─── Highest-value assertion: formatter output ↔ server ISO regex ────
+
+    func test_goal_updatedAt_matchesEFISODateRegex() throws {
+        let json = try encodeCallSitePayload(
+            userId: UUID(),
+            at: Date(timeIntervalSinceReferenceDate: 800_000_000)
+        )
+        let goal = try XCTUnwrap(json["goal"] as? [String: Any])
+        let updatedAt = try XCTUnwrap(goal["updatedAt"] as? String,
+            "goal.updatedAt must encode as a String")
+
+        // EF gate: `typeof g.updatedAt === "string" && ISO_DATE_RE.test(g.updatedAt)`.
+        // This is the highest-value parity check: the client's
+        // ISO8601DateFormatter([.withInternetDateTime, .withFractionalSeconds])
+        // output must satisfy the server's ISO_DATE_RE.
+        XCTAssertNotNil(
+            updatedAt.range(of: Self.efISODateRegex, options: .regularExpression),
+            "goal.updatedAt '\(updatedAt)' must match the EF ISO_DATE_RE"
+        )
+    }
+}


### PR DESCRIPTION
## What & why

The onboarding goal write (`OnboardingView.swift` ~:941) builds a `TraineeGoalUpsertPayload`, encodes it with a bare `JSONEncoder()`, and POSTs it to the `update-trainee-goal` Edge Function, whose `validateRequest` (`supabase/functions/update-trainee-goal/index.ts`) enforces an **exact** shape. Nothing currently proves the client payload encodes to a shape the validator accepts — a silent client/server schema drift here breaks onboarding goal hydration (the iOS side then reads `GoalState.placeholder`, the cold-start fallback).

This adds a contract parity test that locks the wire shape.

## The subtlety being locked

Top-level key is **snake_case** (`user_id`) but the `goal` sub-object keys are **CAMEL-case** (`statement`/`focusAreas`/`updatedAt`). A well-meaning "consistency" refactor that snake-cases `GoalUpsertBody` would silently break the EF. The test is the drift guard against exactly that.

## Test (`ProjectApexTests/OnboardingGoalPayloadTests.swift`)

Encodes the payload **exactly** as the call site does (`ISO8601DateFormatter` with `[.withInternetDateTime, .withFractionalSeconds]`; bare `JSONEncoder()` — no key strategy), then asserts against the EF validator's literal regexes:

- top-level keys are exactly `{user_id, goal}` — no camelCase `userId` leak, no extra keys
- `user_id` matches the EF `UUID_RE`
- `goal` sub-object keys are exactly `{statement, focusAreas, updatedAt}` in camelCase, with **no** `focus_areas`/`updated_at` snake_case variants — the drift guard
- `goal.statement` is a String; `goal.focusAreas` is an array of strings
- `goal.updatedAt` matches the EF `ISO_DATE_RE` (highest-value check: client formatter output ↔ server regex)

The two EF regexes are replicated literally in the test, comment-linked to `update-trainee-goal/index.ts`, so they must change in lockstep.

## Production change (minimal — Option A)

Only `TraineeGoalUpsertPayload` and `GoalUpsertBody` are relaxed `private` → `internal` (with a one-line comment each) so the test can encode them directly via `@testable import`. **No `CodingKeys` added** — the camelCase is required by the EF and is exactly what the test defends.

## Verification

- Focused suite green: `Executed 5 tests, with 0 failures`.
- Full `ProjectApexTests` target green: `Executed 432 tests, with 10 tests skipped and 0 failures` (skips are `APEX_INTEGRATION_TESTS`-gated live-API tests).
- **Drift-guard proof:** temporarily adding `enum CodingKeys { case statement; case focusAreas = "focus_areas"; case updatedAt = "updated_at" }` to `GoalUpsertBody` made **3 of the 5 tests fail (8 assertion failures)** — the camelCase key-set, `focusAreas` type, and `updatedAt` ISO checks; the two `user_id`-only tests stayed green. Reverted before commit.

## Cross-cutting grep (report-only, per CLAUDE.md Process commitment 2)

Grepped for any other client site that builds a goal payload or invokes `update-trainee-goal`:
- `update-trainee-goal` Swift references: only `OnboardingView.swift` (the invoke site + doc comments).
- `TraineeGoalUpsertPayload` / `GoalUpsertBody`: only `OnboardingView.swift`.
- The `DeveloperSettingsView` "Reset Onboarding" path (referenced in the OnboardingView comment) only clears the `onboardingCompletedKey` UserDefaults flag — it does **not** build a goal payload or invoke the EF; the re-write happens by routing the user back through `OnboardingView`.

**No other sites. No fixes made beyond the two visibility relaxations.**

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)