### PR TITLE
feat(#284): per-pattern sessionCount field + idempotent backfill

### DIFF
--- a/supabase/functions/_shared/pattern-session-count-backfill.ts
+++ b/supabase/functions/_shared/pattern-session-count-backfill.ts
@@ -1,0 +1,49 @@
+// Project Apex — PatternProfile sessionCount-backfill helper (#284, Part of #166).
+//
+// The per-pattern `sessionCount` field is introduced by ADR-0020 to drive the
+// pattern confidence lifecycle. Patterns that existed before this slice carry
+// no `sessionCount`, so the bootstrap path (which only runs for newly-trained
+// patterns) never sets it. This pure function seeds missing `sessionCount` from
+// `recentSessionDates.length` so existing patterns get credit for prior sessions
+// rather than restarting the confidence climb from zero.
+//
+// Design (mirrors #173 backfillPatternConfidence):
+// - Producer-side, not SQL: survives future field additions; catches the shape
+//   for any affected user on their next apply.
+// - Idempotent: only writes when `sessionCount` is undefined; once written, the
+//   guard never re-fires.
+// - Conservative seed: `recentSessionDates.length` is a FLOOR on the true count
+//   (it is "approximate for pre-existing patterns; exact going forward"). It can
+//   never over-count, which is the asymmetric-safe direction (ADR-0020).
+// - Audit: returns the count of patterns actually written.
+
+/**
+ * Walks model_json.patterns entries. For each entry missing `sessionCount`,
+ * seeds it from the length of `recentSessionDates` (0 if absent).
+ *
+ * @param patterns - The patterns dict from model_json (shallow-copied; the
+ *   original is not mutated).
+ * @returns The updated patterns dict and `backfilledCount` (patterns written).
+ */
+export function backfillPatternSessionCount(
+  patterns: Record<string, Record<string, unknown>>,
+): {
+  patterns: Record<string, Record<string, unknown>>;
+  backfilledCount: number;
+} {
+  const updated: Record<string, Record<string, unknown>> = {};
+  let backfilledCount = 0;
+
+  for (const [key, profile] of Object.entries(patterns)) {
+    if (profile.sessionCount === undefined) {
+      const recent = profile.recentSessionDates;
+      const floor = Array.isArray(recent) ? recent.length : 0;
+      updated[key] = { ...profile, sessionCount: floor };
+      backfilledCount++;
+    } else {
+      updated[key] = profile;
+    }
+  }
+
+  return { patterns: updated, backfilledCount };
+}

--- a/supabase/functions/_shared/pattern-session-count-backfill_test.ts
+++ b/supabase/functions/_shared/pattern-session-count-backfill_test.ts
@@ -1,0 +1,58 @@
+// Project Apex — unit tests for backfillPatternSessionCount (#284).
+//
+// Run locally:
+//   deno test --allow-all supabase/functions/_shared/pattern-session-count-backfill_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { backfillPatternSessionCount } from "./pattern-session-count-backfill.ts";
+
+Deno.test("backfill: seeds missing sessionCount from recentSessionDates.length", () => {
+  const { patterns, backfilledCount } = backfillPatternSessionCount({
+    horizontal_push: { pattern: "horizontal_push", recentSessionDates: ["a", "b", "c"] },
+  });
+  assertEquals(patterns.horizontal_push.sessionCount, 3);
+  assertEquals(backfilledCount, 1);
+});
+
+Deno.test("backfill: missing recentSessionDates seeds floor of 0", () => {
+  const { patterns, backfilledCount } = backfillPatternSessionCount({
+    squat: { pattern: "squat" },
+  });
+  assertEquals(patterns.squat.sessionCount, 0);
+  assertEquals(backfilledCount, 1);
+});
+
+Deno.test("backfill: leaves an existing sessionCount untouched (idempotent)", () => {
+  const { patterns, backfilledCount } = backfillPatternSessionCount({
+    squat: { pattern: "squat", sessionCount: 9, recentSessionDates: ["a", "b"] },
+  });
+  assertEquals(patterns.squat.sessionCount, 9);
+  assertEquals(backfilledCount, 0);
+});
+
+Deno.test("backfill: a second run writes nothing (idempotent by construction)", () => {
+  const first = backfillPatternSessionCount({
+    p: { pattern: "horizontal_push", recentSessionDates: ["a", "b"] },
+  });
+  const second = backfillPatternSessionCount(first.patterns);
+  assertEquals(second.backfilledCount, 0);
+  assertEquals(second.patterns.p.sessionCount, 2);
+});
+
+Deno.test("backfill: does not mutate the original patterns dict", () => {
+  const original = { p: { pattern: "squat", recentSessionDates: ["a"] } } as Record<
+    string,
+    Record<string, unknown>
+  >;
+  backfillPatternSessionCount(original);
+  assertEquals(original.p.sessionCount, undefined);
+});
+
+Deno.test("backfill: counts only patterns actually written across a mixed dict", () => {
+  const { backfilledCount } = backfillPatternSessionCount({
+    a: { pattern: "squat", recentSessionDates: ["x"] }, // missing → written
+    b: { pattern: "hinge", sessionCount: 4 }, // present → skipped
+    c: { pattern: "horizontal_push" }, // missing → written (floor 0)
+  });
+  assertEquals(backfilledCount, 2);
+});

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -121,6 +121,7 @@ import {
 } from "../_shared/note-classifier.ts";
 import { LLMPermanentError, LLMTransientError } from "../_shared/llm-retry.ts";
 import { backfillPatternConfidence } from "../_shared/pattern-confidence-backfill.ts";
+import { backfillPatternSessionCount } from "../_shared/pattern-session-count-backfill.ts";
 
 export interface UpdateTraineeModelRequest {
   user_id: string;
@@ -815,6 +816,11 @@ function applyPerPatternRules(
         pattern,
         currentPhase: "accumulation",
         sessionsInPhase: 0,
+        // #284 (ADR-0020): per-pattern total session counter (EF-only),
+        // distinct from sessionsInPhase (which resets on phase transition).
+        // Drives pattern confidence advancement; incremented below per
+        // session-apply that trains the pattern.
+        sessionCount: 0,
         consecutiveForceDeloadsOnPattern: 0,
         lastPhaseTransitionAtSessionCount: 0,
         recentSessionDates: [],
@@ -854,6 +860,14 @@ function applyPerPatternRules(
     const sessionsInPhase = wasTrainedThisSession
       ? baseSessionsInPhase + 1
       : baseSessionsInPhase;
+
+    // #284 (ADR-0020): per-pattern total session counter (drives pattern
+    // confidence). Pre-existing patterns are seeded by backfillPatternSessionCount
+    // upstream, so `profile.sessionCount` is defined here.
+    const basePatternSessionCount = (profile.sessionCount as number) ?? 0;
+    const patternSessionCount = wasTrainedThisSession
+      ? basePatternSessionCount + 1
+      : basePatternSessionCount;
 
     const baseRecentDates =
       (profile.recentSessionDates as string[] | undefined) ?? [];
@@ -944,6 +958,7 @@ function applyPerPatternRules(
       ...profile,
       currentPhase: advanced.newPhase,
       sessionsInPhase: advanced.newSessionsInPhase,
+      sessionCount: patternSessionCount,
       consecutiveForceDeloadsOnPattern: advanced.newConsecutiveForceDeloads,
       lastPhaseTransitionAtSessionCount:
         advanced.newLastPhaseTransitionAtSessionCount,
@@ -1694,8 +1709,20 @@ export async function applySession(
         fieldsChanged.push(`patterns.confidence-backfill.count=${backfilled.backfilledCount}`);
       }
 
+      // #284 (ADR-0020): backfill the per-pattern sessionCount on pre-existing
+      // patterns from recentSessionDates.length (conservative floor). Idempotent:
+      // already-set entries are unchanged. Runs before applyPerPatternRules so
+      // the increment reads a seeded value.
+      const sessionCountBackfilled = backfillPatternSessionCount(backfilled.patterns);
+      if (sessionCountBackfilled.backfilledCount > 0) {
+        rulesFired.push("pattern-session-count-backfill");
+        fieldsChanged.push(
+          `patterns.session-count-backfill.count=${sessionCountBackfilled.backfilledCount}`,
+        );
+      }
+
       const ruled = applyPerPatternRules(
-        backfilled.patterns,
+        sessionCountBackfilled.patterns,
         trainedSets.patterns,
         incomingLoggedAt,
         newSessionCount,

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -2077,6 +2077,66 @@ orchestratorTest(
   },
 );
 
+orchestratorTest(
+  "#284 (ADR-0020): per-pattern sessionCount increments once per trained apply; untrained patterns hold",
+  async () => {
+    const userId = await seedFreshUser();
+
+    async function applyBench(day: string): Promise<void> {
+      await applySession(
+        {
+          user_id: userId,
+          session_id: crypto.randomUUID(),
+          session_payload: {
+            logged_at: `2026-06-${day}T10:00:00Z`,
+            set_logs: [
+              { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "top" },
+            ],
+          },
+        },
+        sql,
+        { stage2Hook: noopStage2 },
+      );
+    }
+
+    async function patterns(): Promise<Record<string, Record<string, unknown>>> {
+      const rows = await sql`
+        SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+      `;
+      return (rows[0].model_json as Record<string, unknown>).patterns as Record<
+        string,
+        Record<string, unknown>
+      >;
+    }
+
+    await applyBench("01");
+    assertEquals((await patterns())["horizontal_push"].sessionCount, 1);
+
+    await applyBench("02");
+    assertEquals((await patterns())["horizontal_push"].sessionCount, 2);
+
+    // A squat-only session must not bump the (untrained) horizontal_push counter,
+    // while squat's own counter starts at 1.
+    await applySession(
+      {
+        user_id: userId,
+        session_id: crypto.randomUUID(),
+        session_payload: {
+          logged_at: "2026-06-03T10:00:00Z",
+          set_logs: [
+            { exercise_id: "barbell_back_squat", set_number: 1, weight_kg: 140, reps_completed: 5, intent: "top" },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+    const after = await patterns();
+    assertEquals(after["horizontal_push"].sessionCount, 2);
+    assertEquals(after["squat"].sessionCount, 1);
+  },
+);
+
 // Sentinel "test" that runs last (alphabetically — Deno runs tests in file
 // order, but this trailing close keeps the connection lifecycle local to
 // the test file rather than relying on process-exit cleanup).


### PR DESCRIPTION
## Slice 3 of 5 — Part of #166

Gives the pattern axis the counter its advancement rule (Slice 4, #285) will read. No advancement logic here — just the field + backfill.

### What's here
- New EF-only `PatternProfile.sessionCount` accumulator, incremented +1 per session-apply that trains the pattern (distinct from `sessionsInPhase`, which resets on phase transition). Bootstrap sets it to 0.
- `backfillPatternSessionCount` — idempotent producer-side backfill seeding pre-existing patterns from `recentSessionDates.length` (conservative floor; never over-counts). Mirrors the #173 `backfillPatternConfidence` template; wired in the main path right after it.

### Grep-and-report (not acting, per CLAUDE.md cross-cutting rule)
`recentSessionDates` is appended in `applyPerPatternRules` **without** a `.slice(-N)` bound — it is **unbounded** in the EF write today (pre-existing behavior, despite docstrings describing it as "bounded ~7-10"). Consequence for this slice: the backfill seed is actually *exact* under current behavior, not just a floor. **Recommendation:** file a follow-up issue to bound `recentSessionDates` (unbounded `model_json` growth over a user's lifetime). Not fixed here — out of scope and needs authorization.

### Verification
- `pattern-session-count-backfill_test.ts` → 6 passed (seed, floor-0, idempotent, no-mutation, mixed-count). Helper + `index.ts` `deno check` clean.
- Orchestrator test: counter increments per trained apply; an untrained pattern holds while another's counter starts at 1 — CI `ef-test`.

Merges as "Part of #166".

🤖 Generated with [Claude Code](https://claude.com/claude-code)