### PR TITLE
docs: diary + backlog for P5-D07

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -298,7 +298,7 @@ Captured here so the BACKLOG sweep on 2026-06-01 has a single landing surface. E
 **Not yet filed — surfaced in 2026-06-01 dispatch, awaiting decision:**
 
 - [x] P5-D06: heavy-reassessment banner + goal-review screen + ack writer — **SHIPPED & CLOSED 2026-06-08** as #258 (8 slices, PRs #259–#266). Full build narrative in §2F. Spinoffs filed: P5-D09 (#268), P5-D10 (#269).
-- [ ] P5-D07: One-shot DB migration to strip legacy `reassessmentRecords` JSONB key from existing alpha-cohort rows. Harmless dead-key drift until removed; recommended once #178 has shipped long enough that no client expects to round-trip it.
+- [x] P5-D07: One-shot DB migration to strip legacy `reassessmentRecords` JSONB key from existing rows. **DONE 2026-06-08** (PR #276, migration `20260608120000_strip_legacy_reassessment_records.sql` + doc-only reverse). Applied to prod (deploy job "Apply migrations" green after an ef-test "Setup Supabase CLI" flake re-run). Verbatim clone of the proven `drop_orphan_top_level_recovery` idiom; adversarially reviewed clean. The fixture `docs/fixtures/trainee-model-snapshot.json` keeps its `reassessmentRecords: []` deliberately — decode-tolerance coverage.
 - [x] P5-D08: `ExerciseSwapService` adopted `PromptLoader` (the 6th/last prompt site). **DONE 2026-06-08** (PR #274). Preserved its graceful fallback via `(try? PromptLoader.load(...)) ?? nil` (both read-error throw and not-found collapse to the stub) + comment-stripping. Verified behavior-preserving (all prompt `.txt` ship flat at the bundle root). `Bundle.main.url(forResource:` now lives ONLY in `PromptLoader.swift` — every prompt site consolidated.
 
 **Operator actions (not code changes):**

--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,33 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-08 — Swept an old dead label out of saved user data
+
+**The problem (in plain words):**
+Way back, each saved "trainee model" carried a label called `reassessmentRecords`. The app
+stopped using it months ago and removed it from the code, but the label could still be
+sitting inside existing users' saved rows in the database — harmless clutter, but clutter.
+
+**What I changed (P5-D07):**
+A one-time database cleanup that deletes that dead label from any rows that still have it.
+I copied an already-proven cleanup we'd done before (same exact shape, just a different
+label name), so there were no surprises. I left one copy of the old label alone on purpose —
+it lives in a test file where it actually does a job: it proves the app safely ignores old
+labels it no longer understands.
+
+**How it was checked (this one got the full treatment, since it touches real user data):**
+- One agent traced every place the label is used and confirmed nothing reads or writes it
+  anymore — truly dead.
+- A second agent did an adversarial review of the cleanup, poking at eight different ways it
+  could go wrong (could it run twice safely? could it touch the wrong data? etc.) — all clean.
+- The build system spun up a real throwaway database, applied the cleanup, and it worked.
+- Then the live deploy applied it to the real database — I watched the "apply" step go green
+  (it needed one re-run because an unrelated setup step flaked the first time).
+
+**Status:** merged and live (PR #276). Backlog P5-D07 ticked done.
+
+---
+
 ## 2026-06-08 — Finished the prompt-loader cleanup (the 6th copy)
 
 **The problem (in plain words):**


### PR DESCRIPTION
Diary entry + §2D tick (P5-D07 done) for the reassessmentRecords cleanup migration (PR #276, applied to prod). Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)