### PR TITLE
feat(#297): iOS stretch editing + durable calibration-review ack

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		A3741A0001CAFE0001CAFE01 /* LateArrivalNotificationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */; };
 		A1540154CAFE0154CAFE0001 /* OnboardingGoalPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1540154CAFE0154CAFE0002 /* OnboardingGoalPayloadTests.swift */; };
 		A1540154CAFE0154CAFE0011 /* GoalReviewPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1540154CAFE0154CAFE0012 /* GoalReviewPayloadTests.swift */; };
+		A1540154CAFE0154CAFE0021 /* CalibrationReviewStretchPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1540154CAFE0154CAFE0022 /* CalibrationReviewStretchPayloadTests.swift */; };
 		22000000000000000000F011 /* PromptLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22000000000000000000F012 /* PromptLoaderTests.swift */; };
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
@@ -118,6 +119,7 @@
 		A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LateArrivalNotificationQueueTests.swift; sourceTree = "<group>"; };
 		A1540154CAFE0154CAFE0002 /* OnboardingGoalPayloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OnboardingGoalPayloadTests.swift; sourceTree = "<group>"; };
 		A1540154CAFE0154CAFE0012 /* GoalReviewPayloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GoalReviewPayloadTests.swift; sourceTree = "<group>"; };
+		A1540154CAFE0154CAFE0022 /* CalibrationReviewStretchPayloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CalibrationReviewStretchPayloadTests.swift; sourceTree = "<group>"; };
 		22000000000000000000F012 /* PromptLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptLoaderTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
 		DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetPrescriptionIntentValidationTests.swift; sourceTree = "<group>"; };
@@ -268,6 +270,7 @@
 				A3741A0001CAFE0001CAFE02 /* LateArrivalNotificationQueueTests.swift */,
 				A1540154CAFE0154CAFE0002 /* OnboardingGoalPayloadTests.swift */,
 				A1540154CAFE0154CAFE0012 /* GoalReviewPayloadTests.swift */,
+				A1540154CAFE0154CAFE0022 /* CalibrationReviewStretchPayloadTests.swift */,
 				22000000000000000000F012 /* PromptLoaderTests.swift */,
 			);
 			path = ProjectApexTests;
@@ -422,6 +425,7 @@
 				A3741A0001CAFE0001CAFE01 /* LateArrivalNotificationQueueTests.swift in Sources */,
 				A1540154CAFE0154CAFE0001 /* OnboardingGoalPayloadTests.swift in Sources */,
 				A1540154CAFE0154CAFE0011 /* GoalReviewPayloadTests.swift in Sources */,
+				A1540154CAFE0154CAFE0021 /* CalibrationReviewStretchPayloadTests.swift in Sources */,
 				22000000000000000000F011 /* PromptLoaderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ProjectApex/Features/Onboarding/OnboardingView.swift
+++ b/ProjectApex/Features/Onboarding/OnboardingView.swift
@@ -945,7 +945,9 @@ struct OnboardingView: View {
                 focusAreas: [],
                 updatedAt: isoFormatter.string(from: Date())
             ),
-            acknowledgeTriggeringSessionCount: nil
+            acknowledgeTriggeringSessionCount: nil,
+            stretchEdits: nil,
+            acknowledgeCalibrationReview: nil
         )
         if let encoded = try? JSONEncoder().encode(goalPayload) {
             _ = try? await deps.supabaseClient.invokeFunction(
@@ -1026,12 +1028,34 @@ struct TraineeGoalUpsertPayload: Codable, Sendable {
     /// passes `nil` — the synthesized `encodeIfPresent` then OMITS the key,
     /// keeping the onboarding wire shape exactly `{user_id, goal}`.
     let acknowledgeTriggeringSessionCount: Int?
+    /// #269 S4: OPTIONAL. Athlete-raised stretch targets from the
+    /// calibration-review screen. When non-nil the EF applies an upward-only
+    /// clamp on `model_json.projections.patternProjections`. Synthesized
+    /// `encodeIfPresent` OMITS the key when nil, so other call sites keep their
+    /// exact wire shape.
+    let stretchEdits: [StretchEditBody]?
+    /// #269 S4: OPTIONAL. When true, the EF durably sets
+    /// `model_json.calibrationReviewAcknowledged = true` so the pre-workout
+    /// calibration banner does not reappear after a session sync. Omitted from
+    /// the wire when nil.
+    let acknowledgeCalibrationReview: Bool?
 
     enum CodingKeys: String, CodingKey {
         case userId = "user_id"
         case goal
         case acknowledgeTriggeringSessionCount = "acknowledge_triggering_session_count"
+        case stretchEdits = "stretch_edits"
+        case acknowledgeCalibrationReview = "acknowledge_calibration_review"
     }
+}
+
+/// #269 S4: a single athlete-raised stretch target. Mirrors the EF's
+/// `StretchEdit` shape (`pattern` rawValue + `stretch` kg). The default
+/// member-name CodingKeys match the validator's expected camelCase-free
+/// `{pattern, stretch}` wire shape.
+struct StretchEditBody: Codable, Sendable {
+    let pattern: String
+    let stretch: Double
 }
 
 /// `internal` (not `private`) so the EF-contract parity test can assert the

--- a/ProjectApex/Features/Workout/CalibrationReviewView.swift
+++ b/ProjectApex/Features/Workout/CalibrationReviewView.swift
@@ -1,15 +1,23 @@
 // CalibrationReviewView.swift
 // ProjectApex — Features/Workout
 //
-// #269 S2: the read-only calibration-review display the pre-workout
-// calibration banner's "Review targets" CTA presents. "Your starting targets
-// are ready" — this screen shows the per-pattern floor/stretch projections set
-// at calibration review, plus each pattern's progress state. Nothing is
-// editable here.
+// #269 S2 / S4: the calibration-review screen the pre-workout calibration
+// banner's "Review targets" CTA presents. "Your starting targets are ready" —
+// this screen shows the per-pattern floor/stretch projections set at
+// calibration review, plus each pattern's progress state.
 //
-// On "Got it" it calls the local `acknowledgeCalibrationReview()` (mirrors the
-// heavy-reassessment local ack) so the banner disappears immediately, then
-// dismisses.
+// S4 makes the STRETCH target editable (upward-only). The floor stays
+// read-only (it is the immovable level we keep the athlete at). On "Save
+// targets" the screen:
+//   1. POSTs the raised stretches + acknowledge_calibration_review:true to the
+//      `update-trainee-goal` Edge Function (best-effort, mirrors GoalReviewView).
+//   2. applies the same upward-only clamp to the local cache and records the
+//      local calibration-review ack, so the banner disappears immediately (the
+//      EF returns no model, so the cache can't refresh from the round-trip).
+//   3. dismisses.
+//
+// Even with zero edits, Save still acknowledges the review so "review and
+// accept as-is" hides the banner durably.
 
 import SwiftUI
 
@@ -22,13 +30,55 @@ struct CalibrationReviewView: View {
     @Environment(AppDependencies.self) private var deps
     @Environment(\.dismiss) private var dismiss
 
-    @State private var isAcknowledging: Bool = false
+    @State private var isSaving: Bool = false
+    /// Live, athlete-editable stretch targets keyed by pattern, seeded from the
+    /// injected projections on appear. Upward-only — never drops below the
+    /// original stretch.
+    @State private var editedStretch: [MovementPattern: Double] = [:]
+
+    /// Increment used by the +/- stretch controls.
+    private static let stretchStep: Double = 2.5
 
     private static let accentPurple = Color(red: 0.58, green: 0.45, blue: 0.95)
     private static let darkChrome = Color(red: 0.04, green: 0.04, blue: 0.06)
 
     init(projections: [PatternProjection]) {
         self.projections = projections
+    }
+
+    // MARK: - Pure payload helper (the seam under TDD)
+
+    /// Builds the `update-trainee-goal` payload for a calibration-review Save
+    /// (#269 S4). `stretchEdits` includes ONLY patterns whose `editedStretch`
+    /// is strictly greater than the original stretch (an unchanged or — never
+    /// reachable from the UI — lowered value is omitted; the server applies its
+    /// own upward-only clamp regardless). `acknowledgeCalibrationReview` is
+    /// ALWAYS true so "review and accept as-is" still hides the banner durably.
+    /// Mirrors GoalReviewView.makeGoalPayload's style.
+    static func makeCalibrationStretchPayload(
+        userId: UUID,
+        goal: GoalUpsertBody,
+        editedStretch: [MovementPattern: Double],
+        original: [PatternProjection],
+        now: Date
+    ) -> TraineeGoalUpsertPayload {
+        let originalStretch = Dictionary(
+            original.map { ($0.pattern, $0.stretch) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let raised: [StretchEditBody] = original.compactMap { projection in
+            guard let edited = editedStretch[projection.pattern] else { return nil }
+            let base = originalStretch[projection.pattern] ?? projection.stretch
+            guard edited > base else { return nil }
+            return StretchEditBody(pattern: projection.pattern.rawValue, stretch: edited)
+        }
+        return TraineeGoalUpsertPayload(
+            userId: userId,
+            goal: goal,
+            acknowledgeTriggeringSessionCount: nil,
+            stretchEdits: raised.isEmpty ? nil : raised,
+            acknowledgeCalibrationReview: true
+        )
     }
 
     // MARK: - Body
@@ -42,7 +92,7 @@ struct CalibrationReviewView: View {
                     LazyVStack(spacing: 16) {
                         introCard
                         projectionsCard
-                        gotItButton
+                        saveButton
                         Color.clear.frame(height: 24)
                     }
                     .padding(.horizontal, 16)
@@ -55,6 +105,15 @@ struct CalibrationReviewView: View {
             .toolbarColorScheme(.dark, for: .navigationBar)
         }
         .preferredColorScheme(.dark)
+        .onAppear {
+            // Seed the editable stretch state from the injected projections once.
+            if editedStretch.isEmpty {
+                editedStretch = Dictionary(
+                    projections.map { ($0.pattern, $0.stretch) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+            }
+        }
     }
 
     // MARK: - Intro
@@ -62,14 +121,14 @@ struct CalibrationReviewView: View {
     private var introCard: some View {
         VStack(alignment: .leading, spacing: 10) {
             sectionHeader("WHAT THIS MEANS")
-            Text("Your starting targets are ready. Floor is the level we'll keep you at; stretch is the next milestone to aim for.")
+            Text("Your starting targets are ready. Floor is the level we'll keep you at; stretch is the next milestone to aim for — nudge it up if you want a bigger goal.")
                 .font(.system(size: 13))
                 .foregroundStyle(.white.opacity(0.55))
         }
         .calibrationCardChrome()
     }
 
-    // MARK: - Projections (read-only)
+    // MARK: - Projections (stretch editable)
 
     private var projectionsCard: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -95,7 +154,10 @@ struct CalibrationReviewView: View {
     }
 
     private func projectionRow(_ projection: PatternProjection) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
+        let current = editedStretch[projection.pattern] ?? projection.stretch
+        // Lowering is clamped at the original stretch — never below it.
+        let canLower = current - Self.stretchStep >= projection.stretch
+        return VStack(alignment: .leading, spacing: 8) {
             HStack {
                 Text(projection.pattern.displayName)
                     .font(.system(size: 15, weight: .semibold))
@@ -108,47 +170,110 @@ struct CalibrationReviewView: View {
                     .padding(.vertical, 4)
                     .background(Self.accentPurple.opacity(0.14), in: Capsule())
             }
-            HStack(spacing: 16) {
-                Text("Floor: \(Self.formatWeight(projection.floor)) kg")
-                    .font(.system(size: 13).monospacedDigit())
-                    .foregroundStyle(.white.opacity(0.65))
-                Text("Stretch: \(Self.formatWeight(projection.stretch)) kg")
-                    .font(.system(size: 13).monospacedDigit())
-                    .foregroundStyle(.white.opacity(0.65))
+            Text("Floor: \(Self.formatWeight(projection.floor)) kg")
+                .font(.system(size: 13).monospacedDigit())
+                .foregroundStyle(.white.opacity(0.65))
+            HStack(spacing: 12) {
+                Text("Stretch: \(Self.formatWeight(current)) kg")
+                    .font(.system(size: 13, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.85))
+                Spacer()
+                stretchStepButton(label: "\u{2212}2.5 kg", enabled: canLower) {
+                    editedStretch[projection.pattern] = max(projection.stretch, current - Self.stretchStep)
+                }
+                stretchStepButton(label: "+2.5 kg", enabled: true) {
+                    editedStretch[projection.pattern] = current + Self.stretchStep
+                }
             }
         }
         .padding(.vertical, 12)
     }
 
-    // MARK: - Got it
+    private func stretchStepButton(label: String, enabled: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(size: 13, weight: .semibold).monospacedDigit())
+                .foregroundStyle(enabled ? Self.accentPurple : .white.opacity(0.25))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(
+                    (enabled ? Self.accentPurple.opacity(0.14) : Color.white.opacity(0.04)),
+                    in: Capsule()
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .accessibilityLabel(label)
+    }
 
-    private var gotItButton: some View {
+    // MARK: - Save targets
+
+    private var saveButton: some View {
         Button {
-            Task { await acknowledge() }
+            Task { await save() }
         } label: {
-            Text(isAcknowledging ? "Saving\u{2026}" : "Got it")
+            Text(isSaving ? "Saving\u{2026}" : "Save targets")
                 .font(.system(size: 17, weight: .bold))
                 .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .frame(height: 56)
-                .background(Self.accentPurple.opacity(isAcknowledging ? 0.40 : 0.85),
+                .background(Self.accentPurple.opacity(isSaving ? 0.40 : 0.85),
                            in: RoundedRectangle(cornerRadius: 18, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: 18, style: .continuous)
                         .stroke(.white.opacity(0.20), lineWidth: 0.5)
                 )
         }
-        .disabled(isAcknowledging)
+        .disabled(isSaving)
         .padding(.top, 8)
     }
 
-    // MARK: - Acknowledge
+    // MARK: - Save
 
     @MainActor
-    private func acknowledge() async {
-        isAcknowledging = true
-        defer { isAcknowledging = false }
+    private func save() async {
+        isSaving = true
+        defer { isSaving = false }
+
+        // The current goal carried through unchanged (this screen doesn't edit
+        // it). Read it from the cached model; fall back to the placeholder shape
+        // if the cache is cold.
+        let model = await deps.traineeModelService.read()
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let goalState = model?.goal ?? GoalState.placeholder
+        let goalBody = GoalUpsertBody(
+            statement: goalState.statement,
+            focusAreas: goalState.focusAreas.map(\.rawValue).sorted(),
+            updatedAt: isoFormatter.string(from: goalState.updatedAt)
+        )
+
+        let payload = Self.makeCalibrationStretchPayload(
+            userId: deps.resolvedUserId,
+            goal: goalBody,
+            editedStretch: editedStretch,
+            original: projections,
+            now: Date()
+        )
+
+        // Best-effort server write, mirroring GoalReviewView.save().
+        if let encoded = try? JSONEncoder().encode(payload) {
+            _ = try? await deps.supabaseClient.invokeFunction(
+                "update-trainee-goal",
+                body: encoded
+            )
+        }
+
+        // Local cache update + ack so the banner hides immediately. Apply only
+        // the raised stretches (the service mirrors the upward-only clamp).
+        let raisedEdits: [MovementPattern: Double] = projections.reduce(into: [:]) { acc, projection in
+            if let edited = editedStretch[projection.pattern], edited > projection.stretch {
+                acc[projection.pattern] = edited
+            }
+        }
+        try? await deps.traineeModelService.applyStretchEdits(raisedEdits)
         try? await deps.traineeModelService.acknowledgeCalibrationReview()
+
         dismiss()
     }
 

--- a/ProjectApex/Features/Workout/GoalReviewView.swift
+++ b/ProjectApex/Features/Workout/GoalReviewView.swift
@@ -72,7 +72,9 @@ struct GoalReviewView: View {
                 focusAreas: focusAreas.map(\.rawValue).sorted(),
                 updatedAt: isoFormatter.string(from: now)
             ),
-            acknowledgeTriggeringSessionCount: triggeringSessionCount
+            acknowledgeTriggeringSessionCount: triggeringSessionCount,
+            stretchEdits: nil,
+            acknowledgeCalibrationReview: nil
         )
     }
 

--- a/ProjectApex/Services/TraineeModelService.swift
+++ b/ProjectApex/Services/TraineeModelService.swift
@@ -116,6 +116,25 @@ actor TraineeModelService {
         try await store.save(model)
     }
 
+    /// #269 S4: client mirror of the server's upward-only stretch clamp. Raises
+    /// each targeted pattern's `stretch` to `max(currentStretch, edited)` on the
+    /// cached model so the calibration-review screen reflects the new targets
+    /// immediately (the EF returns no model, so the cache can't refresh from the
+    /// round-trip). Floors are never touched. No-op if no model is cached, the
+    /// model has no projections, or no edit raises a target. Idempotent.
+    func applyStretchEdits(_ edits: [MovementPattern: Double]) async throws {
+        guard var model = await store.load() else { return }
+        guard var projections = model.projections else { return }
+        projections.patternProjections = projections.patternProjections.map { p in
+            guard let edited = edits[p.pattern] else { return p }
+            var updated = p
+            updated.stretch = max(p.stretch, edited) // upward-only clamp
+            return updated
+        }
+        model.projections = projections
+        try await store.save(model)
+    }
+
     // MARK: - Write — enqueue path
 
     /// Enqueues a `trainee_model_update` item carrying the session-

--- a/ProjectApexTests/CalibrationReviewStretchPayloadTests.swift
+++ b/ProjectApexTests/CalibrationReviewStretchPayloadTests.swift
@@ -1,0 +1,141 @@
+// CalibrationReviewStretchPayloadTests.swift
+// ProjectApexTests
+//
+// #269 S4: unit tests for the pure payload helper behind the calibration-review
+// screen, `CalibrationReviewView.makeCalibrationStretchPayload(...)`. SwiftUI
+// bodies aren't unit-testable, so the wire-payload construction lives in a pure
+// static function that takes `now: Date` — these tests pin its behaviour.
+//
+// The contract under test:
+//   • `stretch_edits` includes ONLY patterns whose edited stretch is strictly
+//     greater than the original (unchanged → omitted; lowered → omitted).
+//   • `acknowledge_calibration_review` is ALWAYS true (even with zero edits, so
+//     "review and accept as-is" durably hides the banner).
+//
+// `makeCalibrationStretchPayload` + the payload structs are `internal`, so
+// `@testable` can call/encode them directly.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+@Suite("CalibrationReview stretch payload")
+struct CalibrationReviewStretchPayloadTests {
+
+    private static let fixedNow = Date(timeIntervalSinceReferenceDate: 800_000_000)
+
+    private static let goalBody = GoalUpsertBody(
+        statement: "Hypertrophy",
+        focusAreas: [],
+        updatedAt: "2026-05-12T10:00:00.000Z"
+    )
+
+    private static let original: [PatternProjection] = [
+        PatternProjection(pattern: .squat, floor: 140, stretch: 150, progress: .onTrack),
+        PatternProjection(pattern: .horizontalPush, floor: 100, stretch: 107.5, progress: .onTrack),
+    ]
+
+    /// Encodes the payload the way the Save call site does (bare JSONEncoder)
+    /// and deserializes to a JSON object for wire-shape assertions.
+    private func encode(_ payload: TraineeGoalUpsertPayload) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(payload)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return try #require(obj)
+    }
+
+    // MARK: - Only RAISED patterns appear in stretch_edits
+
+    @Test("A raised pattern is the only entry in stretch_edits")
+    func raisedPatternIncluded() throws {
+        // squat raised 150 → 160; horizontal_push left at its original 107.5.
+        let payload = CalibrationReviewView.makeCalibrationStretchPayload(
+            userId: UUID(),
+            goal: Self.goalBody,
+            editedStretch: [.squat: 160, .horizontalPush: 107.5],
+            original: Self.original,
+            now: Self.fixedNow
+        )
+
+        let edits = try #require(payload.stretchEdits)
+        #expect(edits.count == 1)
+        #expect(edits.first?.pattern == "squat")
+        #expect(edits.first?.stretch == 160)
+    }
+
+    @Test("A pattern left at its original stretch is omitted")
+    func unchangedPatternOmitted() {
+        let payload = CalibrationReviewView.makeCalibrationStretchPayload(
+            userId: UUID(),
+            goal: Self.goalBody,
+            editedStretch: [.squat: 150, .horizontalPush: 107.5],
+            original: Self.original,
+            now: Self.fixedNow
+        )
+        // Both unchanged → no raised edits → nil (so the key omits on the wire).
+        #expect(payload.stretchEdits == nil)
+    }
+
+    @Test("A lowered value is clamped/omitted (never below the original)")
+    func loweredValueOmitted() {
+        let payload = CalibrationReviewView.makeCalibrationStretchPayload(
+            userId: UUID(),
+            goal: Self.goalBody,
+            editedStretch: [.squat: 145, .horizontalPush: 107.5],
+            original: Self.original,
+            now: Self.fixedNow
+        )
+        // 145 < original 150 → not a raise → omitted.
+        #expect(payload.stretchEdits == nil)
+    }
+
+    // MARK: - acknowledge_calibration_review is ALWAYS true
+
+    @Test("acknowledge_calibration_review is true even with raised edits")
+    func ackTrueWithEdits() {
+        let payload = CalibrationReviewView.makeCalibrationStretchPayload(
+            userId: UUID(),
+            goal: Self.goalBody,
+            editedStretch: [.squat: 170],
+            original: Self.original,
+            now: Self.fixedNow
+        )
+        #expect(payload.acknowledgeCalibrationReview == true)
+    }
+
+    @Test("With no edits, stretch_edits omits but the ack flag is still set")
+    func ackTrueWithNoEdits() throws {
+        let payload = CalibrationReviewView.makeCalibrationStretchPayload(
+            userId: UUID(),
+            goal: Self.goalBody,
+            editedStretch: [.squat: 150, .horizontalPush: 107.5],
+            original: Self.original,
+            now: Self.fixedNow
+        )
+        #expect(payload.stretchEdits == nil)
+        #expect(payload.acknowledgeCalibrationReview == true)
+
+        // On the wire: no stretch_edits key, but acknowledge_calibration_review: true.
+        let json = try encode(payload)
+        #expect(json["stretch_edits"] == nil)
+        #expect(json["acknowledge_calibration_review"] as? Bool == true)
+    }
+
+    // MARK: - Wire shape of a raised edit
+
+    @Test("Raised edit encodes as snake_case {pattern, stretch} under stretch_edits")
+    func raisedEditWireShape() throws {
+        let payload = CalibrationReviewView.makeCalibrationStretchPayload(
+            userId: UUID(),
+            goal: Self.goalBody,
+            editedStretch: [.squat: 160],
+            original: Self.original,
+            now: Self.fixedNow
+        )
+        let json = try encode(payload)
+        let edits = try #require(json["stretch_edits"] as? [[String: Any]])
+        #expect(edits.count == 1)
+        #expect(edits.first?["pattern"] as? String == "squat")
+        #expect(edits.first?["stretch"] as? Double == 160)
+        #expect(json["acknowledge_calibration_review"] as? Bool == true)
+    }
+}

--- a/ProjectApexTests/OnboardingGoalPayloadTests.swift
+++ b/ProjectApexTests/OnboardingGoalPayloadTests.swift
@@ -55,7 +55,9 @@ final class OnboardingGoalPayloadTests: XCTestCase {
                 focusAreas: ["legs", "back"],
                 updatedAt: isoFormatter.string(from: date)
             ),
-            acknowledgeTriggeringSessionCount: acknowledge
+            acknowledgeTriggeringSessionCount: acknowledge,
+            stretchEdits: nil,
+            acknowledgeCalibrationReview: nil
         )
         let data = try JSONEncoder().encode(payload)
         return try XCTUnwrap(

--- a/supabase/functions/update-trainee-goal/index.ts
+++ b/supabase/functions/update-trainee-goal/index.ts
@@ -66,6 +66,12 @@ export interface UpdateTraineeGoalRequest {
   // the server clamps upward-only (never below the stored value) and never
   // accepts a floor. Absent for onboarding / heavy-reassessment saves.
   stretch_edits?: StretchEdit[];
+  // #269 S4: OPTIONAL. When true, the EF durably records that the athlete has
+  // seen the one-time calibration-review screen by setting
+  // `model_json.calibrationReviewAcknowledged = true`, so the pre-workout
+  // calibration banner does not reappear after a session sync rehydrates the
+  // local cache. Absent for onboarding / goal-review saves.
+  acknowledge_calibration_review?: boolean;
 }
 
 const ISO_DATE_RE =
@@ -77,8 +83,13 @@ export function validateRequest(
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
     return { error: "request body must be a JSON object" };
   }
-  const { user_id, goal, acknowledge_triggering_session_count, stretch_edits } =
-    body as Record<string, unknown>;
+  const {
+    user_id,
+    goal,
+    acknowledge_triggering_session_count,
+    stretch_edits,
+    acknowledge_calibration_review,
+  } = body as Record<string, unknown>;
   if (typeof user_id !== "string" || !UUID_RE.test(user_id)) {
     return { error: "user_id must be a UUID string" };
   }
@@ -146,6 +157,14 @@ export function validateRequest(
       validatedEdits.push({ pattern: er.pattern, stretch: er.stretch });
     }
   }
+  // #269 S4: OPTIONAL calibration-review ack. Absent → valid exactly as before.
+  // Present → must be a boolean.
+  if (
+    acknowledge_calibration_review !== undefined &&
+    typeof acknowledge_calibration_review !== "boolean"
+  ) {
+    return { error: "acknowledge_calibration_review must be a boolean" };
+  }
   const validated: UpdateTraineeGoalRequest = {
     user_id,
     goal: {
@@ -160,6 +179,10 @@ export function validateRequest(
   }
   if (validatedEdits !== undefined) {
     validated.stretch_edits = validatedEdits;
+  }
+  if (acknowledge_calibration_review !== undefined) {
+    validated.acknowledge_calibration_review =
+      acknowledge_calibration_review as boolean;
   }
   return validated;
 }
@@ -237,6 +260,25 @@ export async function upsertGoal(
   // #296 (#269): apply athlete-raised stretch targets (upward-only clamp).
   if (req.stretch_edits !== undefined && req.stretch_edits.length > 0) {
     await applyStretchEdits(req.user_id, req.stretch_edits, sql);
+  }
+
+  // #269 S4: durably record that the athlete has seen the one-time
+  // calibration-review screen so the pre-workout banner does not reappear after
+  // a session sync rehydrates the local cache. Separate statement, same
+  // connection — like the ack-append block above. Idempotent: re-running with
+  // the flag set leaves the value at `true`. The goal write above stays
+  // byte-for-byte unchanged.
+  if (req.acknowledge_calibration_review === true) {
+    await sql`
+      UPDATE public.trainee_models
+      SET model_json = jsonb_set(
+        COALESCE(model_json, '{}'::jsonb),
+        '{calibrationReviewAcknowledged}',
+        'true'::jsonb,
+        true
+      )
+      WHERE user_id = ${req.user_id}
+    `;
   }
 
   return { ok: true, goal: req.goal };

--- a/supabase/functions/update-trainee-goal/index_test.ts
+++ b/supabase/functions/update-trainee-goal/index_test.ts
@@ -226,3 +226,41 @@ Deno.test("validateRequest_stretch_edits_non_object_entry_returns_400", () => {
   const result = validateRequest(baseRequest({ stretch_edits: ["squat"] }));
   assertEquals("error" in result, true);
 });
+
+// #269 S4: acknowledge_calibration_review validation.
+
+Deno.test("validateRequest_ack_calibration_review_absent_still_valid", () => {
+  // Back-compat: onboarding / goal-review omit the field and must remain valid.
+  const result = validateRequest(baseRequest());
+  assertEquals("error" in result, false);
+  if ("error" in result) return;
+  assertEquals(result.acknowledge_calibration_review, undefined);
+});
+
+Deno.test("validateRequest_ack_calibration_review_true_accepted", () => {
+  const result = validateRequest(
+    baseRequest({ acknowledge_calibration_review: true }),
+  );
+  assertEquals("error" in result, false);
+  if ("error" in result) return;
+  assertEquals(result.acknowledge_calibration_review, true);
+});
+
+Deno.test("validateRequest_ack_calibration_review_false_accepted", () => {
+  // false is a valid boolean; the write only fires on === true.
+  const result = validateRequest(
+    baseRequest({ acknowledge_calibration_review: false }),
+  );
+  assertEquals("error" in result, false);
+  if ("error" in result) return;
+  assertEquals(result.acknowledge_calibration_review, false);
+});
+
+Deno.test("validateRequest_ack_calibration_review_nonBoolean_returns_400", () => {
+  // A truthy string must be rejected (typeof "true" !== "boolean").
+  const result = validateRequest(
+    baseRequest({ acknowledge_calibration_review: "true" }),
+  );
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("acknowledge_calibration_review"), true);
+});

--- a/supabase/functions/update-trainee-goal/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-goal/orchestrator_test.ts
@@ -450,6 +450,46 @@ goalTest(
   },
 );
 
+// #269 S4: acknowledge_calibration_review write-path — durably sets
+// model_json.calibrationReviewAcknowledged so the pre-workout banner does not
+// reappear after a session sync rehydrates the local cache.
+
+goalTest(
+  "#269 S4: acknowledge_calibration_review:true sets model_json.calibrationReviewAcknowledged === true",
+  async () => {
+    const userId = await seedFreshUserWithExistingModel({ goal: GOAL_A });
+
+    await upsertGoal(
+      { user_id: userId, goal: GOAL_A, acknowledge_calibration_review: true },
+      sql,
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    assertEquals(modelJson.goal, GOAL_A);
+    assertEquals(modelJson.calibrationReviewAcknowledged, true);
+  },
+);
+
+goalTest(
+  "#269 S4: goal-save WITHOUT acknowledge_calibration_review leaves the key untouched (absent)",
+  async () => {
+    const userId = await seedFreshUserWithExistingModel({ goal: GOAL_A });
+
+    await upsertGoal({ user_id: userId, goal: GOAL_A }, sql);
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const modelJson = rows[0].model_json as Record<string, unknown>;
+    assertEquals(modelJson.goal, GOAL_A);
+    // No ack sent → the conditional UPDATE never ran → key stays absent.
+    assertEquals("calibrationReviewAcknowledged" in modelJson, false);
+  },
+);
+
 // Sentinel "test" that runs last — closes the shared pool so the connection
 // lifecycle stays local to this file rather than relying on process-exit.
 Deno.test({


### PR DESCRIPTION
## S4 of 5 — Part of #269

Lets the athlete raise their stretch targets, and makes the calibration-review ack durable.

### EF
`update-trainee-goal` accepts `acknowledge_calibration_review` (boolean) → idempotently sets `model_json.calibrationReviewAcknowledged = true`. Without this the banner would reappear after the next session sync rehydrates the local cache (the local-only ack from S2 doesn't survive a server model refresh).

### iOS
- `CalibrationReviewView` stretch is now editable (upward-only +2.5 kg steppers; floor read-only).
- "Save targets" POSTs `stretch_edits` + `acknowledge_calibration_review` (best-effort), then applies the edits + ack to the local cache (banner hides immediately; EF returns no model).
- `TraineeModelService.applyStretchEdits` mirrors the server's upward-only clamp.
- `TraineeGoalUpsertPayload` gains optional `stretchEdits` + `acknowledgeCalibrationReview` (existing sites pass nil; wire shape unchanged when absent).

### Verification
- EF: 27 deno validation tests; 2 DB integration tests (ack sets the flag / absent untouched) on CI `ef-test`. `index.ts` deno check clean.
- iOS: payload-builder suite 6/6 (only raised patterns in stretch_edits; ack always true; no-edits → empty edits + ack). xcodebuild build + tests **SUCCEEDED** (iPhone 17 Pro). Views compile- + logic-verified, not visually QA'd.

Merges on `ef-test` green (EF change) + local-green (iOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)