### PR TITLE
fix(#318): Workout-tab pending-day generation + no phantom session traces

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,7 +7,7 @@ Started 2026-06-07.
 
 ---
 
-## 2026-06-11 — The Workout tab can finally start a brand-new day (PR #PENDING)
+## 2026-06-11 — The Workout tab can finally start a brand-new day (PR #335)
 
 **The problem (in plain words):**
 The app builds each day's workout only when you ask for it — until then the day
@@ -35,7 +35,7 @@ and no stray database record, the other proves resuming a truly empty day quietl
 stops instead of faking a finished workout. The full test suite — 261 tests —
 passed on an iPhone 17 Pro simulator.
 
-**Status:** Done and opened as a pull request for review (PR #PENDING). Part of
+**Status:** Done and opened as a pull request for review (PR #335). Part of
 the bigger eight-part fix-up (#318).
 
 ---

--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,39 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-11 — The Workout tab can finally start a brand-new day (PR #PENDING)
+
+**The problem (in plain words):**
+The app builds each day's workout only when you ask for it — until then the day
+is empty, a blank slate. But the big button on the Workout tab always said
+"Start Workout," even on a day that had nothing in it yet. Tapping it didn't
+build the workout; it just threw an error. Worse, by the time it hit that error
+it had already scribbled two notes to itself: a "you have an unfinished workout"
+flag and a half-started session record in the database. So the next time you
+opened the app it nagged you about a workout you never actually did, showed a
+warning dot on the tab, and could even mark a day you never trained as "paused."
+
+**What changed:**
+On a not-yet-built day, the button now reads "Generate Session" and actually
+builds the workout right there — no more dead-end error. If you haven't set up
+your gym yet, the button politely greys out and points you to Settings instead
+of pretending to work. And the empty-day check now runs *first*, before the app
+writes anything down — so a failed start leaves zero mess behind: no false
+"unfinished workout" flag, no orphaned record, no wrong-day "paused" mark. If
+building the session fails (say your connection drops), it now says so plainly
+instead of failing silently.
+
+**How it was checked:**
+Two new automated tests pin the fixes: one proves a failed start leaves no flag
+and no stray database record, the other proves resuming a truly empty day quietly
+stops instead of faking a finished workout. The full test suite — 261 tests —
+passed on an iPhone 17 Pro simulator.
+
+**Status:** Done and opened as a pull request for review (PR #PENDING). Part of
+the bigger eight-part fix-up (#318).
+
+---
+
 ## 2026-06-11 — The "what did today prove?" screen got designed (PR #333)
 
 **What happened (in plain words):**

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -291,12 +291,35 @@ struct ContentView: View {
 
     // MARK: - Workout Tab
 
+    /// Resolves the mesocycle to render on the Workout tab. Uses the loaded state's
+    /// mesocycle normally; while a day's session is generating in place, falls back to
+    /// `currentMesocycle` so the tab stays on the workout surface rather than collapsing
+    /// to "No Program Yet".
+    private func workoutTabMesocycle(for vm: ProgramViewModel) -> Mesocycle? {
+        switch vm.viewState {
+        case .loaded(let mesocycle):
+            return mesocycle
+        case .generatingSession:
+            return vm.currentMesocycle
+        default:
+            return nil
+        }
+    }
+
     /// The Workout tab. Routes to `WorkoutView` with the first non-completed day
     /// in the mesocycle. Shows a programme-complete state when all days are done,
     /// or a no-program state when no mesocycle is loaded.
     @ViewBuilder
     private var workoutTab: some View {
-        if let vm = programViewModel, case .loaded(let mesocycle) = vm.viewState {
+        // Render the workout surface for a loaded programme OR while a single day's
+        // session is generating in place — the latter keeps currentMesocycle populated,
+        // so the tab must not collapse to "No Program Yet" mid-generation.
+        if let vm = programViewModel,
+           let mesocycle = workoutTabMesocycle(for: vm) {
+            let isGeneratingSession: Bool = {
+                if case .generatingSession = vm.viewState { return true }
+                return false
+            }()
             if let (day, week) = vm.nextIncompleteDay(in: mesocycle) {
                 let allDays = mesocycle.weeks.flatMap { $0.trainingDays }
                 // Skipped sessions advance the programme pointer and count toward progress.
@@ -345,8 +368,41 @@ struct ContentView: View {
                         resumeState: crashResumeToPass,
                         onSkipSession: {
                             // Persistent skip — advances programme_day_index, records skippedAt.
-                            programViewModel?.markDaySkipped(dayId: day.id, weekId: week.id)
+                            // Resolve via crashResumeDay like the completed/paused siblings above
+                            // so a crash-resumed day skips THAT day, not nextIncompleteDay's.
+                            if let resumeDay = crashResumeDay,
+                               let found = vm.findTrainingDay(byId: resumeDay.id, in: mesocycle) {
+                                programViewModel?.markDaySkipped(dayId: found.day.id, weekId: found.week.id)
+                            } else {
+                                programViewModel?.markDaySkipped(dayId: day.id, weekId: week.id)
+                            }
                         },
+                        isGeneratingSession: isGeneratingSession,
+                        onGenerateSession: ((crashResumeDay ?? day).status == .pending && confirmedProfile != nil)
+                            ? {
+                                // Generate this not-yet-generated day's session in place.
+                                // Resolve day+week like the completed/paused/skip siblings:
+                                // crashResumeDay takes precedence (matching the render target),
+                                // falling back to nextIncompleteDay's (day, week) pair.
+                                let targetDay: TrainingDay
+                                let targetWeek: TrainingWeek
+                                if let resumeDay = crashResumeDay,
+                                   let found = vm.findTrainingDay(byId: resumeDay.id, in: mesocycle) {
+                                    targetDay = found.day
+                                    targetWeek = found.week
+                                } else {
+                                    targetDay = day
+                                    targetWeek = week
+                                }
+                                Task {
+                                    await programViewModel?.generateDaySession(
+                                        day: targetDay,
+                                        week: targetWeek,
+                                        gymProfile: confirmedProfile!
+                                    )
+                                }
+                            }
+                            : nil,
                         onCloseToTab0: { selectedTab = 0 },
                         onResumeStateConsumed: {
                             // One-shot — clear so subsequent tab swaps into Tab 1 don't re-apply

--- a/ProjectApex/Features/Workout/PreWorkoutView.swift
+++ b/ProjectApex/Features/Workout/PreWorkoutView.swift
@@ -65,12 +65,23 @@ struct PreWorkoutView: View {
     var onBack: (() -> Void)? = nil
     /// Called when the user taps the × close button on the Tab 1 entry path (idle only).
     var onCloseToTab0: (() -> Void)? = nil
+    /// True while a pending day's session is being generated in place. Shows a spinner
+    /// on the "Generate Session" CTA and disables it.
+    var isGeneratingSession: Bool = false
+    /// Called when the user taps "Generate Session" on a pending day. Non-nil only when
+    /// a gym profile is confirmed; nil renders the CTA disabled with a "set up your gym"
+    /// hint instead of routing to a no-op.
+    var onGenerateSession: (() -> Void)? = nil
 
     // MARK: - Private state
     @State private var showSkipConfirmation: Bool = false
     @State private var welcomeBackBannerDismissed: Bool = false
     @State private var heavyReassessmentBannerDismissed: Bool = false
     @State private var calibrationBannerDismissed: Bool = false
+    /// Set true once the user taps "Generate Session". Combined with the day still being
+    /// pending and generation no longer in progress, this surfaces the inline failure
+    /// line — generateDaySession restores .loaded silently on error (amendment 2.2).
+    @State private var generationAttempted: Bool = false
 
     // MARK: - Body
 
@@ -257,52 +268,69 @@ struct PreWorkoutView: View {
                         .tracking(0.3)
                 }
                 Spacer()
-                // Exercise count badge
-                Text("\(trainingDay.exercises.count) exercises")
-                    .font(.system(size: 13, weight: .bold))
-                    .foregroundStyle(streak.tintColor)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(streak.tintColor.opacity(0.12), in: Capsule())
+                // Exercise count badge — only meaningful once the session is generated.
+                if !isPending {
+                    Text("\(trainingDay.exercises.count) exercises")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(streak.tintColor)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(streak.tintColor.opacity(0.12), in: Capsule())
+                }
             }
             .padding(20)
 
             Divider()
                 .background(.white.opacity(0.08))
 
-            // Exercise list preview (first 3 + overflow)
-            VStack(spacing: 0) {
-                let preview = Array(trainingDay.exercises.prefix(3))
-                ForEach(Array(preview.enumerated()), id: \.offset) { index, exercise in
-                    ExerciseRowPreview(exercise: exercise, tintColor: streak.tintColor)
-                    if index < preview.count - 1 {
-                        Divider()
-                            .background(.white.opacity(0.06))
-                            .padding(.leading, 20)
-                    }
-                }
-                if trainingDay.exercises.count > 3 {
-                    Text("+ \(trainingDay.exercises.count - 3) more exercises")
+            if isPending {
+                // Not-yet-generated day: no exercises exist, so don't render a 0-count
+                // preview or a "~0 min" estimate — say so plainly.
+                HStack(spacing: 6) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.white.opacity(0.35))
+                    Text("Session not generated yet")
                         .font(.system(size: 13, weight: .medium))
                         .foregroundStyle(.white.opacity(0.35))
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, 14)
                 }
-            }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 14)
+            } else {
+                // Exercise list preview (first 3 + overflow)
+                VStack(spacing: 0) {
+                    let preview = Array(trainingDay.exercises.prefix(3))
+                    ForEach(Array(preview.enumerated()), id: \.offset) { index, exercise in
+                        ExerciseRowPreview(exercise: exercise, tintColor: streak.tintColor)
+                        if index < preview.count - 1 {
+                            Divider()
+                                .background(.white.opacity(0.06))
+                                .padding(.leading, 20)
+                        }
+                    }
+                    if trainingDay.exercises.count > 3 {
+                        Text("+ \(trainingDay.exercises.count - 3) more exercises")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.35))
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.vertical, 14)
+                    }
+                }
 
-            // Duration estimate
-            Divider()
-                .background(.white.opacity(0.08))
-            HStack(spacing: 6) {
-                Image(systemName: "clock")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.white.opacity(0.35))
-                Text("~\(estimatedDurationMinutes) min estimated")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.35))
+                // Duration estimate
+                Divider()
+                    .background(.white.opacity(0.08))
+                HStack(spacing: 6) {
+                    Image(systemName: "clock")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.white.opacity(0.35))
+                    Text("~\(estimatedDurationMinutes) min estimated")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.35))
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 14)
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 14)
         }
         .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
         .overlay(
@@ -480,7 +508,102 @@ struct PreWorkoutView: View {
 
     // MARK: - Start Button
 
+    /// A not-yet-generated day shows a "Generate Session" CTA instead of "Start Workout":
+    /// the session has to be created before it can be started.
+    private var isPending: Bool { trainingDay.status == .pending }
+
+    @ViewBuilder
     private var startButton: some View {
+        if isPending {
+            pendingButtonGroup
+        } else {
+            startWorkoutButton
+        }
+    }
+
+    /// CTA group shown when the day's session has not been generated yet.
+    @ViewBuilder
+    private var pendingButtonGroup: some View {
+        VStack(spacing: 12) {
+            if onGenerateSession != nil {
+                generateSessionButton
+                // Inline failure: generateDaySession restores .loaded silently on error,
+                // leaving the day pending. Surface that honestly rather than failing mute.
+                if generationAttempted && !isGeneratingSession {
+                    Text("Couldn't generate the session. Check your connection and try again.")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(Color(red: 1.0, green: 0.55, blue: 0.45))
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            } else {
+                // No confirmed gym profile — generation can't run. Disabled CTA + hint,
+                // not a no-op route.
+                noGymProfileButton
+                Text("Set up your gym in Settings first")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.40))
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .padding(.top, 8)
+    }
+
+    private var generateSessionButton: some View {
+        Button {
+            generationAttempted = true
+            onGenerateSession?()
+        } label: {
+            HStack(spacing: 10) {
+                if isGeneratingSession {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .tint(.white)
+                        .scaleEffect(0.85)
+                } else {
+                    Image(systemName: "wand.and.stars")
+                        .font(.system(size: 18, weight: .semibold))
+                }
+                Text(isGeneratingSession ? "Generating\u{2026}" : "Generate Session")
+                    .font(.system(size: 18, weight: .bold))
+            }
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .frame(height: 60)
+            .background(
+                streak.tintColor.opacity(isGeneratingSession ? 0.40 : 0.85),
+                in: RoundedRectangle(cornerRadius: 18, style: .continuous)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(.white.opacity(0.20), lineWidth: 0.5)
+            )
+            .animation(.easeInOut(duration: 0.15), value: isGeneratingSession)
+        }
+        .disabled(isGeneratingSession)
+    }
+
+    private var noGymProfileButton: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "wand.and.stars")
+                .font(.system(size: 18, weight: .semibold))
+            Text("Generate Session")
+                .font(.system(size: 18, weight: .bold))
+        }
+        .foregroundStyle(.white.opacity(0.45))
+        .frame(maxWidth: .infinity)
+        .frame(height: 60)
+        .background(
+            Color.white.opacity(0.08),
+            in: RoundedRectangle(cornerRadius: 18, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(.white.opacity(0.12), lineWidth: 0.5)
+        )
+    }
+
+    private var startWorkoutButton: some View {
         Button {
             viewModel.startSession(trainingDay: trainingDay, programId: programId, userId: deps.resolvedUserId, weekNumber: weekNumber, startingExerciseIndex: startingExerciseIndex)
         } label: {

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -198,6 +198,14 @@ actor WorkoutSessionManager {
     func startSession(trainingDay: TrainingDay, programId: UUID, userId: UUID = UUID(), weekId: UUID = UUID(), weekNumber: Int = 1, startingExerciseIndex: Int = 0) async {
         guard case .idle = sessionState else { return }
 
+        // An errored start must mutate NOTHING — no state reset, no crash sentinel,
+        // no enqueued session row. A day with no generated exercises can't be started;
+        // this guard runs BEFORE any mutation so a failed start leaves zero durable traces.
+        guard !trainingDay.exercises.isEmpty else {
+            sessionState = .error("Training day has no exercises.")
+            return
+        }
+
         // Reset all session state
         self.trainingDay = trainingDay
         self.currentTrainingDayId = trainingDay.id
@@ -260,10 +268,6 @@ actor WorkoutSessionManager {
         print("[WorkoutSessionManager] Enqueuing session row — id: \(newSession.id), userId: \(newSession.userId), programId: \(programId), dayType: \(trainingDay.dayLabel)")
         try? await writeAheadQueue.enqueue(sessionPayload, table: "workout_sessions")
 
-        guard !trainingDay.exercises.isEmpty else {
-            sessionState = .error("Training day has no exercises.")
-            return
-        }
         let firstExercise = trainingDay.exercises[self.exerciseIndex]
 
         // Fetch streak, RAG memory, weekly fatigue, and session count in parallel

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -91,6 +91,14 @@ struct WorkoutView: View {
     var startingExerciseIndex: Int = 0
     /// Called when the user taps "Skip this session" on the pre-workout screen.
     var onSkipSession: (() -> Void)? = nil
+    /// True while a not-yet-generated day's session is being generated in place
+    /// (ProgramViewModel.viewState == .generatingSession). Drives the spinner on
+    /// the "Generate Session" CTA in PreWorkoutView.
+    var isGeneratingSession: Bool = false
+    /// Called when the user taps "Generate Session" on a pending day. Non-nil only
+    /// when the day is pending and a gym profile is confirmed; nil renders the CTA
+    /// disabled with a "set up your gym" hint instead.
+    var onGenerateSession: (() -> Void)? = nil
     /// Called when the user taps the back button or swipes on the pre-workout screen.
     var onBack: (() -> Void)? = nil
     /// Called when the user taps the × close button on the Tab 1 entry path (idle only).
@@ -220,9 +228,12 @@ struct WorkoutView: View {
                     )
                 }
             }
-            // Detect pause: session went idle while a PausedSessionState exists
+            // Detect pause: session went idle while a PausedSessionState exists FOR THIS DAY.
+            // Gating on trainingDayId prevents an .idle transition with someone else's live
+            // sentinel (e.g. an errored start, or a different paused day) from mis-marking the
+            // currently-rendered day as paused (amendment 2.1).
             if case .idle = newState {
-                if PausedSessionState.load() != nil {
+                if PausedSessionState.load()?.trainingDayId == trainingDay.id {
                     onSessionPaused?()
                 }
             }
@@ -351,7 +362,9 @@ struct WorkoutView: View {
                 },
                 onSkipSession: onSkipSession,
                 onBack: onBack,
-                onCloseToTab0: onCloseToTab0
+                onCloseToTab0: onCloseToTab0,
+                isGeneratingSession: isGeneratingSession,
+                onGenerateSession: onGenerateSession
             )
 
         case .active(let exercise, let setNumber):

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -591,6 +591,101 @@ final class WorkoutSessionManagerTests: XCTestCase {
         XCTAssertEqual(snapshot?.programId, programId, "snapshot must reference the active program")
         XCTAssertEqual(snapshot?.userId, userId, "snapshot must reference the user")
     }
+
+    // MARK: #318 / J-F1 — empty-exercises start leaves ZERO durable traces
+
+    /// An attempt to start a session for a not-yet-generated day (no exercises) must
+    /// error WITHOUT mutating anything durable: no crash sentinel (PausedSessionState)
+    /// and no enqueued workout_sessions row. Pre-fix, the empty-exercises guard ran
+    /// AFTER the sentinel save and the session-row enqueue, so an errored start left a
+    /// phantom "Unfinished Workout" sentinel + an orphaned active session row.
+    func testStartSession_emptyExercises_errorsWithoutSentinelOrSessionRow() async throws {
+        WSMBodyCaptureURLProtocol.reset()
+        let manager = makeBodyCaptureManager()
+        // A day whose session was never generated: status .pending, exercises [].
+        let emptyDay = TrainingDay(
+            id: UUID(),
+            dayOfWeek: 1,
+            dayLabel: "Push_A",
+            exercises: [],
+            sessionNotes: nil,
+            status: .pending
+        )
+
+        await manager.startSession(trainingDay: emptyDay, programId: UUID())
+        // Allow any (incorrect) fire-and-forget enqueue/flush to surface as a request.
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        // 1. State is .error — the start was rejected.
+        let state = await manager.sessionState
+        guard case .error = state else {
+            XCTFail("Expected .error for an empty-exercises start, got \(state)")
+            return
+        }
+
+        // 2. No crash sentinel was written.
+        XCTAssertNil(
+            PausedSessionState.load(),
+            "An errored start must not write a PausedSessionState crash sentinel (J-F1)"
+        )
+
+        // 3. No workout_sessions row was enqueued/POSTed (the orphaned 'active' row).
+        let sessionRowPosts = WSMBodyCaptureURLProtocol.captured.filter {
+            $0.path.contains("workout_sessions") && $0.method == "POST"
+        }
+        XCTAssertTrue(
+            sessionRowPosts.isEmpty,
+            "An errored start must not enqueue a workout_sessions row (J-F1); captured: \(sessionRowPosts.map(\.path))"
+        )
+    }
+
+    // MARK: #318 / J-F2 — resuming an empty/exhausted day aborts without completion
+
+    /// Regression pinning the CORRECTED J-F2 mechanism: resuming a day with no
+    /// remaining exercises ends in .idle with no summary and no fabricated completion.
+    /// finishSession's zero-set guard (completedSets.isEmpty → .idle + return) fires
+    /// before any completion/PATCH, so the day is never mis-marked complete.
+    func testResumeSession_emptyDay_abortsWithoutCompletion() async throws {
+        let manager = makeManager()
+        let emptyDay = TrainingDay(
+            id: UUID(),
+            dayOfWeek: 1,
+            dayLabel: "Push_A",
+            exercises: [],
+            sessionNotes: nil,
+            status: .pending
+        )
+        let paused = PausedSessionState(
+            sessionId: UUID(),
+            trainingDayId: emptyDay.id,
+            weekId: UUID(),
+            weekNumber: 1,
+            exerciseIndex: 0,
+            currentSetNumber: 1,
+            dayType: emptyDay.dayLabel,
+            programId: UUID(),
+            userId: UUID(),
+            pausedAt: Date()
+        )
+
+        await manager.resumeSession(
+            pausedState: paused,
+            trainingDay: emptyDay,
+            completedSetLogs: []
+        )
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // Ends idle — NOT .sessionComplete. No summary was fabricated.
+        let state = await manager.sessionState
+        if case .sessionComplete = state {
+            XCTFail("Resuming an empty day must NOT fabricate a completion; got \(state)")
+            return
+        }
+        XCTAssertEqual(
+            state, .idle,
+            "Resuming a day with no remaining sets must abort to .idle (corrected J-F2)"
+        )
+    }
 }
 
 // MARK: - Body-capturing URLProtocol (#171 — inspect the PATCH payload)


### PR DESCRIPTION
Unit 2 of the 8-unit fix campaign (umbrella #318). The Workout tab can now do its one job on a not-yet-generated ("pending") day, and an errored start leaves zero durable traces.

## What changed, per file

**`ProjectApex/Features/Workout/WorkoutSessionManager.swift`** (J-F1)
- Moved the `guard !trainingDay.exercises.isEmpty` check to the very top of `startSession(...)`, before any state reset, before `PausedSessionState(...).save()`, and before the `writeAheadQueue.enqueue(...)` of the session row. An errored start now mutates nothing — no crash sentinel, no orphaned `workout_sessions` row, no published state beyond `.error`. The rest of the function is unchanged (the `exerciseIndex` clamp and `firstExercise` indexing are now always reached with a non-empty array).

**`ProjectApex/ContentView.swift`** (O-F3, J-F13c)
- `workoutTab` now renders the workout surface when `.loaded(let m)` **or** when a single day's session is generating in place (`.generatingSession` + `vm.currentMesocycle`), via a new `workoutTabMesocycle(for:)` helper — so the tab no longer collapses to "No Program Yet" mid-generation.
- Passes two new params into `WorkoutView`: `isGeneratingSession` (true during `.generatingSession`) and `onGenerateSession` — non-nil only when `(crashResumeDay ?? day).status == .pending && confirmedProfile != nil`, running `await vm.generateDaySession(...)` for the resolved day/week (crashResumeDay precedence mirrors the sibling handlers).
- `onSkipSession` now resolves via `crashResumeDay` (find day by id, skip THAT day/week) exactly like the completed/paused siblings above it, instead of always using `day`.

**`ProjectApex/Features/Workout/WorkoutView.swift`** (J-F2 corrected, amendment 2.1)
- Threads `isGeneratingSession` / `onGenerateSession` through to `PreWorkoutView`.
- The `.onChange` `.idle` handler now fires `onSessionPaused?()` only when `PausedSessionState.load()?.trainingDayId == trainingDay.id` — closing the class where any `.idle` transition with someone else's live sentinel mis-marks the currently-rendered day as paused.

**`ProjectApex/Features/Workout/PreWorkoutView.swift`** (O-F3, amendment 2.2)
- When `trainingDay.status == .pending`: the primary CTA becomes "Generate Session" (wand/sparkles icon) when `onGenerateSession != nil`, with a spinner / disabled state while generating; when `onGenerateSession == nil` it renders DISABLED with "Set up your gym in Settings first" (no no-op route). The session-card metadata replaces the exercise badge / preview / "~N min estimated" with "Session not generated yet".
- Amendment 2.2: because `generateDaySession` returns nil and restores `.loaded` silently on failure, after an attempt that left the day still pending and generation no longer in progress, an inline error line is shown ("Couldn't generate the session. Check your connection and try again."). Implemented with a single `@State generationAttempted` flag plus the already-available `isGeneratingSession` and `trainingDay.status` — no new modal.
- `status != .pending` path is unchanged.

## Data-contract confirmation

The guard reorder REMOVES one write: the orphaned `workout_sessions` row (status `"active"`, `completed=false`, 0 sets) for empty-exercise days. Confirmed by reading the code that the removed row had no real consumer:
- `fetchCompletedSessionCount` filters `completed="true"` → a `completed=false` orphan is invisible.
- `fetchWeeklyFatigue` derives its session count from fetched `set_logs` (`Set(recentLogs.map(\.sessionId)).count`) → a logless orphan contributes 0 logs, inert.
- `GymStreakService` filters `completed="true"` → orphan invisible.
- The `update-trainee-model` Edge Function never reads `workout_sessions` (grep empty) and is only invoked from `finishSession` (never from a 0-set start).

No schema / Edge Function / prompt change.

## Test evidence

- Added two cases to `ProjectApexTests/WorkoutSessionManagerTests.swift` (no pbxproj edit — existing file):
  - `testStartSession_emptyExercises_errorsWithoutSentinelOrSessionRow` — after an empty-exercises start: state `.error`, `PausedSessionState.load() == nil`, and no `workout_sessions` POST captured.
  - `testResumeSession_emptyDay_abortsWithoutCompletion` — pins the corrected J-F2 mechanism: resuming an empty day ends `.idle` with no summary, no fabricated completion.
- Full unit suite: **261 tests, all passed**, on `platform=iOS Simulator,name=iPhone 17 Pro`. `APEX_INTEGRATION_TESTS` left at the shared-scheme default (off), so the known live-API flake `AIInferenceServiceTests.test_liveAPI_*` was correctly not run. No failures this run.

Findings covered: J-F1, J-F2, O-F3, J-F13c.

Part of #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)