### PR TITLE
feat(#258): Slice B — acknowledgment write path (update-trainee-goal EF + iOS payload)

### DIFF
--- a/ProjectApex/Features/Onboarding/OnboardingView.swift
+++ b/ProjectApex/Features/Onboarding/OnboardingView.swift
@@ -944,7 +944,8 @@ struct OnboardingView: View {
                 statement: profile.primaryGoal.rawValue,
                 focusAreas: [],
                 updatedAt: isoFormatter.string(from: Date())
-            )
+            ),
+            acknowledgeTriggeringSessionCount: nil
         )
         if let encoded = try? JSONEncoder().encode(goalPayload) {
             _ = try? await deps.supabaseClient.invokeFunction(
@@ -1019,10 +1020,17 @@ private struct UserInsertRow: Codable, Sendable {
 struct TraineeGoalUpsertPayload: Codable, Sendable {
     let userId: UUID
     let goal: GoalUpsertBody
+    /// P5-D06 Slice B (#258): OPTIONAL top-level field. When non-nil, the EF
+    /// idempotently appends this triggering-session count to
+    /// `model_json.acknowledgedTriggeringSessionCounts`. Onboarding always
+    /// passes `nil` — the synthesized `encodeIfPresent` then OMITS the key,
+    /// keeping the onboarding wire shape exactly `{user_id, goal}`.
+    let acknowledgeTriggeringSessionCount: Int?
 
     enum CodingKeys: String, CodingKey {
         case userId = "user_id"
         case goal
+        case acknowledgeTriggeringSessionCount = "acknowledge_triggering_session_count"
     }
 }
 

--- a/ProjectApexTests/OnboardingGoalPayloadTests.swift
+++ b/ProjectApexTests/OnboardingGoalPayloadTests.swift
@@ -43,7 +43,8 @@ final class OnboardingGoalPayloadTests: XCTestCase {
     /// `Date` for determinism.
     private func encodeCallSitePayload(
         userId: UUID,
-        at date: Date
+        at date: Date,
+        acknowledge: Int? = nil
     ) throws -> [String: Any] {
         let isoFormatter = ISO8601DateFormatter()
         isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -53,7 +54,8 @@ final class OnboardingGoalPayloadTests: XCTestCase {
                 statement: "Hypertrophy",
                 focusAreas: ["legs", "back"],
                 updatedAt: isoFormatter.string(from: date)
-            )
+            ),
+            acknowledgeTriggeringSessionCount: acknowledge
         )
         let data = try JSONEncoder().encode(payload)
         return try XCTUnwrap(
@@ -77,6 +79,44 @@ final class OnboardingGoalPayloadTests: XCTestCase {
             "`userId` leak or any extra key would be rejected by validateRequest"
         )
         XCTAssertNil(json["userId"], "no camelCase `userId` may leak to the wire")
+        // #258 Slice B: the new OPTIONAL ack field must encode as ABSENT (not
+        // `null`) when nil, or onboarding's wire shape would no longer be
+        // exactly {user_id, goal}. The synthesized `encodeIfPresent` omits it.
+        XCTAssertNil(
+            json["acknowledge_triggering_session_count"],
+            "nil ack must omit the key entirely (no `null`) so onboarding stays {user_id, goal}"
+        )
+    }
+
+    func test_payload_withAck_topLevelKeys_includeSnakeCaseAck() throws {
+        let json = try encodeCallSitePayload(
+            userId: UUID(),
+            at: Date(timeIntervalSinceReferenceDate: 800_000_000),
+            acknowledge: 42
+        )
+
+        // #258 Slice B: a non-nil ack adds EXACTLY one top-level snake_case key.
+        XCTAssertEqual(
+            Set(json.keys), ["user_id", "goal", "acknowledge_triggering_session_count"],
+            "EF reads top-level `acknowledge_triggering_session_count` (snake_case)"
+        )
+        XCTAssertNil(
+            json["acknowledgeTriggeringSessionCount"],
+            "no camelCase `acknowledgeTriggeringSessionCount` may leak to the wire"
+        )
+
+        // Value encodes as an Int (JSON number) == 42.
+        XCTAssertEqual(
+            json["acknowledge_triggering_session_count"] as? Int, 42,
+            "ack must encode as the integer value, snake_case key"
+        )
+
+        // The goal sub-object is unaffected — still the #154-locked camelCase set.
+        let goal = try XCTUnwrap(json["goal"] as? [String: Any])
+        XCTAssertEqual(
+            Set(goal.keys), ["statement", "focusAreas", "updatedAt"],
+            "ack must not perturb the goal sub-object shape"
+        )
     }
 
     func test_payload_userId_matchesEFUUIDRegex() throws {

--- a/supabase/functions/update-trainee-goal/index.ts
+++ b/supabase/functions/update-trainee-goal/index.ts
@@ -45,6 +45,12 @@ export interface UpdateTraineeGoalRequest {
     focusAreas: string[];
     updatedAt: string;
   };
+  // P5-D06 Slice B (#258): OPTIONAL. When present, the EF idempotently
+  // appends this triggering-session count to
+  // `model_json.acknowledgedTriggeringSessionCounts` (the Slice-A camelCase
+  // key). Absent for onboarding (a brand-new user cannot have a GPA fire);
+  // sent only by the goal-review screen's Save (a later slice).
+  acknowledge_triggering_session_count?: number;
 }
 
 const ISO_DATE_RE =
@@ -56,7 +62,8 @@ export function validateRequest(
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
     return { error: "request body must be a JSON object" };
   }
-  const { user_id, goal } = body as Record<string, unknown>;
+  const { user_id, goal, acknowledge_triggering_session_count } =
+    body as Record<string, unknown>;
   if (typeof user_id !== "string" || !UUID_RE.test(user_id)) {
     return { error: "user_id must be a UUID string" };
   }
@@ -80,7 +87,23 @@ export function validateRequest(
   if (typeof g.updatedAt !== "string" || !ISO_DATE_RE.test(g.updatedAt)) {
     return { error: "goal.updatedAt must be an ISO 8601 timestamp string" };
   }
-  return {
+  // P5-D06 Slice B (#258): OPTIONAL ack. Absent → valid exactly as before
+  // (back-compat: onboarding never sends it). Present → must be a
+  // non-negative integer.
+  if (
+    acknowledge_triggering_session_count !== undefined &&
+    !(
+      typeof acknowledge_triggering_session_count === "number" &&
+      Number.isInteger(acknowledge_triggering_session_count) &&
+      acknowledge_triggering_session_count >= 0
+    )
+  ) {
+    return {
+      error:
+        "acknowledge_triggering_session_count must be a non-negative integer",
+    };
+  }
+  const validated: UpdateTraineeGoalRequest = {
     user_id,
     goal: {
       statement: g.statement,
@@ -88,6 +111,11 @@ export function validateRequest(
       updatedAt: g.updatedAt,
     },
   };
+  if (acknowledge_triggering_session_count !== undefined) {
+    validated.acknowledge_triggering_session_count =
+      acknowledge_triggering_session_count as number;
+  }
+  return validated;
 }
 
 // deno-lint-ignore no-explicit-any
@@ -130,6 +158,36 @@ export async function upsertGoal(
       ),
       updated_at = NOW()
   `;
+
+  // P5-D06 Slice B (#258): when the goal-review Save acknowledges a
+  // heavy-reassessment trigger, idempotently array-append the triggering
+  // session count to the Slice-A camelCase key. Separate statement, same
+  // connection — the goal write above stays byte-for-byte unchanged.
+  //
+  // The COALESCE(..., '[]') on BOTH the read and the @> containment guard is
+  // load-bearing: a bare `model_json->'key' @> x` is NULL (not false) when
+  // the key is absent, and `NOT NULL` is NULL — so without the COALESCE the
+  // first-ever ack would silently never append. The `NOT @>` guard makes
+  // re-acking an already-present count a no-op.
+  if (req.acknowledge_triggering_session_count !== undefined) {
+    const ack = req.acknowledge_triggering_session_count;
+    await sql`
+      UPDATE public.trainee_models
+      SET model_json = jsonb_set(
+        COALESCE(model_json, '{}'::jsonb),
+        '{acknowledgedTriggeringSessionCounts}',
+        COALESCE(model_json -> 'acknowledgedTriggeringSessionCounts', '[]'::jsonb)
+          || to_jsonb(${ack}::int),
+        true
+      )
+      WHERE user_id = ${req.user_id}
+        AND NOT (
+          COALESCE(model_json -> 'acknowledgedTriggeringSessionCounts', '[]'::jsonb)
+            @> to_jsonb(${ack}::int)
+        )
+    `;
+  }
+
   return { ok: true, goal: req.goal };
 }
 

--- a/supabase/functions/update-trainee-goal/index_test.ts
+++ b/supabase/functions/update-trainee-goal/index_test.ts
@@ -124,3 +124,64 @@ Deno.test("validateRequest_focusAreas_with_muscle_groups_accepted", () => {
   });
   assertEquals("error" in result, false);
 });
+
+// ─── #258 Slice B: optional acknowledge_triggering_session_count ─────────────
+
+Deno.test("validateRequest_ack_valid_nonNegativeInt_accepted", () => {
+  const result = validateRequest(
+    baseRequest({ acknowledge_triggering_session_count: 5 }),
+  );
+  assertEquals("error" in result, false);
+  if ("error" in result) return;
+  assertEquals(result.acknowledge_triggering_session_count, 5);
+});
+
+Deno.test("validateRequest_ack_zero_accepted", () => {
+  // 0 is a valid session count (>= 0); the lower bound is inclusive.
+  const result = validateRequest(
+    baseRequest({ acknowledge_triggering_session_count: 0 }),
+  );
+  assertEquals("error" in result, false);
+});
+
+Deno.test("validateRequest_ack_absent_still_valid", () => {
+  // Back-compat: onboarding omits the field and must remain valid.
+  const result = validateRequest(baseRequest());
+  assertEquals("error" in result, false);
+  if ("error" in result) return;
+  assertEquals(result.acknowledge_triggering_session_count, undefined);
+});
+
+Deno.test("validateRequest_ack_negative_returns_400", () => {
+  const result = validateRequest(
+    baseRequest({ acknowledge_triggering_session_count: -1 }),
+  );
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(
+    result.error.includes("acknowledge_triggering_session_count"),
+    true,
+  );
+});
+
+Deno.test("validateRequest_ack_nonInteger_returns_400", () => {
+  const result = validateRequest(
+    baseRequest({ acknowledge_triggering_session_count: 3.5 }),
+  );
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(
+    result.error.includes("acknowledge_triggering_session_count"),
+    true,
+  );
+});
+
+Deno.test("validateRequest_ack_nonNumber_returns_400", () => {
+  // A numeric-looking string must be rejected (Number.isInteger("5") is false).
+  const result = validateRequest(
+    baseRequest({ acknowledge_triggering_session_count: "5" }),
+  );
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(
+    result.error.includes("acknowledge_triggering_session_count"),
+    true,
+  );
+});

--- a/supabase/functions/update-trainee-goal/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-goal/orchestrator_test.ts
@@ -228,6 +228,128 @@ goalTest(
   },
 );
 
+// ─── #258 Slice B: acknowledgment write path ────────────────────────────────
+//
+// The goal-review Save POSTs `acknowledge_triggering_session_count`; the EF
+// array-appends it to the Slice-A camelCase key
+// `acknowledgedTriggeringSessionCounts`. Like the goal path, the jsonb
+// COALESCE / `NOT @>` semantics are only meaningful against real Postgres.
+
+goalTest(
+  "#258 (B1): existing row, goal-save WITH ack → acknowledgedTriggeringSessionCounts contains the count AND the goal is written",
+  async () => {
+    const userId = await seedFreshUserWithExistingModel({ totalSessionCount: 5 });
+
+    await upsertGoal(
+      { user_id: userId, goal: GOAL_A, acknowledge_triggering_session_count: 42 },
+      sql,
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    assertEquals(modelJson.goal, GOAL_A);
+    assertEquals(modelJson.acknowledgedTriggeringSessionCounts, [42]);
+  },
+);
+
+goalTest(
+  "#258 (B2): idempotent → calling twice with the same count appends it exactly once",
+  async () => {
+    const userId = await seedFreshUserWithExistingModel({ totalSessionCount: 5 });
+
+    await upsertGoal(
+      { user_id: userId, goal: GOAL_A, acknowledge_triggering_session_count: 42 },
+      sql,
+    );
+    await upsertGoal(
+      { user_id: userId, goal: GOAL_A, acknowledge_triggering_session_count: 42 },
+      sql,
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    // The `WHERE NOT @>` guard makes the second ack a no-op.
+    assertEquals(modelJson.acknowledgedTriggeringSessionCounts, [42]);
+  },
+);
+
+goalTest(
+  "#258 (B3): append preserves prior acks → seed [10], ack 20 → [10, 20]",
+  async () => {
+    const userId = await seedFreshUserWithExistingModel({
+      acknowledgedTriggeringSessionCounts: [10],
+    });
+
+    await upsertGoal(
+      { user_id: userId, goal: GOAL_A, acknowledge_triggering_session_count: 20 },
+      sql,
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    assertEquals(modelJson.acknowledgedTriggeringSessionCounts, [10, 20]);
+  },
+);
+
+goalTest(
+  "#258 (B4): ack does NOT clobber other top-level model_json keys",
+  async () => {
+    const seed = {
+      patterns: {
+        squat: { currentPhase: "accumulation", sessionsInPhase: 3, trend: "progressing" },
+      },
+      exercises: {
+        barbell_back_squat: { e1rmCurrent: 151.6667, sessionCount: 2 },
+      },
+    };
+    const userId = await seedFreshUserWithExistingModel(seed);
+
+    await upsertGoal(
+      { user_id: userId, goal: GOAL_A, acknowledge_triggering_session_count: 7 },
+      sql,
+    );
+
+    // patterns + exercises subtrees jsonb-equal to the seed after the ack write.
+    const cmp = await sql`
+      SELECT
+        (model_json -> 'patterns')  = ${sql.json(seed.patterns)}::jsonb  AS patterns_equal,
+        (model_json -> 'exercises') = ${sql.json(seed.exercises)}::jsonb AS exercises_equal
+      FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    assertEquals(cmp[0].patterns_equal, true, "patterns subtree must be untouched");
+    assertEquals(cmp[0].exercises_equal, true, "exercises subtree must be untouched");
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    assertEquals(modelJson.acknowledgedTriggeringSessionCounts, [7]);
+  },
+);
+
+goalTest(
+  "#258 (B5): goal-save WITHOUT the ack field → acknowledgedTriggeringSessionCounts unchanged (remains absent)",
+  async () => {
+    const userId = await seedFreshUserWithExistingModel({ totalSessionCount: 5 });
+
+    await upsertGoal({ user_id: userId, goal: GOAL_A }, sql);
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    assertEquals(modelJson.goal, GOAL_A);
+    // No ack sent → the conditional UPDATE never ran → key stays absent.
+    assertEquals("acknowledgedTriggeringSessionCounts" in modelJson, false);
+  },
+);
+
 // Sentinel "test" that runs last — closes the shared pool so the connection
 // lifecycle stays local to this file rather than relying on process-exit.
 Deno.test({


### PR DESCRIPTION
## What

Slice B of #258 (P5-D06 heavy-reassessment acknowledgment). Adds the **write path** for acknowledging a heavy-reassessment trigger. **No UI in this slice** — the goal-review screen that drives the Save lands in a later slice. Slice A (#259, merged) added the read-side `acknowledgedTriggeringSessionCounts: Set<Int>` to `TraineeModel` and the suppression logic; this slice lets the server persist into it.

Per ADR-0006, only Edge Functions mutate `model_json`, so the append lives in `update-trainee-goal`.

## Changes

**EF `supabase/functions/update-trainee-goal/index.ts`**
- `validateRequest` accepts an OPTIONAL top-level `acknowledge_triggering_session_count`. When present it must satisfy `Number.isInteger(x) && x >= 0`, else rejected with a clear error. Absent → valid exactly as today (back-compat: onboarding never sends it).
- `upsertGoal` leaves the goal `INSERT … ON CONFLICT … jsonb_set('{goal}')` path **byte-for-byte unchanged**, then runs a SEPARATE conditional `UPDATE` (same connection) that idempotently array-appends the count to the camelCase key `acknowledgedTriggeringSessionCounts`.
  - The `COALESCE(…, '[]')` on **both** the read and the `@>` containment guard is the load-bearing correctness detail: a bare `model_json->key @> x` returns NULL (not false) when the key is absent, and `NOT NULL` is NULL — so without it the first-ever ack would silently never append.
  - `WHERE NOT @>` makes re-acking an already-present count a no-op.
- Response shape `{ ok: true, goal }` unchanged.

**iOS `ProjectApex/Features/Onboarding/OnboardingView.swift`**
- `TraineeGoalUpsertPayload` gains optional `acknowledgeTriggeringSessionCount: Int?` with CodingKey `"acknowledge_triggering_session_count"` (top-level snake_case, mirroring `user_id`; NOT inside the shape-locked camelCase `goal` sub-object).
- Synthesized `encodeIfPresent` omits the key when nil → onboarding wire shape stays exactly `{user_id, goal}`. The onboarding call site passes `nil`.

**Tests**
- iOS `OnboardingGoalPayloadTests`: the #154 contract test stays green (nil ack ⇒ no key, no `null`); new test asserts `ack = 42` adds exactly the snake_case top-level key with Int value 42, goal sub-object untouched.
- Deno `orchestrator_test.ts`: 5 DB scenarios — (1) write + goal both land, (2) idempotent double-ack, (3) append preserves prior acks `[10] + 20 → [10,20]`, (4) ack does not clobber other top-level keys, (5) goal-save without ack leaves the key absent.
- Deno `index_test.ts`: validator cases — valid non-negative int, zero, absent, negative-rejected, non-integer-rejected, non-number-rejected.

## CI

The `update-trainee-goal` Deno test step (`.github/workflows/ci.yml`, added for #155) runs `deno test` across the whole function dir, so the new orchestrator + validator cases are covered automatically. No new CI step needed.

## Local test results

- iOS focused `-only-testing:ProjectApexTests/OnboardingGoalPayloadTests`: **6 passed, 0 failed** (full app + test target compiled).
- Deno validator `index_test.ts`: **17 passed, 0 failed** (11 original + 6 new).
- Deno orchestrator `orchestrator_test.ts` (against local Postgres 54322): **11 passed, 0 failed** (5 original + 5 new + sentinel).

## Cross-cutting grep (report-only)

Grepped for other callers of `update-trainee-goal` / `TraineeGoalUpsertPayload` that the new optional field would affect. The ONLY iOS caller/invoker is `OnboardingView.swift` (the onboarding call site at ~:941 and the EF invoke at ~:952). No other call site exists — the optional field is additive and back-compatible. No unauthorized edits made.

Part of #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)