### PR TITLE
feat(#258): Slice A — acknowledgment field + heavy-reassessment suppression (backbone)

### DIFF
--- a/ProjectApex/Models/TraineeModel.swift
+++ b/ProjectApex/Models/TraineeModel.swift
@@ -39,6 +39,12 @@ struct TraineeModel: Codable, Sendable, Hashable {
     /// fired per ADR-0012. nil for users that have never triggered the
     /// 6-session cooldown gate.
     var lastGlobalPhaseAdvanceFiredAtSessionCount: Int?
+    /// Per-trigger acknowledgment of heavy-reassessment GPA fires (#258): each
+    /// member is a `lastGlobalPhaseAdvanceFiredAtSessionCount` the user has
+    /// acknowledged, which suppresses the signal via
+    /// `TraineeModelDigest.deriveHeavyReassessmentSignal`. Grows ~1 int per GPA
+    /// event (≤ ~40/yr), so no pruning is needed.
+    var acknowledgedTriggeringSessionCounts: Set<Int>
 
     init(
         activeProgramId: UUID? = nil,
@@ -57,7 +63,8 @@ struct TraineeModel: Codable, Sendable, Hashable {
         lifeContextEvents: [LifeContextEvent] = [],
         totalSessionCount: Int = 0,
         lastClassifiedNoteCreatedAt: Date? = nil,
-        lastGlobalPhaseAdvanceFiredAtSessionCount: Int? = nil
+        lastGlobalPhaseAdvanceFiredAtSessionCount: Int? = nil,
+        acknowledgedTriggeringSessionCounts: Set<Int> = []
     ) {
         self.activeProgramId = activeProgramId
         self.goal = goal
@@ -76,6 +83,7 @@ struct TraineeModel: Codable, Sendable, Hashable {
         self.totalSessionCount = totalSessionCount
         self.lastClassifiedNoteCreatedAt = lastClassifiedNoteCreatedAt
         self.lastGlobalPhaseAdvanceFiredAtSessionCount = lastGlobalPhaseAdvanceFiredAtSessionCount
+        self.acknowledgedTriggeringSessionCounts = acknowledgedTriggeringSessionCounts
     }
 
     // MARK: Custom Codable for JSONB shape parity (slice A12 / #83)
@@ -109,6 +117,7 @@ struct TraineeModel: Codable, Sendable, Hashable {
         case totalSessionCount
         case lastClassifiedNoteCreatedAt
         case lastGlobalPhaseAdvanceFiredAtSessionCount
+        case acknowledgedTriggeringSessionCounts
     }
 
     init(from decoder: Decoder) throws {
@@ -186,6 +195,11 @@ struct TraineeModel: Codable, Sendable, Hashable {
         self.lastGlobalPhaseAdvanceFiredAtSessionCount = try c.decodeIfPresent(
             Int.self, forKey: .lastGlobalPhaseAdvanceFiredAtSessionCount
         )
+        // Tolerant decode (#258): older rows / server JSON lack the key — mirror
+        // the model's other collections defaulting to empty.
+        self.acknowledgedTriggeringSessionCounts = Set(try c.decodeIfPresent(
+            [Int].self, forKey: .acknowledgedTriggeringSessionCounts
+        ) ?? [])
     }
 
     func encode(to encoder: Encoder) throws {
@@ -218,6 +232,10 @@ struct TraineeModel: Codable, Sendable, Hashable {
         try c.encode(totalSessionCount, forKey: .totalSessionCount)
         try c.encodeIfPresent(lastClassifiedNoteCreatedAt, forKey: .lastClassifiedNoteCreatedAt)
         try c.encodeIfPresent(lastGlobalPhaseAdvanceFiredAtSessionCount, forKey: .lastGlobalPhaseAdvanceFiredAtSessionCount)
+        // Encode SORTED for deterministic JSONB — Swift `Set` Codable is
+        // hash-ordered (randomized per-process), which breaks model_json parity
+        // (cf. prescriptionAccuracy / recentlyAdvancedPatterns sorting). #258.
+        try c.encode(acknowledgedTriggeringSessionCounts.sorted(), forKey: .acknowledgedTriggeringSessionCounts)
     }
 
     // MARK: Major patterns (calibration / phase-advance gating)

--- a/ProjectApex/Models/TraineeModelDigest.swift
+++ b/ProjectApex/Models/TraineeModelDigest.swift
@@ -97,10 +97,11 @@ struct TraineeModelDigest: Codable, Sendable, Hashable {
     /// which the HEAVY REASSESSMENT block remains in the SessionPlan
     /// prompt. Matches the server-side cooldown
     /// (`GLOBAL_PHASE_ADVANCE_COOLDOWN_SESSIONS = 6` in
-    /// `supabase/functions/_shared/constants.ts`). #178 deliberately ships
-    /// without iOS-side acknowledgment state — the AI may mention
+    /// `supabase/functions/_shared/constants.ts`). The AI may mention
     /// reassessment for up to this many consecutive sessions per fire event
-    /// until the UI screen + ack writer land in a follow-up.
+    /// — unless the user acknowledges it: `TraineeModel`'s
+    /// `acknowledgedTriggeringSessionCounts` suppresses the signal early via
+    /// `deriveHeavyReassessmentSignal` (#258 added that iOS-side ack state).
     static let heavyReassessmentCooldownWindow: Int = 6
 
     enum CodingKeys: String, CodingKey {
@@ -240,6 +241,10 @@ extension TraineeModelDigest {
         guard delta >= 0, delta < heavyReassessmentCooldownWindow else {
             return nil
         }
+        // #258: an acknowledged fire-event is silenced for BOTH the banner and the
+        // LLM prompt (both derive from this single function). Check the CURRENT
+        // triggering count specifically — a LATER GPA fire (new count) must still surface.
+        guard !model.acknowledgedTriggeringSessionCounts.contains(lastFired) else { return nil }
         let recentPatterns = model.patterns
             .filter { (pattern, profile) in
                 TraineeModel.majorPatterns.contains(pattern)

--- a/ProjectApexTests/TraineeModelDigestTests.swift
+++ b/ProjectApexTests/TraineeModelDigestTests.swift
@@ -1657,6 +1657,50 @@ final class TraineeModelDigestTests: XCTestCase {
         XCTAssertEqual(sq?.formDegradationFlag, false)
     }
 
+    // MARK: ─── #258: acknowledgment suppresses the heavy-reassessment signal ──
+
+    /// Builds a model whose GPA fired at `firedAt` and whose `totalSessionCount`
+    /// puts it `delta` sessions into the cooldown window (delta < 6 ⇒ in-window).
+    private func makeInWindowGPAModel(firedAt: Int = 18, delta: Int = 2) -> TraineeModel {
+        var model = makeBaselineModel()
+        model.lastGlobalPhaseAdvanceFiredAtSessionCount = firedAt
+        model.totalSessionCount = firedAt + delta
+        return model
+    }
+
+    func test_deriveSignal_suppressedWhenTriggeringCountAcknowledged() {
+        var model = makeInWindowGPAModel(firedAt: 18, delta: 2)
+        model.acknowledgedTriggeringSessionCounts = [18]   // the CURRENT fire
+
+        let signal = TraineeModelDigest.deriveHeavyReassessmentSignal(from: model)
+
+        XCTAssertNil(signal,
+            "An acknowledged triggering count (18) must silence the signal for both banner and LLM")
+    }
+
+    func test_deriveSignal_stillFiresWhenADifferentCountAcknowledged() {
+        var model = makeInWindowGPAModel(firedAt: 18, delta: 2)
+        model.acknowledgedTriggeringSessionCounts = [12]   // an EARLIER fire, not 18
+
+        let signal = TraineeModelDigest.deriveHeavyReassessmentSignal(from: model)
+
+        XCTAssertNotNil(signal,
+            "Acking a different count must NOT suppress a later GPA fire — guards against a naive any-ack-suppresses bug")
+        XCTAssertEqual(signal?.triggeringSessionCount, 18)
+    }
+
+    func test_deriveSignal_emptyAckSet_unchangedInWindowAndOut() {
+        // In-window, no acks → signal present (regression guard).
+        let inWindow = makeInWindowGPAModel(firedAt: 18, delta: 2)
+        XCTAssertNotNil(TraineeModelDigest.deriveHeavyReassessmentSignal(from: inWindow),
+            "Empty ack set in-window must behave exactly as before #258 (signal present)")
+
+        // Out-of-window, no acks → nil (regression guard).
+        let outOfWindow = makeInWindowGPAModel(firedAt: 18, delta: 6) // delta == window ⇒ out
+        XCTAssertNil(TraineeModelDigest.deriveHeavyReassessmentSignal(from: outOfWindow),
+            "Empty ack set out-of-window must remain nil")
+    }
+
     // MARK: ─── B4 (#89) cycle 4: lastGlobalPhaseAdvance pass-through ──────────
 
     func test_digest_lastGlobalPhaseAdvanceFiredAt_passesThroughWhenSet() {

--- a/ProjectApexTests/TraineeModelTests.swift
+++ b/ProjectApexTests/TraineeModelTests.swift
@@ -264,6 +264,36 @@ struct TraineeModelCodableTests {
         #expect(decoded.lastClassifiedNoteCreatedAt == isoDate("2026-04-30"))
         #expect(decoded.lastGlobalPhaseAdvanceFiredAtSessionCount == 18)
     }
+
+    @Test("acknowledgedTriggeringSessionCounts (#258) encodes SORTED and round-trips")
+    func acknowledgedTriggeringSessionCountsEncodesSortedAndRoundTrips() throws {
+        var model = TraineeModel(goal: defaultGoal())
+        // Set literal order is hash-ordered (randomized per-process); the
+        // custom encoder must sort for deterministic JSONB parity.
+        model.acknowledgedTriggeringSessionCounts = [12, 3, 7]
+
+        let data = try JSONEncoder().encode(model)
+
+        // The persisted array must be ascending-sorted, NOT hash-ordered.
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let encodedArray = dict["acknowledgedTriggeringSessionCounts"] as? [Int]
+        #expect(encodedArray == [3, 7, 12])
+
+        // Decoding reconstructs the Set unchanged.
+        let decoded = try JSONDecoder().decode(TraineeModel.self, from: data)
+        #expect(decoded.acknowledgedTriggeringSessionCounts == [12, 3, 7])
+    }
+
+    @Test("Legacy JSON (no acknowledgedTriggeringSessionCounts key) decodes to empty set")
+    func decodesMissingAcknowledgedTriggeringSessionCountsAsEmpty() throws {
+        let model = TraineeModel(goal: defaultGoal())
+        let data = try JSONEncoder().encode(model)
+        var dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        dict.removeValue(forKey: "acknowledgedTriggeringSessionCounts")
+        let stripped = try JSONSerialization.data(withJSONObject: dict)
+        let decoded = try JSONDecoder().decode(TraineeModel.self, from: stripped)
+        #expect(decoded.acknowledgedTriggeringSessionCounts.isEmpty)
+    }
 }
 
 // MARK: - Helpers

--- a/docs/fixtures/trainee-model-snapshot.json
+++ b/docs/fixtures/trainee-model-snapshot.json
@@ -123,5 +123,6 @@
   "reassessmentRecords": [],
   "totalSessionCount": 24,
   "lastClassifiedNoteCreatedAt": "2026-01-04T18:00:00.000Z",
-  "lastGlobalPhaseAdvanceFiredAtSessionCount": 18
+  "lastGlobalPhaseAdvanceFiredAtSessionCount": 18,
+  "acknowledgedTriggeringSessionCounts": []
 }


### PR DESCRIPTION
## What & why

**Part of #258** (P5-D06 heavy-reassessment feature; umbrella issue stays open). This is the tracer-bullet **backbone** — pure model + derivation logic, fully unit-testable. **No UI, no Edge Function** in this slice; those land in later slices.

It adds the data field that records which GPA fire-events the user has acknowledged, and makes the iOS signal-derivation suppress an acknowledged event at a single chokepoint.

## Changes

1. **`TraineeModel.acknowledgedTriggeringSessionCounts: Set<Int>`** — new persisted field. `init` default `[]`, camelCase `model_json` key (matches sibling Phase-2 keys, NOT snake_case), **encoded sorted** for deterministic JSONB parity (Swift `Set` Codable is hash-ordered → randomized per-process), decoded tolerantly (`decodeIfPresent ?? []`) for pre-#258 rows.
2. **`deriveHeavyReassessmentSignal`** now returns `nil` when the **current** triggering count (`lastGlobalPhaseAdvanceFiredAtSessionCount`) is in the acked set. Single chokepoint → silences BOTH the banner (future slice) and the LLM prompt, which both derive from this one function. A **later** GPA fire (new count) still surfaces.
3. Reworded the now-false `heavyReassessmentCooldownWindow` comment (#178's "ships without iOS-side acknowledgment state" no longer holds — this feature adds that state).

## TDD — RED→GREEN proofs (local suite = source of truth)

- **Suppression (RED proof):** before Change 2, `test_deriveSignal_suppressedWhenTriggeringCountAcknowledged` **failed** (signal surfaced despite the ack). After the guard → passes.
- **Different-count (teeth proof):** `test_deriveSignal_stillFiresWhenADifferentCountAcknowledged` passes under the correct `.contains(lastFired)` impl. Verified it has teeth by transiently swapping in a naive `acknowledgedTriggeringSessionCounts.isEmpty`-based guard → the test **failed** (caught the any-ack-suppresses bug); reverted.
- **Empty-set regression guard:** `test_deriveSignal_emptyAckSet_unchangedInWindowAndOut` — in-window present, out-of-window nil. Passes throughout.
- **Codable round-trip (RED proof):** before the CodingKey + sorted encode + tolerant decode, `acknowledgedTriggeringSessionCounts encodes SORTED and round-trips` **failed** (encoded array `nil`, decoded set `[]`). After → encoded array is `[3, 7, 12]` (sorted from `[12, 3, 7]`) and the `Set` round-trips equal. Plus a backward-compat test: a payload **lacking** the key decodes to an empty set.

### Test counts
- Focused TraineeModel/digest run: **101 XCTest + 7 Swift Testing**, 0 failures.
- Full `ProjectApexTests` sweep: **445 XCTest** (10 skipped = `APEX_INTEGRATION_TESTS` live-API tests, intentionally off) **+ 239 Swift Testing in 54 suites**, **0 failures**. `** TEST SUCCEEDED **`.

## Cross-cutting grep (CLAUDE.md Process commitment 2 — report)

**1. Signal-reconstruction sites — single chokepoint confirmed.** Grepped every reader of `lastGlobalPhaseAdvanceFiredAtSessionCount` / `heavy_reassessment_signal` / `HEAVY REASSESSMENT`:
- The only code deriving the heavy-reassessment signal from the fired-at count is `TraineeModelDigest.deriveHeavyReassessmentSignal` (the digest also passes the raw count through as a separate field, but nothing reconstructs the *signal* from it).
- The SessionPlan prompt (`SystemPrompt_SessionPlan.txt`) is a static template that only references `trainee_model_digest.heavy_reassessment_signal`; when the signal is `nil` the optional digest key is omitted, so the LLM sees no block. The future banner will read the same field.
- The TS side (`global-phase-advance.ts`, `update-trainee-model`) is the server-side **detection/write** path (computes & persists the count) — it does not reconstruct the iOS read-side signal, and is out of scope for this slice (no EF work here).
- Conclusion: the single guard in `deriveHeavyReassessmentSignal` silences every consumer.

**2. Snapshot/parity fixture — one site touched, in-scope.** `docs/fixtures/trainee-model-snapshot.json` is the cross-platform `model_json` shape contract (Swift `TraineeModelSnapshotsCrossValidationTests` + TS `orchestrator_test.ts` round-trip). Added `"acknowledgedTriggeringSessionCounts": []` so the contract documents the new persisted field.
  - No parity test actually *broke* (Swift decodes tolerantly; the TS round-trip asserts specific keys' values, not the absence of extra keys), but adding the field to the contract is the model's own-contract maintenance, so the fixture is updated. Verified both consumers stay green.

## Not merging
PR base `main`; do not merge (umbrella #258 stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)