### PR TITLE
feat(#295): iOS calibration-review read-only screen + one-time banner

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
 		C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */; };
 		258DE1F12E000000000000A2 /* HeavyReassessmentBannerCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258DE1F12E000000000000A1 /* HeavyReassessmentBannerCopyTests.swift */; };
+		269DE1F12E000000000000B2 /* CalibrationReviewBannerCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269DE1F12E000000000000B1 /* CalibrationReviewBannerCopyTests.swift */; };
 		C88AB47564E9AD1E0A3C2197 /* TraineeModelUpdateJobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */; };
 		E50E3B4CBD53ED7ABE725DB8 /* EquipmentCatalogSeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DB10776DEDCE5720292FE8 /* EquipmentCatalogSeedTests.swift */; };
 /* End PBXBuildFile section */
@@ -107,6 +108,7 @@
 		70E3BA94C76430CACFD657B5 /* EquipmentRounderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EquipmentRounderTests.swift; sourceTree = "<group>"; };
 		7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelDigestTests.swift; sourceTree = "<group>"; };
 		258DE1F12E000000000000A1 /* HeavyReassessmentBannerCopyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeavyReassessmentBannerCopyTests.swift; sourceTree = "<group>"; };
+		269DE1F12E000000000000B1 /* CalibrationReviewBannerCopyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalibrationReviewBannerCopyTests.swift; sourceTree = "<group>"; };
 		85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelInteractionsTests.swift; sourceTree = "<group>"; };
 		862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelUpdateJobTests.swift; sourceTree = "<group>"; };
 		878B35DC7A9EFE48E1A0B285 /* TraineeModelProfilesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelProfilesTests.swift; sourceTree = "<group>"; };
@@ -260,6 +262,7 @@
 				66C0DE0066C0DE0066C0DE01 /* SetLogPayloadEncoderTests.swift */,
 				7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */,
 				258DE1F12E000000000000A1 /* HeavyReassessmentBannerCopyTests.swift */,
+				269DE1F12E000000000000B1 /* CalibrationReviewBannerCopyTests.swift */,
 				6437BED8DCD7F98C80FF4377 /* TraineeModelServiceTests.swift */,
 				862D553D94F677C0BB009B74 /* TraineeModelUpdateJobTests.swift */,
 				A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */,
@@ -413,6 +416,7 @@
 				66C0DE0066C0DE0066C0DE02 /* SetLogPayloadEncoderTests.swift in Sources */,
 				C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */,
 				258DE1F12E000000000000A2 /* HeavyReassessmentBannerCopyTests.swift in Sources */,
+				269DE1F12E000000000000B2 /* CalibrationReviewBannerCopyTests.swift in Sources */,
 				6587F62EDC961A3C558A6226 /* TraineeModelServiceTests.swift in Sources */,
 				C88AB47564E9AD1E0A3C2197 /* TraineeModelUpdateJobTests.swift in Sources */,
 				A3741A0001CAFE0001CAFE01 /* LateArrivalNotificationQueueTests.swift in Sources */,

--- a/ProjectApex/Features/Workout/CalibrationReviewBannerCopy.swift
+++ b/ProjectApex/Features/Workout/CalibrationReviewBannerCopy.swift
@@ -1,0 +1,47 @@
+// Features/Workout/CalibrationReviewBannerCopy.swift
+// ProjectApex — #269
+//
+// Pure copy logic for the pre-workout calibration-review banner. The SwiftUI
+// body isn't unit-testable, so the copy lives here and is exercised directly
+// by CalibrationReviewBannerCopyTests.
+//
+// The banner is a one-time affordance: constant title + tone, naming the
+// patterns the calibration review set targets for, and offering a "Review
+// targets" CTA into the read-only projection screen.
+
+import Foundation
+
+enum CalibrationReviewBannerCopy {
+
+    /// Constant banner title — tone is fixed here (#269).
+    static let title = "Your starting targets are ready"
+
+    /// Banner body for a calibration-review signal (#269). Names up to 3
+    /// patterns via `MovementPattern.displayName`, collapsing the remainder to
+    /// "and more" beyond 3. Returns a generic fallback when the projection list
+    /// is empty (defensive — the signal isn't produced when empty).
+    static func body(for signal: CalibrationReviewSignal) -> String {
+        let patterns = signal.projections.map(\.pattern)
+        guard !patterns.isEmpty else {
+            return "We've set your starting targets — take a look."
+        }
+        let named = patterns.prefix(3).map(\.displayName)
+        let listed = patterns.count > 3
+            ? named.joined(separator: ", ") + ", and more"
+            : naturalJoin(named)
+        return "We've set floor and stretch targets for your \(listed) — take a look."
+    }
+
+    /// Joins names with commas and a final "and": ["a"] → "a";
+    /// ["a","b"] → "a and b"; ["a","b","c"] → "a, b, and c" (Oxford comma at 3+).
+    private static func naturalJoin(_ names: [String]) -> String {
+        switch names.count {
+        case 0:  return ""
+        case 1:  return names[0]
+        case 2:  return "\(names[0]) and \(names[1])"
+        default:
+            let head = names.dropLast().joined(separator: ", ")
+            return "\(head), and \(names[names.count - 1])"
+        }
+    }
+}

--- a/ProjectApex/Features/Workout/CalibrationReviewView.swift
+++ b/ProjectApex/Features/Workout/CalibrationReviewView.swift
@@ -1,0 +1,212 @@
+// CalibrationReviewView.swift
+// ProjectApex — Features/Workout
+//
+// #269 S2: the read-only calibration-review display the pre-workout
+// calibration banner's "Review targets" CTA presents. "Your starting targets
+// are ready" — this screen shows the per-pattern floor/stretch projections set
+// at calibration review, plus each pattern's progress state. Nothing is
+// editable here.
+//
+// On "Got it" it calls the local `acknowledgeCalibrationReview()` (mirrors the
+// heavy-reassessment local ack) so the banner disappears immediately, then
+// dismisses.
+
+import SwiftUI
+
+struct CalibrationReviewView: View {
+
+    /// Per-pattern floor/stretch projections to display. Passed in from the
+    /// calibration-review signal (already sorted by pattern.rawValue).
+    let projections: [PatternProjection]
+
+    @Environment(AppDependencies.self) private var deps
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var isAcknowledging: Bool = false
+
+    private static let accentPurple = Color(red: 0.58, green: 0.45, blue: 0.95)
+    private static let darkChrome = Color(red: 0.04, green: 0.04, blue: 0.06)
+
+    init(projections: [PatternProjection]) {
+        self.projections = projections
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Self.darkChrome.ignoresSafeArea()
+
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        introCard
+                        projectionsCard
+                        gotItButton
+                        Color.clear.frame(height: 24)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 16)
+                }
+            }
+            .navigationTitle("Your Targets")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(Self.darkChrome, for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Intro
+
+    private var introCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader("WHAT THIS MEANS")
+            Text("Your starting targets are ready. Floor is the level we'll keep you at; stretch is the next milestone to aim for.")
+                .font(.system(size: 13))
+                .foregroundStyle(.white.opacity(0.55))
+        }
+        .calibrationCardChrome()
+    }
+
+    // MARK: - Projections (read-only)
+
+    private var projectionsCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionHeader("STARTING TARGETS")
+
+            if projections.isEmpty {
+                Text("No targets yet — log a few sessions and they'll appear here.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.white.opacity(0.40))
+                    .padding(.vertical, 4)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(Array(projections.enumerated()), id: \.element.pattern) { index, projection in
+                        projectionRow(projection)
+                        if index != projections.count - 1 {
+                            Divider().background(Color.white.opacity(0.06))
+                        }
+                    }
+                }
+            }
+        }
+        .calibrationCardChrome()
+    }
+
+    private func projectionRow(_ projection: PatternProjection) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(projection.pattern.displayName)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.white)
+                Spacer()
+                Text(Self.progressLabel(projection.progress))
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Self.accentPurple)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(Self.accentPurple.opacity(0.14), in: Capsule())
+            }
+            HStack(spacing: 16) {
+                Text("Floor: \(Self.formatWeight(projection.floor)) kg")
+                    .font(.system(size: 13).monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.65))
+                Text("Stretch: \(Self.formatWeight(projection.stretch)) kg")
+                    .font(.system(size: 13).monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.65))
+            }
+        }
+        .padding(.vertical, 12)
+    }
+
+    // MARK: - Got it
+
+    private var gotItButton: some View {
+        Button {
+            Task { await acknowledge() }
+        } label: {
+            Text(isAcknowledging ? "Saving\u{2026}" : "Got it")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 56)
+                .background(Self.accentPurple.opacity(isAcknowledging ? 0.40 : 0.85),
+                           in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .stroke(.white.opacity(0.20), lineWidth: 0.5)
+                )
+        }
+        .disabled(isAcknowledging)
+        .padding(.top, 8)
+    }
+
+    // MARK: - Acknowledge
+
+    @MainActor
+    private func acknowledge() async {
+        isAcknowledging = true
+        defer { isAcknowledging = false }
+        try? await deps.traineeModelService.acknowledgeCalibrationReview()
+        dismiss()
+    }
+
+    // MARK: - Section header
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(.white.opacity(0.40))
+            .kerning(0.8)
+    }
+
+    // MARK: - Display helpers
+
+    /// Maps a ProjectionProgress to its human-facing label.
+    private static func progressLabel(_ progress: ProjectionProgress) -> String {
+        switch progress {
+        case .behind:   return "Behind"
+        case .onTrack:  return "On track"
+        case .ahead:    return "Ahead"
+        case .achieved: return "Achieved"
+        }
+    }
+
+    /// Renders a weight, dropping a trailing ".0" so whole kilos read cleanly.
+    private static func formatWeight(_ value: Double) -> String {
+        value == value.rounded()
+            ? String(Int(value))
+            : String(format: "%.1f", value)
+    }
+}
+
+// MARK: - Card chrome
+
+private extension View {
+    /// The translucent rounded-card surface used across the dark-chrome feature
+    /// screens (matches GoalReviewView's `cardChrome`). Named distinctly to avoid
+    /// clashing with that file's private extension.
+    func calibrationCardChrome() -> some View {
+        self
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .background(Color.white.opacity(0.06),
+                        in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
+            )
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    CalibrationReviewView(projections: [
+        PatternProjection(pattern: .squat, floor: 100, stretch: 107.5, progress: .onTrack),
+        PatternProjection(pattern: .horizontalPush, floor: 80, stretch: 85, progress: .behind),
+        PatternProjection(pattern: .hipHinge, floor: 140, stretch: 150, progress: .ahead),
+    ])
+    .environment(AppDependencies())
+}

--- a/ProjectApex/Features/Workout/PreWorkoutView.swift
+++ b/ProjectApex/Features/Workout/PreWorkoutView.swift
@@ -51,6 +51,13 @@ struct PreWorkoutView: View {
     /// Called when the user taps "Review goals" on the heavy-reassessment banner.
     /// Injected; a later slice (#258 E2) wires it to the goal-review screen. Default no-op.
     var onReviewGoals: () -> Void = {}
+    /// Calibration-review signal (#269). When present (and not locally dismissed),
+    /// shows the one-time targets banner. Takes precedence over the heavy-
+    /// reassessment banner when both are present. Nil → no calibration banner.
+    var calibrationReviewSignal: CalibrationReviewSignal? = nil
+    /// Called when the user taps "Review targets" on the calibration banner (#269).
+    /// Wired to the read-only calibration screen. Default no-op.
+    var onReviewCalibration: () -> Void = {}
     /// Called when the user taps "Skip this session". Defers this day without recording
     /// any session data — the next pending non-skipped day becomes the active session.
     var onSkipSession: (() -> Void)? = nil
@@ -63,6 +70,7 @@ struct PreWorkoutView: View {
     @State private var showSkipConfirmation: Bool = false
     @State private var welcomeBackBannerDismissed: Bool = false
     @State private var heavyReassessmentBannerDismissed: Bool = false
+    @State private var calibrationBannerDismissed: Bool = false
 
     // MARK: - Body
 
@@ -80,7 +88,12 @@ struct PreWorkoutView: View {
                         if isFirstSession {
                             firstSessionBanner
                         }
-                        if let signal = heavyReassessmentSignal, !heavyReassessmentBannerDismissed {
+                        // Precedence (#269): the calibration banner takes priority; the
+                        // heavy-reassessment banner shows only when the calibration banner
+                        // is not currently shown.
+                        if let calibration = calibrationReviewSignal, !calibrationBannerDismissed {
+                            calibrationReviewBanner(calibration)
+                        } else if let signal = heavyReassessmentSignal, !heavyReassessmentBannerDismissed {
                             heavyReassessmentBanner(signal)
                         }
                         if let days = daysSinceLastSession, days >= 14, !welcomeBackBannerDismissed {
@@ -396,6 +409,56 @@ struct PreWorkoutView: View {
             Spacer(minLength: 0)
             Button {
                 heavyReassessmentBannerDismissed = true
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.40))
+                    .padding(6)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(
+            accentColor.opacity(0.10),
+            in: RoundedRectangle(cornerRadius: 14, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(accentColor.opacity(0.25), lineWidth: 0.5)
+        )
+    }
+
+    // MARK: - Calibration Review Banner (#269)
+
+    private func calibrationReviewBanner(_ signal: CalibrationReviewSignal) -> some View {
+        // Distinct blue/purple accent so this card reads apart from the amber
+        // firstSession/welcomeBack banners and the green heavy-reassessment one (#269).
+        let accentColor = Color(red: 0.58, green: 0.45, blue: 0.95)
+        return HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "target")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(accentColor)
+            VStack(alignment: .leading, spacing: 8) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(CalibrationReviewBannerCopy.title)
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundStyle(.white)
+                    Text(CalibrationReviewBannerCopy.body(for: signal))
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundStyle(.white.opacity(0.80))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Button {
+                    onReviewCalibration()
+                } label: {
+                    Text("Review targets")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(accentColor)
+                }
+            }
+            Spacer(minLength: 0)
+            Button {
+                calibrationBannerDismissed = true
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 11, weight: .semibold))

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -47,6 +47,14 @@ struct WorkoutView: View {
     /// banner CTA (#258 E2). On dismiss the signal is re-derived; a saved goal will
     /// have acknowledged the trigger (Slice F1), so the banner then disappears.
     @State private var showGoalReview = false
+    /// Calibration-review signal derived from the cached trainee model (#269).
+    /// Drives the one-time targets banner in PreWorkoutView. Nil when no model /
+    /// review not fired / already acknowledged.
+    @State private var calibrationReviewSignal: CalibrationReviewSignal? = nil
+    /// True while the read-only calibration-review screen is presented from the
+    /// banner CTA (#269). On dismiss the signal is re-derived; acknowledging the
+    /// screen sets calibrationReviewAcknowledged, so the banner then disappears.
+    @State private var showCalibrationReview = false
     /// True when a crash-recovered PausedSessionState exists but its trainingDayId
     /// does not match the current day (and ContentView hasn't handled it via Path A).
     /// Shows a recovery dialog so the user can choose how to proceed.
@@ -148,6 +156,10 @@ struct WorkoutView: View {
             // Read the cached trainee-model digest (minimal existing path — no new
             // service plumbing). Nil model / out-of-window / acknowledged → nil → no banner.
             heavyReassessmentSignal = await deps.traineeModelService.digest()?.heavyReassessmentSignal
+
+            // Calibration-review signal for the pre-workout one-time targets banner (#269).
+            // Same cached-digest path. Nil model / not-fired / acknowledged → nil → no banner.
+            calibrationReviewSignal = await deps.traineeModelService.digest()?.calibrationReviewSignal
 
             guard let vm = viewModel else { return }
 
@@ -278,6 +290,17 @@ struct WorkoutView: View {
                 .presentationDetents([.large])
                 .presentationCornerRadius(24)
         }
+        .sheet(isPresented: $showCalibrationReview, onDismiss: {
+            // Re-derive: the read-only screen's "Got it" acknowledges the review
+            // (#269), so deriveCalibrationReviewSignal now returns nil and the
+            // banner disappears. A mere swipe-dismiss leaves it unchanged.
+            Task {
+                calibrationReviewSignal = await deps.traineeModelService.digest()?.calibrationReviewSignal
+            }
+        }) {
+            CalibrationReviewView(projections: calibrationReviewSignal?.projections ?? [])
+                .presentationDetents([.large])
+        }
         .alert("Session Mismatch", isPresented: $showMismatchRecoveryAlert) {
             Button("Start Fresh") {
                 // Clear the orphaned sentinel so the user can start a new session.
@@ -318,6 +341,10 @@ struct WorkoutView: View {
                 heavyReassessmentSignal: heavyReassessmentSignal,
                 onReviewGoals: {
                     showGoalReview = true
+                },
+                calibrationReviewSignal: calibrationReviewSignal,
+                onReviewCalibration: {
+                    showCalibrationReview = true
                 },
                 onSkipSession: onSkipSession,
                 onBack: onBack,

--- a/ProjectApex/Models/TraineeModel.swift
+++ b/ProjectApex/Models/TraineeModel.swift
@@ -45,6 +45,10 @@ struct TraineeModel: Codable, Sendable, Hashable {
     /// `TraineeModelDigest.deriveHeavyReassessmentSignal`. Grows ~1 int per GPA
     /// event (≤ ~40/yr), so no pruning is needed.
     var acknowledgedTriggeringSessionCounts: Set<Int>
+    /// Whether the user has seen the one-time calibration-review display (#269).
+    /// Set true once they acknowledge the read-only projection screen, which
+    /// suppresses the banner via `TraineeModelDigest.deriveCalibrationReviewSignal`.
+    var calibrationReviewAcknowledged: Bool
 
     init(
         activeProgramId: UUID? = nil,
@@ -64,7 +68,8 @@ struct TraineeModel: Codable, Sendable, Hashable {
         totalSessionCount: Int = 0,
         lastClassifiedNoteCreatedAt: Date? = nil,
         lastGlobalPhaseAdvanceFiredAtSessionCount: Int? = nil,
-        acknowledgedTriggeringSessionCounts: Set<Int> = []
+        acknowledgedTriggeringSessionCounts: Set<Int> = [],
+        calibrationReviewAcknowledged: Bool = false
     ) {
         self.activeProgramId = activeProgramId
         self.goal = goal
@@ -84,6 +89,7 @@ struct TraineeModel: Codable, Sendable, Hashable {
         self.lastClassifiedNoteCreatedAt = lastClassifiedNoteCreatedAt
         self.lastGlobalPhaseAdvanceFiredAtSessionCount = lastGlobalPhaseAdvanceFiredAtSessionCount
         self.acknowledgedTriggeringSessionCounts = acknowledgedTriggeringSessionCounts
+        self.calibrationReviewAcknowledged = calibrationReviewAcknowledged
     }
 
     // MARK: Custom Codable for JSONB shape parity (slice A12 / #83)
@@ -118,6 +124,7 @@ struct TraineeModel: Codable, Sendable, Hashable {
         case lastClassifiedNoteCreatedAt
         case lastGlobalPhaseAdvanceFiredAtSessionCount
         case acknowledgedTriggeringSessionCounts
+        case calibrationReviewAcknowledged = "calibration_review_acknowledged"
     }
 
     init(from decoder: Decoder) throws {
@@ -200,6 +207,11 @@ struct TraineeModel: Codable, Sendable, Hashable {
         self.acknowledgedTriggeringSessionCounts = Set(try c.decodeIfPresent(
             [Int].self, forKey: .acknowledgedTriggeringSessionCounts
         ) ?? [])
+        // Tolerant decode (#269): older rows / server JSON lack the key — default
+        // to false (the banner is still eligible to fire).
+        self.calibrationReviewAcknowledged = try c.decodeIfPresent(
+            Bool.self, forKey: .calibrationReviewAcknowledged
+        ) ?? false
     }
 
     func encode(to encoder: Encoder) throws {
@@ -236,6 +248,7 @@ struct TraineeModel: Codable, Sendable, Hashable {
         // hash-ordered (randomized per-process), which breaks model_json parity
         // (cf. prescriptionAccuracy / recentlyAdvancedPatterns sorting). #258.
         try c.encode(acknowledgedTriggeringSessionCounts.sorted(), forKey: .acknowledgedTriggeringSessionCounts)
+        try c.encode(calibrationReviewAcknowledged, forKey: .calibrationReviewAcknowledged)
     }
 
     // MARK: Major patterns (calibration / phase-advance gating)

--- a/ProjectApex/Models/TraineeModelDigest.swift
+++ b/ProjectApex/Models/TraineeModelDigest.swift
@@ -81,6 +81,10 @@ struct TraineeModelDigest: Codable, Sendable, Hashable {
     /// this projection is derived at iOS digest-assembly time from that
     /// persisted value plus the per-pattern transition log (#178).
     var heavyReassessmentSignal: HeavyReassessmentSignal?
+    /// Present iff the calibration review has fired and the user has not yet
+    /// acknowledged the one-time read-only projection display (#269). Drives the
+    /// pre-workout calibration banner + read-only target screen. Nil otherwise.
+    var calibrationReviewSignal: CalibrationReviewSignal?
 
     /// Threshold below which a fatigue interaction is excluded from
     /// coaching prompts per ADR-0005.
@@ -119,7 +123,22 @@ struct TraineeModelDigest: Codable, Sendable, Hashable {
         case perExerciseSummary        = "per_exercise_summary"
         case weeklyFatigue             = "weekly_fatigue"
         case heavyReassessmentSignal   = "heavy_reassessment_signal"
+        case calibrationReviewSignal   = "calibration_review_signal"
     }
+}
+
+// MARK: - CalibrationReviewSignal
+
+/// Present iff calibration review has fired (server set
+/// `ProjectionState.calibrationReviewFiredAt`) and the user has not yet
+/// acknowledged the one-time read-only projection display (#269). Carries the
+/// per-pattern floor/stretch projections to render the read-only target screen.
+struct CalibrationReviewSignal: Codable, Sendable, Hashable {
+    /// Per-pattern floor/stretch projections, sorted by `pattern.rawValue` for
+    /// deterministic ordering.
+    var projections: [PatternProjection]
+
+    enum CodingKeys: String, CodingKey { case projections }
 }
 
 // MARK: - HeavyReassessmentSignal
@@ -208,6 +227,7 @@ extension TraineeModelDigest {
             ?? WeekFatigueSignals.compute(from: [], sessionCount: 0)
 
         let heavyReassessmentSignal = Self.deriveHeavyReassessmentSignal(from: model)
+        let calibrationReviewSignal = Self.deriveCalibrationReviewSignal(from: model)
 
         self.init(
             goal: model.goal,
@@ -223,7 +243,8 @@ extension TraineeModelDigest {
             lastGlobalPhaseAdvanceFiredAtSessionCount: model.lastGlobalPhaseAdvanceFiredAtSessionCount,
             perExerciseSummary: perExerciseSummary,
             weeklyFatigue: resolvedWeeklyFatigue,
-            heavyReassessmentSignal: heavyReassessmentSignal
+            heavyReassessmentSignal: heavyReassessmentSignal,
+            calibrationReviewSignal: calibrationReviewSignal
         )
     }
 
@@ -258,6 +279,19 @@ extension TraineeModelDigest {
             sessionsSinceTriggered: delta,
             recentlyAdvancedPatterns: recentPatterns
         )
+    }
+
+    /// Returns a signal iff calibration review has fired and the user has not yet
+    /// acknowledged the one-time read-only display (#269). Nil when review hasn't
+    /// fired, when already acknowledged, or when there are no projections to show.
+    static func deriveCalibrationReviewSignal(
+        from model: TraineeModel
+    ) -> CalibrationReviewSignal? {
+        guard let proj = model.projections, proj.calibrationReviewFiredAt != nil else { return nil }
+        guard !model.calibrationReviewAcknowledged else { return nil }
+        let ps = proj.patternProjections.sorted { $0.pattern.rawValue < $1.pattern.rawValue }
+        guard !ps.isEmpty else { return nil }
+        return CalibrationReviewSignal(projections: ps)
     }
 }
 

--- a/ProjectApex/Services/TraineeModelService.swift
+++ b/ProjectApex/Services/TraineeModelService.swift
@@ -106,6 +106,16 @@ actor TraineeModelService {
         try await store.save(model)
     }
 
+    /// #269: records local acknowledgment of the one-time calibration-review
+    /// display so the pre-workout calibration banner disappears immediately once
+    /// the user has seen the read-only projection screen. No-op if no model is
+    /// cached. Idempotent (a plain Bool set).
+    func acknowledgeCalibrationReview() async throws {
+        guard var model = await store.load() else { return }
+        model.calibrationReviewAcknowledged = true
+        try await store.save(model)
+    }
+
     // MARK: - Write — enqueue path
 
     /// Enqueues a `trainee_model_update` item carrying the session-

--- a/ProjectApexTests/CalibrationReviewBannerCopyTests.swift
+++ b/ProjectApexTests/CalibrationReviewBannerCopyTests.swift
@@ -1,0 +1,57 @@
+// CalibrationReviewBannerCopyTests.swift
+// ProjectApexTests
+//
+// Verifies the pure copy helper for the pre-workout calibration-review banner
+// (#269). The SwiftUI body isn't unit-testable, so the copy logic lives in
+// CalibrationReviewBannerCopy and is exercised here.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("CalibrationReviewBannerCopy")
+struct CalibrationReviewBannerCopyTests {
+
+    /// Builds a signal naming the given patterns (floor/stretch values are
+    /// irrelevant to the copy — only the pattern displayNames are surfaced).
+    private func signal(_ patterns: [MovementPattern]) -> CalibrationReviewSignal {
+        CalibrationReviewSignal(
+            projections: patterns.map {
+                PatternProjection(pattern: $0, floor: 100, stretch: 110, progress: .onTrack)
+            }
+        )
+    }
+
+    @Test("names a single pattern via displayName — no raw snake_case tokens leak")
+    func onePatternUsesDisplayName() {
+        let body = CalibrationReviewBannerCopy.body(for: signal([.horizontalPush]))
+        #expect(body.contains("Horizontal Push"))
+        #expect(!body.contains("_"), "body leaked a raw machine token: \(body)")
+    }
+
+    @Test("names up to three patterns via displayName — no raw snake_case tokens leak")
+    func threePatternsUseDisplayNames() {
+        let body = CalibrationReviewBannerCopy.body(
+            for: signal([.squat, .horizontalPush, .hipHinge])
+        )
+        #expect(body.contains("Squat"))
+        #expect(body.contains("Horizontal Push"))
+        #expect(body.contains("Hip Hinge"))
+        #expect(!body.contains("_"), "body leaked a raw machine token: \(body)")
+    }
+
+    @Test("caps at three named patterns then collapses the remainder to \"and more\"")
+    func fourOrMorePatternsCapAtThree() {
+        let body = CalibrationReviewBannerCopy.body(
+            for: signal([.squat, .horizontalPush, .hipHinge, .lunge])
+        )
+        #expect(body.contains("and more"))
+        // The fourth pattern's display name must NOT be spelled out.
+        #expect(!body.contains("Lunge"), "fourth pattern should be folded into \"and more\": \(body)")
+    }
+
+    @Test("title is a constant affordance")
+    func titleIsConstant() {
+        #expect(CalibrationReviewBannerCopy.title == "Your starting targets are ready")
+    }
+}

--- a/ProjectApexTests/TraineeModelDigestTests.swift
+++ b/ProjectApexTests/TraineeModelDigestTests.swift
@@ -1803,4 +1803,79 @@ final class TraineeModelDigestTests: XCTestCase {
                         "overhead_press→incline_bench_press"],
                        "Only transfers with R²≥0.4 AND pairedObservations≥5 should surface in the digest")
     }
+
+    // MARK: ─── #269: deriveCalibrationReviewSignal ──────────────────────────
+
+    private func makeProjection(_ pattern: MovementPattern) -> PatternProjection {
+        PatternProjection(pattern: pattern, floor: 100, stretch: 110, progress: .onTrack)
+    }
+
+    func test_deriveCalibrationReviewSignal_nilWhenReviewNeverFired() {
+        var model = makeBaselineModel()
+        // Projections present but calibrationReviewFiredAt nil → no signal.
+        model.projections = ProjectionState(
+            patternProjections: [makeProjection(.squat)],
+            calibrationReviewFiredAt: nil
+        )
+
+        XCTAssertNil(TraineeModelDigest.deriveCalibrationReviewSignal(from: model),
+            "No signal until calibration review has fired")
+    }
+
+    func test_deriveCalibrationReviewSignal_nilWhenAcknowledged() {
+        var model = makeBaselineModel()
+        model.projections = ProjectionState(
+            patternProjections: [makeProjection(.squat)],
+            calibrationReviewFiredAt: ref
+        )
+        model.calibrationReviewAcknowledged = true
+
+        XCTAssertNil(TraineeModelDigest.deriveCalibrationReviewSignal(from: model),
+            "An acknowledged calibration review must silence the banner signal")
+    }
+
+    func test_deriveCalibrationReviewSignal_nilWhenProjectionsEmpty() {
+        var model = makeBaselineModel()
+        model.projections = ProjectionState(
+            patternProjections: [],
+            calibrationReviewFiredAt: ref
+        )
+
+        XCTAssertNil(TraineeModelDigest.deriveCalibrationReviewSignal(from: model),
+            "No signal when there are no projections to display")
+    }
+
+    func test_deriveCalibrationReviewSignal_returnsSortedProjectionsWhenEligible() {
+        var model = makeBaselineModel()
+        // Out-of-rawValue order on input — derive must sort by pattern.rawValue.
+        model.projections = ProjectionState(
+            patternProjections: [
+                makeProjection(.squat),          // "squat"
+                makeProjection(.hipHinge),       // "hip_hinge"
+                makeProjection(.horizontalPush), // "horizontal_push"
+            ],
+            calibrationReviewFiredAt: ref
+        )
+        model.calibrationReviewAcknowledged = false
+
+        let signal = TraineeModelDigest.deriveCalibrationReviewSignal(from: model)
+
+        XCTAssertNotNil(signal)
+        XCTAssertEqual(signal?.projections.map(\.pattern),
+                       [.hipHinge, .horizontalPush, .squat],
+                       "Projections must be sorted by pattern.rawValue")
+    }
+
+    func test_digest_calibrationReviewSignal_assignedFromDerive() {
+        var model = makeBaselineModel()
+        model.projections = ProjectionState(
+            patternProjections: [makeProjection(.squat)],
+            calibrationReviewFiredAt: ref
+        )
+
+        let digest = TraineeModelDigest(from: model, asOf: ref)
+
+        XCTAssertEqual(digest.calibrationReviewSignal?.projections.map(\.pattern), [.squat],
+            "init(from:) must assign the derived calibration-review signal")
+    }
 }


### PR DESCRIPTION
## S2 of 5 — Part of #269

Surfaces the calibration-review projections (from S1) to the athlete, read-only.

- `deriveCalibrationReviewSignal` on the digest, gated on `calibrationReviewFiredAt != nil` + non-empty projections + not-yet-acknowledged.
- A distinct pre-workout banner (purple; **precedence over** the heavy-reassessment banner) → routes to a new read-only `CalibrationReviewView` (floor read-only, stretch, progress per major pattern).
- "Got it" local acknowledge (`TraineeModel.calibrationReviewAcknowledged` + `acknowledgeCalibrationReview()`), mirroring #258's banner→screen→ack. **Robust server-side ack persistence** (surviving a server model refresh) lands with the edit slice #297.

### Verification
Built + tested locally via xcodebuild (iPhone 17 Pro): **BUILD + TEST SUCCEEDED** — `TraineeModelDigestTests` 102/102 (incl. 5 new gating tests), `CalibrationReviewBannerCopy` 4/4. **Views are compile- + logic-verified, not visually QA'd** (no simulator render check this session). Merges on local-green (iOS Build & Test is the known flake).

Part of #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)