### PR TITLE
feat(#258): Slice D+E1 — pre-workout heavy-reassessment banner

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
 		C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */; };
+		258DE1F12E000000000000A2 /* HeavyReassessmentBannerCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258DE1F12E000000000000A1 /* HeavyReassessmentBannerCopyTests.swift */; };
 		C88AB47564E9AD1E0A3C2197 /* TraineeModelUpdateJobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */; };
 		E50E3B4CBD53ED7ABE725DB8 /* EquipmentCatalogSeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */; };
 /* End PBXBuildFile section */
@@ -103,6 +104,7 @@
 		6DC23D0A3EB460CF97B18574 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		70E3BA94C76430CACFD657B5 /* EquipmentRounderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EquipmentRounderTests.swift; sourceTree = "<group>"; };
 		7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelDigestTests.swift; sourceTree = "<group>"; };
+		258DE1F12E000000000000A1 /* HeavyReassessmentBannerCopyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeavyReassessmentBannerCopyTests.swift; sourceTree = "<group>"; };
 		85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelInteractionsTests.swift; sourceTree = "<group>"; };
 		862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelUpdateJobTests.swift; sourceTree = "<group>"; };
 		878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelProfilesTests.swift; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 				ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */,
 				66C0DE0066C0DE0066C0DE01 /* SetLogPayloadEncoderTests.swift */,
 				7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */,
+				258DE1F12E000000000000A1 /* HeavyReassessmentBannerCopyTests.swift */,
 				6437BED8DCD7F98C80FF4377 /* TraineeModelServiceTests.swift */,
 				862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */,
 				A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */,
@@ -403,6 +406,7 @@
 				7D8C4E6ADC8DEDCA31B72B1D /* ManualLogIntentGateTests.swift in Sources */,
 				66C0DE0066C0DE0066C0DE02 /* SetLogPayloadEncoderTests.swift in Sources */,
 				C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */,
+				258DE1F12E000000000000A2 /* HeavyReassessmentBannerCopyTests.swift in Sources */,
 				6587F62EDC961A3C558A6226 /* TraineeModelServiceTests.swift in Sources */,
 				C88AB47564E9AD1E0A3C2197 /* TraineeModelUpdateJobTests.swift in Sources */,
 				A3741A0001CAFE0001CAFE01 /* LateArrivalNotificationQueueTests.swift in Sources */,

--- a/ProjectApex/Features/Workout/HeavyReassessmentBannerCopy.swift
+++ b/ProjectApex/Features/Workout/HeavyReassessmentBannerCopy.swift
@@ -1,0 +1,48 @@
+// Features/Workout/HeavyReassessmentBannerCopy.swift
+// ProjectApex — P5-D06 (#258)
+//
+// Pure copy logic for the pre-workout heavy-reassessment banner. The SwiftUI
+// body isn't unit-testable, so the copy lives here and is exercised directly
+// by HeavyReassessmentBannerCopyTests.
+//
+// The banner is a stable affordance: constant title + tone, NO per-
+// sessionsSinceTriggered calibration (the LLM prompt handles tone per ADR-0005;
+// the banner just names what advanced and offers a goal-review CTA).
+
+import Foundation
+
+enum HeavyReassessmentBannerCopy {
+
+    /// Constant banner title — tone is fixed here; calibration lives in the LLM
+    /// prompt, not the banner (#258).
+    static let title = "Your training has leveled up"
+
+    /// Banner body for a heavy-reassessment signal (#258). Names up to 3
+    /// recently-advanced patterns via `MovementPattern.displayName`, collapsing
+    /// the remainder to "and more" beyond 3. Returns a generic fallback when the
+    /// pattern list is empty (the normal case late in the cooldown window).
+    static func body(for signal: HeavyReassessmentSignal) -> String {
+        let patterns = signal.recentlyAdvancedPatterns
+        guard !patterns.isEmpty else {
+            return "You've made broad progress lately — a good moment to revisit your goal."
+        }
+        let named = patterns.prefix(3).map(\.displayName)
+        let listed = patterns.count > 3
+            ? named.joined(separator: ", ") + ", and more"
+            : naturalJoin(named)
+        return "Your \(listed) have all moved up lately — a good moment to revisit your goal."
+    }
+
+    /// Joins names with commas and a final "and": ["a"] → "a";
+    /// ["a","b"] → "a and b"; ["a","b","c"] → "a, b, and c" (Oxford comma at 3+).
+    private static func naturalJoin(_ names: [String]) -> String {
+        switch names.count {
+        case 0:  return ""
+        case 1:  return names[0]
+        case 2:  return "\(names[0]) and \(names[1])"
+        default:
+            let head = names.dropLast().joined(separator: ", ")
+            return "\(head), and \(names[names.count - 1])"
+        }
+    }
+}

--- a/ProjectApex/Features/Workout/PreWorkoutView.swift
+++ b/ProjectApex/Features/Workout/PreWorkoutView.swift
@@ -45,6 +45,12 @@ struct PreWorkoutView: View {
     /// Days since the user's last completed session — nil means first-ever session.
     /// Drives the welcome-back banner when the gap is ≥ 14 days (2.4A).
     var daysSinceLastSession: Int? = nil
+    /// Heavy-reassessment signal (#258). When present (and not locally dismissed),
+    /// shows the level-up banner naming recently-advanced patterns. Nil → no banner.
+    var heavyReassessmentSignal: HeavyReassessmentSignal? = nil
+    /// Called when the user taps "Review goals" on the heavy-reassessment banner.
+    /// Injected; a later slice (#258 E2) wires it to the goal-review screen. Default no-op.
+    var onReviewGoals: () -> Void = {}
     /// Called when the user taps "Skip this session". Defers this day without recording
     /// any session data — the next pending non-skipped day becomes the active session.
     var onSkipSession: (() -> Void)? = nil
@@ -56,6 +62,7 @@ struct PreWorkoutView: View {
     // MARK: - Private state
     @State private var showSkipConfirmation: Bool = false
     @State private var welcomeBackBannerDismissed: Bool = false
+    @State private var heavyReassessmentBannerDismissed: Bool = false
 
     // MARK: - Body
 
@@ -72,6 +79,9 @@ struct PreWorkoutView: View {
                         programProgressSection
                         if isFirstSession {
                             firstSessionBanner
+                        }
+                        if let signal = heavyReassessmentSignal, !heavyReassessmentBannerDismissed {
+                            heavyReassessmentBanner(signal)
                         }
                         if let days = daysSinceLastSession, days >= 14, !welcomeBackBannerDismissed {
                             welcomeBackBanner(days: days)
@@ -352,6 +362,56 @@ struct PreWorkoutView: View {
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .stroke(amberColor.opacity(0.25), lineWidth: 0.5)
+        )
+    }
+
+    // MARK: - Heavy Reassessment Banner (#258)
+
+    private func heavyReassessmentBanner(_ signal: HeavyReassessmentSignal) -> some View {
+        // Distinct non-amber "progress / level-up" accent so this card reads apart
+        // from the amber firstSession/welcomeBack banners when stacked (#258).
+        let accentColor = Color(red: 0.20, green: 0.80, blue: 0.55)
+        return HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "chart.line.uptrend.xyaxis")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(accentColor)
+            VStack(alignment: .leading, spacing: 8) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(HeavyReassessmentBannerCopy.title)
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundStyle(.white)
+                    Text(HeavyReassessmentBannerCopy.body(for: signal))
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundStyle(.white.opacity(0.80))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Button {
+                    onReviewGoals()
+                } label: {
+                    Text("Review goals")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(accentColor)
+                }
+            }
+            Spacer(minLength: 0)
+            Button {
+                heavyReassessmentBannerDismissed = true
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.40))
+                    .padding(6)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(
+            accentColor.opacity(0.10),
+            in: RoundedRectangle(cornerRadius: 14, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(accentColor.opacity(0.25), lineWidth: 0.5)
         )
     }
 

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -39,6 +39,10 @@ struct WorkoutView: View {
     /// Days since the user's last completed session — nil on first-ever session.
     /// Used by PreWorkoutView to show the welcome-back banner after a long gap.
     @State private var daysSinceLastSession: Int? = nil
+    /// Heavy-reassessment signal derived from the cached trainee model (#258).
+    /// Drives the level-up banner in PreWorkoutView. Nil when no model / out of
+    /// the cooldown window / acknowledged.
+    @State private var heavyReassessmentSignal: HeavyReassessmentSignal? = nil
     /// True when a crash-recovered PausedSessionState exists but its trainingDayId
     /// does not match the current day (and ContentView hasn't handled it via Path A).
     /// Shows a recovery dialog so the user can choose how to proceed.
@@ -135,6 +139,11 @@ struct WorkoutView: View {
                     daysSinceLastSession = Calendar.current.dateComponents([.day], from: date, to: Date()).day
                 }
             }
+
+            // Heavy-reassessment signal for the pre-workout level-up banner (#258).
+            // Read the cached trainee-model digest (minimal existing path — no new
+            // service plumbing). Nil model / out-of-window / acknowledged → nil → no banner.
+            heavyReassessmentSignal = await deps.traineeModelService.digest()?.heavyReassessmentSignal
 
             guard let vm = viewModel else { return }
 
@@ -290,6 +299,10 @@ struct WorkoutView: View {
                 completedDayCount: completedDayCount,
                 totalDayCount: totalDayCount,
                 daysSinceLastSession: daysSinceLastSession,
+                heavyReassessmentSignal: heavyReassessmentSignal,
+                onReviewGoals: {
+                    // TODO(#258 E2): present goal-review screen
+                },
                 onSkipSession: onSkipSession,
                 onBack: onBack,
                 onCloseToTab0: onCloseToTab0

--- a/ProjectApexTests/HeavyReassessmentBannerCopyTests.swift
+++ b/ProjectApexTests/HeavyReassessmentBannerCopyTests.swift
@@ -1,0 +1,63 @@
+// HeavyReassessmentBannerCopyTests.swift
+// ProjectApexTests
+//
+// Verifies the pure copy helper for the pre-workout heavy-reassessment banner
+// (#258, Slice D+E1). The SwiftUI body isn't unit-testable, so the copy logic
+// lives in HeavyReassessmentBannerCopy and is exercised here.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("HeavyReassessmentBannerCopy")
+struct HeavyReassessmentBannerCopyTests {
+
+    /// HeavyReassessmentSignal is a simple struct — construct it directly.
+    private func signal(_ patterns: [MovementPattern]) -> HeavyReassessmentSignal {
+        HeavyReassessmentSignal(
+            triggeringSessionCount: 18,
+            sessionsSinceTriggered: 2,
+            recentlyAdvancedPatterns: patterns
+        )
+    }
+
+    @Test("names up to three patterns via displayName — no raw snake_case tokens leak")
+    func threePatternsUseDisplayNames() {
+        let body = HeavyReassessmentBannerCopy.body(
+            for: signal([.squat, .horizontalPush, .hipHinge])
+        )
+        #expect(body.contains("Squat"))
+        #expect(body.contains("Horizontal Push"))
+        #expect(body.contains("Hip Hinge"))
+        #expect(!body.contains("_"), "body leaked a raw machine token: \(body)")
+    }
+
+    @Test("caps at three named patterns then collapses the remainder to \"and more\"")
+    func fourOrMorePatternsCapAtThree() {
+        let body = HeavyReassessmentBannerCopy.body(
+            for: signal([.squat, .horizontalPush, .hipHinge, .lunge])
+        )
+        #expect(body.contains("and more"))
+        // The fourth pattern's display name must NOT be spelled out.
+        #expect(!body.contains("Lunge"), "fourth pattern should be folded into \"and more\": \(body)")
+    }
+
+    @Test("empty pattern list returns the generic fallback — no names, no \", and\" artifacts")
+    func emptyPatternsUseGenericFallback() {
+        let body = HeavyReassessmentBannerCopy.body(for: signal([]))
+        #expect(body == "You've made broad progress lately — a good moment to revisit your goal.")
+        #expect(!body.contains(", and"), "fallback must not contain empty-join artifacts: \(body)")
+        // Defensive: the generic line should name no pattern.
+        for pattern in MovementPattern.allCases {
+            #expect(
+                !body.contains(pattern.displayName),
+                "fallback should name no patterns, found \(pattern.displayName): \(body)"
+            )
+        }
+    }
+
+    @Test("title is a constant, tone-stable affordance")
+    func titleIsConstant() {
+        #expect(HeavyReassessmentBannerCopy.title == "Your training has leveled up")
+    }
+}


### PR DESCRIPTION
Part of #258 (P5-D06 heavy-reassessment feature).

## What this slice does
Surfaces the heavy-reassessment signal to the user on the pre-workout screen and renders a distinct banner that names the recently-advanced patterns. No acknowledgment write here — Dismiss is a transient local hide. The "Review goals" CTA is wired to an **injected no-op closure** (a later slice, #258 E2, builds the goal-review screen and wires it).

## Changes
- **`HeavyReassessmentBannerCopy`** (new, pure helper) — unit-tested copy logic kept out of the SwiftUI body. Names up to 3 patterns via `MovementPattern.displayName` (Slice C), Oxford-comma "and", collapses to "and more" beyond 3, and returns a generic fallback when the pattern list is empty (the normal late-window case). Constant title — no per-`sessionsSinceTriggered` calibration (the LLM handles tone; the banner is a stable affordance per ADR-0005).
- **`WorkoutView`** — reads the signal off the cached trainee-model digest (`deps.traineeModelService.digest()?.heavyReassessmentSignal`) inside the existing `.task` (minimal existing read path — no new service plumbing) and threads it + a no-op `onReviewGoals` into `PreWorkoutView`. Nil-safe: no model / out-of-window / acknowledged → nil → no banner.
- **`PreWorkoutView`** — new `heavyReassessmentBanner` rendered between `firstSessionBanner` and `welcomeBackBanner`. Reuses the `welcomeBackBanner` idiom (corner radius 14, padding, opacity conventions) but with a **distinct non-amber teal/green "level-up" accent** + `chart.line.uptrend.xyaxis` icon so stacked cards stay legible. Transient Dismiss "✕" (no persistence, no ack write).

## Banner copy (reviewable)
- **3 patterns** `[.squat, .horizontalPush, .hipHinge]`:
  > Your Squat, Horizontal Push, and Hip Hinge have all moved up lately — a good moment to revisit your goal.
- **Empty patterns** (normal late-window case):
  > You've made broad progress lately — a good moment to revisit your goal.

## Tests
New `HeavyReassessmentBannerCopyTests` — **4 tests, 0 failures** (focused run on iPhone 17 Pro sim). Covers: 3-pattern display-name naming (no underscores), 4+ patterns cap at 3 + "and more", empty-list generic fallback (no names, no ", and" artifact), constant title. Full `ProjectApex` app target **BUILD SUCCEEDED**.

## Cross-cutting grep (report-only)
`PreWorkoutView(` is instantiated only from `WorkoutView.swift:282` (the call site updated here) plus 3 `#Preview` blocks inside `PreWorkoutView.swift` itself. The two new props have defaults (`= nil`, `= {}`), so the previews compile untouched. No other instantiation exists — nothing else needed changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)