### PR TITLE
feat(#305 slice 1/3): EF re-calibration mechanism (capability outgrows the band)

### DIFF
--- a/supabase/functions/_shared/calibration-projection.ts
+++ b/supabase/functions/_shared/calibration-projection.ts
@@ -38,7 +38,11 @@ export const STRETCH_MARGIN_BY_TREND: Record<ProgressionTrend, number> = {
 /** Calibration review fires once ≥ this many of the 6 major patterns establish. */
 export const CALIBRATION_REVIEW_MIN_ESTABLISHED_MAJORS = 4;
 
-function roundTo(value: number, increment: number, dir: "down" | "up"): number {
+export function roundTo(
+  value: number,
+  increment: number,
+  dir: "down" | "up",
+): number {
   const q = value / increment;
   return (dir === "down" ? Math.floor(q) : Math.ceil(q)) * increment;
 }

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -79,6 +79,7 @@ import {
   deriveProjection,
   type PatternProjection,
 } from "../_shared/calibration-projection.ts";
+import { rederiveOutgrownProjection } from "./recalibration.ts";
 import {
   appendObservation,
   shouldContribute,
@@ -1953,6 +1954,8 @@ export async function applySession(
         patternProjections?: PatternProjection[];
         calibrationReviewFiredAt?: string | null;
         goalLastRenegotiatedAt?: string | null;
+        lastRecalibratedAtSessionCount?: number | null;
+        lastRecalibratedPatterns?: string[];
       } | undefined;
       const establishedMajors = MAJOR_PATTERNS.filter(
         (mp) => (patternsForProj[mp]?.confidence as string | undefined) === "established",
@@ -1993,6 +1996,29 @@ export async function applySession(
           }
         }
 
+        // #305 (ADR-0023): re-calibrate established majors whose demonstrated
+        // capability has outgrown their band (median a full band-width past
+        // stretch). Floor steps up (monotonic, never overstates), stretch +
+        // progress re-derive; idempotent by construction. Per-pattern, here in
+        // session-apply where capability is computed. Runs before the progress
+        // recompute so that arm sees the new bands.
+        const recalibratedPatterns: string[] = [];
+        for (const mp of establishedMajors) {
+          const existing = projById.get(mp);
+          if (existing === undefined) continue;
+          const recal = rederiveOutgrownProjection(
+            existing,
+            patternE1RMSessions(mp, exercisesForProj),
+            cadenceFor(mp),
+            (patternsForProj[mp]?.trend as ProgressionTrend) ?? "progressing",
+          );
+          if (recal !== null) {
+            projById.set(mp, recal);
+            recalibratedPatterns.push(mp);
+            projectionsChanged = true;
+          }
+        }
+
         // Recompute progress for every existing projection.
         for (const [mp, proj] of projById) {
           const current = currentCapability(
@@ -2007,6 +2033,19 @@ export async function applySession(
           }
         }
 
+        // Re-calibration watermark: advance only when a pattern actually
+        // re-calibrated this apply; otherwise carry the prior watermark through
+        // so the projections write never drops it. The watermark + the list of
+        // patterns that moved drive the surfaced re-calibration banner (Slice 2).
+        let lastRecalibratedAtSessionCount =
+          priorProjections?.lastRecalibratedAtSessionCount ?? null;
+        let lastRecalibratedPatterns = priorProjections?.lastRecalibratedPatterns ?? [];
+        if (recalibratedPatterns.length > 0) {
+          lastRecalibratedAtSessionCount = newSessionCount;
+          lastRecalibratedPatterns = [...recalibratedPatterns].sort();
+          rulesFired.push("calibration-recalibrated");
+        }
+
         if (projectionsChanged) {
           newModelJson = {
             ...newModelJson,
@@ -2014,6 +2053,8 @@ export async function applySession(
               patternProjections: Array.from(projById.values()),
               calibrationReviewFiredAt: calibrationFiredAt,
               goalLastRenegotiatedAt: priorProjections?.goalLastRenegotiatedAt ?? null,
+              lastRecalibratedAtSessionCount,
+              lastRecalibratedPatterns,
             },
           };
           rulesFired.push("calibration-projection");

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -2293,6 +2293,72 @@ orchestratorTest(
   },
 );
 
+orchestratorTest(
+  "#305 (ADR-0023): a major pattern whose capability outgrows its band re-calibrates (floor steps up) + stamps the re-calibration watermark; other patterns untouched",
+  async () => {
+    const userId = await seedFreshUser();
+
+    // Full-body session; squat load is parameterised so we can ramp it.
+    async function applyDay(day: number, squatKg: number): Promise<Record<string, unknown>> {
+      await applySession(
+        {
+          user_id: userId,
+          session_id: crypto.randomUUID(),
+          session_payload: {
+            logged_at: `2026-10-${String(day).padStart(2, "0")}T10:00:00Z`,
+            set_logs: [
+              { exercise_id: "barbell_bench_press", set_number: 1, weight_kg: 100, reps_completed: 5, intent: "top" },
+              { exercise_id: "barbell_back_squat", set_number: 1, weight_kg: squatKg, reps_completed: 5, intent: "top" },
+              { exercise_id: "barbell_row", set_number: 1, weight_kg: 80, reps_completed: 5, intent: "top" },
+              { exercise_id: "overhead_press", set_number: 1, weight_kg: 60, reps_completed: 5, intent: "top" },
+            ],
+          },
+        },
+        sql,
+        { stage2Hook: noopStage2 },
+      );
+      const rows = await sql`
+        SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+      `;
+      return rows[0].model_json as Record<string, unknown>;
+    }
+
+    const squatFloor = (m: Record<string, unknown>): number => {
+      const proj = (m.projections as { patternProjections: Array<Record<string, unknown>> })
+        .patternProjections.find((p) => p.pattern === "squat")!;
+      return proj.floor as number;
+    };
+
+    // Days 1-6 at a stable squat load → 4 majors establish → calibration fires.
+    let modelJson: Record<string, unknown> = {};
+    for (let d = 1; d <= 6; d++) modelJson = await applyDay(d, 140);
+    const proj0 = modelJson.projections as {
+      patternProjections: Array<Record<string, unknown>>;
+      lastRecalibratedAtSessionCount?: number | null;
+    };
+    assertExists(proj0.patternProjections.find((p) => p.pattern === "squat"));
+    const floorBefore = squatFloor(modelJson);
+    // No re-calibration has happened yet (capability sits inside the fresh band).
+    assertEquals(proj0.lastRecalibratedAtSessionCount ?? null, null);
+
+    // Days 7-12: squat load jumps well past its band; other patterns hold.
+    for (let d = 7; d <= 12; d++) modelJson = await applyDay(d, 170);
+
+    const proj = modelJson.projections as {
+      patternProjections: Array<Record<string, unknown>>;
+      lastRecalibratedAtSessionCount: number | null;
+      lastRecalibratedPatterns: string[];
+    };
+    // Squat's floor stepped UP to demonstrated capability.
+    assertEquals(squatFloor(modelJson) > floorBefore, true);
+    // The watermark + the moved-pattern list are stamped.
+    assertEquals(proj.lastRecalibratedAtSessionCount !== null, true);
+    assertEquals(proj.lastRecalibratedPatterns.includes("squat"), true);
+    // Patterns that did NOT outgrow their band are not in the list.
+    assertEquals(proj.lastRecalibratedPatterns.includes("horizontal_push"), false);
+  },
+);
+
 // Sentinel "test" that runs last (alphabetically — Deno runs tests in file
 // order, but this trailing close keeps the connection lifecycle local to
 // the test file rather than relying on process-exit cleanup).

--- a/supabase/functions/update-trainee-model/recalibration.ts
+++ b/supabase/functions/update-trainee-model/recalibration.ts
@@ -1,0 +1,75 @@
+// Project Apex — capability-driven projection re-calibration (#305, ADR-0023).
+//
+// Pure helpers for "re-calibrate when capability outgrows the band": when an
+// athlete's demonstrated capability (the same recent-window median the floor was
+// derived from) has climbed a FULL band-width past their stretch target, the
+// projection is re-derived from current capability.
+//
+// Refines ADR-0021/0005's "floor immovable" to "floor MONOTONIC non-decreasing":
+// the floor steps UP only, never above demonstrated capability (round-down
+// median, so it still never overstates), and the stretch + progress re-derive
+// on top of it. Uses ONLY the individual's own logged lifts — no cohort number.
+//
+// Idempotency is structural, not bolted-on: newFloor = round-down(current)
+// forces current < newFloor + increment ≤ deriveStretch(newFloor) ≤ newStretch,
+// so a re-calibrated pattern can never read "achieved" against its new band on
+// the next apply — the trigger cannot re-fire until a fresh band-width of growth.
+//
+// Pure: no I/O, no clock reads.
+
+import {
+  currentCapability,
+  deriveProgress,
+  deriveStretch,
+  type PatternProjection,
+  PROJECTION_INCREMENT_KG,
+  roundTo,
+} from "../_shared/calibration-projection.ts";
+import type { E1RMSession, ProgressionTrend } from "../_shared/plateau-verdict.ts";
+
+/**
+ * True iff demonstrated capability has climbed a full band-width past stretch —
+ * i.e. capability is now as far above stretch as stretch was above floor. The
+ * threshold is self-relative (the athlete's own band), never an absolute kg or
+ * cross-athlete constant.
+ */
+export function outgrewBand(
+  projection: PatternProjection,
+  current: number,
+): boolean {
+  const band = projection.stretch - projection.floor;
+  return current >= projection.stretch + band;
+}
+
+/**
+ * Re-calibrate a projection whose demonstrated capability has outgrown its band.
+ * Returns the new {floor, stretch, progress} — floor monotonic non-decreasing,
+ * stretch upward-only, progress recomputed against the new band — or null when
+ * there is no e1RM signal or the band has not been outgrown.
+ */
+export function rederiveOutgrownProjection(
+  projection: PatternProjection,
+  e1rmSessions: E1RMSession[],
+  cadenceDays: number | null,
+  trend: ProgressionTrend,
+): PatternProjection | null {
+  const current = currentCapability(e1rmSessions, cadenceDays);
+  if (current === null) return null;
+  if (!outgrewBand(projection, current)) return null;
+
+  // Floor steps up to demonstrated capability (round-down median → never
+  // overstates); monotonic guard keeps it from ever retreating.
+  const newFloor = Math.max(
+    projection.floor,
+    roundTo(current, PROJECTION_INCREMENT_KG, "down"),
+  );
+  // Upward-only: never lowers a stretch the athlete deliberately raised (#269).
+  const newStretch = Math.max(projection.stretch, deriveStretch(newFloor, trend));
+  const newProgress = deriveProgress(current, newFloor, newStretch);
+  return {
+    pattern: projection.pattern,
+    floor: newFloor,
+    stretch: newStretch,
+    progress: newProgress,
+  };
+}

--- a/supabase/functions/update-trainee-model/recalibration_test.ts
+++ b/supabase/functions/update-trainee-model/recalibration_test.ts
@@ -1,0 +1,96 @@
+// Project Apex — unit tests for capability-driven projection re-calibration
+// (#305, ADR-0023). Pure helpers — no DB, no clock.
+//
+// Run locally:
+//   deno test supabase/functions/update-trainee-model/recalibration_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { outgrewBand, rederiveOutgrownProjection } from "./recalibration.ts";
+import type { PatternProjection } from "../_shared/calibration-projection.ts";
+import type { E1RMSession } from "../_shared/plateau-verdict.ts";
+
+const proj = (
+  floor: number,
+  stretch: number,
+  progress: PatternProjection["progress"] = "on_track",
+): PatternProjection => ({ pattern: "squat", floor, stretch, progress });
+
+/** Sessions all at the same e1RM → median == that value for any window. */
+function flat(e1rm: number, n = 4): E1RMSession[] {
+  return Array.from({ length: n }, (_, i) => ({
+    loggedAt: new Date(2026, 0, i + 1),
+    e1rm,
+    avgRPE: 8,
+  }));
+}
+
+// ─── outgrewBand ────────────────────────────────────────────────────────────
+
+Deno.test("outgrewBand: below a full band past stretch → false", () => {
+  // floor 100, stretch 110, band 10 → threshold 120.
+  assertEquals(outgrewBand(proj(100, 110), 119), false);
+});
+
+Deno.test("outgrewBand: exactly a full band past stretch → true", () => {
+  assertEquals(outgrewBand(proj(100, 110), 120), true);
+});
+
+Deno.test("outgrewBand: well past → true", () => {
+  assertEquals(outgrewBand(proj(100, 110), 135), true);
+});
+
+// ─── rederiveOutgrownProjection ─────────────────────────────────────────────
+
+Deno.test("rederive: capability inside the band → null (not outgrown)", () => {
+  assertEquals(
+    rederiveOutgrownProjection(proj(100, 110), flat(115), 3, "progressing"),
+    null,
+  );
+});
+
+Deno.test("rederive: no e1RM history → null", () => {
+  assertEquals(
+    rederiveOutgrownProjection(proj(100, 110), [], 3, "progressing"),
+    null,
+  );
+});
+
+Deno.test("rederive: outgrown (progressing) → floor steps up to demonstrated, stretch + progress re-derive", () => {
+  // current 125: newFloor = round-down 125 = 125; stretch = round-up(125×1.075=134.375)=135;
+  // progress = deriveProgress(125,125,135) → on_track.
+  const out = rederiveOutgrownProjection(proj(100, 110, "achieved"), flat(125), 3, "progressing");
+  assertEquals(out, { pattern: "squat", floor: 125, stretch: 135, progress: "on_track" });
+});
+
+Deno.test("rederive: floor is monotonic non-decreasing (never below the old floor)", () => {
+  const out = rederiveOutgrownProjection(proj(100, 110), flat(125), 3, "progressing")!;
+  assertEquals(out.floor >= 100, true);
+});
+
+Deno.test("rederive: re-applying the result is a no-op — idempotent (progressing)", () => {
+  const first = rederiveOutgrownProjection(proj(100, 110), flat(125), 3, "progressing")!;
+  // Same capability, now against the new band → must NOT re-fire.
+  assertEquals(
+    rederiveOutgrownProjection(first, flat(125), 3, "progressing"),
+    null,
+  );
+});
+
+Deno.test("rederive: idempotent even on a DECLINING trend (the small-margin case)", () => {
+  // declining margin is only 2.5%, but newFloor = round-down(current) guarantees
+  // stretch ≥ floor+2.5 > current, so it can never stay 'achieved' → no flip-flop.
+  const first = rederiveOutgrownProjection(proj(100, 110), flat(125), 3, "declining")!;
+  assertEquals(first.stretch > 125, true); // strictly above current
+  assertEquals(
+    rederiveOutgrownProjection(first, flat(125), 3, "declining"),
+    null,
+  );
+});
+
+Deno.test("rederive: a user-raised stretch above the re-derived value is preserved (upward-only)", () => {
+  // floor 100, stretch manually raised to 320; band 220 → threshold 540.
+  const out = rederiveOutgrownProjection(proj(100, 320, "achieved"), flat(545), 3, "progressing")!;
+  // newFloor = 545; deriveStretch(545,progressing)=round-up(585.875)=587.5; max(320,587.5)=587.5.
+  assertEquals(out.floor, 545);
+  assertEquals(out.stretch, 587.5);
+});


### PR DESCRIPTION
Part of #305 (slice 1 of 3). Does not close the umbrella.

Option D, slice 1 — the **server mechanism** for "re-calibrate when capability outgrows the band" (see #305 pivot comment + forthcoming ADR-0023).

## What
- `recalibration.ts` — pure helpers: `outgrewBand` (capability ≥ stretch + a full band-width, self-relative) + `rederiveOutgrownProjection` (floor steps up monotonically to round-down(current), stretch upward-only, progress recomputed). **Idempotency is structural** — `newFloor = round-down(current)` forces `current < newFloor+incr ≤ deriveStretch(newFloor) ≤ newStretch`, so a re-calibrated pattern can't read "achieved" next apply. (The grill's "declining-trend flip-flop" worry was verified a false alarm and locked by a test.)
- Wired into the `update-trainee-model` projection arm (per-pattern, after lazy-derive, before progress-recompute). Stamps a **watermark** (`lastRecalibratedAtSessionCount` + `lastRecalibratedPatterns`) — written here, consumed by the slice-2 surface.
- Exported `roundTo` from `_shared/calibration-projection.ts`.

## Scope
EF-only. No SQL migration. The watermark is written but not yet surfaced (slice 2).

## Tests
- 10 pure unit tests (`recalibration_test.ts`), green locally.
- 1 orchestrator DB test (CI `ef-test`): calibrate via stable sessions → ramp squat past its band → assert floor steps up, watermark + moved-pattern list stamped, other patterns untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)