### PR TITLE
fix(#246): normalize day_label at the SessionPlanService mint point

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		478DD9F12F9928C6001D3636 /* SkipFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 478DD9F02F9928C5001D3636 /* SkipFeatureTests.swift */; };
 		47BB8E5A2F626C900082C53F /* WorkoutProgramTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E592F626C900082C53F /* WorkoutProgramTests.swift */; };
 		47BB8E602F626D430082C53F /* ProgramGenerationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E5F2F626D430082C53F /* ProgramGenerationServiceTests.swift */; };
+		47BB8E622F626D430082C53F /* SessionPlanServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E612F626D430082C53F /* SessionPlanServiceTests.swift */; };
 		47BB8E622F6273750082C53F /* EquipmentConstraintValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E612F6273750082C53F /* EquipmentConstraintValidationTests.swift */; };
 		47BB8E662F6273F30082C53F /* ProgramPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E652F6273F30082C53F /* ProgramPersistenceTests.swift */; };
 		47BB8E752F6294B00082C53F /* WorkoutSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */; };
@@ -74,6 +75,7 @@
 		478DD9F02F9928C5001D3636 /* SkipFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkipFeatureTests.swift; sourceTree = "<group>"; };
 		47BB8E592F626C900082C53F /* WorkoutProgramTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutProgramTests.swift; sourceTree = "<group>"; };
 		47BB8E5F2F626D430082C53F /* ProgramGenerationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramGenerationServiceTests.swift; sourceTree = "<group>"; };
+		47BB8E612F626D430082C53F /* SessionPlanServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPlanServiceTests.swift; sourceTree = "<group>"; };
 		47BB8E612F6273750082C53F /* EquipmentConstraintValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquipmentConstraintValidationTests.swift; sourceTree = "<group>"; };
 		47BB8E652F6273F30082C53F /* ProgramPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramPersistenceTests.swift; sourceTree = "<group>"; };
 		47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSessionManagerTests.swift; sourceTree = "<group>"; };
@@ -218,6 +220,7 @@
 				47E356DB2F61D07B00C69CD6 /* GymFactStoreTests.swift */,
 				47BB8E592F626C900082C53F /* WorkoutProgramTests.swift */,
 				47BB8E5F2F626D430082C53F /* ProgramGenerationServiceTests.swift */,
+				47BB8E612F626D430082C53F /* SessionPlanServiceTests.swift */,
 				47BB8E612F6273750082C53F /* EquipmentConstraintValidationTests.swift */,
 				47BB8E652F6273F30082C53F /* ProgramPersistenceTests.swift */,
 				47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */,
@@ -360,6 +363,7 @@
 				47BB8E752F6294B00082C53F /* WorkoutSessionManagerTests.swift in Sources */,
 				47C5C1BC2F62C08E0005F99E /* MemoryServiceTests.swift in Sources */,
 				47BB8E602F626D430082C53F /* ProgramGenerationServiceTests.swift in Sources */,
+				47BB8E622F626D430082C53F /* SessionPlanServiceTests.swift in Sources */,
 				47BB8E5A2F626C900082C53F /* WorkoutProgramTests.swift in Sources */,
 				47E356CF2F61BFCF00C69CD6 /* EquipmentMergerTests.swift in Sources */,
 				47E356DA2F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift in Sources */,

--- a/ProjectApex/Services/SessionPlanService.swift
+++ b/ProjectApex/Services/SessionPlanService.swift
@@ -496,7 +496,9 @@ actor SessionPlanService {
 
     // MARK: - Private: Build TrainingDay
 
-    private func buildTrainingDay(
+    // #246: relaxed from `private` to internal so SessionPlanServiceTests can drive the
+    // payload→TrainingDay mapping directly (the day_label normalization seam). Nothing else touched.
+    func buildTrainingDay(
         from payload: SessionPlanPayload,
         stub: TrainingDay,
         fatigue: WeekFatigueSignals
@@ -536,7 +538,7 @@ actor SessionPlanService {
         return TrainingDay(
             id: stub.id,
             dayOfWeek: stub.dayOfWeek,
-            dayLabel: payload.dayLabel,
+            dayLabel: MacroPlanService.normalizeDayLabel(payload.dayLabel),   // #246: normalize the third (final) mint point
             exercises: exercises,
             sessionNotes: notes?.trimmingCharacters(in: .whitespaces),
             status: .generated

--- a/ProjectApexTests/SessionPlanServiceTests.swift
+++ b/ProjectApexTests/SessionPlanServiceTests.swift
@@ -1,0 +1,109 @@
+// SessionPlanServiceTests.swift
+// ProjectApexTests
+//
+// Mirrors `MacroPlanServiceDayLabelNormalizationTests` (#192/#229) and
+// `ProgramGenerationServiceDayLabelNormalizationTests` (#243/#245) for the THIRD
+// and final day_label mint point: the decoded-payload → TrainingDay mapping in
+// `SessionPlanService.buildTrainingDay` (#246). A raw LLM label like
+// "Arms & Shoulders" must be normalized so the day stays a stable per-user key
+// (ADR-0017). Asserts PARITY with the canonical `MacroPlanService.normalizeDayLabel`
+// rather than re-deriving the algorithm, plus one explicit literal example.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+// MARK: - Minimal no-op LLM provider for service construction
+
+private struct NeverCalledProvider: LLMProvider {
+    func complete(systemPrompt: String, userPayload: String) async throws -> String {
+        throw URLError(.notConnectedToInternet)
+    }
+}
+
+@Suite("SessionPlanService — day_label normalization (#192/#243 sibling, #246)")
+struct SessionPlanServiceDayLabelNormalizationTests {
+
+    /// Builds a SessionPlanService backed by no-op dependencies. Only the pure
+    /// `buildTrainingDay` mapping is exercised — no network or LLM call is made.
+    @MainActor
+    private func makeService() -> SessionPlanService {
+        let fakeURL = URL(string: "https://localhost")!
+        let supabase = SupabaseClient(supabaseURL: fakeURL, anonKey: "test")
+        let provider: any LLMProvider = NeverCalledProvider()
+        let memory = MemoryService(supabase: supabase, embeddingAPIKey: "test")
+        return SessionPlanService(
+            provider: provider,
+            memoryService: memory,
+            supabaseClient: supabase
+        )
+    }
+
+    /// Decodes a session-plan payload exactly as `callAndDecodeSession` would,
+    /// so the fixture flows through the real `SessionPlanWrapper`/`SessionPlanPayload`
+    /// Codable path with the given raw `day_label`.
+    private func decodePayload(rawDayLabel: String) throws -> SessionPlanPayload {
+        let json = """
+        {
+          "session_plan": {
+            "day_label": "\(rawDayLabel)",
+            "session_notes": null,
+            "is_deload": false,
+            "is_fatigue_management_day": false,
+            "exercises": []
+          }
+        }
+        """
+        let data = Data(json.utf8)
+        return try JSONDecoder().decode(SessionPlanWrapper.self, from: data).sessionPlan
+    }
+
+    private func makeStub(dayLabel: String) -> TrainingDay {
+        TrainingDay(
+            id: UUID(),
+            dayOfWeek: 1,
+            dayLabel: dayLabel,
+            exercises: [],
+            sessionNotes: nil,
+            status: .pending
+        )
+    }
+
+    @Test("buildTrainingDay normalizes a free-text day_label from the decoded payload")
+    @MainActor
+    func normalizesDayLabelFromPayload() async throws {
+        let service = makeService()
+        let fatigue = WeekFatigueSignals.compute(from: [], sessionCount: 0)
+
+        // Special-char label straight from the LLM payload.
+        let payload = try decodePayload(rawDayLabel: "Arms & Shoulders")
+        let stub = makeStub(dayLabel: "Push_A")
+
+        let day = await service.buildTrainingDay(from: payload, stub: stub, fatigue: fatigue)
+
+        // Parity with the canonical normalizer — do not hardcode the algorithm here.
+        #expect(day.dayLabel == MacroPlanService.normalizeDayLabel("Arms & Shoulders"))
+        // Plus one explicit literal example (before the fix this was "Arms & Shoulders").
+        #expect(day.dayLabel == "Arms_Shoulders")
+        // The minted label must be snake_case-safe.
+        #expect(
+            day.dayLabel.range(of: "^[A-Za-z0-9_]+$", options: .regularExpression) != nil,
+            "day label must be snake_case-safe, got \(day.dayLabel)"
+        )
+    }
+
+    @Test("buildTrainingDay normalizes slash-delimited day_label with parity")
+    @MainActor
+    func normalizesSlashDelimitedDayLabel() async throws {
+        let service = makeService()
+        let fatigue = WeekFatigueSignals.compute(from: [], sessionCount: 0)
+
+        let payload = try decodePayload(rawDayLabel: "Chest/Back")
+        let stub = makeStub(dayLabel: "Pull_A")
+
+        let day = await service.buildTrainingDay(from: payload, stub: stub, fatigue: fatigue)
+
+        #expect(day.dayLabel == MacroPlanService.normalizeDayLabel("Chest/Back"))
+        #expect(day.dayLabel == "Chest_Back")
+    }
+}


### PR DESCRIPTION
Closes #246.

## What
Third and **final** day-label mint point in the chain. The day-label is a stable per-user key (ADR-0017); a raw LLM label like `Arms & Shoulders` must be normalized so history stays attached. `SessionPlanService.buildTrainingDay` was passing `payload.dayLabel` through unnormalized when mapping a decoded session payload → `TrainingDay`.

The first two mint points were already fixed:
- `MacroPlanService.normalizeDayLabel` (PR #229)
- `ProgramGenerationService` legacy path (PR #245, `Closes #243`)

This slice was surfaced as grep-and-report by #245 and closes the third.

## Fix (minimal, no refactor)
`ProjectApex/Services/SessionPlanService.swift:541`
```diff
-            dayLabel: payload.dayLabel,
+            dayLabel: MacroPlanService.normalizeDayLabel(payload.dayLabel),   // #246: normalize the third (final) mint point
```
`normalizeDayLabel` is `static` on `MacroPlanService` (same module) → directly callable. `buildTrainingDay` was relaxed `private`→internal (with a `#246` comment) purely to expose the payload→TrainingDay mapping as a test seam — nothing else touched.

## TDD (mirrors PR #245's `ProgramGenerationServiceDayLabelNormalizationTests`)
New `ProjectApexTests/SessionPlanServiceTests.swift` decodes a session payload through the real `SessionPlanWrapper`/`SessionPlanPayload` Codable path with a special-char `day_label`, calls `buildTrainingDay`, and asserts **parity** with the canonical normalizer (`MacroPlanService.normalizeDayLabel("Arms & Shoulders")`) plus one explicit literal (`"Arms_Shoulders"`) and a snake_case-safe regex check. (The new file was added to the `ProjectApexTests` target in `project.pbxproj`; that group is not filesystem-synchronized.)

### RED → GREEN proof
- **RED** (fix not yet applied, visibility already relaxed): `Test run with 2 tests in 1 suite failed ... with 5 issues` — `day.dayLabel → "Arms & Shoulders"` (and `"Chest/Back"`) ≠ the normalized value.
- **GREEN** (one-line fix applied): `✔ Test run with 2 tests in 1 suite passed`.
- **Broader target:** `ProjectApexTests` → `✔ Test run with 237 tests in 54 suites passed`, `** TEST SUCCEEDED **`.

## Cross-cutting grep (report-only, per CLAUDE.md Process commitment 2 — fixed NONE beyond :541)
Grepped `dayLabel:` / `day_label` across Services, Models, Features. Classification:

| Site | Kind | Verdict |
|------|------|---------|
| `MacroPlanService.swift:324/328` | mint #1 | ✅ already normalized (#229) |
| `ProgramGenerationService.swift:507` | mint #2 | ✅ already normalized (#245) |
| `SessionPlanService.swift:541` | mint #3 | ✅ **normalized in this PR** |
| `SessionPlanService.swift:417` (`skeletonDay.dayLabel`) | pass-through into `SessionPlanRequest` | safe — skeletonDay already normalized by #229 (and not a `TrainingDay` mint) |
| `ProgramGenerationService.swift:352` (`day.dayLabel`) | read-only into `EmptyTrainingDayViolation` (validation) | not a mint |
| `WorkoutSessionManager.swift:1026` (`sess.dayType`) | read-only into `SessionMetadata` (telemetry) | not a mint; value already normalized upstream |
| `WorkoutProgram.swift:364/376`, `PausedSessionBannerView.swift:63` | hardcoded `"Push_A"`/`"Pull_A"`/`"upper_body_a"` literals in mocks/previews | snake_case-safe, not LLM-derived |
| `ProgramDayDetailView.swift:938` | `print(...)` diagnostic | read-only |
| Various `let dayLabel: String` / init params | type/field declarations | not mints |

No fourth raw mint point exists. **With all three mint points now normalized, if a FOURTH ever appears the right move is to extract a shared `DayLabel` normalizer util rather than chase a fourth call site** (the #245 recommendation) — deliberately NOT done here to keep this change minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)