### PR TITLE
feat(#221): adopt USER-REPORTED SIGNALS section in the Inference prompt

### DIFF
--- a/ProjectApex/AICoach/AIInferenceService.swift
+++ b/ProjectApex/AICoach/AIInferenceService.swift
@@ -1161,6 +1161,12 @@ actor AIInferenceService {
 
     // MARK: - System Prompt
     //
+    // VERSION: 7.0 — 2026-06-08 — #221: added REACTING TO USER-REPORTED SIGNALS
+    // FROM PRIOR SETS block (pain / form_breakdown / intent-deviation reactions
+    // off within_session_performance + current_exercise_sets_today — those
+    // fields already shipped in the payload; only the guidance was missing).
+    // Cumulative cache-bust on top of v6.0.
+    //
     // VERSION: 6.0 — 2026-05-13 — B4 (#89) digest collapse: added PRESCRIPTION
     // ACCURACY, CROSS-EXERCISE TRANSFER, CROSS-PATTERN FATIGUE INTERACTIONS,
     // ACTIVE LIMITATIONS, FORM-DEGRADATION FLAG blocks; rewrote DELOAD DETECTION

--- a/ProjectApex/Resources/Prompts/SystemPrompt_Inference.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_Inference.txt
@@ -184,6 +184,29 @@ most recent working set on this exercise), hold rir_target one step higher, focu
 coaching_cue on form quality (not load), and do not push for a PR. The flag overrides
 PROGRESSIVE OVERLOAD and PER-PATTERN TREND for this exercise until it clears.
 
+REACTING TO USER-REPORTED SIGNALS FROM PRIOR SETS (#221):
+The within_session_performance and current_exercise_sets_today arrays may carry, on each set:
+  - intent              — what the user actually did (the resolved intent).
+  - prescribed_intent   — what you prescribed for that set (nil if freestyle).
+  - is_deviation        — true when intent ≠ prescribed_intent. The user explicitly chose
+                          a different set type than what you suggested. High signal.
+  - completion_flags    — array drawn from "pain", "form_breakdown". User-reported,
+                          immediately post-set.
+How to react:
+  - completion_flags includes "pain": treat as the highest-priority signal. Reduce load on
+    the next set of this pattern, consider modifying the movement, and surface
+    "pain_reported" in safety_flags. Pain is a one-strike rule; do not push through it.
+  - completion_flags includes "form_breakdown": the user reports their form degraded under
+    load. Reduce reps or weight on the next set to restore quality.
+  - is_deviation=true with the user picking AMRAP when you prescribed Top: they pushed
+    harder than asked. Next set, consider reducing if fatigue is showing in RPE.
+  - is_deviation=true with the user picking Backoff when you prescribed Top: they pulled
+    back. Consider whether the target was too aggressive; bias future top sets cautious.
+  - is_deviation=true with the user picking Warmup or Technique when you prescribed work:
+    something's off — either the user is signalling they're not ready for working sets, or
+    they re-classified mid-set after a poor first attempt. Bias the next prescription light;
+    consider raising deload_recommended if the pattern repeats across exercises.
+
 FIRST-SESSION CALIBRATION: If is_first_session is true, prescribe ~60% estimated 1RM.
 Use user_profile.bodyweight_kg and training_age as anchors.
 

--- a/ProjectApexTests/TraineeModelDigestTests.swift
+++ b/ProjectApexTests/TraineeModelDigestTests.swift
@@ -717,6 +717,27 @@ final class TraineeModelDigestTests: XCTestCase {
                       "Inference must include the asymmetric-error override clause")
     }
 
+    func test_inferencePrompt_containsUserReportedSignalsBlock() {
+        // #221: the LLM must be told to react to within-session pain /
+        // form_breakdown / intent-deviation signals (the fields already ship in
+        // the payload; only the interpretation guidance was missing).
+        let prompt = AIInferenceService.systemPrompt
+
+        XCTAssertTrue(prompt.contains("REACTING TO USER-REPORTED SIGNALS FROM PRIOR SETS"),
+                      "Inference prompt must include the USER-REPORTED SIGNALS section header (#221)")
+        // Reads the arrays that actually carry the per-set fields — NOT session_log.
+        XCTAssertTrue(prompt.contains("within_session_performance") && prompt.contains("current_exercise_sets_today"),
+                      "Section must reference the arrays that carry the per-set signal fields")
+        XCTAssertTrue(prompt.contains("completion_flags includes \"pain\""),
+                      "Section must include the pain one-strike rule")
+        XCTAssertTrue(prompt.contains("Pain is a one-strike rule"),
+                      "Section must state pain is one-strike (back off, do not push through)")
+        XCTAssertTrue(prompt.contains("completion_flags includes \"form_breakdown\""),
+                      "Section must include the form-breakdown reaction")
+        XCTAssertTrue(prompt.contains("is_deviation=true"),
+                      "Section must include the intent-deviation reactions")
+    }
+
     // MARK: ─── B2 (#87): VOLUME DEFICIT block — prompt-shape anchors ──────────
 
     func test_sessionPlanPrompt_containsVolumeDeficitBlock_andLacksLegacyVolumeDeficitsPhrases() throws {


### PR DESCRIPTION
Adopts the USER-REPORTED SIGNALS section into the production Inference prompt (full section, per the product decision).

### The gap
The per-set fields `intent`, `prescribed_intent`, `is_deviation`, `completion_flags` are **already serialized into every `prescribe()` payload** (inside `within_session_performance` / `current_exercise_sets_today`), but the prompt never told the model what to do with them. So the data was burning tokens with zero effect — including a near-safety-gap: the user can flag **pain** mid-session and the AI saw the flag but had no directive to back off.

### Change (text-only)
New `REACTING TO USER-REPORTED SIGNALS FROM PRIOR SETS` section in `SystemPrompt_Inference.txt`:
- **pain** → one-strike: reduce load next set, consider modifying the movement, surface `pain_reported` in `safety_flags`. Do not push through.
- **form_breakdown** → lighten the next set to restore quality.
- **is_deviation** → bias the next prescription (AMRAP-over-Top = pushed hard → ease if RPE rising; Backoff-over-Top = target too aggressive; Warmup/Technique-over-work = not ready → go light).

No payload/model/UI change — the input already flows.

### Two corrections baked in
- The original section text claimed `session_log` carries these fields; it doesn't. Fixed to reference `within_session_performance` / `current_exercise_sets_today` (where `CompletedSet` actually carries them).
- Bumped the prompt `VERSION` comment 6.0 → 7.0 (cache-bust documentation; editing the body auto-invalidates the `PromptCachingProvider` cache).

### Verification
- New golden-lock anchor test `test_inferencePrompt_containsUserReportedSignalsBlock` + existing inference-prompt anchors: **2 tests, 0 failures, TEST SUCCEEDED.**

### Note / scope
`completion_flags` is **within-session only** today (client-side carrier; cross-session persistence is tracked as #43). This section reacts within the same session, which is where the signals live.

Closes #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)