### PR TITLE
feat(#258): Slice F1 — TraineeModelService.acknowledgeReassessment (local banner-hide)

### DIFF
--- a/ProjectApex/Services/TraineeModelService.swift
+++ b/ProjectApex/Services/TraineeModelService.swift
@@ -93,6 +93,19 @@ actor TraineeModelService {
         return TraineeModelDigest(from: model, weeklyFatigue: weeklyFatigue, asOf: now())
     }
 
+    // MARK: - Write — local acknowledgment
+
+    /// #258: records local acknowledgment of a heavy-reassessment GPA fire so the
+    /// pre-workout banner and the LLM prompt block disappear immediately on Save —
+    /// the `update-trainee-goal` EF returns no model, so the cache can't refresh from
+    /// the server round-trip; this is the client-side write that hides the banner.
+    /// No-op if no model is cached. Idempotent (Set insert).
+    func acknowledgeReassessment(triggeringSessionCount: Int) async throws {
+        guard var model = await store.load() else { return }
+        model.acknowledgedTriggeringSessionCounts.insert(triggeringSessionCount)
+        try await store.save(model)
+    }
+
     // MARK: - Write — enqueue path
 
     /// Enqueues a `trainee_model_update` item carrying the session-

--- a/ProjectApexTests/TraineeModelServiceTests.swift
+++ b/ProjectApexTests/TraineeModelServiceTests.swift
@@ -309,6 +309,99 @@ final class TraineeModelServiceTests: XCTestCase {
         XCTAssertEqual(second["intent"] as? String, "backoff")
     }
 
+    // MARK: ─── acknowledgeReassessment — local banner-hide (#258 Slice F1) ──────
+    //
+    // The goal-review Save (Slice F2) must hide the heavy-reassessment banner
+    // immediately. The update-trainee-goal EF returns no model, so the local
+    // cache can't refresh from the server; this method is the client-side write
+    // that inserts the acknowledged triggeringSessionCount and persists it, after
+    // which deriveHeavyReassessmentSignal returns nil for that trigger (the
+    // suppression shipped in Slice A).
+
+    /// Builds a model whose GPA fire is inside the cooldown window, so
+    /// deriveHeavyReassessmentSignal is non-nil unless the trigger is acked.
+    private func makeReassessmentModel(
+        lastFired: Int?,
+        totalSessions: Int,
+        acked: Set<Int> = []
+    ) -> TraineeModel {
+        TraineeModel(
+            goal: GoalState(statement: "Strength + size",
+                            focusAreas: [.legs, .back],
+                            updatedAt: ref),
+            totalSessionCount: totalSessions,
+            lastGlobalPhaseAdvanceFiredAtSessionCount: lastFired,
+            acknowledgedTriggeringSessionCounts: acked
+        )
+    }
+
+    func test_acknowledgeReassessment_recordsTrigger_andHidesSignal() async throws {
+        // GPA fired at session 5; total is 8 → delta 3, inside the 6-session
+        // cooldown window. Empty ack set → signal must be present first.
+        try store.save(makeReassessmentModel(lastFired: 5, totalSessions: 8))
+
+        let beforeRead = await service.read()
+        let before = try XCTUnwrap(beforeRead)
+        XCTAssertNotNil(
+            TraineeModelDigest.deriveHeavyReassessmentSignal(from: before),
+            "Pre-ack: signal must be present so the banner shows"
+        )
+
+        try await service.acknowledgeReassessment(triggeringSessionCount: 5)
+
+        let afterRead = await service.read()
+        let after = try XCTUnwrap(afterRead)
+        XCTAssertTrue(after.acknowledgedTriggeringSessionCounts.contains(5),
+                      "Ack must persist the triggering session count")
+        XCTAssertNil(
+            TraineeModelDigest.deriveHeavyReassessmentSignal(from: after),
+            "Post-ack: signal must vanish — this is the load-bearing banner-hide invariant"
+        )
+    }
+
+    func test_acknowledgeReassessment_noModel_isNoOp() async throws {
+        // Empty store (setUp leaves it empty). Must not throw, must leave nothing.
+        try await service.acknowledgeReassessment(triggeringSessionCount: 1)
+
+        let result = await service.read()
+        XCTAssertNil(result, "No cached model → ack is a no-op, store stays empty")
+    }
+
+    func test_acknowledgeReassessment_isIdempotent() async throws {
+        try store.save(makeReassessmentModel(lastFired: 5, totalSessions: 8))
+
+        try await service.acknowledgeReassessment(triggeringSessionCount: 5)
+        try await service.acknowledgeReassessment(triggeringSessionCount: 5)
+
+        let afterRead = await service.read()
+        let after = try XCTUnwrap(afterRead)
+        XCTAssertEqual(after.acknowledgedTriggeringSessionCounts, [5],
+                       "Set insert: acking twice must not duplicate or grow the set")
+    }
+
+    func test_acknowledgeReassessment_doesNotSuppressLaterFire() async throws {
+        // Ack trigger 5, then a NEW GPA fires at session 11 (total 14 → delta 3,
+        // inside the window) which has NOT been acked. The signal must return —
+        // ack is per-trigger ("current count, not any-ack"), the Slice A contract.
+        try store.save(makeReassessmentModel(lastFired: 5, totalSessions: 8))
+        try await service.acknowledgeReassessment(triggeringSessionCount: 5)
+
+        let ackedRead = await service.read()
+        var model = try XCTUnwrap(ackedRead)
+        model.lastGlobalPhaseAdvanceFiredAtSessionCount = 11
+        model.totalSessionCount = 14
+        try store.save(model)
+
+        let afterRead = await service.read()
+        let after = try XCTUnwrap(afterRead)
+        XCTAssertTrue(after.acknowledgedTriggeringSessionCounts.contains(5),
+                      "The earlier ack of 5 must still be on record")
+        XCTAssertNotNil(
+            TraineeModelDigest.deriveHeavyReassessmentSignal(from: after),
+            "A later, un-acked fire (11) must still surface despite 5 being acked"
+        )
+    }
+
     func test_enqueueUpdate_setLogs_skipsEntriesMissingIntent() async throws {
         let session = makeSession()
         // Mix of valid + nil-intent sets — the latter must be filtered out so


### PR DESCRIPTION
## What & why

Part of #258 (P5-D06 heavy-reassessment). The goal-review screen's Save (built in Slice F2) must make the heavy-reassessment banner disappear **immediately**. But the `update-trainee-goal` Edge Function returns `{ok, goal}` — **not the model** — so the server round-trip cannot refresh the local cache. The banner-hide therefore has to be a synchronous **local** cache mutation the client performs itself.

This slice builds **only** that method + its tests. No UI, no EF call.

## The method

`TraineeModelService.acknowledgeReassessment(triggeringSessionCount:)` inserts the acknowledged `triggeringSessionCount` into the cached `TraineeModel.acknowledgedTriggeringSessionCounts` and persists it. After that, `TraineeModelDigest.deriveHeavyReassessmentSignal(from:)` returns `nil` for that trigger (suppression already shipped in Slice A), so the banner **and** the LLM prompt block both vanish.

- No-op if no model is cached.
- Idempotent (Set insert).
- Matches the existing store conventions: `await store.load()` / `try await store.save(model)` (the `@MainActor` `TraineeModelLocalStore`).

## Tests (4 new — extend `TraineeModelServiceTests`)

1. **Ack records + hides** — seed `lastGlobalPhaseAdvanceFiredAtSessionCount = 5`, `totalSessionCount = 8` (delta 3, inside the 6-session cooldown), empty ack set → assert signal is **non-nil** first; ack 5; re-read → `acknowledgedTriggeringSessionCounts.contains(5)` **and** signal now **nil**. *(the load-bearing banner-hide invariant)*
2. **No-model no-op** — empty store → ack does not throw, store stays empty.
3. **Idempotent** — acking 5 twice → set is exactly `{5}`.
4. **Per-trigger** — ack 5, then a later un-acked fire at 11 (`totalSessionCount = 14`, delta 3) → signal **non-nil**. Guards the "current count, not any-ack" contract from Slice A.

## Verification

- Focused `TraineeModelServiceTests`: **14 tests, 0 failures** (incl. the ack→signal-nil proof).
- Full `ProjectApexTests` target: **450 tests, 0 failures, 10 skipped** (the `APEX_INTEGRATION_TESTS`-gated live-API tests).

## Cross-cutting grep (report-only)

`store.save` in production code is called from exactly one prior site — `ProjectApex/Services/TraineeModelUpdateJob.swift:190`. This slice adds the **second** writer (the local ack in `TraineeModelService`). That is legitimate: it is still a client-local SwiftData cache write, not a server `model_json` write — ADR-0006's single-writer rule governs server writes, not the local read cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)