### PR TITLE
feat(#294): EF calibration-review projection derivation

### DIFF
--- a/supabase/functions/_shared/calibration-projection.ts
+++ b/supabase/functions/_shared/calibration-projection.ts
@@ -1,0 +1,117 @@
+// Project Apex — calibration-review projection derivation (#294, Part of #269).
+//
+// Pure helpers that derive per-pattern capability targets at calibration review
+// (ADR-0005 §projections; design pinned during the #269 grilling). Floor =
+// recent demonstrated capability (immovable); stretch = an upward, trend-scaled
+// target (user-adjustable upward only); progress = where current capability
+// sits between them.
+//
+// Uses ONLY live inputs — the per-pattern Epley e1RM session series, the
+// pattern's cadence, and its trend. `ExerciseProfile.e1rmMedian`/`e1rmPeak` are
+// dead fields (never written) and must not be used.
+//
+// Pure: no I/O, no clock reads.
+
+import type { E1RMSession, ProgressionTrend } from "./plateau-verdict.ts";
+import { windowSize } from "./plateau-verdict.ts";
+
+/** `ProjectionProgress` raw values — must mirror the Swift enum. */
+export type ProjectionProgress = "behind" | "on_track" | "ahead" | "achieved";
+
+export interface PatternProjection {
+  pattern: string;
+  floor: number;
+  stretch: number;
+  progress: ProjectionProgress;
+}
+
+/** Plate increment all projection numbers round to (kg). */
+export const PROJECTION_INCREMENT_KG = 2.5;
+
+/** Trend-scaled stretch margin over the floor (ADR-0005 §projections, #269). */
+export const STRETCH_MARGIN_BY_TREND: Record<ProgressionTrend, number> = {
+  progressing: 0.075,
+  plateaued: 0.04,
+  declining: 0.025,
+};
+
+/** Calibration review fires once ≥ this many of the 6 major patterns establish. */
+export const CALIBRATION_REVIEW_MIN_ESTABLISHED_MAJORS = 4;
+
+function roundTo(value: number, increment: number, dir: "down" | "up"): number {
+  const q = value / increment;
+  return (dir === "down" ? Math.floor(q) : Math.ceil(q)) * increment;
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+/**
+ * Recent demonstrated capability for a pattern: the median of the heaviest-
+ * e1RM-per-session over the last `windowSize(cadence)` sessions (the same
+ * window the trend engine uses). Returns null when there is no e1RM history.
+ */
+export function currentCapability(
+  e1rmSessions: E1RMSession[],
+  cadenceDays: number | null,
+): number | null {
+  if (e1rmSessions.length === 0) return null;
+  const ordered = [...e1rmSessions].sort(
+    (a, b) => a.loggedAt.getTime() - b.loggedAt.getTime(),
+  );
+  const window = ordered.slice(-windowSize(cadenceDays)).map((s) => s.e1rm);
+  return median(window);
+}
+
+/** Floor = round-down-to-increment of the recent capability (never overstates). */
+export function deriveFloor(
+  e1rmSessions: E1RMSession[],
+  cadenceDays: number | null,
+): number | null {
+  const capability = currentCapability(e1rmSessions, cadenceDays);
+  if (capability === null) return null;
+  return roundTo(capability, PROJECTION_INCREMENT_KG, "down");
+}
+
+/** Stretch = round-up of floor × (1 + margin(trend)); always ≥ floor + 1 increment. */
+export function deriveStretch(floor: number, trend: ProgressionTrend): number {
+  const raw = floor * (1 + STRETCH_MARGIN_BY_TREND[trend]);
+  const rounded = roundTo(raw, PROJECTION_INCREMENT_KG, "up");
+  return Math.max(rounded, floor + PROJECTION_INCREMENT_KG);
+}
+
+/** Progress of `current` within the floor→stretch band. */
+export function deriveProgress(
+  current: number,
+  floor: number,
+  stretch: number,
+): ProjectionProgress {
+  if (current < floor) return "behind";
+  if (current >= stretch) return "achieved";
+  const pos = (current - floor) / (stretch - floor);
+  return pos < 0.5 ? "on_track" : "ahead";
+}
+
+/**
+ * Derive a full projection for one pattern from its live signal. Returns null
+ * when there is no e1RM history to anchor the floor (the pattern then simply
+ * gets no projection this apply — it is picked up lazily once it has history).
+ */
+export function deriveProjection(
+  pattern: string,
+  e1rmSessions: E1RMSession[],
+  cadenceDays: number | null,
+  trend: ProgressionTrend,
+): PatternProjection | null {
+  const capability = currentCapability(e1rmSessions, cadenceDays);
+  if (capability === null) return null;
+  const floor = roundTo(capability, PROJECTION_INCREMENT_KG, "down");
+  const stretch = deriveStretch(floor, trend);
+  const progress = deriveProgress(capability, floor, stretch);
+  return { pattern, floor, stretch, progress };
+}

--- a/supabase/functions/_shared/calibration-projection_test.ts
+++ b/supabase/functions/_shared/calibration-projection_test.ts
@@ -1,0 +1,79 @@
+// Project Apex — unit tests for calibration-review projection derivation (#294).
+//
+// Run locally:
+//   deno test --allow-all supabase/functions/_shared/calibration-projection_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  deriveFloor,
+  deriveProgress,
+  deriveProjection,
+  deriveStretch,
+} from "./calibration-projection.ts";
+import type { E1RMSession } from "./plateau-verdict.ts";
+
+function sessions(e1rms: number[]): E1RMSession[] {
+  // loggedAt strictly increasing so the "recent window" ordering is well-defined.
+  return e1rms.map((e1rm, i) => ({
+    loggedAt: new Date(2026, 0, i + 1),
+    e1rm,
+    avgRPE: 8,
+  }));
+}
+
+Deno.test("deriveFloor: round-DOWN median of the recent window (fast cadence → 3)", () => {
+  // last 3 of [100,102,104,103] = [102,104,103], median 103 → round down 2.5 → 102.5
+  assertEquals(deriveFloor(sessions([100, 102, 104, 103]), 1), 102.5);
+});
+
+Deno.test("deriveFloor: never overstates — rounds down, not nearest", () => {
+  // median 101 → round down to 100 (not 102.5)
+  assertEquals(deriveFloor(sessions([101, 101, 101]), 1), 100);
+});
+
+Deno.test("deriveFloor: slow cadence widens the window to 4", () => {
+  // cadence > 3.5 → window 4. last 4 of [100,200,100,100,100]=[200,100,100,100] median (100+100)/2=100
+  assertEquals(deriveFloor(sessions([100, 200, 100, 100, 100]), 7), 100);
+});
+
+Deno.test("deriveFloor: no e1RM history → null", () => {
+  assertEquals(deriveFloor(sessions([]), 1), null);
+});
+
+Deno.test("deriveStretch: progressing adds 7.5% then rounds up", () => {
+  // 100 * 1.075 = 107.5 → round up 2.5 → 107.5
+  assertEquals(deriveStretch(100, "progressing"), 107.5);
+});
+
+Deno.test("deriveStretch: declining adds only 2.5%", () => {
+  // 100 * 1.025 = 102.5 → 102.5
+  assertEquals(deriveStretch(100, "declining"), 102.5);
+});
+
+Deno.test("deriveStretch: never collapses to floor — at least one increment above", () => {
+  // tiny floor where margin rounds to floor: 2.5 * 1.025 = 2.5625 → round up → 5.0 ≥ floor+2.5
+  assertEquals(deriveStretch(2.5, "declining"), 5.0);
+});
+
+Deno.test("deriveProgress: below floor → behind", () => {
+  assertEquals(deriveProgress(95, 100, 110), "behind");
+});
+
+Deno.test("deriveProgress: at/above stretch → achieved", () => {
+  assertEquals(deriveProgress(110, 100, 110), "achieved");
+});
+
+Deno.test("deriveProgress: lower half of band → on_track; upper half → ahead", () => {
+  assertEquals(deriveProgress(102, 100, 110), "on_track"); // pos 0.2
+  assertEquals(deriveProgress(106, 100, 110), "ahead"); // pos 0.6
+});
+
+Deno.test("deriveProjection: fresh-from-review pattern starts on_track (current ≈ floor)", () => {
+  // stable 100s: capability 100, floor 100, stretch 107.5 (progressing); current 100 → pos 0 → on_track
+  const p = deriveProjection("squat", sessions([100, 100, 100]), 1, "progressing");
+  assertEquals(p, { pattern: "squat", floor: 100, stretch: 107.5, progress: "on_track" });
+});
+
+Deno.test("deriveProjection: no e1RM history → null (no projection this apply)", () => {
+  assertEquals(deriveProjection("squat", sessions([]), 1, "progressing"), null);
+});

--- a/supabase/functions/_shared/plateau-verdict.ts
+++ b/supabase/functions/_shared/plateau-verdict.ts
@@ -45,7 +45,7 @@ export interface E1RMSession {
  * for the wider between-session noise floor). Nil cadence (no
  * derived value yet) defaults to the 3-session window.
  */
-const windowSize = (cadenceDays: number | null): number => {
+export const windowSize = (cadenceDays: number | null): number => {
   if (cadenceDays === null) return 3;
   return cadenceDays <= FREQUENCY_SCALED_WINDOW_CADENCE_THRESHOLD_DAYS ? 3 : 4;
 };

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -73,6 +73,13 @@ import {
 } from "../_shared/plateau-verdict.ts";
 import { proposePatternConfidence } from "../_shared/pattern-confidence.ts";
 import {
+  CALIBRATION_REVIEW_MIN_ESTABLISHED_MAJORS,
+  currentCapability,
+  deriveProgress,
+  deriveProjection,
+  type PatternProjection,
+} from "../_shared/calibration-projection.ts";
+import {
   appendObservation,
   shouldContribute,
   type InterSessionGapBucket,
@@ -110,6 +117,7 @@ import {
 import {
   CLASSIFIER_BOOTSTRAP_MAX_NOTES,
   CLASSIFIER_BOOTSTRAP_MAX_SESSIONS,
+  MAJOR_PATTERNS,
 } from "../_shared/constants.ts";
 import {
   derivedTrainedJoints,
@@ -1927,6 +1935,90 @@ export async function applySession(
         };
         rulesFired.push("global-phase-advance");
         fieldsChanged.push("lastGlobalPhaseAdvanceFiredAtSessionCount");
+      }
+
+      // #294 (#269): calibration-review projection derivation. Runs at the
+      // pipeline tail so it reads FINALIZED pattern confidence. Once ≥4/6 major
+      // patterns are .established the review is active: set calibrationReviewFiredAt
+      // once (drives the one-time banner), lazily derive a projection for each
+      // established major lacking one (so late-maturing majors get one too;
+      // existing floors are never re-derived), and recompute each projection's
+      // progress (current capability moves). Advance/derive-only — never writes
+      // goal/renegotiation state. Per the #269 grilling + ADR-0005 §projections.
+      const patternsForProj =
+        (newModelJson.patterns as Record<string, Record<string, unknown>> | undefined) ?? {};
+      const exercisesForProj =
+        (newModelJson.exercises as Record<string, Record<string, unknown>> | undefined) ?? {};
+      const priorProjections = newModelJson.projections as {
+        patternProjections?: PatternProjection[];
+        calibrationReviewFiredAt?: string | null;
+        goalLastRenegotiatedAt?: string | null;
+      } | undefined;
+      const establishedMajors = MAJOR_PATTERNS.filter(
+        (mp) => (patternsForProj[mp]?.confidence as string | undefined) === "established",
+      );
+      let calibrationFiredAt = priorProjections?.calibrationReviewFiredAt ?? null;
+      const reviewActive = calibrationFiredAt !== null ||
+        establishedMajors.length >= CALIBRATION_REVIEW_MIN_ESTABLISHED_MAJORS;
+
+      if (reviewActive) {
+        const cadenceFor = (mp: string): number | null =>
+          sessionsCadenceDays(
+            (patternsForProj[mp]?.recentSessionDates as string[] | undefined) ?? [],
+          );
+        const projById = new Map<string, PatternProjection>();
+        for (const p of priorProjections?.patternProjections ?? []) {
+          projById.set(p.pattern, p);
+        }
+        let projectionsChanged = false;
+
+        if (calibrationFiredAt === null) {
+          calibrationFiredAt = incomingLoggedAt.toISOString();
+          projectionsChanged = true;
+          rulesFired.push("calibration-review-fired");
+        }
+
+        // Lazy-derive established majors that lack a projection.
+        for (const mp of establishedMajors) {
+          if (projById.has(mp)) continue;
+          const derived = deriveProjection(
+            mp,
+            patternE1RMSessions(mp, exercisesForProj),
+            cadenceFor(mp),
+            (patternsForProj[mp]?.trend as ProgressionTrend) ?? "progressing",
+          );
+          if (derived !== null) {
+            projById.set(mp, derived);
+            projectionsChanged = true;
+          }
+        }
+
+        // Recompute progress for every existing projection.
+        for (const [mp, proj] of projById) {
+          const current = currentCapability(
+            patternE1RMSessions(mp, exercisesForProj),
+            cadenceFor(mp),
+          );
+          if (current === null) continue;
+          const newProgress = deriveProgress(current, proj.floor, proj.stretch);
+          if (newProgress !== proj.progress) {
+            projById.set(mp, { ...proj, progress: newProgress });
+            projectionsChanged = true;
+          }
+        }
+
+        if (projectionsChanged) {
+          newModelJson = {
+            ...newModelJson,
+            projections: {
+              patternProjections: Array.from(projById.values()),
+              calibrationReviewFiredAt: calibrationFiredAt,
+              goalLastRenegotiatedAt: priorProjections?.goalLastRenegotiatedAt ?? null,
+            },
+          };
+          rulesFired.push("calibration-projection");
+          fieldsChanged.push("projections");
+        }
       }
     }
 

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -2229,6 +2229,70 @@ orchestratorTest(
   },
 );
 
+orchestratorTest(
+  "#294 (#269): calibration review fires + derives projections once ≥4/6 major patterns establish; never before",
+  async () => {
+    const userId = await seedFreshUser();
+
+    // A full-body session training 4 distinct major patterns with stable loads.
+    async function applyFullBody(day: number): Promise<Record<string, unknown>> {
+      await applySession(
+        {
+          user_id: userId,
+          session_id: crypto.randomUUID(),
+          session_payload: {
+            logged_at: `2026-09-${String(day).padStart(2, "0")}T10:00:00Z`,
+            set_logs: [
+              { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "top" }, // horizontal_push
+              { exercise_id: "barbell_back_squat", set_number: 1, weight_kg: 140, reps_completed: 5, intent: "top" }, // squat
+              { exercise_id: "barbell_row", set_number: 1, weight_kg: 80, reps_completed: 5, intent: "top" }, // horizontal_pull
+              { exercise_id: "overhead_press", set_number: 1, weight_kg: 60, reps_completed: 5, intent: "top" }, // vertical_push
+            ],
+          },
+        },
+        sql,
+        { stage2Hook: noopStage2 },
+      );
+      const rows = await sql`
+        SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+      `;
+      return rows[0].model_json as Record<string, unknown>;
+    }
+
+    // After 5 sessions the 4 majors are still .calibrating → review NOT fired,
+    // no projections.
+    let modelJson: Record<string, unknown> = {};
+    for (let d = 1; d <= 5; d++) modelJson = await applyFullBody(d);
+    const before = modelJson.projections as Record<string, unknown> | undefined;
+    if (before !== undefined) {
+      assertEquals(before.calibrationReviewFiredAt ?? null, null);
+      assertEquals((before.patternProjections as unknown[] | undefined)?.length ?? 0, 0);
+    }
+
+    // 6th session: all 4 majors reach .established → ≥4/6 → review fires + derives.
+    modelJson = await applyFullBody(6);
+    const proj = modelJson.projections as {
+      patternProjections: Array<Record<string, unknown>>;
+      calibrationReviewFiredAt: string | null;
+    };
+    assertExists(proj);
+    assertEquals(proj.calibrationReviewFiredAt !== null, true);
+    assertEquals(proj.patternProjections.length, 4);
+    const patterns = proj.patternProjections.map((p) => p.pattern as string).sort();
+    assertEquals(patterns, ["horizontal_pull", "horizontal_push", "squat", "vertical_push"]);
+    for (const p of proj.patternProjections) {
+      const floor = p.floor as number;
+      const stretch = p.stretch as number;
+      assertEquals(floor > 0, true);
+      assertEquals(stretch > floor, true);
+      assertEquals(
+        ["behind", "on_track", "ahead", "achieved"].includes(p.progress as string),
+        true,
+      );
+    }
+  },
+);
+
 // Sentinel "test" that runs last (alphabetically — Deno runs tests in file
 // order, but this trailing close keeps the connection lifecycle local to
 // the test file rather than relying on process-exit cleanup).


### PR DESCRIPTION
## S1 of 5 — Part of #269

Derives per-pattern projections server-side when the calibration review fires (≥4/6 major patterns `.established`).

### Logic (pipeline tail, reads finalized confidence)
- **Per-pattern lazy derive**: each established major lacking a projection gets floor/stretch/progress; floors never re-derived; late-maturing majors picked up when they establish.
- **One-time** `calibrationReviewFiredAt` (≥4/6 majors → drives the banner).
- **Recompute progress** for existing projections each apply.
- **Derive-only** — never writes goal/renegotiation state.

### Formulas (live inputs only; `e1rmMedian`/`e1rmPeak` are dead)
- floor = round-down-2.5kg(median(last windowSize(cadence)=3–4 per-session Epley e1RMs))
- stretch = round-up-2.5kg(floor × (1+margin(trend))); margin progressing 7.5% / plateaued 4% / declining 2.5%; ≥ floor+2.5
- progress: behind (<floor), achieved (≥stretch), else on_track/ahead at midpoint

### Verification
- 12 unit tests (incl. asymmetric-error round-down floor, no-history→null, fresh-from-review→on_track) + plateau-verdict regression (29). Helper + index + orchestrator_test `deno check` clean.
- Orchestrator integration: 6 full-body sessions → 4 majors establish → review fires, 4 projections derived; nothing before. CI `ef-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)