### PR TITLE
feat(#285): pattern-axis confidence advancement (unblocks #269)

### DIFF
--- a/supabase/functions/_shared/pattern-confidence.ts
+++ b/supabase/functions/_shared/pattern-confidence.ts
@@ -1,0 +1,44 @@
+// Project Apex — pattern-axis confidence advancement rule (#285, Part of #166).
+//
+// Per ADR-0020 §"Per-axis gate table": the pattern axis matures on a session
+// count plus a real (data-backed) progression-trend verdict. This pure helper
+// computes the PROPOSED next confidence state; the caller routes it through
+// `monotonicAdvance` (confidence-lifecycle.ts).
+//
+// Pattern `.established` is the highest-value transition: at ≥4 of 6 major
+// patterns it flips the client-derived `isReadyForCalibrationReview` (which
+// #269 builds on). It must not fire on the bootstrap-default trend — hence the
+// `trendEvaluable` gate (see `isTrendEvaluable` in plateau-verdict.ts).
+//
+// Pure: no I/O, no clock reads.
+
+import type { ConfidenceWriteState } from "./confidence-lifecycle.ts";
+
+/** → calibrating: enough trained sessions logged. */
+export const PATTERN_CALIBRATING_MIN_SESSIONS = 3;
+/** → established: session-count floor (bottom of ADR-0005's ~6-8 window). */
+export const PATTERN_ESTABLISHED_MIN_SESSIONS = 6;
+
+/**
+ * Propose the pattern axis's confidence state:
+ * - `.established` when `sessionCount ≥ 6` AND the trend verdict is data-backed
+ *   (`trendEvaluable` — at least one plateau track has enough observations).
+ * - `.calibrating` when `sessionCount ≥ 3`.
+ * - `.bootstrapping` otherwise.
+ *
+ * Returns the PROPOSED state (pre-clamp); the caller applies `monotonicAdvance`.
+ */
+export function proposePatternConfidence(input: {
+  sessionCount: number;
+  trendEvaluable: boolean;
+}): ConfidenceWriteState {
+  const { sessionCount, trendEvaluable } = input;
+
+  if (sessionCount >= PATTERN_ESTABLISHED_MIN_SESSIONS && trendEvaluable) {
+    return "established";
+  }
+  if (sessionCount >= PATTERN_CALIBRATING_MIN_SESSIONS) {
+    return "calibrating";
+  }
+  return "bootstrapping";
+}

--- a/supabase/functions/_shared/pattern-confidence_test.ts
+++ b/supabase/functions/_shared/pattern-confidence_test.ts
@@ -1,0 +1,62 @@
+// Project Apex — unit tests for the pattern-axis confidence rule (#285).
+//
+// Run locally:
+//   deno test --allow-all supabase/functions/_shared/pattern-confidence_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { proposePatternConfidence } from "./pattern-confidence.ts";
+import { isTrendEvaluable } from "./plateau-verdict.ts";
+
+Deno.test("pattern: below the session floor stays bootstrapping", () => {
+  assertEquals(
+    proposePatternConfidence({ sessionCount: 2, trendEvaluable: false }),
+    "bootstrapping",
+  );
+});
+
+Deno.test("pattern: 3 sessions → calibrating", () => {
+  assertEquals(
+    proposePatternConfidence({ sessionCount: 3, trendEvaluable: false }),
+    "calibrating",
+  );
+});
+
+Deno.test("pattern: 6 sessions with a data-backed trend → established", () => {
+  assertEquals(
+    proposePatternConfidence({ sessionCount: 6, trendEvaluable: true }),
+    "established",
+  );
+});
+
+Deno.test("pattern: 6 sessions but trend not yet evaluable stays calibrating", () => {
+  assertEquals(
+    proposePatternConfidence({ sessionCount: 6, trendEvaluable: false }),
+    "calibrating",
+  );
+});
+
+// --- isTrendEvaluable (plateau-verdict.ts) ---
+
+const DAY = new Date("2026-05-10T10:00:00Z");
+const e1 = (n: number) =>
+  Array.from({ length: n }, () => ({ loggedAt: DAY, e1rm: 100, avgRPE: 8 }));
+const vol = (n: number) =>
+  Array.from({ length: n }, () => ({ loggedAt: DAY, weeklyVolumeLoad: 1000, avgRPE: 8 }));
+
+Deno.test("isTrendEvaluable: e1RM track reaches its window (3 at fast cadence) → evaluable", () => {
+  assertEquals(isTrendEvaluable(e1(3), vol(0), 1), true);
+});
+
+Deno.test("isTrendEvaluable: 2 e1RM sessions at fast cadence, no volume buckets → not evaluable", () => {
+  assertEquals(isTrendEvaluable(e1(2), vol(0), 1), false);
+});
+
+Deno.test("isTrendEvaluable: slow cadence needs 4 e1RM sessions (3 is not enough)", () => {
+  assertEquals(isTrendEvaluable(e1(3), vol(0), 7), false);
+  assertEquals(isTrendEvaluable(e1(4), vol(0), 7), true);
+});
+
+Deno.test("isTrendEvaluable: high-rep pattern (no valid e1RM) becomes evaluable via 4 volume buckets", () => {
+  assertEquals(isTrendEvaluable(e1(0), vol(3), 1), false);
+  assertEquals(isTrendEvaluable(e1(0), vol(4), 1), true);
+});

--- a/supabase/functions/_shared/plateau-verdict.ts
+++ b/supabase/functions/_shared/plateau-verdict.ts
@@ -212,6 +212,28 @@ export function plateauVerdict(
 }
 
 /**
+ * Whether `plateauVerdict` is DATA-BACKED rather than the insufficient-data
+ * default. The verdict returns "progressing" both when a pattern has too little
+ * history (each track falls back to "improving") AND when it is genuinely
+ * progressing — so the verdict value alone cannot distinguish the two. This
+ * predicate is true once at least one track has enough observations to emit a
+ * real reading: the e1RM track needs `windowSize(cadence)` sessions (3 or 4),
+ * the volume-load track needs `VOLUME_LOAD_PLATEAU_WINDOW_N` (4) weekly buckets.
+ * Used by the pattern confidence gate (ADR-0020) so a pattern never reaches
+ * `.established` on a fabricated default trend.
+ */
+export function isTrendEvaluable(
+  e1rmSessions: E1RMSession[],
+  volumeLoadSessions: VolumeLoadSession[],
+  cadenceDays: number | null,
+): boolean {
+  return (
+    e1rmSessions.length >= windowSize(cadenceDays) ||
+    volumeLoadSessions.length >= VOLUME_LOAD_PLATEAU_WINDOW_N
+  );
+}
+
+/**
  * Per-pattern trend + confidence used for muscle-level aggregation.
  * `confidence` is the `PatternProfile.confidence` field; only patterns
  * above `bootstrapping` participate per the ADR-0009 amendment.

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -65,11 +65,13 @@ import {
 } from "../_shared/phase-advance.ts";
 import { computeTransitionModeUntil } from "../_shared/transition-mode-expiry.ts";
 import {
+  isTrendEvaluable,
   plateauVerdict,
   type E1RMSession,
   type ProgressionTrend,
   type VolumeLoadSession,
 } from "../_shared/plateau-verdict.ts";
+import { proposePatternConfidence } from "../_shared/pattern-confidence.ts";
 import {
   appendObservation,
   shouldContribute,
@@ -954,6 +956,31 @@ function applyPerPatternRules(
       fieldsChanged.push(`patterns.${patternKey}.trend`);
     }
 
+    // #285 (ADR-0020): advance pattern confidence. established requires a
+    // data-backed trend (not the bootstrap-default "progressing"), so it gates
+    // on isTrendEvaluable over the same plateau-track inputs. Clamped forward-
+    // only via monotonicAdvance. At ≥4/6 major patterns established this flips
+    // the client-derived isReadyForCalibrationReview (#269). This rule advances
+    // confidence ONLY — it never writes projections / calibrationReviewFiredAt.
+    const trendEvaluable = isTrendEvaluable(
+      e1rmSessionsForPattern,
+      volumeSessionsForPattern,
+      cadenceDays,
+    );
+    const currentPatternConfidence =
+      (profile.confidence as ConfidenceWriteState | undefined) ?? "bootstrapping";
+    const advancedPatternConfidence = monotonicAdvance(
+      currentPatternConfidence,
+      proposePatternConfidence({
+        sessionCount: patternSessionCount,
+        trendEvaluable,
+      }),
+    );
+    if (advancedPatternConfidence !== currentPatternConfidence) {
+      rulesFired.add("pattern-confidence");
+      fieldsChanged.push(`patterns.${patternKey}.confidence`);
+    }
+
     newPatterns[patternKey] = {
       ...profile,
       currentPhase: advanced.newPhase,
@@ -966,6 +993,7 @@ function applyPerPatternRules(
       recentSessionDates: recentDates,
       weeklyVolumeLoadHistory: newVolumeHistory,
       trend: newTrend,
+      confidence: advancedPatternConfidence,
     };
   }
 

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -2137,6 +2137,55 @@ orchestratorTest(
   },
 );
 
+orchestratorTest(
+  "#285 (ADR-0020): pattern confidence advances to established; feature never writes projections",
+  async () => {
+    const userId = await seedFreshUser();
+
+    async function applyBench(day: number): Promise<Record<string, unknown>> {
+      await applySession(
+        {
+          user_id: userId,
+          session_id: crypto.randomUUID(),
+          session_payload: {
+            logged_at: `2026-07-${String(day).padStart(2, "0")}T10:00:00Z`,
+            set_logs: [
+              { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "top" },
+            ],
+          },
+        },
+        sql,
+        { stage2Hook: noopStage2 },
+      );
+      const rows = await sql`
+        SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+      `;
+      return rows[0].model_json as Record<string, unknown>;
+    }
+
+    // 3 sessions → calibrating.
+    let modelJson: Record<string, unknown> = {};
+    for (let d = 1; d <= 3; d++) modelJson = await applyBench(d);
+    let push = (modelJson.patterns as Record<string, Record<string, unknown>>)[
+      "horizontal_push"
+    ];
+    assertEquals(push.confidence, "calibrating");
+
+    // 3 more (total 6) with a data-backed trend → established (calibrating→
+    // established is one monotonicAdvance step, landing on the 6th apply).
+    for (let d = 4; d <= 6; d++) modelJson = await applyBench(d);
+    push = (modelJson.patterns as Record<string, Record<string, unknown>>)[
+      "horizontal_push"
+    ];
+    assertEquals(push.sessionCount, 6);
+    assertEquals(push.confidence, "established");
+
+    // Boundary guard (ADR-0020 / #269): advancing confidence must NOT derive
+    // projections or set calibrationReviewFiredAt — that is #269's job.
+    assertEquals(modelJson.projections, undefined);
+  },
+);
+
 // Sentinel "test" that runs last (alphabetically — Deno runs tests in file
 // order, but this trailing close keeps the connection lifecycle local to
 // the test file rather than relying on process-exit cleanup).


### PR DESCRIPTION
## Slice 4 of 5 — Part of #166

The highest-value slice: makes `PatternProfile.confidence` advance to `.established`, which at ≥4/6 major patterns flips the client-derived `isReadyForCalibrationReview` — the gate #269 is blocked on.

### Gates (ADR-0020)
- **→ calibrating**: per-pattern `sessionCount ≥ 3`.
- **→ established**: `sessionCount ≥ 6` AND a **data-backed** trend.
- Routed through `monotonicAdvance` (forward-only, no-skip).

### The "data-backed trend" problem + fix
`plateauVerdict` returns `progressing` BOTH as the insufficient-data default AND as a genuine verdict, so the trend *value* can't tell them apart. Added `isTrendEvaluable(e1rmSessions, volumeSessions, cadenceDays)` to plateau-verdict.ts — true once a track has enough observations (e1RM ≥ `windowSize` = 3-4 by cadence, OR ≥4 weekly volume-load buckets). established gates on it, so a pattern never establishes on a fabricated default trend. (High-rep patterns with no valid e1RM still establish via the 4-bucket volume track.)

### Scope boundary (Q9)
Advance-only. Verified `isReadyForCalibrationReview` has zero production consumers, so flipping it true surfaces nothing broken. This rule **never** writes `projections` / `calibrationReviewFiredAt` — #269 owns those. An orchestrator boundary-guard assertion enforces it.

### Verification
- `pattern-confidence_test.ts` → 8 passed (gates + isTrendEvaluable incl. slow-cadence and high-rep cases); `plateau-verdict_test.ts` → 29 passed (regression). Helpers + `index.ts` `deno check` clean.
- Orchestrator test drives bootstrapping → calibrating (3 sessions) → established (6 sessions) and asserts `projections` stays absent — CI `ef-test`.

Merges as "Part of #166".

🤖 Generated with [Claude Code](https://claude.com/claude-code)