### PR TITLE
feat(#286): muscle-axis confidence aggregation from participating patterns

### DIFF
--- a/supabase/functions/_shared/per-muscle-rules.ts
+++ b/supabase/functions/_shared/per-muscle-rules.ts
@@ -17,6 +17,7 @@ import {
   type MovementPattern,
   type PrimaryMuscle,
 } from "./exercise-library.ts";
+import type { ConfidenceWriteState } from "./confidence-lifecycle.ts";
 
 /** ADR-0005 ProgressionTrend enum — must mirror Swift rawValues. */
 export type ProgressionTrend = "progressing" | "plateaued" | "declining";
@@ -280,4 +281,48 @@ export function aggregateStagnationStatus(
     if (profile.trend === "plateaued") sawPlateau = true;
   }
   return sawPlateau ? "plateaued" : "progressing";
+}
+
+/**
+ * Propose a muscle's confidence by AGGREGATING from its participating
+ * movement patterns' confidence (ADR-0020 §"Per-axis gate table"; #286).
+ * Reuses the same `MUSCLE_PARTICIPATING_PATTERNS` walk as
+ * `aggregateStagnationStatus`, and the same convention of skipping patterns
+ * with no profile (never trained). Muscle confidence is parasitic on its
+ * patterns and never exceeds the evidence beneath it.
+ *
+ * - `.established` when at least `ceil(2/3)` of the muscle's participating
+ *   patterns that have a profile are `.established`. The 2/3 supermajority
+ *   mirrors the calibration-review ≥4/6 (=2/3) major-pattern bar; `ceil`
+ *   keeps small participating sets under-claiming.
+ * - `.calibrating` when ≥1 participating pattern has left `.bootstrapping`.
+ * - `.bootstrapping` otherwise — including the empty-effective-set case
+ *   (no participating pattern has a profile yet), which is guarded
+ *   explicitly to avoid the `ceil(0) >= 0` vacuous-truth trap.
+ *
+ * Counts the FULL participating set (incl. isolation / accessory patterns),
+ * NOT just the 6 major patterns — muscles like biceps participate in zero
+ * major patterns, so a major-only rule would make them un-establishable.
+ *
+ * Returns the PROPOSED state (pre-clamp); the caller applies `monotonicAdvance`.
+ */
+export function proposeMuscleConfidence(
+  muscleGroup: MuscleGroup,
+  patternProfiles: Record<string, { confidence: AxisConfidence }>,
+): ConfidenceWriteState {
+  const participating = MUSCLE_PARTICIPATING_PATTERNS[muscleGroup];
+  let withProfile = 0;
+  let established = 0;
+  let pastBootstrap = 0;
+  for (const pattern of participating) {
+    const profile = patternProfiles[pattern];
+    if (profile === undefined) continue; // never trained → not in the effective set
+    withProfile++;
+    if (profile.confidence === "established") established++;
+    if (profile.confidence !== "bootstrapping") pastBootstrap++;
+  }
+  if (withProfile === 0) return "bootstrapping"; // empty-effective-set guard
+  if (established >= Math.ceil(withProfile * (2 / 3))) return "established";
+  if (pastBootstrap >= 1) return "calibrating";
+  return "bootstrapping";
 }

--- a/supabase/functions/_shared/per-muscle-rules_test.ts
+++ b/supabase/functions/_shared/per-muscle-rules_test.ts
@@ -16,6 +16,7 @@ import {
   bootstrapMuscleProfile,
   computeFocusWeight,
   computeVolumeDeficit,
+  proposeMuscleConfidence,
 } from "./per-muscle-rules.ts";
 
 Deno.test("bootstrapMuscleProfile: legs returns ADR-0005 defaults + Q1-locked MEV threshold", () => {
@@ -179,4 +180,57 @@ Deno.test("computeFocusWeight: 1.0 iff muscleGroup ∈ goal.focusAreas (Q4 binar
   assertEquals(computeFocusWeight("legs", ["legs", "back"]), 1.0);
   // Non-membership → 0.0.
   assertEquals(computeFocusWeight("chest", ["legs", "back"]), 0.0);
+});
+
+Deno.test("proposeMuscleConfidence: empty effective set (no participating pattern has a profile) → bootstrapping", () => {
+  assertEquals(proposeMuscleConfidence("legs", {}), "bootstrapping");
+});
+
+Deno.test("proposeMuscleConfidence: all participating patterns still bootstrapping → bootstrapping (no vacuous established)", () => {
+  assertEquals(
+    proposeMuscleConfidence("legs", {
+      squat: { confidence: "bootstrapping" },
+      hip_hinge: { confidence: "bootstrapping" },
+    }),
+    "bootstrapping",
+  );
+});
+
+Deno.test("proposeMuscleConfidence: ≥1 participating pattern past bootstrapping → calibrating", () => {
+  assertEquals(
+    proposeMuscleConfidence("legs", {
+      squat: { confidence: "calibrating" },
+      hip_hinge: { confidence: "bootstrapping" },
+    }),
+    "calibrating",
+  );
+});
+
+Deno.test("proposeMuscleConfidence: 2/3 supermajority established (2 of 2 trained) → established", () => {
+  assertEquals(
+    proposeMuscleConfidence("legs", {
+      squat: { confidence: "established" },
+      hip_hinge: { confidence: "established" },
+    }),
+    "established",
+  );
+});
+
+Deno.test("proposeMuscleConfidence: short of 2/3 (1 of 2 established) → calibrating", () => {
+  assertEquals(
+    proposeMuscleConfidence("legs", {
+      squat: { confidence: "established" },
+      hip_hinge: { confidence: "calibrating" },
+    }),
+    "calibrating",
+  );
+});
+
+Deno.test("proposeMuscleConfidence: biceps (zero major patterns; isolation only) CAN reach established", () => {
+  assertEquals(
+    proposeMuscleConfidence("biceps", {
+      isolation: { confidence: "established" },
+    }),
+    "established",
+  );
 });

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -100,6 +100,7 @@ import {
   bootstrapMuscleProfile,
   computeFocusWeight,
   computeVolumeDeficit,
+  proposeMuscleConfidence,
   MUSCLE_GROUPS,
   MUSCLE_VOLUME_WINDOW,
   type AxisConfidence,
@@ -1138,6 +1139,23 @@ function applyPerMuscleRules(
       profile.focusWeight = newFocusWeight;
       rulesFired.add("muscle-focus-weight");
       fieldsChanged.push(`muscles.${muscleKey}.focusWeight`);
+    }
+
+    // (e) Advance muscle confidence by aggregating from participating
+    // patterns' confidence (ADR-0020 / #286). Reuses the same participating-
+    // patterns walk as stagnationStatus; reads the post-pattern-pipeline
+    // confidence (this pipeline runs after applyPerPatternRules), so a muscle
+    // never claims more confidence than the evidence beneath it. Forward-only.
+    const currentMuscleConfidence =
+      (profile.confidence as ConfidenceWriteState | undefined) ?? "bootstrapping";
+    const advancedMuscleConfidence = monotonicAdvance(
+      currentMuscleConfidence,
+      proposeMuscleConfidence(muscleGroup, patternProfilesForAggregation),
+    );
+    if (advancedMuscleConfidence !== currentMuscleConfidence) {
+      profile.confidence = advancedMuscleConfidence;
+      rulesFired.add("muscle-confidence");
+      fieldsChanged.push(`muscles.${muscleKey}.confidence`);
     }
 
     merged[muscleKey] = profile;

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -2186,6 +2186,49 @@ orchestratorTest(
   },
 );
 
+orchestratorTest(
+  "#286 (ADR-0020): muscle confidence aggregates from its patterns — calibrating then established as its pattern matures",
+  async () => {
+    const userId = await seedFreshUser();
+
+    async function applyBench(day: number): Promise<Record<string, unknown>> {
+      await applySession(
+        {
+          user_id: userId,
+          session_id: crypto.randomUUID(),
+          session_payload: {
+            logged_at: `2026-08-${String(day).padStart(2, "0")}T10:00:00Z`,
+            set_logs: [
+              { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "top" },
+            ],
+          },
+        },
+        sql,
+        { stage2Hook: noopStage2 },
+      );
+      const rows = await sql`
+        SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+      `;
+      return rows[0].model_json as Record<string, unknown>;
+    }
+
+    function muscle(modelJson: Record<string, unknown>): Record<string, unknown> {
+      return (modelJson.muscles as Record<string, Record<string, unknown>>)["chest"];
+    }
+
+    // Chest's only trained participating pattern is horizontal_push (bench).
+    // 3 sessions: pattern calibrating → chest aggregates to calibrating.
+    let modelJson: Record<string, unknown> = {};
+    for (let d = 1; d <= 3; d++) modelJson = await applyBench(d);
+    assertEquals(muscle(modelJson).confidence, "calibrating");
+
+    // 6 sessions: pattern established → chest aggregates to established
+    // (2/3 of its 1 profiled participating pattern = 1).
+    for (let d = 4; d <= 6; d++) modelJson = await applyBench(d);
+    assertEquals(muscle(modelJson).confidence, "established");
+  },
+);
+
 // Sentinel "test" that runs last (alphabetically — Deno runs tests in file
 // order, but this trailing close keeps the connection lifecycle local to
 // the test file rather than relying on process-exit cleanup).


### PR DESCRIPTION
## Slice 5 of 5 (final) — Part of #166

Makes `MuscleProfile.confidence` advance by aggregating from its participating movement patterns' confidence. Runs after the pattern pipeline, so it reads fresh pattern confidence; muscle never claims more than the evidence beneath it.

### Gates (ADR-0020)
- **→ calibrating**: ≥1 participating pattern has left `.bootstrapping`.
- **→ established**: `≥ ceil(2/3)` of the muscle's *profiled* participating patterns are `.established` (2/3 mirrors the calibration ≥4/6 bar; `ceil` keeps small sets under-claiming).
- Counts the **full** participating set (incl. isolation/accessory), not major-only — so **biceps** (which participates in *zero* major patterns; all biceps exercises are isolation) can still establish.
- **Empty / all-bootstrapping effective set guarded**: no vacuous `ceil(0) ≥ 0` established.
- Routed through `monotonicAdvance` (forward-only).

### Scope
`#164`/`#165` untouched — muscle aggregates from patterns, **not** its own volume signal, so volumeTolerance adaptation stays an independent follow-up. (Carry-item verified: isolation/non-major patterns get PatternProfiles + the new sessionCount via the pattern pipeline, so biceps/triceps can reach established.)

### Verification
- `per-muscle-rules_test.ts` → 11 passed (6 new: empty guard, all-bootstrapping, ≥1-past-bootstrap, 2/3 supermajority, short-of-2/3, biceps-zero-major). Helper + `index.ts` `deno check` clean.
- Orchestrator test: chest aggregates bootstrapping → calibrating (3 sessions) → established (6 sessions) as its horizontal_push pattern matures — CI `ef-test`.

Final slice — once merged, #166 can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)