### PR TITLE
refactor(#220): extract PromptLoader; consolidate 5 system-prompt loaders

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		A3741A0001CAFE0001CAFE01 /* LateArrivalNotificationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */; };
 		A1540154CAFE0154CAFE0001 /* OnboardingGoalPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1540154CAFE0154CAFE0002 /* OnboardingGoalPayloadTests.swift */; };
 		A1540154CAFE0154CAFE0011 /* GoalReviewPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1540154CAFE0154CAFE0012 /* GoalReviewPayloadTests.swift */; };
+		22000000000000000000F011 /* PromptLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22000000000000000000F012 /* PromptLoaderTests.swift */; };
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
 		C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */; };
@@ -115,6 +116,7 @@
 		A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LateArrivalNotificationQueueTests.swift; sourceTree = "<group>"; };
 		A1540154CAFE0154CAFE0002 /* OnboardingGoalPayloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingGoalPayloadTests.swift; sourceTree = "<group>"; };
 		A1540154CAFE0154CAFE0012 /* GoalReviewPayloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GoalReviewPayloadTests.swift; sourceTree = "<group>"; };
+		22000000000000000000F012 /* PromptLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptLoaderTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
 		DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetPrescriptionIntentValidationTests.swift; sourceTree = "<group>"; };
 		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
@@ -263,6 +265,7 @@
 				A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */,
 				A1540154CAFE0154CAFE0002 /* OnboardingGoalPayloadTests.swift */,
 				A1540154CAFE0154CAFE0012 /* GoalReviewPayloadTests.swift */,
+				22000000000000000000F012 /* PromptLoaderTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -415,6 +418,7 @@
 				A3741A0001CAFE0001CAFE01 /* LateArrivalNotificationQueueTests.swift in Sources */,
 				A1540154CAFE0154CAFE0001 /* OnboardingGoalPayloadTests.swift in Sources */,
 				A1540154CAFE0154CAFE0011 /* GoalReviewPayloadTests.swift in Sources */,
+				22000000000000000000F011 /* PromptLoaderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/AICoach/AIInferenceService.swift
+++ b/ProjectApex/AICoach/AIInferenceService.swift
@@ -1181,17 +1181,10 @@ actor AIInferenceService {
     internal static var systemPrompt: String { try! loadSystemPrompt() }
 
     internal static func loadSystemPrompt() throws -> String {
-        if let url = Bundle.main.url(
-            forResource: "SystemPrompt_Inference",
-            withExtension: "txt",
-            subdirectory: "Prompts"
-        ) ?? Bundle.main.url(
-            forResource: "SystemPrompt_Inference",
-            withExtension: "txt"
-        ) {
-            return try String(contentsOf: url, encoding: .utf8)
+        guard let prompt = try PromptLoader.load("SystemPrompt_Inference") else {
+            throw AIInferenceError.systemPromptNotFound
         }
-        throw AIInferenceError.systemPromptNotFound
+        return prompt
     }
 }
 

--- a/ProjectApex/AICoach/InferenceSpike.swift
+++ b/ProjectApex/AICoach/InferenceSpike.swift
@@ -130,17 +130,10 @@ enum InferenceSpike {
 
     /// Loads `SystemPrompt_Inference.txt` from the main bundle.
     static func loadSystemPrompt() throws -> String {
-        guard let url = Bundle.main.url(
-            forResource: "SystemPrompt_Inference",
-            withExtension: "txt",
-            subdirectory: "Prompts"
-        ) ?? Bundle.main.url(
-            forResource: "SystemPrompt_Inference",
-            withExtension: "txt"
-        ) else {
+        guard let prompt = try PromptLoader.load("SystemPrompt_Inference") else {
             throw SystemPromptError.fileNotFound
         }
-        return try String(contentsOf: url, encoding: .utf8)
+        return prompt
     }
 
     enum SystemPromptError: LocalizedError {

--- a/ProjectApex/Services/MacroPlanService.swift
+++ b/ProjectApex/Services/MacroPlanService.swift
@@ -386,17 +386,10 @@ actor MacroPlanService {
     // MARK: - Private: Helpers
 
     private static func loadSystemPrompt() throws -> String {
-        if let url = Bundle.main.url(
-            forResource: "SystemPrompt_MacroPlan",
-            withExtension: "txt",
-            subdirectory: "Prompts"
-        ) ?? Bundle.main.url(
-            forResource: "SystemPrompt_MacroPlan",
-            withExtension: "txt"
-        ) {
-            return try String(contentsOf: url, encoding: .utf8)
+        guard let prompt = try PromptLoader.load("SystemPrompt_MacroPlan") else {
+            throw MacroPlanError.systemPromptNotFound
         }
-        throw MacroPlanError.systemPromptNotFound
+        return prompt
     }
 
     private static func stripMarkdownFences(_ input: String) -> String {

--- a/ProjectApex/Services/ProgramGenerationService.swift
+++ b/ProjectApex/Services/ProgramGenerationService.swift
@@ -632,18 +632,10 @@ actor ProgramGenerationService {
     // MARK: - Private: System Prompt
 
     private static func loadSystemPrompt() throws -> String {
-        if let url = Bundle.main.url(
-            forResource: "SystemPrompt_MacroGeneration",
-            withExtension: "txt",
-            subdirectory: "Prompts"
-        ) ?? Bundle.main.url(
-            forResource: "SystemPrompt_MacroGeneration",
-            withExtension: "txt"
-        ) {
-            let base = try String(contentsOf: url, encoding: .utf8)
-            return base + ExerciseLibrary.promptReferenceBlock()
+        guard let base = try PromptLoader.load("SystemPrompt_MacroGeneration") else {
+            throw ProgramGenerationError.systemPromptNotFound
         }
-        throw ProgramGenerationError.systemPromptNotFound
+        return base + ExerciseLibrary.promptReferenceBlock()
     }
 
     // MARK: - Private: LLM JSON repair

--- a/ProjectApex/Services/PromptLoader.swift
+++ b/ProjectApex/Services/PromptLoader.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Single resolver for bundled system-prompt resources (#220).
+///
+/// Consolidates the previously-duplicated
+/// `Bundle.main.url(forResource:withExtension:"txt",subdirectory:"Prompts")
+/// ?? <flat-bundle fallback>` + `String(contentsOf:)` pattern that lived
+/// verbatim in five services (`AIInferenceService`, `SessionPlanService`,
+/// `ProgramGenerationService`, `MacroPlanService`, `InferenceSpike`).
+///
+/// Only the *resolution + read* is shared here — each caller keeps its own
+/// typed not-found error and any post-processing (e.g. appending the exercise
+/// reference block), so caller-visible behavior is unchanged.
+nonisolated enum PromptLoader {
+    /// Loads a bundled prompt's UTF-8 contents. Tries the `Prompts/`
+    /// subdirectory first, then the flat bundle root (resources are flattened
+    /// in some build configurations). Returns `nil` when the resource cannot be
+    /// located — so each caller can throw its own typed error — and throws only
+    /// if the file is found but cannot be read.
+    static func load(_ name: String) throws -> String? {
+        guard let url = Bundle.main.url(forResource: name, withExtension: "txt", subdirectory: "Prompts")
+            ?? Bundle.main.url(forResource: name, withExtension: "txt")
+        else {
+            return nil
+        }
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+}

--- a/ProjectApex/Services/SessionPlanService.swift
+++ b/ProjectApex/Services/SessionPlanService.swift
@@ -669,18 +669,10 @@ actor SessionPlanService {
     }
 
     private static func loadSystemPrompt() throws -> String {
-        if let url = Bundle.main.url(
-            forResource: "SystemPrompt_SessionPlan",
-            withExtension: "txt",
-            subdirectory: "Prompts"
-        ) ?? Bundle.main.url(
-            forResource: "SystemPrompt_SessionPlan",
-            withExtension: "txt"
-        ) {
-            let base = try String(contentsOf: url, encoding: .utf8)
-            return base + ExerciseLibrary.promptReferenceBlock()
+        guard let base = try PromptLoader.load("SystemPrompt_SessionPlan") else {
+            throw SessionPlanError.systemPromptNotFound
         }
-        throw SessionPlanError.systemPromptNotFound
+        return base + ExerciseLibrary.promptReferenceBlock()
     }
 
     private static func stripMarkdownFences(_ input: String) -> String {

--- a/ProjectApexTests/PromptLoaderTests.swift
+++ b/ProjectApexTests/PromptLoaderTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import ProjectApex
+
+/// #220 — the shared `PromptLoader` that the five system-prompt services now
+/// resolve through. The contract the callers depend on: an existing bundled
+/// prompt loads with contents; a missing resource returns `nil` (not a throw)
+/// so each caller can map it to its own typed not-found error.
+final class PromptLoaderTests: XCTestCase {
+
+    func test_load_existingBundledPrompt_returnsNonEmptyContents() throws {
+        // SystemPrompt_Inference ships in the app bundle (Copy Bundle Resources);
+        // the existing inference-prompt anchor tests rely on the same resolution.
+        let contents = try PromptLoader.load("SystemPrompt_Inference")
+        XCTAssertNotNil(contents, "An existing bundled prompt must resolve to its contents")
+        XCTAssertFalse(contents?.isEmpty ?? true, "Loaded prompt must be non-empty")
+    }
+
+    func test_load_missingResource_returnsNil_doesNotThrow() throws {
+        // The load-bearing contract: a missing resource is a nil return, NOT a
+        // throw — each caller turns the nil into its own typed error.
+        let contents = try PromptLoader.load("NoSuchPrompt_zzz_doesNotExist")
+        XCTAssertNil(contents, "A missing resource must return nil rather than throwing")
+    }
+}


### PR DESCRIPTION
Extracts a single `PromptLoader.load(_:)` and routes every duplicated system-prompt loader through it.

### The duplication
Five services each had a byte-identical `loadSystemPrompt() throws`:
```
Bundle.main.url(forResource: <name>, withExtension: "txt", subdirectory: "Prompts")
  ?? Bundle.main.url(forResource: <name>, withExtension: "txt")
→ String(contentsOf:) on success, throw <Service>Error.systemPromptNotFound on nil
```
differing only in the resource name and the typed error.

### Change
- **New `ProjectApex/Services/PromptLoader.swift`** — `static func load(_ name: String) throws -> String?`: tries the `Prompts/` subdirectory then the flat-bundle fallback, returns `nil` when unresolved (so each caller maps it to its own typed error), throws only on read failure. Resolution shape unchanged (per the issue's out-of-scope note).
- **Five consumers** route through it, each keeping its own typed not-found error and post-processing (`SessionPlanService` + `ProgramGenerationService` still append `ExerciseLibrary.promptReferenceBlock()`). **Behavior-preserving.**

### Scope (was 3, did 5 — per your "all 5" call)
The issue named 3 (`AIInferenceService`, `SessionPlanService`, `InferenceSpike`); grep found 2 more identical copies — `ProgramGenerationService`, `MacroPlanService` — folded in too.

### Cross-cutting grep (report-only)
A **6th** bundled-prompt site exists at `ExerciseSwapService.swift:103`, but it's structurally different — a `static let systemPrompt = {…}()` with a graceful **fallback string (no throw)** and comment-stripping — and is tracked as backlog **P5-D08**. Left untouched; `PromptLoader` is now available for it to adopt.

### Verification
- New `PromptLoaderTests` (2): existing prompt loads non-empty; missing resource → `nil` (not a throw). Registered in the pbxproj (`ProjectApexTests` is a plain group, not a synchronized one).
- `PromptLoaderTests` + `TraineeModelDigestTests` (Inference + SessionPlan prompt anchors) + `ProgramGenerationServiceTests`: **all green** (97 + 9). Full app + test target builds. `** TEST SUCCEEDED **`.

Closes #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)