### PR TITLE
fix(#242): fail loud when post-workout AI insights don't run

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0CFD5EC802FC7842DCAC24AE /* SetCompletionFormStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1E4BCA9CBB3EDBB8068E06 /* SetCompletionFormStateTests.swift */; };
+		242F2420242F2420242F2401 /* PostWorkoutSummaryInsightsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 242F2420242F2420242F2402 /* PostWorkoutSummaryInsightsTests.swift */; };
 		32736E74E3F688020744DE5E /* EquipmentRounderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E3BA94C76430CACFD657B5 /* EquipmentRounderTests.swift */; };
 		39E16C19CFE1B1EF9BE00A32 /* TraineeModelEnumsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */; };
 		474B848D2F67D31C001E0879 /* MacroPlanServiceDayCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474B848C2F67D31C001E0879 /* MacroPlanServiceDayCountTests.swift */; };
@@ -116,6 +117,7 @@
 		E2D46426254666742A81E0B8 /* MuscleTaxonomyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MuscleTaxonomyTests.swift; sourceTree = "<group>"; };
 		E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelLocalStoreTests.swift; sourceTree = "<group>"; };
 		ED1E4BCA9CBB3EDBB8068E06 /* SetCompletionFormStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetCompletionFormStateTests.swift; sourceTree = "<group>"; };
+		242F2420242F2420242F2402 /* PostWorkoutSummaryInsightsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostWorkoutSummaryInsightsTests.swift; sourceTree = "<group>"; };
 		ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualLogIntentGateTests.swift; sourceTree = "<group>"; };
 		66C0DE0066C0DE0066C0DE01 /* SetLogPayloadEncoderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetLogPayloadEncoderTests.swift; sourceTree = "<group>"; };
 		EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelEnumsTests.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 				E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */,
 				18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */,
 				ED1E4BCA9CBB3EDBB8068E06 /* SetCompletionFormStateTests.swift */,
+				242F2420242F2420242F2402 /* PostWorkoutSummaryInsightsTests.swift */,
 				DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */,
 				ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */,
 				66C0DE0066C0DE0066C0DE01 /* SetLogPayloadEncoderTests.swift */,
@@ -395,6 +398,7 @@
 				A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */,
 				E50E3B4CBD53ED7ABE725DB8 /* EquipmentCatalogSeedTests.swift in Sources */,
 				0CFD5EC802FC7842DCAC24AE /* SetCompletionFormStateTests.swift in Sources */,
+				242F2420242F2420242F2401 /* PostWorkoutSummaryInsightsTests.swift in Sources */,
 				8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */,
 				7D8C4E6ADC8DEDCA31B72B1D /* ManualLogIntentGateTests.swift in Sources */,
 				66C0DE0066C0DE0066C0DE02 /* SetLogPayloadEncoderTests.swift in Sources */,

--- a/ProjectApex/Features/Workout/PostWorkoutSummaryView.swift
+++ b/ProjectApex/Features/Workout/PostWorkoutSummaryView.swift
@@ -35,6 +35,8 @@ struct PostWorkoutSummaryView: View {
 
     // MARK: - AI Insights State
 
+    // `internal` (not `private`) so PostWorkoutSummaryInsightsTests can exercise
+    // the fail-loud helper via `@testable import` (#242).
     enum InsightsState {
         case loading
         case loaded([String])
@@ -42,6 +44,18 @@ struct PostWorkoutSummaryView: View {
     }
 
     @State private var insightsState: InsightsState = .loading
+
+    /// The fail-loud notice shown when AI insights couldn't be generated (#242, ADR-0007 §3).
+    /// `nil` when the AI succeeded (or is still loading) — non-nil only for `.failed`.
+    /// Single source of truth for the badge copy; the `.failed` render branch reads from here.
+    static func insightsFallbackNotice(for state: InsightsState) -> String? {
+        switch state {
+        case .loading, .loaded:
+            return nil
+        case .failed:
+            return "Couldn't generate AI insights — showing a basic summary."
+        }
+    }
 
     // MARK: - Late-Arrival Notifications (Slice A3 / ADR-0008)
 
@@ -471,28 +485,53 @@ struct PostWorkoutSummaryView: View {
                 .padding(.vertical, 14)
                 .background(.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
 
-            case .loaded(let insights), .failed(let insights):
-                VStack(alignment: .leading, spacing: 8) {
-                    ForEach(Array(insights.enumerated()), id: \.offset) { _, insight in
-                        HStack(alignment: .top, spacing: 10) {
-                            Circle()
-                                .fill(streak.tintColor)
-                                .frame(width: 5, height: 5)
-                                .padding(.top, 6)
-                            Text(insight)
-                                .font(.system(size: 13, weight: .regular))
-                                .foregroundStyle(.white.opacity(0.75))
-                                .lineLimit(4)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                    }
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 14)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            case .loaded(let insights):
+                // AI succeeded — bullet list only, no notice.
+                insightsListCard(insights, notice: nil)
+
+            case .failed(let insights):
+                // Fail loud (#242, ADR-0007 §3): still show the deterministic
+                // fallback insights, but surface that the AI didn't run.
+                insightsListCard(insights, notice: Self.insightsFallbackNotice(for: insightsState))
             }
         }
+    }
+
+    /// Insights bullet card. When `notice` is non-nil (the `.failed` fail-loud
+    /// path), a small warning row is prepended above the list (#242).
+    @ViewBuilder
+    private func insightsListCard(_ insights: [String], notice: String?) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let notice {
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.6))
+                    Text(notice)
+                        .font(.system(size: 12, weight: .regular))
+                        .foregroundStyle(.white.opacity(0.6))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.bottom, 2)
+            }
+            ForEach(Array(insights.enumerated()), id: \.offset) { _, insight in
+                HStack(alignment: .top, spacing: 10) {
+                    Circle()
+                        .fill(streak.tintColor)
+                        .frame(width: 5, height: 5)
+                        .padding(.top, 6)
+                    Text(insight)
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundStyle(.white.opacity(0.75))
+                        .lineLimit(4)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
     // MARK: - Insights Loading

--- a/ProjectApexTests/PostWorkoutSummaryInsightsTests.swift
+++ b/ProjectApexTests/PostWorkoutSummaryInsightsTests.swift
@@ -1,0 +1,42 @@
+// PostWorkoutSummaryInsightsTests.swift
+// ProjectApexTests — #242
+//
+// Fail-loud contract for PostWorkoutSummaryView's AI insights (ADR-0007 §3,
+// foreground tier: "Never silently degrade … the user MUST see that the AI
+// didn't run").
+//
+//   .failed  ⇒ a visible "AI didn't run" notice is surfaced to the user
+//   .loaded  ⇒ no notice (AI succeeded)
+//   .loading ⇒ no notice (still running)
+//
+// Locks the single source of truth for the fallback-notice copy so the
+// `.failed` render branch can never again render byte-identically to `.loaded`.
+
+import XCTest
+@testable import ProjectApex
+
+final class PostWorkoutSummaryInsightsTests: XCTestCase {
+
+    func test_failedState_surfacesFailLoudNotice() {
+        let notice = PostWorkoutSummaryView.insightsFallbackNotice(
+            for: .failed(["Total session volume: 4200kg across 12 sets."])
+        )
+        XCTAssertNotNil(notice, ".failed must surface a fail-loud notice (ADR-0007 §3)")
+        XCTAssertTrue(
+            notice?.contains("Couldn't generate AI insights") ?? false,
+            "Notice must tell the user AI insights couldn't be generated; got: \(String(describing: notice))"
+        )
+    }
+
+    func test_loadedState_hasNoNotice() {
+        let notice = PostWorkoutSummaryView.insightsFallbackNotice(
+            for: .loaded(["Bench Press up 5kg from last Push A."])
+        )
+        XCTAssertNil(notice, ".loaded means the AI succeeded — no fail-loud notice")
+    }
+
+    func test_loadingState_hasNoNotice() {
+        let notice = PostWorkoutSummaryView.insightsFallbackNotice(for: .loading)
+        XCTAssertNil(notice, ".loading is not a failure — no notice")
+    }
+}


### PR DESCRIPTION
## What & why

`PostWorkoutSummaryView` merged the `.loaded` and `.failed` insight states into a single render branch:

```swift
case .loaded(let insights), .failed(let insights):  // ← byte-identical rendering
```

So when the AI insights call failed, the deterministic fallback rendered **byte-identically** to a genuine AI result — same "Session Insights" + sparkles header, same bullet list. The user had no way to tell the AI didn't run. That's a silent degradation, which **ADR-0007 §3 (foreground tier)** forbids: *"Never silently degrade … the user MUST see that the AI didn't run."*

## The fix (minimal, fail-loud)

- **Keep** the deterministic fallback insights (still useful). **No retry button** (out of scope).
- **Split** the render switch: `.loaded` renders exactly as before; `.failed` prepends a small warning row (`exclamationmark.triangle.fill` + *"Couldn't generate AI insights — showing a basic summary."*), matching the existing card idiom (small font, `.white.opacity`, the same `RoundedRectangle` card).
- The four `.failed(deterministicInsights())` set-sites are **unchanged**.
- The notice copy is sourced from a new **pure, testable helper** — single source of truth for the badge copy:

```swift
/// nil when the AI succeeded (or is still loading) — non-nil only for `.failed`.
static func insightsFallbackNotice(for state: InsightsState) -> String?
```

`InsightsState` and the helper are `internal` (a `#242` comment notes why) so the test can reach them via `@testable import`.

## TDD (RED → GREEN)

New file `ProjectApexTests/PostWorkoutSummaryInsightsTests.swift` (XCTest, matching the suite).

- **RED** (before the helper existed): focused run failed to compile —
  `Type 'PostWorkoutSummaryView' has no member 'insightsFallbackNotice'` (×3). The test was correctly wired into the target and failed for the right reason.
- **GREEN** (after helper + render split): focused run — **3 tests, 0 failures**.
- **Full target**: `-only-testing:ProjectApexTests` — **237 tests in 54 suites passed** (was 234 before these 3).

Contract locked: `.failed` ⇒ a visible "AI didn't run" notice; `.loaded`/`.loading` ⇒ none.

## Cross-cutting grep (report-only, per CLAUDE.md Process commitment 2)

Audited the other foreground AI call sites (ADR-0007 §3) for the same silent-substitution anti-pattern. **All compliant — no other site silently substitutes; fixed none beyond `PostWorkoutSummaryView`:**

| Site | Failure handling | Verdict |
|------|------------------|---------|
| `AIInferenceService.prescribe` / `prescribeAdaptation` | return `.fallback(reason:)` → surfaced via `InferenceRetrySheet` / visible fallback reason (`RestTimerView.swift:256`) | ✅ compliant |
| `SessionPlanService.callAndDecodeSession` | `throws SessionPlanError.*` on every failure path; never synthesizes a session | ✅ compliant |
| `ExerciseSwapService.sendMessage` | every `catch` calls `appendAssistantError(...)` (user-visible) + emits `FallbackLogRecord`; never fabricates a swap | ✅ compliant |

`PostWorkoutSummaryView` was the lone violator.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)