### PR TITLE
docs: diary + backlog for P5-D08

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -299,7 +299,7 @@ Captured here so the BACKLOG sweep on 2026-06-01 has a single landing surface. E
 
 - [x] P5-D06: heavy-reassessment banner + goal-review screen + ack writer — **SHIPPED & CLOSED 2026-06-08** as #258 (8 slices, PRs #259–#266). Full build narrative in §2F. Spinoffs filed: P5-D09 (#268), P5-D10 (#269).
 - [ ] P5-D07: One-shot DB migration to strip legacy `reassessmentRecords` JSONB key from existing alpha-cohort rows. Harmless dead-key drift until removed; recommended once #178 has shipped long enough that no client expects to round-trip it.
-- [ ] P5-D08: Cross-cutting `ExerciseSwapService.swift:103` carries its own `private static let systemPrompt: String = {...}` inline-prompt pattern. Reported again by the #220 grep. **`PromptLoader` (P5-D01, #272) now exists to adopt** — but this site is structurally different (graceful FALLBACK string instead of throw, plus `//`-comment stripping), so adoption must preserve that fallback behavior, not just swap the resolver.
+- [x] P5-D08: `ExerciseSwapService` adopted `PromptLoader` (the 6th/last prompt site). **DONE 2026-06-08** (PR #274). Preserved its graceful fallback via `(try? PromptLoader.load(...)) ?? nil` (both read-error throw and not-found collapse to the stub) + comment-stripping. Verified behavior-preserving (all prompt `.txt` ship flat at the bundle root). `Bundle.main.url(forResource:` now lives ONLY in `PromptLoader.swift` — every prompt site consolidated.
 
 **Operator actions (not code changes):**
 

--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,31 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-08 — Finished the prompt-loader cleanup (the 6th copy)
+
+**The problem (in plain words):**
+Earlier today I merged five copies of "find and read a prompt file" into one shared
+helper, but left a sixth, odder copy in the exercise-swap code for its own ticket. This
+finishes that — folds the sixth one in too, so there's now exactly one place that does it.
+
+**What I changed (P5-D08):**
+Pointed the exercise-swap prompt at the shared `PromptLoader`. The tricky part: unlike the
+other five, this one is meant to *not* error — if the file is missing it quietly falls back
+to a short default prompt. I kept that exact behaviour (both "file missing" and "couldn't
+read it" still land on the fallback), along with its little habit of stripping comment lines.
+Before changing it I checked where the prompt files actually live in the built app — they sit
+flat at the top, not in a sub-folder — which confirmed the swap doesn't change which file
+gets loaded.
+
+**How it was checked:**
+App builds clean. A grep confirms the low-level "open a bundled file" call now appears in only
+one file (the shared loader); the shared loader already has its own tests from earlier today.
+
+**Status:** merged (PR #274). Backlog P5-D08 ticked done — the prompt-loader consolidation is
+fully complete across all six places.
+
+---
+
 ## 2026-06-08 — Two small cleanups: tidy lift names, and one prompt loader
 
 **The problem (in plain words):**


### PR DESCRIPTION
Diary entry + §2D tick (P5-D08 done) for the ExerciseSwapService→PromptLoader change (PR #274). Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)