### PR TITLE
feat(#305 slice 2/3): surface re-calibration via the re-armed calibration banner

### DIFF
--- a/ProjectApex/Features/Workout/CalibrationReviewBannerCopy.swift
+++ b/ProjectApex/Features/Workout/CalibrationReviewBannerCopy.swift
@@ -13,14 +13,29 @@ import Foundation
 
 enum CalibrationReviewBannerCopy {
 
-    /// Constant banner title — tone is fixed here (#269).
-    static let title = "Your starting targets are ready"
+    /// Banner title — first calibration vs a re-calibration (#269, #305). A
+    /// re-calibration celebrates the level-up; the first calibration introduces
+    /// the targets.
+    static func title(isRecalibration: Bool) -> String {
+        isRecalibration ? "You've leveled up" : "Your starting targets are ready"
+    }
 
-    /// Banner body for a calibration-review signal (#269). Names up to 3
-    /// patterns via `MovementPattern.displayName`, collapsing the remainder to
-    /// "and more" beyond 3. Returns a generic fallback when the projection list
-    /// is empty (defensive — the signal isn't produced when empty).
+    /// Banner body for a calibration-review signal. For a re-calibration (#305)
+    /// it names the patterns that outgrew their targets and frames it as
+    /// SUSTAINED progress (the trigger is the recent-window median, not a single
+    /// PR). For a first calibration (#269) it introduces the new targets. Both
+    /// name up to 3 patterns via `MovementPattern.displayName`, collapsing the
+    /// remainder to "and more" beyond 3.
     static func body(for signal: CalibrationReviewSignal) -> String {
+        if signal.isRecalibration {
+            let patterns = signal.recalibratedPatterns
+            let named = patterns.prefix(3).map(\.displayName)
+            let listed = patterns.count > 3
+                ? named.joined(separator: ", ") + ", and more"
+                : naturalJoin(named)
+            let target = patterns.count > 1 ? "targets" : "target"
+            return "You've consistently climbed past your \(listed) \(target) — here's a higher one."
+        }
         let patterns = signal.projections.map(\.pattern)
         guard !patterns.isEmpty else {
             return "We've set your starting targets — take a look."

--- a/ProjectApex/Features/Workout/CalibrationReviewView.swift
+++ b/ProjectApex/Features/Workout/CalibrationReviewView.swift
@@ -26,6 +26,10 @@ struct CalibrationReviewView: View {
     /// Per-pattern floor/stretch projections to display. Passed in from the
     /// calibration-review signal (already sorted by pattern.rawValue).
     let projections: [PatternProjection]
+    /// #305 (ADR-0023): patterns that just re-calibrated (capability outgrew
+    /// the band). Empty ⇒ first-ever calibration. Drives the celebratory intro
+    /// copy + the per-row "Levelled up" badge.
+    let recalibratedPatterns: Set<MovementPattern>
 
     @Environment(AppDependencies.self) private var deps
     @Environment(\.dismiss) private var dismiss
@@ -42,9 +46,13 @@ struct CalibrationReviewView: View {
     private static let accentPurple = Color(red: 0.58, green: 0.45, blue: 0.95)
     private static let darkChrome = Color(red: 0.04, green: 0.04, blue: 0.06)
 
-    init(projections: [PatternProjection]) {
+    init(projections: [PatternProjection], recalibratedPatterns: Set<MovementPattern> = []) {
         self.projections = projections
+        self.recalibratedPatterns = recalibratedPatterns
     }
+
+    /// True iff this presentation is a re-calibration (vs the first calibration).
+    private var isRecalibration: Bool { !recalibratedPatterns.isEmpty }
 
     // MARK: - Pure payload helper (the seam under TDD)
 
@@ -121,7 +129,9 @@ struct CalibrationReviewView: View {
     private var introCard: some View {
         VStack(alignment: .leading, spacing: 10) {
             sectionHeader("WHAT THIS MEANS")
-            Text("Your starting targets are ready. Floor is the level we'll keep you at; stretch is the next milestone to aim for — nudge it up if you want a bigger goal.")
+            Text(isRecalibration
+                ? "You've consistently climbed past some of your targets — so we've raised them. Floor is the level we'll keep you at; stretch is your next milestone. Nudge it up if you want a bigger goal."
+                : "Your starting targets are ready. Floor is the level we'll keep you at; stretch is the next milestone to aim for — nudge it up if you want a bigger goal.")
                 .font(.system(size: 13))
                 .foregroundStyle(.white.opacity(0.55))
         }
@@ -163,12 +173,24 @@ struct CalibrationReviewView: View {
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(.white)
                 Spacer()
-                Text(Self.progressLabel(projection.progress))
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(Self.accentPurple)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 4)
-                    .background(Self.accentPurple.opacity(0.14), in: Capsule())
+                // #305: a freshly re-calibrated pattern shows a "Levelled up"
+                // badge rather than its (just-reset) progress label, so hitting
+                // the old target reads as a win, not a demotion to "On track".
+                if recalibratedPatterns.contains(projection.pattern) {
+                    Text("Levelled up")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Self.accentPurple)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(Self.accentPurple.opacity(0.14), in: Capsule())
+                } else {
+                    Text(Self.progressLabel(projection.progress))
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Self.accentPurple)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(Self.accentPurple.opacity(0.14), in: Capsule())
+                }
             }
             Text("Floor: \(Self.formatWeight(projection.floor)) kg")
                 .font(.system(size: 13).monospacedDigit())

--- a/ProjectApex/Features/Workout/PreWorkoutView.swift
+++ b/ProjectApex/Features/Workout/PreWorkoutView.swift
@@ -440,7 +440,7 @@ struct PreWorkoutView: View {
                 .foregroundStyle(accentColor)
             VStack(alignment: .leading, spacing: 8) {
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(CalibrationReviewBannerCopy.title)
+                    Text(CalibrationReviewBannerCopy.title(isRecalibration: signal.isRecalibration))
                         .font(.system(size: 14, weight: .bold))
                         .foregroundStyle(.white)
                     Text(CalibrationReviewBannerCopy.body(for: signal))

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -298,7 +298,10 @@ struct WorkoutView: View {
                 calibrationReviewSignal = await deps.traineeModelService.digest()?.calibrationReviewSignal
             }
         }) {
-            CalibrationReviewView(projections: calibrationReviewSignal?.projections ?? [])
+            CalibrationReviewView(
+                projections: calibrationReviewSignal?.projections ?? [],
+                recalibratedPatterns: Set(calibrationReviewSignal?.recalibratedPatterns ?? [])
+            )
                 .presentationDetents([.large])
         }
         .alert("Session Mismatch", isPresented: $showMismatchRecoveryAlert) {

--- a/ProjectApex/Models/TraineeModel.swift
+++ b/ProjectApex/Models/TraineeModel.swift
@@ -49,6 +49,12 @@ struct TraineeModel: Codable, Sendable, Hashable {
     /// Set true once they acknowledge the read-only projection screen, which
     /// suppresses the banner via `TraineeModelDigest.deriveCalibrationReviewSignal`.
     var calibrationReviewAcknowledged: Bool
+    /// #305 (ADR-0023): the highest re-calibration watermark
+    /// (`ProjectionState.lastRecalibratedAtSessionCount`) the athlete has
+    /// acknowledged. A watermark newer than this re-arms the calibration banner.
+    /// Event-keyed (not a boolean) so a session-apply re-arm and a goal-EF ack
+    /// advance disjoint values rather than clobbering one boolean.
+    var acknowledgedRecalibrationSessionCount: Int?
 
     init(
         activeProgramId: UUID? = nil,
@@ -69,7 +75,8 @@ struct TraineeModel: Codable, Sendable, Hashable {
         lastClassifiedNoteCreatedAt: Date? = nil,
         lastGlobalPhaseAdvanceFiredAtSessionCount: Int? = nil,
         acknowledgedTriggeringSessionCounts: Set<Int> = [],
-        calibrationReviewAcknowledged: Bool = false
+        calibrationReviewAcknowledged: Bool = false,
+        acknowledgedRecalibrationSessionCount: Int? = nil
     ) {
         self.activeProgramId = activeProgramId
         self.goal = goal
@@ -90,6 +97,7 @@ struct TraineeModel: Codable, Sendable, Hashable {
         self.lastGlobalPhaseAdvanceFiredAtSessionCount = lastGlobalPhaseAdvanceFiredAtSessionCount
         self.acknowledgedTriggeringSessionCounts = acknowledgedTriggeringSessionCounts
         self.calibrationReviewAcknowledged = calibrationReviewAcknowledged
+        self.acknowledgedRecalibrationSessionCount = acknowledgedRecalibrationSessionCount
     }
 
     // MARK: Custom Codable for JSONB shape parity (slice A12 / #83)
@@ -125,6 +133,10 @@ struct TraineeModel: Codable, Sendable, Hashable {
         case lastGlobalPhaseAdvanceFiredAtSessionCount
         case acknowledgedTriggeringSessionCounts
         case calibrationReviewAcknowledged = "calibration_review_acknowledged"
+        // camelCase (no override) so the goal-EF write and this decode agree —
+        // consistent with totalSessionCount / projections.* (see #305 report on
+        // the legacy calibration_review_acknowledged snake-case mismatch).
+        case acknowledgedRecalibrationSessionCount
     }
 
     init(from decoder: Decoder) throws {
@@ -212,6 +224,11 @@ struct TraineeModel: Codable, Sendable, Hashable {
         self.calibrationReviewAcknowledged = try c.decodeIfPresent(
             Bool.self, forKey: .calibrationReviewAcknowledged
         ) ?? false
+        // Tolerant decode (#305): absent on rows predating re-calibration → nil
+        // (no watermark acknowledged yet, so a re-calibration is eligible to fire).
+        self.acknowledgedRecalibrationSessionCount = try c.decodeIfPresent(
+            Int.self, forKey: .acknowledgedRecalibrationSessionCount
+        )
     }
 
     func encode(to encoder: Encoder) throws {
@@ -249,6 +266,7 @@ struct TraineeModel: Codable, Sendable, Hashable {
         // (cf. prescriptionAccuracy / recentlyAdvancedPatterns sorting). #258.
         try c.encode(acknowledgedTriggeringSessionCounts.sorted(), forKey: .acknowledgedTriggeringSessionCounts)
         try c.encode(calibrationReviewAcknowledged, forKey: .calibrationReviewAcknowledged)
+        try c.encodeIfPresent(acknowledgedRecalibrationSessionCount, forKey: .acknowledgedRecalibrationSessionCount)
     }
 
     // MARK: Major patterns (calibration / phase-advance gating)

--- a/ProjectApex/Models/TraineeModelDigest.swift
+++ b/ProjectApex/Models/TraineeModelDigest.swift
@@ -137,8 +137,21 @@ struct CalibrationReviewSignal: Codable, Sendable, Hashable {
     /// Per-pattern floor/stretch projections, sorted by `pattern.rawValue` for
     /// deterministic ordering.
     var projections: [PatternProjection]
+    /// #305 (ADR-0023): the patterns that just re-calibrated (capability outgrew
+    /// the band). Empty ⇒ this is the FIRST calibration display; non-empty ⇒ a
+    /// re-calibration — which flips the banner/screen to celebratory copy + a
+    /// "Levelled up" badge on these patterns' rows.
+    var recalibratedPatterns: [MovementPattern]
 
-    enum CodingKeys: String, CodingKey { case projections }
+    /// True iff this signal is a re-calibration (vs the first-ever calibration).
+    var isRecalibration: Bool { !recalibratedPatterns.isEmpty }
+
+    init(projections: [PatternProjection], recalibratedPatterns: [MovementPattern] = []) {
+        self.projections = projections
+        self.recalibratedPatterns = recalibratedPatterns
+    }
+
+    enum CodingKeys: String, CodingKey { case projections; case recalibratedPatterns }
 }
 
 // MARK: - HeavyReassessmentSignal
@@ -287,11 +300,30 @@ extension TraineeModelDigest {
     static func deriveCalibrationReviewSignal(
         from model: TraineeModel
     ) -> CalibrationReviewSignal? {
-        guard let proj = model.projections, proj.calibrationReviewFiredAt != nil else { return nil }
-        guard !model.calibrationReviewAcknowledged else { return nil }
+        guard let proj = model.projections else { return nil }
         let ps = proj.patternProjections.sorted { $0.pattern.rawValue < $1.pattern.rawValue }
         guard !ps.isEmpty else { return nil }
-        return CalibrationReviewSignal(projections: ps)
+
+        // Re-calibration (#305): a watermark strictly newer than the one the
+        // athlete has acknowledged. Event-keyed (watermark vs ack-watermark), so
+        // it survives a server sync and can't be reverted by an unrelated write.
+        let recalUnacked: Bool = {
+            guard let recalAt = proj.lastRecalibratedAtSessionCount else { return false }
+            guard let acked = model.acknowledgedRecalibrationSessionCount else { return true }
+            return recalAt > acked
+        }()
+
+        // First calibration (#269): fired and not yet acknowledged.
+        let firstUnacked = proj.calibrationReviewFiredAt != nil && !model.calibrationReviewAcknowledged
+
+        guard recalUnacked || firstUnacked else { return nil }
+
+        // A re-calibration display names the patterns that moved (celebratory
+        // copy + badge); a first calibration carries an empty list (neutral copy).
+        let recalibrated = recalUnacked
+            ? proj.lastRecalibratedPatterns.sorted { $0.rawValue < $1.rawValue }
+            : []
+        return CalibrationReviewSignal(projections: ps, recalibratedPatterns: recalibrated)
     }
 }
 

--- a/ProjectApex/Models/TraineeModelProfiles.swift
+++ b/ProjectApex/Models/TraineeModelProfiles.swift
@@ -217,14 +217,38 @@ struct ProjectionState: Codable, Sendable, Hashable {
     var patternProjections: [PatternProjection]
     var calibrationReviewFiredAt: Date?
     var goalLastRenegotiatedAt: Date?
+    /// #305 (ADR-0023): the session-count at which a pattern most recently
+    /// re-calibrated (capability outgrew its band), and which patterns moved in
+    /// that apply. EF-written; drive the re-calibration banner re-arm + copy.
+    var lastRecalibratedAtSessionCount: Int?
+    var lastRecalibratedPatterns: [MovementPattern]
 
     init(
         patternProjections: [PatternProjection] = [],
         calibrationReviewFiredAt: Date? = nil,
-        goalLastRenegotiatedAt: Date? = nil
+        goalLastRenegotiatedAt: Date? = nil,
+        lastRecalibratedAtSessionCount: Int? = nil,
+        lastRecalibratedPatterns: [MovementPattern] = []
     ) {
         self.patternProjections = patternProjections
         self.calibrationReviewFiredAt = calibrationReviewFiredAt
         self.goalLastRenegotiatedAt = goalLastRenegotiatedAt
+        self.lastRecalibratedAtSessionCount = lastRecalibratedAtSessionCount
+        self.lastRecalibratedPatterns = lastRecalibratedPatterns
+    }
+
+    // Tolerant decode: rows written before #305 lack the re-calibration keys.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.patternProjections =
+            try c.decodeIfPresent([PatternProjection].self, forKey: .patternProjections) ?? []
+        self.calibrationReviewFiredAt =
+            try c.decodeIfPresent(Date.self, forKey: .calibrationReviewFiredAt)
+        self.goalLastRenegotiatedAt =
+            try c.decodeIfPresent(Date.self, forKey: .goalLastRenegotiatedAt)
+        self.lastRecalibratedAtSessionCount =
+            try c.decodeIfPresent(Int.self, forKey: .lastRecalibratedAtSessionCount)
+        self.lastRecalibratedPatterns =
+            try c.decodeIfPresent([MovementPattern].self, forKey: .lastRecalibratedPatterns) ?? []
     }
 }

--- a/ProjectApex/Services/TraineeModelService.swift
+++ b/ProjectApex/Services/TraineeModelService.swift
@@ -113,6 +113,15 @@ actor TraineeModelService {
     func acknowledgeCalibrationReview() async throws {
         guard var model = await store.load() else { return }
         model.calibrationReviewAcknowledged = true
+        // #305: also advance the re-calibration ack watermark to the current
+        // watermark so the repeating re-calibration banner hides immediately
+        // (mirrors the server ack). max() keeps it monotonic. No-op when no
+        // re-calibration has fired (watermark nil).
+        if let recalAt = model.projections?.lastRecalibratedAtSessionCount {
+            model.acknowledgedRecalibrationSessionCount = max(
+                model.acknowledgedRecalibrationSessionCount ?? Int.min, recalAt
+            )
+        }
         try await store.save(model)
     }
 

--- a/ProjectApexTests/CalibrationReviewBannerCopyTests.swift
+++ b/ProjectApexTests/CalibrationReviewBannerCopyTests.swift
@@ -22,6 +22,16 @@ struct CalibrationReviewBannerCopyTests {
         )
     }
 
+    /// A re-calibration signal (#305): the given patterns just outgrew their band.
+    private func recalSignal(_ patterns: [MovementPattern]) -> CalibrationReviewSignal {
+        CalibrationReviewSignal(
+            projections: patterns.map {
+                PatternProjection(pattern: $0, floor: 100, stretch: 110, progress: .onTrack)
+            },
+            recalibratedPatterns: patterns
+        )
+    }
+
     @Test("names a single pattern via displayName — no raw snake_case tokens leak")
     func onePatternUsesDisplayName() {
         let body = CalibrationReviewBannerCopy.body(for: signal([.horizontalPush]))
@@ -50,8 +60,39 @@ struct CalibrationReviewBannerCopyTests {
         #expect(!body.contains("Lunge"), "fourth pattern should be folded into \"and more\": \(body)")
     }
 
-    @Test("title is a constant affordance")
-    func titleIsConstant() {
-        #expect(CalibrationReviewBannerCopy.title == "Your starting targets are ready")
+    @Test("first-calibration title introduces the targets")
+    func firstCalibrationTitle() {
+        #expect(CalibrationReviewBannerCopy.title(isRecalibration: false) == "Your starting targets are ready")
+    }
+
+    @Test("re-calibration title celebrates the level-up (#305)")
+    func recalibrationTitle() {
+        #expect(CalibrationReviewBannerCopy.title(isRecalibration: true) == "You've leveled up")
+    }
+
+    @Test("re-calibration body names the outgrown patterns + frames it as sustained progress (#305)")
+    func recalibrationBodyNamesOutgrownPatterns() {
+        let body = CalibrationReviewBannerCopy.body(for: recalSignal([.squat, .horizontalPush]))
+        #expect(body.contains("Squat"))
+        #expect(body.contains("Horizontal Push"))
+        // "consistently climbed past" — the median trigger, not a one-day PR.
+        #expect(body.contains("consistently"))
+        #expect(!body.contains("starting"), "re-calibration must not call these 'starting' targets: \(body)")
+        #expect(!body.contains("_"), "body leaked a raw machine token: \(body)")
+    }
+
+    @Test("re-calibration body names only the outgrown patterns, not all projections (#305)")
+    func recalibrationBodyNamesOnlyOutgrown() {
+        // Projections cover squat + bench, but only squat outgrew its band.
+        let signal = CalibrationReviewSignal(
+            projections: [
+                PatternProjection(pattern: .squat, floor: 100, stretch: 110, progress: .onTrack),
+                PatternProjection(pattern: .horizontalPush, floor: 80, stretch: 90, progress: .ahead),
+            ],
+            recalibratedPatterns: [.squat]
+        )
+        let body = CalibrationReviewBannerCopy.body(for: signal)
+        #expect(body.contains("Squat"))
+        #expect(!body.contains("Horizontal Push"), "only the outgrown pattern should be named: \(body)")
     }
 }

--- a/ProjectApexTests/TraineeModelDigestTests.swift
+++ b/ProjectApexTests/TraineeModelDigestTests.swift
@@ -1864,6 +1864,61 @@ final class TraineeModelDigestTests: XCTestCase {
         XCTAssertEqual(signal?.projections.map(\.pattern),
                        [.hipHinge, .horizontalPush, .squat],
                        "Projections must be sorted by pattern.rawValue")
+        XCTAssertEqual(signal?.isRecalibration, false,
+            "A first calibration carries no re-calibrated patterns")
+    }
+
+    // MARK: ─── #305: re-calibration re-arm (watermark vs ack-watermark) ──────
+
+    func test_deriveCalibrationReviewSignal_reArmsWhenRecalibrationWatermarkUnacked() {
+        var model = makeBaselineModel()
+        // First calibration already acknowledged, but a re-calibration fired at
+        // session 8 and has NOT been acked → the banner re-arms.
+        model.projections = ProjectionState(
+            patternProjections: [makeProjection(.squat), makeProjection(.horizontalPush)],
+            calibrationReviewFiredAt: ref,
+            lastRecalibratedAtSessionCount: 8,
+            lastRecalibratedPatterns: [.squat]
+        )
+        model.calibrationReviewAcknowledged = true
+        model.acknowledgedRecalibrationSessionCount = nil
+
+        let signal = TraineeModelDigest.deriveCalibrationReviewSignal(from: model)
+        XCTAssertNotNil(signal, "An unacknowledged re-calibration must re-arm the banner")
+        XCTAssertEqual(signal?.isRecalibration, true)
+        XCTAssertEqual(signal?.recalibratedPatterns, [.squat],
+            "The signal names exactly the patterns that re-calibrated")
+    }
+
+    func test_deriveCalibrationReviewSignal_silencedWhenRecalibrationAcknowledged() {
+        var model = makeBaselineModel()
+        model.projections = ProjectionState(
+            patternProjections: [makeProjection(.squat)],
+            calibrationReviewFiredAt: ref,
+            lastRecalibratedAtSessionCount: 8,
+            lastRecalibratedPatterns: [.squat]
+        )
+        model.calibrationReviewAcknowledged = true
+        model.acknowledgedRecalibrationSessionCount = 8 // acked up to this watermark
+
+        XCTAssertNil(TraineeModelDigest.deriveCalibrationReviewSignal(from: model),
+            "A re-calibration acked at the current watermark must silence the banner")
+    }
+
+    func test_deriveCalibrationReviewSignal_reArmsWhenNewerWatermarkThanAck() {
+        var model = makeBaselineModel()
+        model.projections = ProjectionState(
+            patternProjections: [makeProjection(.squat)],
+            calibrationReviewFiredAt: ref,
+            lastRecalibratedAtSessionCount: 12, // a newer re-calibration
+            lastRecalibratedPatterns: [.squat]
+        )
+        model.calibrationReviewAcknowledged = true
+        model.acknowledgedRecalibrationSessionCount = 8 // only acked the older one
+
+        let signal = TraineeModelDigest.deriveCalibrationReviewSignal(from: model)
+        XCTAssertNotNil(signal, "A watermark newer than the ack must re-arm the banner")
+        XCTAssertEqual(signal?.isRecalibration, true)
     }
 
     func test_digest_calibrationReviewSignal_assignedFromDerive() {

--- a/supabase/functions/update-trainee-goal/index.ts
+++ b/supabase/functions/update-trainee-goal/index.ts
@@ -264,12 +264,24 @@ export async function upsertGoal(
   // the flag set leaves the value at `true`. The goal write above stays
   // byte-for-byte unchanged.
   if (req.acknowledge_calibration_review === true) {
+    // Acks BOTH calibration banners: the one-time first calibration
+    // (`calibrationReviewAcknowledged`) and the repeating re-calibration (#305,
+    // ADR-0023) by advancing `acknowledgedRecalibrationSessionCount` to the
+    // current re-calibration watermark (`projections.lastRecalibratedAtSessionCount`).
+    // The watermark only ever advances (EF-written, monotonic), so copying it is
+    // a monotonic ack — a later re-calibration bumps the watermark above this and
+    // re-arms the banner. Absent watermark (no re-calibration yet) → no-op copy.
     await sql`
       UPDATE public.trainee_models
       SET model_json = jsonb_set(
-        COALESCE(model_json, '{}'::jsonb),
-        '{calibrationReviewAcknowledged}',
-        'true'::jsonb,
+        jsonb_set(
+          COALESCE(model_json, '{}'::jsonb),
+          '{calibrationReviewAcknowledged}',
+          'true'::jsonb,
+          true
+        ),
+        '{acknowledgedRecalibrationSessionCount}',
+        COALESCE(model_json -> 'projections' -> 'lastRecalibratedAtSessionCount', 'null'::jsonb),
         true
       )
       WHERE user_id = ${req.user_id}

--- a/supabase/functions/update-trainee-goal/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-goal/orchestrator_test.ts
@@ -647,6 +647,58 @@ goalTest(
   },
 );
 
+// #305 (ADR-0023): acknowledge_calibration_review advances the re-calibration
+// ack watermark to the current projection watermark, so the repeating
+// re-calibration banner is acknowledged (not just the one-time first banner).
+
+goalTest(
+  "#305: acknowledge advances acknowledgedRecalibrationSessionCount to the re-calibration watermark",
+  async () => {
+    const userId = await seedFreshUserWithExistingModel({
+      goal: GOAL_A,
+      projections: {
+        patternProjections: [
+          { pattern: "squat", floor: 140, stretch: 150, progress: "on_track" },
+        ],
+        calibrationReviewFiredAt: "2026-05-12T10:00:00.000Z",
+        lastRecalibratedAtSessionCount: 8,
+        lastRecalibratedPatterns: ["squat"],
+      },
+    });
+
+    await upsertGoal(
+      { user_id: userId, goal: GOAL_A, acknowledge_calibration_review: true },
+      sql,
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const m = rows[0].model_json as Record<string, unknown>;
+    assertEquals(m.calibrationReviewAcknowledged, true);
+    assertEquals(m.acknowledgedRecalibrationSessionCount, 8);
+  },
+);
+
+goalTest(
+  "#305: acknowledge with no re-calibration watermark yet leaves the ack-watermark null",
+  async () => {
+    const userId = await seedFreshUserWithExistingModel({ goal: GOAL_A });
+
+    await upsertGoal(
+      { user_id: userId, goal: GOAL_A, acknowledge_calibration_review: true },
+      sql,
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const m = rows[0].model_json as Record<string, unknown>;
+    assertEquals(m.calibrationReviewAcknowledged, true);
+    assertEquals(m.acknowledgedRecalibrationSessionCount ?? null, null);
+  },
+);
+
 // Sentinel "test" that runs last — closes the shared pool so the connection
 // lifecycle stays local to this file rather than relying on process-exit.
 Deno.test({


### PR DESCRIPTION
Part of #305 (slice 2 of 3). Does not close the umbrella.

Option D, slice 2 — the **athlete-facing surface** for re-calibration. Consumes slice 1's watermark (#307) and re-arms the existing one-time calibration banner/screen for the repeating event.

## Watermark, not boolean (the grill's key surface decision)
The shipped `calibrationReviewAcknowledged` is a single boolean built for a one-time event; a repeating re-calibration can't re-show through it. So re-calibration is **event-keyed**: the EF stamps `projections.lastRecalibratedAtSessionCount`; the ack advances `acknowledgedRecalibrationSessionCount`; the banner re-arms iff watermark > ack. Append/advance semantics — no boolean clobber, survives a server sync.

## What
- **Decode:** `ProjectionState` reads the slice-1 watermark fields (tolerant); `TraineeModel` gains `acknowledgedRecalibrationSessionCount` (**camelCase**, so server-write and client-read agree).
- **Re-arm:** `deriveCalibrationReviewSignal` fires on an unacked first-calibration **or** a newer-than-ack re-calibration watermark; carries `recalibratedPatterns`.
- **Copy/UI:** celebratory title/body ("You've leveled up" / "consistently climbed past your <pattern> target" — framed as *sustained* progress, matching the median trigger) + a **"Levelled up" badge** on re-calibrated rows so hitting the old target reads as a win, not a demotion to "On track". Names only the outgrown patterns.
- **Ack:** goal-EF advances the watermark (server); `TraineeModelService.acknowledgeCalibrationReview` mirrors it (client). Both monotonic.

## Tests
- 7 banner-copy (first vs re-cal title/body; names-only-outgrown), 3 digest re-arm (unacked / acked / newer-watermark), 2 EF DB (ack advances watermark, no-op when no watermark).
- `xcodebuild build-for-testing` **SUCCEEDED**; 105 digest + 7 copy + 6 fixture-decode green locally. EF DB tests run in CI `ef-test`.

## Found, not fixed (cross-cutting grep rule → reported for a separate fix)
Legacy `calibrationReviewAcknowledged` has a camel/snake key mismatch (EF writes camelCase, Swift CodingKey is `calibration_review_acknowledged`, no snake decode strategy) → the #269 **server** ack doesn't survive a sync; only the local mirror hides that banner. Pre-existing, orthogonal to #305. My new field uses camelCase to avoid it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)