### PR TITLE
feat(#258): Slice E2 — wire heavy-reassessment banner CTA to GoalReviewView

### DIFF
--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -43,6 +43,10 @@ struct WorkoutView: View {
     /// Drives the level-up banner in PreWorkoutView. Nil when no model / out of
     /// the cooldown window / acknowledged.
     @State private var heavyReassessmentSignal: HeavyReassessmentSignal? = nil
+    /// True while the goal-review screen is presented from the heavy-reassessment
+    /// banner CTA (#258 E2). On dismiss the signal is re-derived; a saved goal will
+    /// have acknowledged the trigger (Slice F1), so the banner then disappears.
+    @State private var showGoalReview = false
     /// True when a crash-recovered PausedSessionState exists but its trainingDayId
     /// does not match the current day (and ContentView hasn't handled it via Path A).
     /// Shows a recovery dialog so the user can choose how to proceed.
@@ -262,6 +266,18 @@ struct WorkoutView: View {
                 .presentationCornerRadius(24)
             }
         }
+        .sheet(isPresented: $showGoalReview, onDismiss: {
+            // Re-derive the signal: a goal saved in GoalReviewView acknowledged
+            // the trigger (Slice F1), so deriveHeavyReassessmentSignal now returns
+            // nil and the banner disappears. A mere cancel leaves it unchanged.
+            Task {
+                heavyReassessmentSignal = await deps.traineeModelService.digest()?.heavyReassessmentSignal
+            }
+        }) {
+            GoalReviewView(triggeringSessionCount: heavyReassessmentSignal?.triggeringSessionCount)
+                .presentationDetents([.large])
+                .presentationCornerRadius(24)
+        }
         .alert("Session Mismatch", isPresented: $showMismatchRecoveryAlert) {
             Button("Start Fresh") {
                 // Clear the orphaned sentinel so the user can start a new session.
@@ -301,7 +317,7 @@ struct WorkoutView: View {
                 daysSinceLastSession: daysSinceLastSession,
                 heavyReassessmentSignal: heavyReassessmentSignal,
                 onReviewGoals: {
-                    // TODO(#258 E2): present goal-review screen
+                    showGoalReview = true
                 },
                 onSkipSession: onSkipSession,
                 onBack: onBack,


### PR DESCRIPTION
## Slice E2 of #258 — wire the banner CTA to the goal-review screen

The pre-workout level-up banner (Slice D+E1) had its **"Review goals"** button bound to a no-op `// TODO(#258 E2)` closure. This slice makes the button do its job.

### What changed (`WorkoutView.swift`, +17/-1)
- New `@State private var showGoalReview` drives a `.sheet`.
- The `onReviewGoals` closure now sets `showGoalReview = true`.
- The sheet presents `GoalReviewView(triggeringSessionCount: heavyReassessmentSignal?.triggeringSessionCount)` (Slice F2), threading the current trigger so Save can acknowledge it.
- **`onDismiss` re-derives the signal**: a goal saved in `GoalReviewView` calls `acknowledgeReassessment` (Slice F1) → `deriveHeavyReassessmentSignal` now returns nil → the banner disappears. A mere cancel re-derives to the same non-nil signal, so the banner stays. This is the loop that makes "Review goals → Save" visibly dismiss the banner.

### Verification
- `xcodebuild build` (ProjectApex scheme, iPhone 17 Pro sim): **BUILD SUCCEEDED**, 0 errors.
- Pure additive UI wiring — no logic touched, no test seam (the testable payload logic lives in F2's `makeGoalPayload`, already covered).

### Cross-cutting grep (report-only)
- `GoalReviewView` is now instantiated in exactly one place (this new sheet); `onReviewGoals` has one consumer (`PreWorkoutView`, threaded from here). Self-contained.

Part of #258 (NOT "Closes" — umbrella issue stays open until Slice G lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)