### PR TITLE
docs(design): UI-overhaul foundation — DESIGN.md, behavior spec, onboarding flow

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,219 @@
+# Apex — DESIGN.md
+
+The visual design system for the Phase 3 UI overhaul. This file is the canonical
+token spec; the behavioral/interaction spec lives in `docs/design/ui-overhaul-spec.md`,
+and per-screen design docs live in `docs/design/` (first one: `onboarding-calibration.md`).
+
+Format and philosophy follow the [design.md](https://github.com/google-labs-code/design.md)
+guide: high-contrast neutrals, ONE accent used sparingly as the sole interaction
+driver, named tokens with prose rationale, an architectural concept grounding the
+identity. Motion is our own added pillar (the guide omits it).
+
+**Status:** Foundation locked 2026-06-10, including all fixes from the two-agent
+UI/UX expert review (see Decision log). Per-screen specs layer on top.
+
+## Overview
+
+Architectural concept: **"A single ink, drawn precisely."** An engineer's technical
+drawing — one ink (ultramarine) on warm paper (cream), high contrast, zero
+decoration. Color is meaning, not garnish: when ultramarine appears, the coach is
+doing something. Calm and exact in the live loop; the ink floods full-bleed for
+brand + coaching moments. No serif, no multi-color palette, no generic-Apple look —
+the restraint is the premium.
+
+## Colors
+
+High-contrast neutrals + ONE accent (the anti-generic move). Light ("paper") is the
+default appearance; the dim variant below remaps the same roles.
+
+```yaml
+colors:
+  paper:        "#F6F2E8"   # cream canvas (user call 2026-06-10; supersedes true white)
+  surface:      "#FFFFFF"   # cards/sheets lift BRIGHTER than paper — crisp, no warm shadowing
+  well:         "#EDE7D9"   # recessed cream — input wells, inactive tracks
+  hairline:     "#DCD5C4"   # 1px structural borders, cream-tinted (cool grey reads dirty on cream)
+  ink:          "#14151A"   # near-black — ALL text, labels, icons by default (~15:1 on paper)
+  ink-muted:    "#66645C"   # warm grey — metadata, secondary labels (≥4.5:1 on paper)
+  accent-ink:   "#1322CC"   # deep ultramarine — the DEFAULT interactive color (links,
+                            # buttons-as-text, active tab, selected icon). ~6:1 on paper: AA.
+  accent:       "#1B2CFF"   # bright ultramarine — LARGE FILLS ONLY (primary button fields,
+                            # full-bleed brand floods, gauge fill, big graphic shapes).
+                            # ~4.3:1 on paper: fails AA for normal text — never use it for
+                            # text, small icons, or hairlines.
+  accent-press: "#0E1Aa3"   # pressed/active depth on accent fills
+  on-accent:    "#FFFFFF"   # text/icons on ultramarine fields
+  alert:        "#C9241B"   # back-off / safety / destructive TEXT and icons (AA on paper)
+  alert-fill:   "#FF3B30"   # alert as a large fill (banner field, stop button) with white on it
+```
+
+Rationale:
+- **Contrast roles are the load-bearing fix** from the UI review (P0-4): bright
+  `accent` on cream is ~4.3:1, which fails WCAG AA for normal text and makes thin
+  strokes shimmer in gym lighting. So: reading surfaces are always `ink`;
+  interactive emphasis is `accent-ink`; bright `accent` is reserved for shapes big
+  enough that contrast is about presence, not legibility.
+- **Success is NOT green.** A "win" reads in ultramarine — on-brand, earned, plus
+  weight/motion/haptic. Red is reserved strictly for "back off / stop" so it always
+  means exactly that.
+- **Never** introduce a third hue. State changes come from ink, weight, and motion
+  (see States), not from new colors.
+
+### Dim variant
+
+Same roles, remapped — "the negative of the page." Specced now (review P1): a gym
+app shipping light-only earns day-one glare complaints in dark home gyms and
+late-night sessions. Not a separate design; a token remap.
+
+```yaml
+colors-dim:
+  paper:        "#14151A"   # ink becomes the canvas
+  surface:      "#1C1E25"   # cards lift LIGHTER than paper (no shadows in dim)
+  well:         "#101116"   # recessed
+  hairline:     "#2A2D36"
+  ink:          "#F6F2E8"   # cream becomes the text
+  ink-muted:    "#9B9DA6"
+  accent-ink:   "#7B85FF"   # ultramarine lifted for dark — #1B2CFF is ~1.6:1 on ink and
+                            # unusable; this cut holds AA for interactive text/icons
+  accent:       "#1B2CFF"   # full-bleed floods stay TRUE ultramarine with white on top —
+                            # the brand color itself never shifts, only its small-scale cut
+  accent-press: "#98A0FF"
+  on-accent:    "#FFFFFF"
+  alert:        "#FF6B61"
+  alert-fill:   "#FF3B30"
+```
+
+Follow the system appearance by default; offer an in-app override in Settings.
+
+## Typography
+
+Bold display sans + clean UI sans. **No serif anywhere** — editorial character comes
+from weight and scale, not serifs.
+
+```yaml
+type:
+  display:  { family: "Space Grotesk", weight: 600, tracking: "-0.02em" }
+            # coach's voice, brand moments, big headlines
+  hero-num: { family: "Space Grotesk", weight: 700, features: ["tnum"] }
+            # weight × reps, huge; tabular figures so digits never jitter
+  ui:       { family: "Inter", weight: 500 }   # labels, nav, controls
+  body:     { family: "Inter", weight: 400 }   # reading text
+```
+
+Scale anchors (pt, before Dynamic Type):
+
+```yaml
+type-scale:
+  hero-num: 64     # the live-loop weight/reps numbers
+  display:  34     # coach's read, screen titles in brand moments
+  title:    22     # section titles
+  body:     17
+  label:    13     # metadata, axis labels (ink-muted)
+```
+
+### Dynamic Type & localization (review P2)
+
+- Body, labels, and UI text track Dynamic Type through the AX sizes.
+- `hero-num` and `display` cap at 1.3× — past that, layout sheds decoration
+  (gauge shrinks, metadata hides) before numbers truncate. Numbers never ellipsize.
+- The coach's-read hero must survive 4-line wrap at AX sizes without clipping.
+- Buttons size to their label (no fixed-width text buttons); all-caps only in
+  brand moments and never on localized strings; minimum tap target 44pt.
+
+## Spacing & Shape
+
+```yaml
+spacing: { xs: 4, sm: 8, md: 16, lg: 24, xl: 32, xxl: 48 }
+rounded: { sm: 8, md: 16, lg: 24, pill: 999 }
+elevation:
+  card: "y2 blur12 rgba(20,21,26,0.06)"   # only the active/coach surface lifts (light mode)
+```
+
+Friendly-but-engineered rounding; depth from hairlines + one soft shadow, never
+shadow stacks. In dim, depth comes from surface lightness, not shadow.
+
+## States (review P0-4)
+
+A single accent can't carry every state, so states are built from **ink + weight +
+motion**, not more colors:
+
+```yaml
+states:
+  interactive: "accent-ink text/icon (the only resting use of the accent at small scale)"
+  pressed:     "accent-press + log-settle motion (below)"
+  selected:    "surface card, 2px ink border, label steps 500 → 600 — selection is
+                structural, so the accent stays free to mean 'act here'"
+  disabled:    "ink-muted at 40%, no motion"
+  focus:       "2px accent-ink ring, 2pt offset (keyboard/a11y)"
+  success:     "ultramarine moment — never green: weight + ratchet motion + haptic"
+  error:       "alert — reserved for back-off / stop / destructive meanings only"
+```
+
+## Data visualization (review P2)
+
+One accent has to chart everything, and charts must encode **confidence** (the
+trainee model distinguishes measured from estimated — see `ui-overhaul-spec.md` §8):
+
+```yaml
+data-viz:
+  series-primary:   "accent-ink line, 2pt"
+  series-compare:   "ink at 30% opacity, 2pt"
+  band:             "accent at 8% fill, hairline edges (floor/stretch capability band)"
+  projection:       "dashed 4-2, accent-ink — anything projected/estimated is dashed"
+  point-measured:   "solid accent-ink dot"
+  point-estimated:  "hollow dot (ink stroke) — low-confidence data LOOKS less certain"
+  axis:             "label type, ink-muted; hairline gridlines, horizontal only"
+```
+
+## Iconography
+
+SF Symbols, medium weight (≈1.75pt stroke at 17pt), `ink` by default, `accent-ink`
+only when interactive. Filled variant only for the selected tab. No decorative icons.
+
+## Motion
+
+Motion is a first-class identity pillar — but **restrained** (review P1): expressive
+motion is reserved for the **bookends** (≤4 moments); routine navigation is fast and
+invisible. "Drain-and-rise on every transition" is explicitly rejected — it tires by
+session three and risks ProMotion jank.
+
+```yaml
+motion:
+  # Expressive — bookends ONLY: app open, workout start, post-workout reveal,
+  # milestone celebration. Nowhere else.
+  transition-bookend: "drain-and-rise — color washes down/away, next screen rises
+                       through it. spring(response:0.5, damping:0.85)"
+  gauge-focus:        "iris/aperture segments rotate into alignment, tiny overshoot.
+                       spring(response:0.5, damping:0.7)"
+  celebrate-ratchet:  "milestone — the floor line clicks up one notch with a confident
+                       bounce + haptic thud"
+  # Workhorse — everything else.
+  transition-nav:     "150ms ease-out fade/slide. Routine nav should feel like nothing."
+  card-morph:         "the live session card reshapes between sets via shared-element —
+                       never a hard cut. ~350ms"
+  log-settle:         "one-tap 'done' presses down and locks. 0.2s, crisp, no bounce"
+reduce-motion: "every expressive transition falls back to a 150ms crossfade; haptics kept"
+```
+
+Feel: Apple-fluid springs, Opal-alive, a touch of Duolingo snap — never floaty.
+
+## Haptics (review P2)
+
+```yaml
+haptics:
+  set-logged:      "impact(.medium) — the thud of a plate set down"
+  rest-complete:   "two light taps"
+  milestone:       "notification(.success) + impact(.rigid) — the ratchet click"
+  back-off:        "notification(.warning)"
+  feel-pill:       "none — ignoring it must cost nothing (see spec §5)"
+  routine-nav:     "none — motion carries it"
+```
+
+## Decision log
+
+| Date | Decision |
+|---|---|
+| 2026-06-10 | Full rebuild scope; guiding principle "quietly right in the moment, visibly smart around it"; 3-tab nav (Today / Train / Progress). |
+| 2026-06-10 | Identity rounds: dark-first rejected; serif rejected (bold sans only); Claude palette + bone/limestone warm-whites rejected; then **cream `#F6F2E8` chosen over true white** by user — supersedes the true-white call earlier the same day. |
+| 2026-06-10 | **Ultramarine `#1B2CFF`** chosen by user as the single accent (over Klein cobalt, acid lime, vivid emerald). |
+| 2026-06-10 | Two-agent review (UI expert + UX expert, Uber-calibre brief) — all four P0s and the P1s accepted: **P0-1** feel-pill ignore ≠ confirm (spec §5); **P0-2** deterministic local fallback for every coach line (spec §4/§6); **P0-3** onboarding/first-run calibration flow is a required design target (`onboarding-calibration.md`); **P0-4** contrast roles — text/icons in ink, `accent-ink #1322CC` as default interactive, bright accent for large fills only. P1: dim variant specced now; motion restraint; live-loop edge cases + plan-peek. P2: gauge always backed by literal number + label; data-viz/icon/haptic/Dynamic-Type tokens added. |
+| 2026-06-10 | Motion: drain-and-rise restricted to ≤4 bookend moments; 150ms workhorse nav; Reduce Motion fallback mandatory. |

--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,32 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-10 — The new look has a rulebook, and new users get a proper welcome
+
+**What happened (in plain words):**
+We're rebuilding how the whole app looks and feels. Today the ground rules got
+written down for real: one signature color (a deep blue called ultramarine) on warm
+cream paper, bold clean lettering, and animation saved for the big moments so it
+stays special. Two expert reviewers (one for looks, one for experience) went over
+the plan and found real problems — the blue text was too hard to read on cream, the
+app had no plan for brand-new users, and a couple of spots where the app could
+quietly invent data about you. All of their must-fixes are now baked into the rules.
+
+**The biggest piece:**
+A design for the app's first three minutes. A new user answers a handful of quick
+questions (goal, experience, equipment, schedule, and roughly what they can lift —
+guessing is fine, skipping is fine), and then watches the app literally draw its
+starting picture of them. Honest guesses are marked as guesses, and the first
+workouts firm them up.
+
+**What this is and isn't:**
+These are design documents — the rulebook (DESIGN.md) and two specs in docs/design/.
+No app code changed yet. Building it comes next, screen by screen.
+
+**Status:** Merged into main.
+
+---
+
 ## 2026-06-10 — A whole chapter is finished: the coach that actually learns you
 
 **The big picture (in plain words):**

--- a/docs/design/onboarding-calibration.md
+++ b/docs/design/onboarding-calibration.md
@@ -1,0 +1,184 @@
+# Onboarding / first-run calibration — design spec
+
+**Status:** designed 2026-06-10. This is the fix for review finding **P0-3**: a
+coach that *models you* is useless on day one with no model — a cold-start cliff
+where trust craters before the moat exists. The UX reviewer called this the single
+highest-leverage missing piece. Companion docs: `DESIGN.md` (tokens),
+`ui-overhaul-spec.md` (locked behavior, esp. §8 data-honesty rules).
+
+## 1. What this flow is for
+
+Three jobs, in priority order:
+
+1. **Seed the trainee model** — initial capability estimate per movement pattern,
+   each with an explicit confidence tier. Honest seeds, not fake precision.
+2. **Reach the first workout fast** — target under ~3 minutes, 8 screens max.
+   Activation is the metric; every screen must visibly buy intelligence.
+3. **Land the first "visibly smart" moment** — the payoff screen where the user
+   *watches* their model get drawn. The product's promise ("a coach that models
+   you") is demonstrated before the first set is ever lifted.
+
+## 2. Principles
+
+- **One question per screen**, thin ink progress line at top, big tap targets.
+  (Fitbod's 8-step pattern — the reference everyone copies because it works.)
+- **Every question shows its payoff.** A `label`-type line under each question
+  says what the answer buys ("This sets your starting squat band"). Never ask
+  what we can infer.
+- **Estimates are welcome, and tagged.** "It's okay to guess — your first
+  sessions sharpen this" (Yazio's microcopy pattern). A guess seeds the model at
+  low confidence; it never masquerades as a measurement (spec §8).
+- **Skip is honest.** Everything after goal is skippable. Skipping a lift seeds a
+  wider, lower-confidence band derived from experience + bodyweight — it never
+  invents a number the user "said."
+- **No theater.** The "building your model" moment shows real derived values and
+  lasts only as long as it needs to. No fake percent counters (Cal AI's 18%
+  screen is the anti-pattern), no 20-question quiz wall, no paywall before the
+  payoff.
+
+## 3. The flow
+
+```
+0 Splash → 1 Goal → 2 Experience → 3 Equipment → 4 Schedule
+        → 5 Bodyweight → 6 Capability seeding (core) → 7 Model reveal (payoff)
+        → Today, first workout ready
+```
+
+### 0. Splash / brand moment
+
+Ultramarine flood, bold display sans, then **drain-and-rise** into screen 1 (this
+is one of the four sanctioned bookend moments). One line of voice: what the app
+is — *"the coach that models you."* No carousel, no feature tour; the tour is the
+payoff screen.
+
+### 1. Goal
+
+Single-select list (Centr/Fitbod pattern): get stronger / build muscle / both-ish
+general strength. Selected state per `DESIGN.md` §States (ink border + weight, not
+accent fill). Payoff line: "Sets what your program optimizes for."
+Goal text feeds the existing goal machinery (heavy-reassessment, renegotiation).
+
+### 2. Experience
+
+Three options with one-line descriptions (Fitbod's exact pattern): new to lifting /
+have lifted, getting back or inconsistent / train consistently. Payoff line:
+"Calibrates how we ask about your lifts — and how wide your starting bands are."
+This answer **branches screen 6** (see below).
+
+### 3. Equipment
+
+Multi-select illustrated grid (Fitbod): barbell / dumbbells / machines / cables /
+kettlebells / bodyweight-only, plus "full commercial gym" shortcut that selects
+everything. Payoff line: "Filters every exercise we'll ever prescribe."
+
+### 4. Schedule
+
+Days per week, single tap (2 / 3 / 4 / 5+). Payoff line: "Shapes your week
+structure." Feeds the program skeleton layer.
+
+### 5. Bodyweight
+
+One big tabular number, numpad, kg/lb unit pill (Yazio pattern — the unit choice
+persists app-wide). Microcopy: "It's okay to guess." Used for relative-strength
+estimation in screen 6's fallbacks (and AMRAP/bodyweight exercises later).
+
+### 6. Capability seeding — the core screen
+
+One sub-screen per big pattern, same layout each time, hero numbers huge
+(`hero-num` type): **squat, bench (horizontal push), deadlift (hinge)**, and — only
+if "train consistently" was chosen — **overhead press**. Three to four sub-screens.
+
+Per pattern, a three-way segmented choice, strongest data first:
+
+| Option | Input | Seeds | Confidence |
+|---|---|---|---|
+| **A set I've done recently** | weight × reps (numpad + steppers) | e1RM via the engine's standard formula | **measured-ish (high)** |
+| **My best guess** | weight for "about 5 solid reps" | e1RM from the guess | **estimated (medium)** |
+| **Not sure** | nothing | band from experience level × bodyweight heuristics | **unknown (low)** |
+
+Rules:
+- "Beginner" experience flips the default to "Not sure" and reframes the prompt
+  ("Most people skip this — your first session works it out").
+- Microcopy under every variant: "A guess is fine — your first sessions sharpen
+  this."
+- The skip affordance is calm and equal-weight; skipping = option C, recorded as
+  unknown. **Never** silently recorded as an answer (spec §8 rule 1).
+- Plate-math nicety: weight input snaps to real increments for the chosen unit.
+
+### 7. The model reveal — the payoff bookend
+
+Two beats, both real:
+
+1. **Drawing (~2s, honest):** short checklist ticking as actual derivation runs
+   (stoic's "preparing the app for you" pattern, restyled ink-on-cream):
+   "Placing your squat band ✓ / Setting your floors ✓ / Building week 1 ✓". The
+   Lens iris focuses as items resolve (`gauge-focus` motion).
+2. **Reveal:** the user's starting model, drawn as capability bands per pattern
+   (`DESIGN.md` §Data-viz): band fill, floor line, position dot — **solid dot for
+   pattern A answers, hollow for guesses/unknowns**, so confidence is visible from
+   minute one. One coach line in `display` type, grounded per spec §8:
+   *"Starting your squat at 80–95 kg. Two sessions and these lines get sharp."*
+
+Below the reveal: the first workout's shape (day count + first session's main
+lifts) and one **Start when ready** action → drain-and-rise to **Today**.
+
+### Landing on Today
+
+The Today coach line for day one frames calibration honestly: *"First session
+doubles as calibration — expect a weight check or two."* First-session prescriptions
+derived from low-confidence seeds start deliberately conservative; the in-session
+"Adjust" path and feel pill do the sharpening (existing calibration-review
+machinery re-fits after real sessions — onboarding only plants the seed it refines).
+
+## 4. What this flow explicitly avoids
+
+- Quiz walls (15+ questions) and any question whose payoff we can't name on-screen.
+- Fake progress theater; fabricated precision in the reveal ("your squat 1RM is
+  103.4 kg" from a guess — bands and hollow dots, not false decimals).
+- Asking for measurements mid-flow that the model doesn't use yet (height, age,
+  sex are **not** asked in v1 — add only when an engine consumer exists).
+- Account creation before the payoff. Auth happens after screen 7 (or deferred
+  until first sync) — never as a gate between questions and reveal.
+
+## 5. Model integration notes (for the build, later)
+
+- Seeds map to the existing per-pattern capability machinery (floor/stretch bands,
+  ADR-0021/ADR-0023 world). The new requirement is a **confidence tier on the
+  seed** (`measured / estimated / unknown`) that widens the band and weights how
+  fast real session data displaces the seed.
+- Onboarding pattern vocabulary must use the engine's canonical pattern names
+  (e.g. `horizontal_push`) — the EF already rejects junk patterns; don't invent a
+  parallel list.
+- The reveal's coach line is deterministic v1 (template + derived numbers), per
+  the P0-2 fallback rule — no AI call in the activation path.
+
+## 6. Open questions (decide at build time)
+
+1. Exact pattern set & count for screen 6 — match the engine's stimulus/pattern
+   table; 3 patterns for beginners vs 4 for experienced is the current call.
+2. Where auth lands (post-reveal vs deferred to first sync) — needs the Supabase
+   session model looked at.
+3. Whether schedule (screen 4) also asks session length — only if the skeleton
+   layer actually consumes it.
+4. Re-onboarding: can a user re-run calibration from Settings? (Probably yes,
+   cheap — same screens, prefilled.)
+
+## 7. Mobbin references
+
+Question screens:
+- [Fitbod — experience level](https://mobbin.com/screens/c13fe9c7-71cb-4a4b-aaac-3ea77b36f072) — 3 options + descriptions, step counter, skip. Our screen 2.
+- [Fitbod — equipment grid](https://mobbin.com/screens/0cc5bce0-769e-4112-be08-3d1a7a5ccde5) — illustrated multi-select. Our screen 3.
+- [Fitbod — goal select](https://mobbin.com/screens/58498852-f344-4b62-b10e-0988ac6f0091) (+ [selected state](https://mobbin.com/screens/047da3e6-9de7-4ea0-a426-65e15d0ed05a)) — our screen 1.
+- [Centr — personalized goal headline](https://mobbin.com/screens/baf07542-7afb-4d8e-8af8-36ece724db81) — radio list + progress bar; take the directness, skip the name-injection (we don't have a name yet).
+
+Numeric entry:
+- [Yazio — weight entry](https://mobbin.com/screens/2b2b032e-f176-4680-972d-3de0c98154df) — big number, unit pill, numpad, "okay to guess" microcopy. Our screens 5–6.
+- [MyFitnessPal — estimate microcopy](https://mobbin.com/screens/3dfe2002-71de-42d7-97f2-98f707da5b3c) and [Lifesum — wheel + why-we-ask footer](https://mobbin.com/screens/af8c7994-f702-4497-a86a-c07b3609561f) — payoff-line precedent.
+- [adidas Running — step checklist](https://mobbin.com/screens/65a226b8-d0eb-46ad-8459-d5cd90ac8099) — upcoming-steps disclosure; consider for the flow's first question screen.
+
+Payoff:
+- [stoic — preparing checklist](https://mobbin.com/screens/6af627cc-8437-4dc8-bb9f-bec83e87a9ae) — closest to our beat 1, already ink-on-paper minimal.
+- [stoic — plan ready](https://mobbin.com/screens/03bc31f1-71ec-4587-a2ab-e8615a694ef3) — "focused on:" recap; our reveal is this + real bands.
+- [Speak — building your plan](https://mobbin.com/screens/139db00b-6179-4bb5-a77e-f682265ee343) — single-accent loading ring; on-identity.
+- [Cal AI — percent counter](https://mobbin.com/screens/63944ee4-76ea-4bcd-8f0f-543e7240f4ff) — the **anti-pattern**: fake theater, kept as a what-not-to-do.
+- [Yazio — hang-tight recap](https://mobbin.com/screens/3023715f-a48a-4581-a866-fadce01bea57) — input-recap card idea, minus mascot.

--- a/docs/design/ui-overhaul-spec.md
+++ b/docs/design/ui-overhaul-spec.md
@@ -1,0 +1,150 @@
+# UI overhaul — locked behavior & interaction spec
+
+**Status:** locked 2026-06-10 after a grilled decision process (panel splits on each
+major surface) and a two-agent UI/UX expert review whose accepted fixes are folded
+in below. Visual tokens live in the repo-root `DESIGN.md`. Per-screen design docs
+layer on top in `docs/design/` (first: `onboarding-calibration.md`).
+
+This is a design spec, not an implementation plan — no slices or issues exist for
+it yet.
+
+## 1. Scope & guiding principle
+
+Full UI rebuild from scratch. The one-line test every screen answers to:
+
+> **Quietly right in the moment, visibly smart around it.**
+
+Calm and dead-simple while you're lifting (the live loop earns trust by getting out
+of the way); smart and expressive around the workout (Today, post-workout, progress
+— where the coach shows its thinking).
+
+## 2. Navigation
+
+Three tabs, settings tucked in a corner (not a tab):
+
+- **Today** — the coach/home surface: next workout + one-tap start.
+- **Train** — the program: calendar, week structure, exercise library. Exercise
+  detail/history is also reachable contextually from "Why this?" inside a session.
+- **Progress** — capability bands, e1RM trends, history.
+
+(The Train/Today boundary was a review P2: Today owns *now*, Train owns *the plan*.)
+
+## 3. Today screen
+
+- Hero: the next workout and a single one-tap **Start**.
+- One short coach line above it ("Recovered — push squats today"). Grounded in at
+  least one concrete number from the model; terse honesty over praise.
+- Coach alerts (back-off, re-calibration, goal review) are a **calm list** below the
+  start action — never pop-ups in front of it.
+- **Fallback (review P0-2):** the coach line must have a deterministic local
+  fallback computed from model/session data with no AI call. Rule-based ships
+  first; the AI line is an upgrade, not a dependency. If even the fallback has
+  nothing meaningful to say, the line collapses — an empty slot, never filler.
+
+## 4. Live session loop
+
+- **One set at a time.** One screen owns the current set: exercise, target
+  weight × reps as hero numbers, one big **done** tap.
+- Rest timer lives on the same screen post-log (the card morphs; no modal, no
+  separate screen).
+- **Feel pill** after each set: a small "how did that feel?" pill — optional by
+  design.
+- **Plan-peek (review P1):** a collapsed session overview is always one swipe away
+  without leaving the loop — experienced lifters can see the whole session;
+  one-set-only must never feel infantilizing.
+- "Adjust" handles weight/rep deviations from prescription.
+
+### Data integrity — ignore ≠ confirm (review P0-1, revises the original decision)
+
+An ignored feel pill **does not** record an on-target feel. It logs "reps as
+prescribed, **feel unknown**" — never a fabricated feel. Everything downstream
+(e1RM, readiness, floor/ratchet logic) treats unknown-feel sets with reduced
+confidence. A lifter who ignores the pill 80% of the time must not poison the
+model with data that never happened — the moat depends on this.
+
+### Edge cases are first-class (review P1)
+
+The off-path is the real path for serious lifters. The loop must handle, without
+dumping everything on "Adjust":
+
+- warm-up sets (distinct from working sets, lighter logging),
+- AMRAP / max-rep sets,
+- failed or missed reps,
+- supersets / paired exercises,
+- prescribed load unachievable with available plates,
+- mid-session interruption — a paused session is **resumable**, mandatory.
+
+## 5. Post-workout summary
+
+- **Hero: the coach's read** — 1–2 lines naming what the session *proved* about
+  you ("Squat's clearing its band cleanly — third week it's held; bench is where
+  the work is next"). Grounded in ≥1 concrete logged number; fails toward terse
+  honesty over praise. A generic or wrong line is worse than nothing.
+- **Numbers sit underneath as evidence**, not headline: the most-moved capability,
+  position vs floor/stretch — plus one quiet volume/PR stat line (review P2: don't
+  fully delete the scoreboard).
+- **PRs fold into the read** ("…and you set a PR doing it"), not a trophy section.
+- **Celebration is earned:** genuine milestones only (PR / level-up / floor-ratchet)
+  get the flourish + haptic; flat days stay in the calm coach voice. Honest flat
+  days must feel respected, not punished.
+- **Cut:** trophy hero, total-volume-as-hero, sets ring, duration stat,
+  "AI adjustments" count, share-as-primary.
+- **Fallback (review P0-2):** same rule as Today — a deterministic read from set
+  data ("3 of 4 top sets hit; the last one was a grind") whenever the AI line is
+  unavailable, slow, or fails validation.
+
+Rationale (unanimous two-lens panel, including the reward/retention lens): for
+committed trainees, *being seen doing it well* is the dopamine — relationship and
+accountability drive return, not a volume tally you could compute yourself. The
+per-session delta was rejected as hero because honest sessions often move e1RM ~0:
+a delta-hero manufactures fake precision or frequent visible nothing; the read
+survives a bad day.
+
+## 6. The Lens (readiness/score gauge)
+
+A camera-iris aperture: opens with readiness, *focuses* as data resolves. Brand
+texture, not sole carrier (review P2): always backed by a literal number + word
+label — glanceable in gym light and readable by VoiceOver.
+
+## 7. Motion
+
+Expressive motion at the bookends only (app open, workout start, post-workout
+reveal, milestone); 150ms workhorse transitions everywhere else; Reduce Motion
+falls back to crossfade. Full token spec in `DESIGN.md` §Motion.
+
+## 8. Cross-cutting data-honesty rules
+
+These came out of the review touching every surface; they are design law, not
+per-screen details:
+
+1. **Never fabricate data.** Absence of input is recorded as absence (feel
+   unknown), not as a default that looks like a measurement.
+2. **Confidence is visible.** Estimated/low-confidence values *look* less certain
+   wherever they render (hollow points, dashed projections — `DESIGN.md`
+   §Data visualization). Applies from onboarding seeds (see
+   `onboarding-calibration.md`) through capability charts.
+3. **Every coach utterance is grounded** in at least one concrete number the user
+   can verify, and every AI-generated line has a deterministic local fallback.
+
+## 9. Review record (2026-06-10)
+
+Two independent agents — one UI expert, one UX expert, both briefed as senior
+Uber-calibre practitioners optimizing customer satisfaction/usage/experience.
+Headline: *the design trusts the AI's judgment and the user's compliance; v1 must
+let both fail loudly instead of silently.*
+
+| # | Finding | Disposition |
+|---|---|---|
+| P0-1 | Feel-pill "accept by ignoring" fabricates data | **Accepted** — §4 ignore ≠ confirm |
+| P0-2 | Coach's read has no failure mode | **Accepted** — §3/§5 deterministic fallbacks |
+| P0-3 | No onboarding = cold-start cliff, no activation | **Accepted** — `onboarding-calibration.md` |
+| P0-4 | Ultramarine text on cream fails WCAG AA | **Accepted** — `DESIGN.md` contrast roles |
+| P1 | Dim variant now; motion restraint; loop edge cases; plan-peek | **Accepted** — `DESIGN.md` + §4/§7 |
+| P2 | Gauge needs literal number; Train/Today boundary; quiet stat; missing tokens | **Accepted** — §6/§2/§5 + `DESIGN.md` |
+
+## 10. Next design targets (not started)
+
+1. ~~Onboarding / first-run calibration~~ — specced in `onboarding-calibration.md`.
+2. Splash / brand moment + Today screen visual design (with Mobbin references).
+3. Live-loop screen visual design; Progress; Train.
+4. Per-screen specs then get broken into issues/slices for implementation.


### PR DESCRIPTION
## What

Locks the Phase 3 UI-overhaul foundation as repo docs, with every accepted fix from the two-agent UI/UX expert review folded in:

- **`DESIGN.md`** (repo root) — token system: ultramarine `#1B2CFF` on cream `#F6F2E8`, contrast-fixed roles (text/icons always ink, `#1322CC` as the default interactive ink — review P0-4), dim variant (P1), bookend-only expressive motion, state roles from ink+weight+motion, data-viz/iconography/haptics/Dynamic-Type tokens, decision log.
- **`docs/design/ui-overhaul-spec.md`** — the locked behavior spec: 3-tab nav, Today, live set loop with **ignore ≠ confirm** feel-pill logging (P0-1) and first-class edge cases (P1), post-workout coach's-read hero with deterministic local fallback (P0-2), earned-celebration gating, the Lens gauge, cross-cutting data-honesty rules, full review record.
- **`docs/design/onboarding-calibration.md`** — the review's biggest gap (P0-3): an 8-screen first-run calibration flow that seeds the trainee model with explicit confidence tiers (measured / estimated / unknown) and ends on a model-reveal payoff. Grounded in Mobbin references (Fitbod, Yazio, stoic, Speak, Centr; Cal AI kept as anti-pattern).
- **`DIARY.md`** — plain-words entry.

## What this is not

No app code changes. Per-screen visual design (splash, Today, live loop) and implementation slices come next, separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)