### PR TITLE
feat(#283): exercise-axis confidence advancement

### DIFF
--- a/supabase/functions/_shared/ewma-engine.ts
+++ b/supabase/functions/_shared/ewma-engine.ts
@@ -81,13 +81,19 @@ export interface TransitionModeResult {
 
 /**
  * Transition-mode mean per ADR-0005: plain mean of the heaviest e1RM per
- * session across the 3 most recent SESSIONS (not top sets), with sample
- * variance using Bessel correction.
+ * session across the most recent `window` SESSIONS (not top sets), with
+ * sample variance using Bessel correction.
+ *
+ * `window` defaults to `TRANSITION_MODE_WINDOW_N` (=3 per ADR-0005's
+ * transition-mode collapse). The exercise confidence gate (ADR-0020) passes
+ * a wider window to measure e1RM stability over more sessions; the variance
+ * it reads is the same Bessel-corrected sample variance.
  *
  * @returns null when no valid top sets exist.
  */
 export function transitionModeMean(
   topSets: TopSet[],
+  window: number = TRANSITION_MODE_WINDOW_N,
 ): TransitionModeResult | null {
   const valid = topSets.filter(
     (s) => s.reps >= TOP_SET_REP_VALIDITY_MIN &&
@@ -106,7 +112,7 @@ export function transitionModeMean(
     }
   }
   const values = Array.from(sessionValues.values()).slice(
-    -TRANSITION_MODE_WINDOW_N,
+    -window,
   );
   const n = values.length;
   const mean = values.reduce((a, b) => a + b, 0) / n;

--- a/supabase/functions/_shared/exercise-confidence.ts
+++ b/supabase/functions/_shared/exercise-confidence.ts
@@ -1,0 +1,70 @@
+// Project Apex — exercise-axis confidence advancement rule (#283, Part of #166).
+//
+// Per ADR-0020 §"Per-axis gate table": the exercise axis matures on capability
+// stability. This pure helper computes the PROPOSED next confidence state from
+// an exercise's accumulated signal; the caller routes it through
+// `monotonicAdvance` (confidence-lifecycle.ts) so it never regresses or skips.
+//
+// Pure: no I/O, no clock reads.
+
+import type { ConfidenceWriteState } from "./confidence-lifecycle.ts";
+import {
+  TOP_SET_REP_VALIDITY_MAX,
+  TOP_SET_REP_VALIDITY_MIN,
+} from "./constants.ts";
+import { type TopSet, transitionModeMean } from "./ewma-engine.ts";
+
+/** → calibrating: enough sessions logged. */
+export const EXERCISE_CALIBRATING_MIN_SESSIONS = 3;
+/** → calibrating: enough validity-filtered top sets that the e1RM EWMA is genuine. */
+export const EXERCISE_CALIBRATING_MIN_TOP_SETS = 3;
+/** → established: session-count floor (well inside the ~6-8 calibration window). */
+export const EXERCISE_ESTABLISHED_MIN_SESSIONS = 8;
+/** → established: e1RM stability is measured over the last N distinct sessions. */
+export const EXERCISE_ESTABLISHED_CV_WINDOW = 5;
+/** → established: require this many distinct valid e1RM sessions in the window. */
+export const EXERCISE_ESTABLISHED_MIN_DISTINCT_SESSIONS = 4;
+/** → established: e1RM coefficient of variation must be at or below this. */
+export const EXERCISE_ESTABLISHED_MAX_CV = 0.075;
+
+/**
+ * Propose the exercise axis's confidence state from its accumulated signal:
+ * - `.established` when `sessionCount ≥ 8` AND the e1RM is stable (coefficient
+ *   of variation of heaviest-e1RM-per-session over the last 5 distinct sessions
+ *   ≤ 7.5%), guarded by ≥4 distinct valid e1RM sessions.
+ * - `.calibrating` when `sessionCount ≥ 3` AND there are ≥3 validity-filtered
+ *   top sets (so the EWMA reflects real data, not a single lift).
+ * - `.bootstrapping` otherwise.
+ *
+ * Returns the PROPOSED state (pre-clamp); the caller applies `monotonicAdvance`.
+ */
+export function proposeExerciseConfidence(input: {
+  sessionCount: number;
+  topSets: TopSet[];
+}): ConfidenceWriteState {
+  const { sessionCount, topSets } = input;
+
+  if (sessionCount >= EXERCISE_ESTABLISHED_MIN_SESSIONS) {
+    const stability = transitionModeMean(topSets, EXERCISE_ESTABLISHED_CV_WINDOW);
+    if (
+      stability !== null &&
+      stability.sessionCount >= EXERCISE_ESTABLISHED_MIN_DISTINCT_SESSIONS &&
+      stability.mean > 0
+    ) {
+      const cv = Math.sqrt(stability.variance) / stability.mean;
+      if (cv <= EXERCISE_ESTABLISHED_MAX_CV) return "established";
+    }
+  }
+
+  const validTopSetCount = topSets.filter(
+    (s) => s.reps >= TOP_SET_REP_VALIDITY_MIN && s.reps <= TOP_SET_REP_VALIDITY_MAX,
+  ).length;
+  if (
+    sessionCount >= EXERCISE_CALIBRATING_MIN_SESSIONS &&
+    validTopSetCount >= EXERCISE_CALIBRATING_MIN_TOP_SETS
+  ) {
+    return "calibrating";
+  }
+
+  return "bootstrapping";
+}

--- a/supabase/functions/_shared/exercise-confidence_test.ts
+++ b/supabase/functions/_shared/exercise-confidence_test.ts
@@ -1,0 +1,79 @@
+// Project Apex — unit tests for the exercise-axis confidence rule (#283).
+//
+// Run locally:
+//   deno test --allow-all supabase/functions/_shared/exercise-confidence_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { proposeExerciseConfidence } from "./exercise-confidence.ts";
+import type { TopSet } from "./ewma-engine.ts";
+
+const DAY = new Date("2026-05-10T10:00:00Z");
+
+/** Build a top set for session `sid` with the given load/reps. */
+function ts(weight: number, reps: number, sid: string): TopSet {
+  return { weight, reps, loggedAt: DAY, sessionId: sid };
+}
+
+/** N distinct sessions, one stable top set each (identical load/reps). */
+function stableSessions(n: number, weight = 100, reps = 5): TopSet[] {
+  return Array.from({ length: n }, (_, i) => ts(weight, reps, `s${i}`));
+}
+
+Deno.test("exercise: below the session floor stays bootstrapping", () => {
+  assertEquals(
+    proposeExerciseConfidence({ sessionCount: 2, topSets: stableSessions(2) }),
+    "bootstrapping",
+  );
+});
+
+Deno.test("exercise: 3 sessions + 3 valid top sets → calibrating", () => {
+  assertEquals(
+    proposeExerciseConfidence({ sessionCount: 3, topSets: stableSessions(3) }),
+    "calibrating",
+  );
+});
+
+Deno.test("exercise: 3 sessions but only 2 valid top sets stays bootstrapping", () => {
+  assertEquals(
+    proposeExerciseConfidence({ sessionCount: 3, topSets: stableSessions(2) }),
+    "bootstrapping",
+  );
+});
+
+Deno.test("exercise: only out-of-range-rep top sets don't count toward calibrating", () => {
+  // reps 12 are outside the 3-10 validity window → zero valid top sets.
+  const invalid = [ts(60, 12, "s0"), ts(60, 12, "s1"), ts(60, 12, "s2")];
+  assertEquals(
+    proposeExerciseConfidence({ sessionCount: 5, topSets: invalid }),
+    "bootstrapping",
+  );
+});
+
+Deno.test("exercise: 8 sessions with stable e1RM over ≥4 distinct sessions → established", () => {
+  assertEquals(
+    proposeExerciseConfidence({ sessionCount: 8, topSets: stableSessions(5) }),
+    "established",
+  );
+});
+
+Deno.test("exercise: 8 sessions but noisy e1RM (CV > 7.5%) stays calibrating", () => {
+  const noisy = [
+    ts(80, 5, "s0"),
+    ts(120, 5, "s1"),
+    ts(80, 5, "s2"),
+    ts(120, 5, "s3"),
+    ts(80, 5, "s4"),
+  ];
+  assertEquals(
+    proposeExerciseConfidence({ sessionCount: 8, topSets: noisy }),
+    "calibrating",
+  );
+});
+
+Deno.test("exercise: 8 sessions but fewer than 4 distinct valid e1RM sessions stays calibrating", () => {
+  // Only 3 distinct sessions with valid top sets → fails the ≥4 guard.
+  assertEquals(
+    proposeExerciseConfidence({ sessionCount: 8, topSets: stableSessions(3) }),
+    "calibrating",
+  );
+});

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -40,6 +40,11 @@ import {
   type TopSet as EwmaTopSet,
 } from "../_shared/ewma-engine.ts";
 import {
+  type ConfidenceWriteState,
+  monotonicAdvance,
+} from "../_shared/confidence-lifecycle.ts";
+import { proposeExerciseConfidence } from "../_shared/exercise-confidence.ts";
+import {
   classifyStimulus,
   type SetIntent,
 } from "../_shared/stimulus-classifier.ts";
@@ -446,6 +451,23 @@ function applyPerExerciseRules(
         newProfile.e1rmCurrent = newE1RM;
         rulesFired.add("ewma");
         fieldsChanged.push(`exercises.${exerciseId}.e1rmCurrent`);
+      }
+
+      // ADR-0020: advance exercise confidence on capability stability.
+      // Proposed state is clamped forward-only via monotonicAdvance.
+      const currentConfidence =
+        (profile.confidence as ConfidenceWriteState | undefined) ?? "bootstrapping";
+      const advancedConfidence = monotonicAdvance(
+        currentConfidence,
+        proposeExerciseConfidence({
+          sessionCount: newProfile.sessionCount as number,
+          topSets: ewmaInput,
+        }),
+      );
+      if (advancedConfidence !== currentConfidence) {
+        newProfile.confidence = advancedConfidence;
+        rulesFired.add("exercise-confidence");
+        fieldsChanged.push(`exercises.${exerciseId}.confidence`);
       }
     }
 

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -2026,6 +2026,57 @@ orchestratorTest(
   },
 );
 
+orchestratorTest(
+  "#283 (ADR-0020): exercise confidence advances bootstrapping → calibrating → established over repeated stable sessions",
+  async () => {
+    const userId = await seedFreshUser();
+
+    // Apply `count` sessions of one stable top set (100kg × 5) for bench,
+    // starting at `dayOffset` days past a base date. Returns the bench
+    // ExerciseProfile after the last apply.
+    async function applyStableSessions(
+      count: number,
+      dayOffset: number,
+    ): Promise<Record<string, unknown>> {
+      for (let i = 0; i < count; i++) {
+        const day = String(8 + dayOffset + i).padStart(2, "0");
+        await applySession(
+          {
+            user_id: userId,
+            session_id: crypto.randomUUID(),
+            session_payload: {
+              logged_at: `2026-05-${day}T10:00:00Z`,
+              set_logs: [
+                { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "top" },
+              ],
+            },
+          },
+          sql,
+          { stage2Hook: noopStage2 },
+        );
+      }
+      const rows = await sql`
+        SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+      `;
+      const exercises = (rows[0].model_json as Record<string, unknown>)
+        .exercises as Record<string, Record<string, unknown>>;
+      return exercises["barbell_bench_press"];
+    }
+
+    // After 3 stable sessions: calibrating (sessionCount≥3 AND ≥3 valid top sets).
+    const afterThree = await applyStableSessions(3, 0);
+    assertEquals(afterThree.sessionCount, 3);
+    assertEquals(afterThree.confidence, "calibrating");
+
+    // 5 more (total 8) stable sessions: established (sessionCount≥8 AND e1RM
+    // CV ≤ 7.5% over ≥4 distinct sessions). calibrating→established is one
+    // monotonicAdvance step, so it lands on the 8th apply.
+    const afterEight = await applyStableSessions(5, 3);
+    assertEquals(afterEight.sessionCount, 8);
+    assertEquals(afterEight.confidence, "established");
+  },
+);
+
 // Sentinel "test" that runs last (alphabetically — Deno runs tests in file
 // order, but this trailing close keeps the connection lifecycle local to
 // the test file rather than relying on process-exit cleanup).


### PR DESCRIPTION
## Slice 2 of 5 — Part of #166

Makes `ExerciseProfile.confidence` advance end-to-end. The exercise axis matures on capability stability.

### Gates (ADR-0020)
- **→ calibrating**: `sessionCount ≥ 3` AND ≥3 validity-filtered top sets.
- **→ established**: `sessionCount ≥ 8` AND e1RM coefficient of variation ≤ 7.5% over the last 5 distinct sessions, guarded by ≥4 distinct valid e1RM sessions.
- Proposed state routed through `monotonicAdvance` (forward-only, no-skip).

### Notes
- `transitionModeMean` gained a backward-compatible `window` param (default `TRANSITION_MODE_WINDOW_N`=3) so the established gate measures stability over 5 sessions while existing callers (transition-mode collapse) are unchanged. The statistical method (heaviest-e1RM-per-session, Bessel-corrected variance) stays in one place. *(This is why the ADR's "existing transition-mode primitive" stays accurate.)*
- `learningPhase` untouched.

### Verification
- `exercise-confidence_test.ts` → 7 passed; `ewma-engine_test.ts` → 13 passed (window-param regression). Both `_shared` helpers + `index.ts` `deno check` clean.
- Orchestrator integration test drives bootstrapping → calibrating (3 stable sessions) → established (8 stable sessions) — gated by CI `ef-test` (local Docker unavailable this session).

Merges as "Part of #166"; umbrella stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)