### PR TITLE
refactor(#268): consolidate MovementPattern humanizers onto .displayName

### DIFF
--- a/ProjectApex/Features/Program/ProgramOverviewView.swift
+++ b/ProjectApex/Features/Program/ProgramOverviewView.swift
@@ -378,7 +378,7 @@ struct ProgramOverviewView: View {
     private func patternPhaseRow(_ summary: PatternSummary) -> some View {
         HStack(spacing: 10) {
             // Human-readable pattern name (e.g. "Horizontal Push")
-            Text(formatPatternName(summary.pattern.rawValue))
+            Text(summary.pattern.displayName)
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(.white.opacity(0.75))
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -400,10 +400,6 @@ struct ProgramOverviewView: View {
         case .peaking:         return "PEAK"
         case .deload:          return "DELOAD"
         }
-    }
-
-    private func formatPatternName(_ pattern: String) -> String {
-        pattern.split(separator: "_").map { $0.capitalized }.joined(separator: " ")
     }
 
     // MARK: - Phase Progress Bar

--- a/ProjectApex/Features/Progress/TrendBannerView.swift
+++ b/ProjectApex/Features/Progress/TrendBannerView.swift
@@ -24,7 +24,7 @@ struct TrendBannerView: View {
                 .foregroundStyle(iconColor)
                 .font(.system(size: 20))
             VStack(alignment: .leading, spacing: 2) {
-                Text(displayPatternName)
+                Text(summary.pattern.displayName)
                     .font(.subheadline.bold())
                     .foregroundStyle(.white)
                 Text(bannerMessage)
@@ -35,14 +35,6 @@ struct TrendBannerView: View {
         }
         .padding(12)
         .background(bannerBackground, in: RoundedRectangle(cornerRadius: 10))
-    }
-
-    // Format snake_case pattern rawValue as "Horizontal Push" etc.
-    private var displayPatternName: String {
-        summary.pattern.rawValue
-            .split(separator: "_")
-            .map { $0.prefix(1).uppercased() + $0.dropFirst() }
-            .joined(separator: " ")
     }
 
     private var iconName: String {


### PR DESCRIPTION
Folds the two ad-hoc `MovementPattern` humanizers onto `MovementPattern.displayName` (added in #258 Slice C, #261).

### Changes (−14/+2)
- **`TrendBannerView.swift`** — `Text(displayPatternName)` → `Text(summary.pattern.displayName)`; deleted the `displayPatternName` computed property.
- **`ProgramOverviewView.swift`** — `Text(formatPatternName(summary.pattern.rawValue))` → `Text(summary.pattern.displayName)`; deleted the `formatPatternName(_:)` helper.

Both local helpers did snake_case→Title-Case on `summary.pattern.rawValue`; for the 8 `MovementPattern` cases the output is byte-identical to `displayName`, so this is **behavior-preserving**. No test asserted the old output.

### Verification
`xcodebuild build` (ProjectApex scheme, iPhone 17 Pro sim): **BUILD SUCCEEDED**, 0 errors. No remaining references to either deleted helper.

### Cross-cutting grep (report-only, per CLAUDE.md Process commitment 2)
Other `split("_")` / `replacingOccurrences(of: "_")` humanizers exist but operate on **different types** and have no `MovementPattern` to fold onto — left untouched:
- `exerciseId`: `ProgressView.swift:207`, `ProgressViewModel.swift:326`, `PostWorkoutSummaryView.swift:546`
- `primaryMuscle`: `ActiveSetView.swift:314`, `GoalReviewView.swift:229`
- `dayLabel`: `ProgramDayDetailView.swift:1520`, `ManualSessionLogView.swift:832`
- generic String extension: `ProgramOverviewView.swift:906`

Closes #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)