### PR TITLE
docs: cite PR #314 in the design-foundation diary entry

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -29,7 +29,7 @@ workouts firm them up.
 These are design documents — the rulebook (DESIGN.md) and two specs in docs/design/.
 No app code changed yet. Building it comes next, screen by screen.
 
-**Status:** Merged into main.
+**Status:** Merged into main in pull request #314.
 
 ---
 


### PR DESCRIPTION
One-line follow-up: the diary entry for the UI-overhaul design foundation shipped inside #314 itself, so it couldn't cite its own PR number. This adds the reference per the diary convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)