### PR TITLE
refactor(P5-D08): adopt PromptLoader in ExerciseSwapService (6th prompt site)

### DIFF
--- a/ProjectApex/Services/ExerciseSwapService.swift
+++ b/ProjectApex/Services/ExerciseSwapService.swift
@@ -100,8 +100,12 @@ actor ExerciseSwapService {
     private let provider: any LLMProvider
 
     private static let systemPrompt: String = {
-        guard let url = Bundle.main.url(forResource: "SystemPrompt_ExerciseSwap", withExtension: "txt"),
-              let raw = try? String(contentsOf: url, encoding: .utf8) else {
+        // Resolve via the shared PromptLoader (#220). The graceful fallback is
+        // preserved: PromptLoader.load returns nil when the resource is absent
+        // and throws on a read failure, so `try?` + `?? nil` collapse BOTH to
+        // nil → the stub prompt (this site intentionally does not throw, unlike
+        // the five `loadSystemPrompt() throws` callers).
+        guard let raw = (try? PromptLoader.load("SystemPrompt_ExerciseSwap")) ?? nil else {
             return "You are an exercise swap assistant. Return JSON with display_message and optional suggestion."
         }
         // Strip comment lines, then append the canonical exercise library block


### PR DESCRIPTION
Completes the prompt-loader consolidation started in #220 by folding in the last (6th) bundled-prompt site.

### Why it was separate from #220
`ExerciseSwapService` is **structurally different** from the five identical `loadSystemPrompt() throws` callers: it's a `private static let systemPrompt = {…}()` with a **graceful fallback string (no throw)** and `//`-comment stripping. So it was correctly left out of #220 and tracked as backlog **P5-D08**.

### Change
Route resolution through `PromptLoader.load` while **preserving the graceful fallback exactly**:
```swift
guard let raw = (try? PromptLoader.load("SystemPrompt_ExerciseSwap")) ?? nil else {
    return "You are an exercise swap assistant. …"   // stub fallback, unchanged
}
```
`try?` collapses a read-error throw to nil, and `?? nil` collapses the not-found nil — so both failure modes still yield the stub, never a throw. Comment-stripping + `ExerciseLibrary.promptReferenceBlock()` append are untouched.

### Behavior-preserving (verified)
All six prompt `.txt` files ship **flat at the bundle root** (no `Prompts/` subdir — confirmed by inspecting the built `.app`). So the prior flat-only lookup already resolved the real 3571-byte prompt (not the stub), and `PromptLoader`'s subdir-then-flat resolution lands on the same file. No production prompt change.

### Verification
- `xcodebuild build`: **BUILD SUCCEEDED**, 0 errors.
- Cross-cutting grep: `Bundle.main.url(forResource:` now appears **only** in `PromptLoader.swift` — every prompt site is consolidated.
- No dedicated `ExerciseSwapService` test exists and `systemPrompt` is `private` (not worth widening the surface for a behavior-preserving swap); `PromptLoader` itself is unit-tested (#220).

Completes backlog **P5-D08**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)