### PR TITLE
chore(P5-D07): strip legacy reassessmentRecords key from trainee_models

### DIFF
--- a/docs/migrations/down/20260608120000_strip_legacy_reassessment_records.sql
+++ b/docs/migrations/down/20260608120000_strip_legacy_reassessment_records.sql
@@ -1,0 +1,23 @@
+-- Reverse migration for: supabase/migrations/20260608120000_strip_legacy_reassessment_records.sql
+-- Documentation only — manual operator use (`psql -f`); not auto-applied
+-- by `supabase db push`.
+--
+-- Restores a synthetic top-level `reassessmentRecords` key (empty array) on
+-- every trainee_models row that lacks it. The field was a write-orphan — no
+-- production path ever populated it — so the only value any legacy row could
+-- have carried was the empty array `[]` (the Swift default before the field
+-- was removed in #224). The reverse therefore restores the SHAPE as `[]`,
+-- without claiming to restore data (there was none to restore).
+--
+-- Use only when rolling back to a client/state that expects the key to exist.
+-- The current Swift decoder ignores `reassessmentRecords` whether present or
+-- absent, so a rollback should not be necessary in practice.
+
+UPDATE public.trainee_models
+SET model_json = jsonb_set(
+  model_json,
+  '{reassessmentRecords}',
+  '[]'::jsonb,
+  true
+)
+WHERE NOT (model_json ? 'reassessmentRecords');

--- a/supabase/migrations/20260608120000_strip_legacy_reassessment_records.sql
+++ b/supabase/migrations/20260608120000_strip_legacy_reassessment_records.sql
@@ -1,0 +1,23 @@
+-- Reverse migration: docs/migrations/down/20260608120000_strip_legacy_reassessment_records.sql
+-- (documentation only; not auto-applied by `supabase db push`)
+--
+-- P5-D07: strip the legacy top-level `model_json.reassessmentRecords` key
+-- from existing trainee_models rows.
+--
+-- `reassessmentRecords` was declared on `TraineeModel` at Phase 1 inception
+-- (commit cf8b48f, 2026-05-04) but never written by any production path — a
+-- write-orphan. It was removed from the Swift struct and `CodingKeys` in #224
+-- (commit 56d90bd, 2026-06-01); the decoder now silently ignores the legacy
+-- key on any row that still carries it. This migration strips the dead key
+-- from existing alpha-cohort rows so the JSONB column reflects only the
+-- canonical shape.
+--
+-- The `-` operator on jsonb is idempotent: rows without the key are
+-- unaffected, and the `WHERE ... ?` existence guard makes the migration safe
+-- to re-run. No production code reads or writes the key, so this is
+-- order-independent relative to any deploy. Forward-only per the migrations
+-- workflow.
+
+UPDATE public.trainee_models
+SET model_json = model_json - 'reassessmentRecords'
+WHERE model_json ? 'reassessmentRecords';


### PR DESCRIPTION
One-shot cleanup migration removing the dead `model_json.reassessmentRecords` JSONB key from existing `trainee_models` rows.

> ⚠️ **Auto-applies to production on merge** — CI's `deploy` job runs `supabase db push --linked` on every push to `main`.

### Why it's safe
`reassessmentRecords` is a **confirmed write-orphan**: declared on `TraineeModel` at Phase 1 inception (`cf8b48f`, 2026-05-04), **never written by any production path**, and removed from the Swift struct + `CodingKeys` in #224 (`56d90bd`, 2026-06-01). The decoder now silently ignores the key. A repo-wide trace found zero readers/writers — only a doc comment, the BACKLOG, and a test fixture reference it.

### The migration
Verbatim structural clone of the already-shipped, already-prod-applied `20260512055424_drop_orphan_top_level_recovery.sql`:
```sql
UPDATE public.trainee_models
SET model_json = model_json - 'reassessmentRecords'
WHERE model_json ? 'reassessmentRecords';
```
- `jsonb - 'key'` removes only the top-level key; idempotent; `WHERE ... ?` guard makes it re-run-safe and a no-op on rows without the key.
- Reverse migration (`docs/migrations/down/`, doc-only) restores the `[]` shape, guarded against clobbering rows that already have the key.
- `20260608120000` sorts after the latest migration (`20260606042014`); pointer comment present.

### Verification
- **Adversarial static review: SAFE TO MERGE** — clean on idempotency, operator correctness, null-safety (column is `jsonb NOT NULL`; even `'null'::jsonb` degrades safely), blast radius (only the one key; siblings byte-identical), filename ordering, pointer comment, reverse fidelity, and parity-test safety (no byte-exact round-trip test references the key).
- **Not run against a live DB** — local Docker/Supabase was down. Given the verbatim parity with a proven prod-applied migration + the static review, confidence is high; likely a **no-op on prod** anyway (nothing ever wrote the key).

### Deliberately left alone
`docs/fixtures/trainee-model-snapshot.json` keeps `"reassessmentRecords": []` — it's decode-tolerance coverage (proves the Swift/TS decoders ignore a stray legacy key), independent of the DB.

Completes backlog **P5-D07**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)