### PR TITLE
feat(#258): Slice F2 — GoalReviewView goal-review screen + tested payload helper

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* TopSetSnapshotFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */; };
 		A3741A0001CAFE0001CAFE01 /* LateArrivalNotificationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */; };
 		A1540154CAFE0154CAFE0001 /* OnboardingGoalPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1540154CAFE0154CAFE0002 /* OnboardingGoalPayloadTests.swift */; };
+		A1540154CAFE0154CAFE0011 /* GoalReviewPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1540154CAFE0154CAFE0012 /* GoalReviewPayloadTests.swift */; };
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
 		C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */; };
@@ -113,6 +114,7 @@
 		A12FA719C0DE0002CAFE0002 /* TraineeModelSnapshotsCrossValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelSnapshotsCrossValidationTests.swift; sourceTree = "<group>"; };
 		A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LateArrivalNotificationQueueTests.swift; sourceTree = "<group>"; };
 		A1540154CAFE0154CAFE0002 /* OnboardingGoalPayloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingGoalPayloadTests.swift; sourceTree = "<group>"; };
+		A1540154CAFE0154CAFE0012 /* GoalReviewPayloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GoalReviewPayloadTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
 		DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetPrescriptionIntentValidationTests.swift; sourceTree = "<group>"; };
 		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
@@ -260,6 +262,7 @@
 				862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */,
 				A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */,
 				A1540154CAFE0154CAFE0002 /* OnboardingGoalPayloadTests.swift */,
+				A1540154CAFE0154CAFE0012 /* GoalReviewPayloadTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -411,6 +414,7 @@
 				C88AB47564E9AD1E0A3C2197 /* TraineeModelUpdateJobTests.swift in Sources */,
 				A3741A0001CAFE0001CAFE01 /* LateArrivalNotificationQueueTests.swift in Sources */,
 				A1540154CAFE0154CAFE0001 /* OnboardingGoalPayloadTests.swift in Sources */,
+				A1540154CAFE0154CAFE0011 /* GoalReviewPayloadTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/Features/Workout/GoalReviewView.swift
+++ b/ProjectApex/Features/Workout/GoalReviewView.swift
@@ -1,0 +1,306 @@
+// GoalReviewView.swift
+// ProjectApex — Features/Workout
+//
+// P5-D06 Slice F2 (#258): the goal-review screen the heavy-reassessment
+// banner's "Review goals" CTA presents. "Your training leveled up" — this
+// screen lets the user revise their plain-language goal and focus areas in
+// response, showing their current capability numbers as read-only context.
+//
+// On Save it (1) POSTs the revised goal to the `update-trainee-goal` Edge
+// Function carrying the acknowledgment count (so the server appends it to
+// model_json.acknowledgedTriggeringSessionCounts), and (2) calls the local
+// banner-hide `acknowledgeReassessment` (Slice F1) so the banner disappears
+// immediately — the EF returns no model, so the cache can't refresh from the
+// round-trip and the local write is what hides the banner.
+//
+// STANDALONE / presentable: `triggeringSessionCount` defaults to nil so the
+// screen previews and opens outside the heavy-reassessment flow. Slice E2
+// wires the banner → this screen and passes the real count. This slice does
+// NOT touch WorkoutView / PreWorkoutView wiring (E2 owns that).
+
+import SwiftUI
+
+struct GoalReviewView: View {
+
+    /// E2 will pass the banner's triggering-session count; default nil keeps
+    /// the screen previewable and presentable outside the reassessment flow.
+    /// When nil, Save skips the local ack (there is no banner to hide) and the
+    /// wire payload omits the acknowledgment key entirely.
+    var triggeringSessionCount: Int? = nil
+
+    @Environment(AppDependencies.self) private var deps
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var statement: String = ""
+    @State private var selectedFocusAreas: Set<MuscleGroup> = []
+    @State private var capabilities: [ExerciseProfile] = []
+    @State private var isSaving: Bool = false
+    @State private var hasLoaded: Bool = false
+
+    /// Cap the read-only capability list to the strongest few so the screen
+    /// stays readable — the model can track dozens of exercises.
+    private static let maxCapabilitiesShown = 8
+
+    private static let accentBlue = Color(red: 0.23, green: 0.56, blue: 1.00)
+    private static let darkChrome = Color(red: 0.04, green: 0.04, blue: 0.06)
+
+    private var canSave: Bool {
+        !isSaving &&
+        !statement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - Pure payload helper (the seam under TDD)
+
+    /// Builds the update-trainee-goal payload from the edited goal fields (#258 F2).
+    /// focusAreas are emitted as SORTED rawValue strings for deterministic JSONB
+    /// (mirrors the Set-sort determinism convention in TraineeModel). The ack count
+    /// is threaded straight through — nil when the screen is opened outside the
+    /// heavy-reassessment flow, an Int when the banner triggered it.
+    static func makeGoalPayload(
+        userId: UUID,
+        statement: String,
+        focusAreas: Set<MuscleGroup>,
+        triggeringSessionCount: Int?,
+        now: Date
+    ) -> TraineeGoalUpsertPayload {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return TraineeGoalUpsertPayload(
+            userId: userId,
+            goal: GoalUpsertBody(
+                statement: statement,
+                focusAreas: focusAreas.map(\.rawValue).sorted(),
+                updatedAt: isoFormatter.string(from: now)
+            ),
+            acknowledgeTriggeringSessionCount: triggeringSessionCount
+        )
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Self.darkChrome.ignoresSafeArea()
+
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        goalCard
+                        focusAreasCard
+                        capabilitiesCard
+                        Color.clear.frame(height: 24)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 16)
+                }
+            }
+            .navigationTitle("Review Goals")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(Self.darkChrome, for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(.white.opacity(0.70))
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { Task { await save() } }
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(canSave ? Self.accentBlue : .white.opacity(0.30))
+                        .disabled(!canSave)
+                }
+            }
+            .task {
+                guard !hasLoaded else { return }
+                hasLoaded = true
+                let model = await deps.traineeModelService.read()
+                statement = model?.goal.statement ?? ""
+                selectedFocusAreas = Set(model?.goal.focusAreas ?? [])
+                capabilities = (model?.exercises.values.sorted { $0.e1rmCurrent > $1.e1rmCurrent } ?? [])
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Your goal
+
+    private var goalCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader("YOUR GOAL")
+            Text("Your training leveled up. Revise what you're working toward.")
+                .font(.system(size: 13))
+                .foregroundStyle(.white.opacity(0.55))
+
+            TextField(
+                "What are you training for?",
+                text: $statement,
+                axis: .vertical
+            )
+            .lineLimit(3...6)
+            .font(.system(size: 16))
+            .foregroundStyle(.white)
+            .padding(14)
+            .background(Color.white.opacity(0.08),
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .cardChrome()
+    }
+
+    // MARK: - Focus areas
+
+    private var focusAreasCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader("FOCUS AREAS")
+
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 96), spacing: 10)],
+                alignment: .leading,
+                spacing: 10
+            ) {
+                ForEach(MuscleGroup.allCases, id: \.self) { area in
+                    focusChip(area)
+                }
+            }
+        }
+        .cardChrome()
+    }
+
+    private func focusChip(_ area: MuscleGroup) -> some View {
+        let isSelected = selectedFocusAreas.contains(area)
+        return Button {
+            if isSelected {
+                selectedFocusAreas.remove(area)
+            } else {
+                selectedFocusAreas.insert(area)
+            }
+        } label: {
+            Text(area.rawValue.capitalized)
+                .font(.system(size: 14, weight: .semibold))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(
+                    isSelected ? Self.accentBlue : Color.white.opacity(0.08),
+                    in: Capsule()
+                )
+                .overlay(
+                    Capsule().stroke(
+                        isSelected ? Color.clear : Color.white.opacity(0.12),
+                        lineWidth: 0.5
+                    )
+                )
+                .foregroundStyle(isSelected ? .white : .white.opacity(0.60))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(area.rawValue.capitalized)
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    // MARK: - Where you are now (read-only)
+
+    private var capabilitiesCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader("WHERE YOU ARE NOW")
+            Text("Current estimated 1RMs — informational, not editable.")
+                .font(.system(size: 13))
+                .foregroundStyle(.white.opacity(0.55))
+
+            if capabilities.isEmpty {
+                Text("No capability estimates yet — log a few sessions and they'll appear here.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.white.opacity(0.40))
+                    .padding(.vertical, 4)
+            } else {
+                VStack(spacing: 0) {
+                    let shown = capabilities.prefix(Self.maxCapabilitiesShown)
+                    ForEach(Array(shown.enumerated()), id: \.element.exerciseId) { index, profile in
+                        capabilityRow(profile)
+                        if index != shown.count - 1 {
+                            Divider().background(Color.white.opacity(0.06))
+                        }
+                    }
+                }
+            }
+        }
+        .cardChrome()
+    }
+
+    private func capabilityRow(_ profile: ExerciseProfile) -> some View {
+        HStack {
+            Text(profile.exerciseId.replacingOccurrences(of: "_", with: " ").capitalized)
+                .font(.system(size: 14))
+                .foregroundStyle(.white.opacity(0.85))
+            Spacer()
+            Text("\(Int(profile.e1rmCurrent.rounded())) kg")
+                .font(.system(size: 14, weight: .semibold, design: .rounded).monospacedDigit())
+                .foregroundStyle(.white)
+        }
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Section header
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(.white.opacity(0.40))
+            .kerning(0.8)
+    }
+
+    // MARK: - Save
+
+    @MainActor
+    private func save() async {
+        isSaving = true
+        defer { isSaving = false }
+
+        // Both writes are best-effort, mirroring onboarding's goal hydration.
+        let payload = Self.makeGoalPayload(
+            userId: deps.resolvedUserId,
+            statement: statement,
+            focusAreas: selectedFocusAreas,
+            triggeringSessionCount: triggeringSessionCount,
+            now: Date()
+        )
+        if let encoded = try? JSONEncoder().encode(payload) {
+            _ = try? await deps.supabaseClient.invokeFunction(
+                "update-trainee-goal",
+                body: encoded
+            )
+        }
+
+        // Local banner-hide (Slice F1): only when a banner triggered this
+        // screen. The local ack is what hides the banner immediately.
+        if let triggeringSessionCount {
+            try? await deps.traineeModelService.acknowledgeReassessment(
+                triggeringSessionCount: triggeringSessionCount
+            )
+        }
+
+        dismiss()
+    }
+}
+
+// MARK: - Card chrome
+
+private extension View {
+    /// The translucent rounded-card surface used across the dark-chrome
+    /// feature screens (matches ManualSessionLogView's card styling).
+    func cardChrome() -> some View {
+        self
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .background(Color.white.opacity(0.06),
+                        in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
+            )
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    GoalReviewView()
+        .environment(AppDependencies())
+}

--- a/ProjectApexTests/GoalReviewPayloadTests.swift
+++ b/ProjectApexTests/GoalReviewPayloadTests.swift
@@ -1,0 +1,186 @@
+// GoalReviewPayloadTests.swift
+// ProjectApexTests
+//
+// P5-D06 Slice F2 (#258): unit tests for the pure payload helper behind the
+// goal-review screen, `GoalReviewView.makeGoalPayload(...)`. SwiftUI bodies
+// aren't unit-testable, so the wire-payload construction lives in a pure
+// static function that takes `now: Date` (no hidden `Date()`) — these tests
+// pin its behaviour deterministically.
+//
+// The same drift the #154 / Slice B contract locks apply: the encoded shape
+// must match the `update-trainee-goal` Edge Function validator. These tests
+// reuse the JSONEncoder-top-level-keys assertion style from
+// `OnboardingGoalPayloadTests` to prove the OPTIONAL ack key OMITS when nil
+// (so a non-banner Save keeps the wire shape exactly {user_id, goal}) and
+// appears as a single snake_case key when present.
+//
+// `makeGoalPayload` + the two payload structs are `internal`, so `@testable`
+// can call/encode them directly.
+
+import XCTest
+@testable import ProjectApex
+
+final class GoalReviewPayloadTests: XCTestCase {
+
+    /// Fixed instant for deterministic `updatedAt` assertions.
+    private static let fixedNow = Date(timeIntervalSinceReferenceDate: 800_000_000)
+
+    /// Encodes a `makeGoalPayload` result the way the Save call site does
+    /// (bare `JSONEncoder()`, no key strategy) and deserializes to a JSON
+    /// object for top-level/sub-object key assertions.
+    private func encode(_ payload: TraineeGoalUpsertPayload) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(payload)
+        return try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            "encoded payload must deserialize to a JSON object"
+        )
+    }
+
+    // MARK: ─── 1. focusAreas → sorted rawValue strings ─────────────────────────
+
+    func test_makeGoalPayload_focusAreas_areSortedRawValues() {
+        let payload = GoalReviewView.makeGoalPayload(
+            userId: UUID(),
+            statement: "Get stronger",
+            focusAreas: [.legs, .back, .chest],
+            triggeringSessionCount: nil,
+            now: Self.fixedNow
+        )
+
+        XCTAssertEqual(
+            payload.goal.focusAreas, ["back", "chest", "legs"],
+            "focusAreas must be the rawValue strings, sorted for deterministic JSONB"
+        )
+    }
+
+    func test_makeGoalPayload_emptyFocusAreas_encodeAsEmptyArray() throws {
+        let payload = GoalReviewView.makeGoalPayload(
+            userId: UUID(),
+            statement: "Get stronger",
+            focusAreas: [],
+            triggeringSessionCount: nil,
+            now: Self.fixedNow
+        )
+
+        XCTAssertEqual(payload.goal.focusAreas, [], "empty selection → empty array, no artifacts")
+
+        // And it survives encoding as a JSON array (not null / not absent).
+        let json = try encode(payload)
+        let goal = try XCTUnwrap(json["goal"] as? [String: Any])
+        let focusAreas = try XCTUnwrap(goal["focusAreas"] as? [Any],
+            "focusAreas must encode as a JSON array even when empty")
+        XCTAssertTrue(focusAreas.isEmpty, "empty focusAreas must encode as []")
+    }
+
+    // MARK: ─── 2. ack threaded; OPTIONAL key omits when nil ───────────────────
+
+    func test_makeGoalPayload_ack_threadedThrough() {
+        let withAck = GoalReviewView.makeGoalPayload(
+            userId: UUID(),
+            statement: "Get stronger",
+            focusAreas: [],
+            triggeringSessionCount: 7,
+            now: Self.fixedNow
+        )
+        XCTAssertEqual(withAck.acknowledgeTriggeringSessionCount, 7,
+            "non-nil triggeringSessionCount must thread straight through")
+
+        let withoutAck = GoalReviewView.makeGoalPayload(
+            userId: UUID(),
+            statement: "Get stronger",
+            focusAreas: [],
+            triggeringSessionCount: nil,
+            now: Self.fixedNow
+        )
+        XCTAssertNil(withoutAck.acknowledgeTriggeringSessionCount,
+            "nil triggeringSessionCount must stay nil on the payload")
+    }
+
+    /// The load-bearing proof: a nil ack OMITS the key entirely (no `null`),
+    /// so a Save opened outside the heavy-reassessment flow keeps the wire
+    /// shape exactly {user_id, goal} — the same invariant the onboarding write
+    /// depends on. (Synthesized `encodeIfPresent` from the Int? optional.)
+    func test_makeGoalPayload_nilAck_omitsKey_topLevelIsUserIdAndGoal() throws {
+        let payload = GoalReviewView.makeGoalPayload(
+            userId: UUID(),
+            statement: "Get stronger",
+            focusAreas: [.chest],
+            triggeringSessionCount: nil,
+            now: Self.fixedNow
+        )
+        let json = try encode(payload)
+
+        XCTAssertEqual(
+            Set(json.keys), ["user_id", "goal"],
+            "nil ack must omit acknowledge_triggering_session_count → wire shape stays {user_id, goal}"
+        )
+        XCTAssertNil(
+            json["acknowledge_triggering_session_count"],
+            "nil ack must encode as ABSENT, not `null`"
+        )
+        XCTAssertNil(json["userId"], "no camelCase `userId` may leak to the wire")
+    }
+
+    func test_makeGoalPayload_nonNilAck_addsExactlyOneSnakeCaseKey() throws {
+        let payload = GoalReviewView.makeGoalPayload(
+            userId: UUID(),
+            statement: "Get stronger",
+            focusAreas: [.chest],
+            triggeringSessionCount: 7,
+            now: Self.fixedNow
+        )
+        let json = try encode(payload)
+
+        XCTAssertEqual(
+            Set(json.keys), ["user_id", "goal", "acknowledge_triggering_session_count"],
+            "non-nil ack adds EXACTLY one top-level snake_case key"
+        )
+        XCTAssertEqual(
+            json["acknowledge_triggering_session_count"] as? Int, 7,
+            "ack must encode as the integer value under the snake_case key"
+        )
+        XCTAssertNil(
+            json["acknowledgeTriggeringSessionCount"],
+            "no camelCase ack key may leak to the wire"
+        )
+    }
+
+    // MARK: ─── 3. statement passthrough + updatedAt is ISO8601 round-trips ─────
+
+    func test_makeGoalPayload_statement_passedVerbatim() {
+        let statement = "Build a 200kg deadlift while staying injury-free"
+        let payload = GoalReviewView.makeGoalPayload(
+            userId: UUID(),
+            statement: statement,
+            focusAreas: [.back, .legs],
+            triggeringSessionCount: nil,
+            now: Self.fixedNow
+        )
+        XCTAssertEqual(payload.goal.statement, statement,
+            "statement must be copied verbatim into the payload")
+    }
+
+    func test_makeGoalPayload_updatedAt_isISO8601_roundTripsToNow() throws {
+        let payload = GoalReviewView.makeGoalPayload(
+            userId: UUID(),
+            statement: "Get stronger",
+            focusAreas: [],
+            triggeringSessionCount: nil,
+            now: Self.fixedNow
+        )
+
+        let parser = ISO8601DateFormatter()
+        parser.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let parsed = try XCTUnwrap(
+            parser.date(from: payload.goal.updatedAt),
+            "updatedAt '\(payload.goal.updatedAt)' must parse back via ISO8601 (.withFractionalSeconds)"
+        )
+
+        XCTAssertEqual(
+            parsed.timeIntervalSinceReferenceDate,
+            Self.fixedNow.timeIntervalSinceReferenceDate,
+            accuracy: 1.0,
+            "updatedAt must round-trip to the `now` passed in (to the second)"
+        )
+    }
+}


### PR DESCRIPTION
## Slice F2 of P5-D06 (#258) — the goal-review screen

Part of #258.

Builds the **standalone, presentable** goal-review screen that the heavy-reassessment banner's "Review goals" CTA will eventually present. The banner CTA (`onReviewGoals`) is still wired to a no-op `// TODO(#258 E2)` in `WorkoutView` — **a later slice (E2) wires the banner → this screen and passes the real `triggeringSessionCount`**. This slice deliberately does NOT touch that wiring.

### What ships
- **`GoalReviewView`** (`Features/Workout/GoalReviewView.swift`) — dark-chrome `NavigationStack` screen (matches `ManualSessionLogView` styling) with three sections:
  1. **Your goal** — multiline `TextField` prefilled from `model.goal.statement`.
  2. **Focus areas** — selectable chips over `MuscleGroup.allCases` (label `rawValue.capitalized`), prefilled from `model.goal.focusAreas`.
  3. **Where you are now** — read-only list of current estimated 1RMs (`ExerciseProfile.e1rmCurrent`, strongest first, capped at 8), with an empty-state line.
  - **Save** POSTs the revised goal to the `update-trainee-goal` EF (best-effort, mirroring onboarding) and calls the local banner-hide `acknowledgeReassessment` (Slice F1) **only when `triggeringSessionCount` is non-nil**. Save is disabled when the trimmed statement is empty (no overwriting the goal with blank).
  - `triggeringSessionCount: Int? = nil` default → previewable / openable outside the reassessment flow.
- **`makeGoalPayload`** — the pure, testable seam. Takes `now: Date` (no hidden `Date()`); emits `focusAreas` as **sorted rawValue strings** for deterministic JSONB; threads the ack count straight through. Reuses the existing `internal` `TraineeGoalUpsertPayload` / `GoalUpsertBody` (not redefined).

### Tests (`ProjectApexTests/GoalReviewPayloadTests.swift`)
7 tests on the pure helper, mirroring the #154 / Slice B JSONEncoder-top-level-keys style:
- focusAreas → sorted rawValues; empty selection → `[]` (no artifacts).
- ack threaded through; **nil ack OMITS the key** so the wire shape stays exactly `{user_id, goal}`; non-nil ack adds exactly one snake_case key (`= 7`).
- statement verbatim; `updatedAt` round-trips via `ISO8601DateFormatter([.withInternetDateTime, .withFractionalSeconds])` to the `now` passed in.

### Verification
- Focused run: **`Executed 7 tests, with 0 failures`** (incl. `test_makeGoalPayload_nilAck_omitsKey_topLevelIsUserIdAndGoal` — the nil-ack-omits-key proof).
- Full `ProjectApex` app target + `ProjectApexTests` **build clean** (the focused test run compiles both targets; `GoalReviewView` compiles into the app).
- Cross-cutting grep: exactly **1** definition each of `TraineeGoalUpsertPayload` / `GoalUpsertBody` (reused); `WorkoutView.swift` / `PreWorkoutView.swift` **unmodified** — `TODO(#258 E2)` intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)