### PR TITLE
feat(#222): machine weight-increment rule in the Inference prompt

### DIFF
--- a/ProjectApex/AICoach/AIInferenceService.swift
+++ b/ProjectApex/AICoach/AIInferenceService.swift
@@ -1161,6 +1161,12 @@ actor AIInferenceService {
 
     // MARK: - System Prompt
     //
+    // VERSION: 8.0 — 2026-06-08 — #222: split weight-stack / plate-loaded
+    // machines out of the 2.5 kg increment bucket into a 5 kg rule + round-to-
+    // nearest-5 (stacks have no 2.5 kg steps; 32.5/37.5 kg on a machine is
+    // impossible). Matches DefaultWeightIncrements.machineStack. Cumulative
+    // cache-bust on top of v7.0.
+    //
     // VERSION: 7.0 — 2026-06-08 — #221: added REACTING TO USER-REPORTED SIGNALS
     // FROM PRIOR SETS block (pain / form_breakdown / intent-deviation reactions
     // off within_session_performance + current_exercise_sets_today — those

--- a/ProjectApex/Resources/Prompts/SystemPrompt_Inference.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_Inference.txt
@@ -56,7 +56,11 @@ BAD set_framings to avoid:
 
 EQUIPMENT-AWARE WEIGHT INCREMENTS:
 - barbell: minimum 5 kg increment. Use 2.5 kg only near a natural plate boundary (20/60/100 kg).
-- dumbbell / kettlebell / cable / machine: minimum 2.5 kg increment.
+- dumbbell / kettlebell / cable: minimum 2.5 kg increment.
+- weight-stack / plate-loaded machine (leg press, hack squat, chest-press machine,
+  shoulder-press machine, leg extension, leg curl, pec deck, Smith machine, preacher curl):
+  minimum 5 kg increment — weight stacks do NOT have 2.5 kg steps. Round any machine
+  prescription to the nearest 5 kg (e.g. 32.5 kg or 37.5 kg on a stack machine is impossible).
 
 ANTI-OSCILLATION: Do not reverse a weight direction within an exercise unless user_corrected_weight is true.
 

--- a/ProjectApexTests/TraineeModelDigestTests.swift
+++ b/ProjectApexTests/TraineeModelDigestTests.swift
@@ -738,6 +738,23 @@ final class TraineeModelDigestTests: XCTestCase {
                       "Section must include the intent-deviation reactions")
     }
 
+    func test_inferencePrompt_machineWeightsRoundToNearest5() {
+        // #222: weight-stack / plate-loaded machines step in 5 kg, not 2.5 kg —
+        // the prompt must forbid impossible half-kg machine prescriptions.
+        let prompt = AIInferenceService.systemPrompt
+
+        XCTAssertTrue(prompt.contains("weight-stack / plate-loaded machine"),
+                      "Inference prompt must carry the machine-specific increment rule (#222)")
+        // The rounding instruction wraps across a line in the prompt, so match on
+        // whitespace-collapsed text rather than an exact newline/indent.
+        let collapsed = prompt.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        XCTAssertTrue(collapsed.contains("Round any machine prescription to the nearest 5 kg"),
+                      "Machine rule must instruct rounding to the nearest 5 kg")
+        // The old line lumped machine into the 2.5 kg bucket — must be gone.
+        XCTAssertFalse(prompt.contains("dumbbell / kettlebell / cable / machine"),
+                       "Legacy line lumping machine into the 2.5 kg bucket must be removed (#222)")
+    }
+
     // MARK: ─── B2 (#87): VOLUME DEFICIT block — prompt-shape anchors ──────────
 
     func test_sessionPlanPrompt_containsVolumeDeficitBlock_andLacksLegacyVolumeDeficitsPhrases() throws {


### PR DESCRIPTION
Fixes the impossible-machine-weight bug by teaching the Inference prompt that weight-stack / plate-loaded machines step in **5 kg, not 2.5 kg** (prompt edit now; deterministic snap deferred to **#279** per the product decision).

### The bug
The condensed prompt said `dumbbell / kettlebell / cable / machine: minimum 2.5 kg increment`. But weight-stack machines have no 2.5 kg steps — so the AI could prescribe **37.5 kg on a leg press**, a weight that physically doesn't exist on the stack.

### Change (text-only)
Split `machine` out of the 2.5 kg line into its own rule:
> weight-stack / plate-loaded machine (leg press, hack squat, chest-press, shoulder-press, leg extension, leg curl, pec deck, Smith machine, preacher curl): **minimum 5 kg increment** — round any machine prescription to the nearest 5 kg.

This matches the app's own `DefaultWeightIncrements.machineStack` (the source of truth for the manual weight stepper). The input is already satisfied — `equipment_type_key` ships in every `prescribe()` payload. Bumped `VERSION` 7.0 → 8.0 (cache-bust).

### Verification
- New golden-lock anchor `test_inferencePrompt_machineWeightsRoundToNearest5` (asserts the machine rule + round-to-5, and that the legacy lumped line is gone) + the #221 anchor: **2 tests, 0 failures, TEST SUCCEEDED.**

### Follow-up (#279)
The prompt rule is LLM-best-effort. The bulletproof fix — deterministically snapping `weight_kg` to a legal increment via `DefaultWeightIncrements` in the inference post-processing — is filed as **#279** (needs a design pass: nearest-vs-round-down, scope, GymFactStore interaction).

### Cross-cutting report (NOT changed — grep-and-report)
`DefaultWeightIncrements.cableStack` also steps in **5 kg**, yet both the old and new prompt say **cable = 2.5 kg**. The expanded source the issue referenced also said cable = 2.5 kg, and real cable stacks often take 2.5 kg add-on micro-plates — so cable is genuinely debatable and out of scope for the machine bug. **Left as-is; flagged for a separate decision.**

Closes #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)