### PR TITLE
fix(#309): decode calibrationReviewAcknowledged from the EF's camelCase key

### DIFF
--- a/ProjectApex/Models/TraineeModel.swift
+++ b/ProjectApex/Models/TraineeModel.swift
@@ -132,11 +132,20 @@ struct TraineeModel: Codable, Sendable, Hashable {
         case lastClassifiedNoteCreatedAt
         case lastGlobalPhaseAdvanceFiredAtSessionCount
         case acknowledgedTriggeringSessionCounts
-        case calibrationReviewAcknowledged = "calibration_review_acknowledged"
-        // camelCase (no override) so the goal-EF write and this decode agree —
-        // consistent with totalSessionCount / projections.* (see #305 report on
-        // the legacy calibration_review_acknowledged snake-case mismatch).
+        // #309: camelCase — matches what the goal EF writes
+        // (`model_json.calibrationReviewAcknowledged`) and the dominant model_json
+        // convention (totalSessionCount / projections.*). Was snake_case, which
+        // silently never decoded the SERVER ack (no snake decoding strategy on the
+        // sync path); a legacy snake fallback in init(from:) preserves prior
+        // local-cache acks.
+        case calibrationReviewAcknowledged
         case acknowledgedRecalibrationSessionCount
+    }
+
+    /// #309: decode-only key for the pre-fix snake_case spelling, so a prior ack
+    /// cached locally under the old key is not dropped on upgrade.
+    private enum LegacyCodingKeys: String, CodingKey {
+        case calibrationReviewAcknowledged = "calibration_review_acknowledged"
     }
 
     init(from decoder: Decoder) throws {
@@ -219,11 +228,14 @@ struct TraineeModel: Codable, Sendable, Hashable {
         self.acknowledgedTriggeringSessionCounts = Set(try c.decodeIfPresent(
             [Int].self, forKey: .acknowledgedTriggeringSessionCounts
         ) ?? [])
-        // Tolerant decode (#269): older rows / server JSON lack the key — default
-        // to false (the banner is still eligible to fire).
+        // Tolerant decode (#269 / #309): read the camelCase key the EF writes;
+        // fall back to the legacy snake_case key so a prior local-cache ack
+        // survives the #309 key-casing fix; default false (banner still eligible).
+        let legacyAck = try decoder.container(keyedBy: LegacyCodingKeys.self)
+            .decodeIfPresent(Bool.self, forKey: .calibrationReviewAcknowledged)
         self.calibrationReviewAcknowledged = try c.decodeIfPresent(
             Bool.self, forKey: .calibrationReviewAcknowledged
-        ) ?? false
+        ) ?? legacyAck ?? false
         // Tolerant decode (#305): absent on rows predating re-calibration → nil
         // (no watermark acknowledged yet, so a re-calibration is eligible to fire).
         self.acknowledgedRecalibrationSessionCount = try c.decodeIfPresent(

--- a/ProjectApexTests/TraineeModelTests.swift
+++ b/ProjectApexTests/TraineeModelTests.swift
@@ -294,6 +294,52 @@ struct TraineeModelCodableTests {
         let decoded = try JSONDecoder().decode(TraineeModel.self, from: stripped)
         #expect(decoded.acknowledgedTriggeringSessionCounts.isEmpty)
     }
+
+    // #309: the Edge Function writes `calibrationReviewAcknowledged` (camelCase),
+    // but the Swift CodingKey was snake_case (`calibration_review_acknowledged`)
+    // with no snake decoding strategy — so the SERVER ack never decoded on the
+    // client (it survived only via the local mirror). Fix: read camelCase
+    // (matching the EF), with a legacy snake fallback so a prior local-cache ack
+    // is not dropped, and encode camelCase going forward.
+
+    private func encodedDict(_ model: TraineeModel) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(model)
+        return try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    }
+
+    private func decode(_ dict: [String: Any]) throws -> TraineeModel {
+        try JSONDecoder().decode(
+            TraineeModel.self,
+            from: try JSONSerialization.data(withJSONObject: dict)
+        )
+    }
+
+    @Test("#309: the server's camelCase calibrationReviewAcknowledged decodes")
+    func decodesCamelCaseServerAck() throws {
+        var dict = try encodedDict(TraineeModel(goal: defaultGoal()))
+        dict.removeValue(forKey: "calibration_review_acknowledged")
+        dict.removeValue(forKey: "calibrationReviewAcknowledged")
+        dict["calibrationReviewAcknowledged"] = true // what the EF actually writes
+        #expect(try decode(dict).calibrationReviewAcknowledged == true)
+    }
+
+    @Test("#309: a legacy snake-cased ack still decodes (local-cache back-compat)")
+    func decodesLegacySnakeAck() throws {
+        var dict = try encodedDict(TraineeModel(goal: defaultGoal()))
+        dict.removeValue(forKey: "calibration_review_acknowledged")
+        dict.removeValue(forKey: "calibrationReviewAcknowledged")
+        dict["calibration_review_acknowledged"] = true // older local-cache shape
+        #expect(try decode(dict).calibrationReviewAcknowledged == true)
+    }
+
+    @Test("#309: calibrationReviewAcknowledged now encodes camelCase, matching the EF")
+    func encodesCamelCaseAck() throws {
+        var model = TraineeModel(goal: defaultGoal())
+        model.calibrationReviewAcknowledged = true
+        let dict = try encodedDict(model)
+        #expect(dict["calibrationReviewAcknowledged"] as? Bool == true)
+        #expect(dict["calibration_review_acknowledged"] == nil)
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
Closes #309.

The #269 calibration-review ack had a JSON key-casing mismatch: the goal EF writes `model_json.calibrationReviewAcknowledged` (**camelCase**), but the Swift CodingKey was **snake_case** (`calibration_review_acknowledged`) and the server→client decode path (`TraineeModelUpdateJob` / `TraineeModelLocalStore`) uses a plain `JSONDecoder()` with no `keyDecodingStrategy`. So the **server** ack never decoded on the client — only the local mirror hid the banner, and a fresh sync (reinstall / cache clear) would lose it.

## Fix
- CodingKey → camelCase `calibrationReviewAcknowledged` (matches the EF + the dominant model_json convention: `totalSessionCount`, `projections.*`, etc.).
- `init(from:)` reads camelCase with a **legacy snake_case fallback**, so a prior ack cached locally under the old key isn't dropped by the casing change — this *is* the ack-durability bug, so the fix must not itself drop an ack.
- Encode now emits camelCase.

## Tests (TraineeModelCodableTests)
- camelCase server ack decodes (the bug — was red), legacy snake still decodes (back-compat), encode emits camelCase.
- `xcodebuild build` + 111 targeted tests green locally (incl. 105 digest + 6 fixture-decode unaffected).

Swift-only (no EF change). Found during #305 slice 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)