### PR TITLE
feat(#258): Slice C — MovementPattern.displayName human-readable map

### DIFF
--- a/ProjectApex/Models/MovementPattern.swift
+++ b/ProjectApex/Models/MovementPattern.swift
@@ -20,4 +20,20 @@ enum MovementPattern: String, Codable, Sendable, Hashable, CaseIterable {
     case squat
     case verticalPull   = "vertical_pull"
     case verticalPush   = "vertical_push"
+
+    /// Human-readable label for UI surfaces (e.g. the heavy-reassessment banner, #258).
+    /// Title-cased, space-separated — consistent with how SystemPrompt_SessionPlan.txt
+    /// already refers to patterns ("horizontal push", "hip hinge").
+    var displayName: String {
+        switch self {
+        case .hipHinge:       return "Hip Hinge"
+        case .horizontalPull: return "Horizontal Pull"
+        case .horizontalPush: return "Horizontal Push"
+        case .isolation:      return "Isolation"
+        case .lunge:          return "Lunge"
+        case .squat:          return "Squat"
+        case .verticalPull:   return "Vertical Pull"
+        case .verticalPush:   return "Vertical Push"
+        }
+    }
 }

--- a/ProjectApexTests/MovementPatternTests.swift
+++ b/ProjectApexTests/MovementPatternTests.swift
@@ -31,4 +31,31 @@ struct MovementPatternTests {
         #expect(!actualRawValues.contains("calves"))
         #expect(!actualRawValues.contains("core"))
     }
+
+    @Test("displayName humanizes a representative sample (#258)")
+    func displayNameRepresentativeSample() {
+        #expect(MovementPattern.squat.displayName == "Squat")
+        #expect(MovementPattern.horizontalPush.displayName == "Horizontal Push")
+        #expect(MovementPattern.hipHinge.displayName == "Hip Hinge")
+        #expect(MovementPattern.verticalPull.displayName == "Vertical Pull")
+    }
+
+    @Test("every case's displayName is humanized — no underscores, no raw machine token leaks")
+    func displayNameExhaustivenessGuard() {
+        for pattern in MovementPattern.allCases {
+            // No display name should leak the snake_case machine token.
+            #expect(
+                !pattern.displayName.contains("_"),
+                "displayName for \(pattern) contains an underscore: \(pattern.displayName)"
+            )
+            // Multi-token patterns must not equal their raw value verbatim
+            // (i.e. they got humanized rather than falling back to the token).
+            if pattern.rawValue.contains("_") {
+                #expect(
+                    pattern.displayName != pattern.rawValue,
+                    "displayName for \(pattern) equals its raw token: \(pattern.rawValue)"
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What

Part of #258 (P5-D06 heavy-reassessment feature). Slice C adds a `displayName` computed property to `MovementPattern` so user-facing surfaces (e.g. the heavy-reassessment banner, a later slice) can name recently-advanced patterns in plain English instead of the machine tokens (`horizontal_push`, `hip_hinge`, …).

Pure model utility — no UI wired up yet.

## How

- `MovementPattern.displayName` is an **exhaustive `switch`** over all 8 cases (compiler enforces a new case can't silently fall back to a raw token).
- Title-cased, space-separated — consistent with how `SystemPrompt_SessionPlan.txt` already refers to patterns ("horizontal push", "hip hinge"). No marketing copy invented; no hand-tuning needed (every default title-case read cleanly).
- `MovementPattern` already conformed to `CaseIterable`, so no conformance change was required.

## Complete case → displayName mapping

| Case | rawValue | displayName |
|---|---|---|
| `.hipHinge` | `hip_hinge` | Hip Hinge |
| `.horizontalPull` | `horizontal_pull` | Horizontal Pull |
| `.horizontalPush` | `horizontal_push` | Horizontal Push |
| `.isolation` | `isolation` | Isolation |
| `.lunge` | `lunge` | Lunge |
| `.squat` | `squat` | Squat |
| `.verticalPull` | `vertical_pull` | Vertical Pull |
| `.verticalPush` | `vertical_push` | Vertical Push |

## Tests (`ProjectApexTests/MovementPatternTests.swift`, Swift Testing)

- `displayNameRepresentativeSample` — `.squat`→"Squat", `.horizontalPush`→"Horizontal Push", `.hipHinge`→"Hip Hinge", `.verticalPull`→"Vertical Pull".
- `displayNameExhaustivenessGuard` — iterates `allCases`: asserts no `displayName` contains `_`, and that every multi-token pattern's `displayName` differs from its raw token (catches a forgotten case).

Focused run: **4 tests passed** (2 new + 2 existing) in suite "MovementPattern". Full `ProjectApexTests` target: **TEST BUILD SUCCEEDED**.

## Cross-cutting grep (report-only — nothing fixed here)

Two existing sites already render a `MovementPattern` to the user via local ad-hoc humanization of `.rawValue`. A future slice could consolidate both onto `displayName`:

- `ProjectApex/Features/Progress/TrendBannerView.swift:40` — private `displayPatternName` computed property that splits `summary.pattern.rawValue` on `_` and title-cases each token (identical logic to `displayName`).
- `ProjectApex/Features/Program/ProgramOverviewView.swift:381` — `Text(formatPatternName(summary.pattern.rawValue))`, where `formatPatternName(_:)` (defined at line 405) is a local humanizer.

(Other `.rawValue` hits — `ProgramViewModel.swift:560`, `TraineeModel.swift:219/222`, `ExerciseLibrary.swift:36` — are persistence/keying, not user-facing, so out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)