### PR TITLE
feat(#258): Slice G — heavy-reassessment prompt edits for the ack world

### DIFF
--- a/ProjectApex/Resources/Prompts/SystemPrompt_SessionPlan.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_SessionPlan.txt
@@ -302,13 +302,20 @@ within a trailing 6-session window (force-deload counts as a transition per ADR-
 coaching framing:
 • Acknowledge the milestone — name the recently_advanced_patterns specifically (e.g.
   "Your squat, horizontal push, and hip hinge have all moved forward recently — your
-  training landscape has shifted.").
-• Suggest the user open the goal-review screen in the app to revisit targets. Do NOT
+  training landscape has shifted."). If recently_advanced_patterns is EMPTY (the
+  pattern transitions have aged out of the window though the signal is still live), do
+  NOT name specific lifts — use a generic framing instead ("You've made broad progress
+  across your training lately — a good moment to revisit what you're working toward.").
+• Suggest the user tap "Review goals" on the pre-workout screen to revisit their goal —
+  their plain-language aim and focus areas; there are no numeric targets to edit. Do NOT
   generate new numerical targets in this session's prescriptions — goal renegotiation
   is a UI flow, not an inference output.
 • sessions_since_triggered tells you whether this is fresh (0–1) or has already been
-  surfaced for several sessions (2+). Calibrate emphasis: fresh → lead with the
-  framing; later → brief reminder, do not belabor.
+  surfaced for several sessions (2+). A signal still present at 2+ means the user has
+  NOT yet acknowledged it (saving the goal-review screen silences this block
+  immediately), so do not assume they ignored you — they may simply not be ready to
+  renegotiate. Calibrate emphasis: fresh → lead with the framing; later → a brief,
+  low-pressure reminder, do not belabor.
 • Block absent → no reassessment commentary; do not invent the trigger. Absence means
   either GPA has never fired or the cooldown window has elapsed since the last fire.
 

--- a/ProjectApexTests/TraineeModelDigestTests.swift
+++ b/ProjectApexTests/TraineeModelDigestTests.swift
@@ -678,6 +678,19 @@ final class TraineeModelDigestTests: XCTestCase {
                       "SessionPlan must explicitly prohibit inventing numerical goal targets — goal renegotiation is a UI flow per ADR-0005")
         XCTAssertTrue(prompt.contains("Block absent → no reassessment commentary"),
                       "SessionPlan must include the absent-block negative anchor — the LLM should not invent the trigger when the signal is missing")
+
+        // #258 Slice G: point the LLM at the real "Review goals" affordance, not
+        // the nonexistent "targets" (the goal-review screen edits a plain-language
+        // goal + focus areas, never numbers).
+        XCTAssertTrue(prompt.contains("\"Review goals\""),
+                      "SessionPlan must reference the real 'Review goals' button label (#258 Slice G)")
+        XCTAssertFalse(prompt.contains("revisit targets"),
+                       "Legacy 'revisit targets' phrasing implies numeric targets that don't exist — replaced in #258 Slice G")
+        // #258 Slice G: empty-patterns fallback — recently_advanced_patterns can be
+        // empty late in the window while the signal is still live; the LLM must not
+        // name lifts then.
+        XCTAssertTrue(prompt.contains("If recently_advanced_patterns is EMPTY"),
+                      "SessionPlan must include the empty-patterns fallback so the LLM uses a generic framing when no lifts are nameable (#258 Slice G)")
     }
 
     func test_inferencePrompt_containsPerPatternTrendBlock() {


### PR DESCRIPTION
## Slice G of #258 — the Q5 prompt-coordination edits

The HEAVY REASSESSMENT block of `SystemPrompt_SessionPlan.txt` told the LLM to send the user to "revisit **targets**" — but no numeric targets exist, and (pre-#258) there was no screen and no way to acknowledge it. Now that the goal-review screen + acknowledgment exist (Slices A–F2, E2), the prompt is brought into line with reality. Three edits, each golden-locked with a test anchor in `TraineeModelDigestTests.test_sessionPlanPrompt_containsHeavyReassessmentBlock`.

### Edits
1. **"revisit targets" → tap "Review goals".** Points at the real pre-workout affordance and clarifies the screen edits a plain-language goal + focus areas, *not* numbers. The **"Do NOT generate new numerical targets"** guardrail is kept verbatim.
2. **Empty-patterns fallback.** `recently_advanced_patterns` can be empty late in the cooldown window while the signal is still live (the per-pattern transitions age out before `sessions_since_triggered` hits 6). The LLM is now told: if the list is empty, do **not** name specific lifts — use a generic "broad progress" framing (mirrors `HeavyReassessmentBannerCopy`'s empty fallback).
3. **Re-bless the `sessions_since_triggered` "2+" branch for the ack world.** A signal still present at 2+ now means the user *hasn't acknowledged it* (saving the goal-review screen silences the block immediately) — so stay brief and low-pressure rather than assuming they ignored the coach.

> The "fix the now-false comment at `TraineeModelDigest.swift:96-103`" item from Q5 was already done in **Slice A** (#259) — verified, so no digest code change here.

### New golden anchors (TDD)
- `prompt.contains("\"Review goals\"")` — real button label present.
- `!prompt.contains("revisit targets")` — legacy numeric-implying phrasing gone.
- `prompt.contains("If recently_advanced_patterns is EMPTY")` — empty-patterns fallback present.
- All pre-existing anchors (`HEAVY REASSESSMENT (ADR-0005 / ADR-0012)`, `heavy_reassessment_signal`, `recently_advanced_patterns`, `sessions_since_triggered`, `Do NOT generate new numerical targets`, `Block absent → …`) still hold.

### Verification
- `xcodebuild test -only-testing:…/test_sessionPlanPrompt_containsHeavyReassessmentBlock`: **Executed 1 test, 0 failures. ** TEST SUCCEEDED ****.

Part of #258 (this is the final functional slice; closing the umbrella issue is a follow-up step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)