### PR TITLE
fix(#318): honest copy + wire dead-end CTAs in onboarding/program/session flows

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,36 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-11 — The app stops making promises it can't keep (PR #337)
+
+**What happened (in plain words):**
+A flow audit found a bunch of places where the app's words didn't match
+reality. The onboarding screen promised "session reminders" that don't exist.
+The final onboarding screen said "your program is loaded" even when generation
+had failed or the gym scan was skipped. An error message blamed your "API key"
+— something a normal user has never heard of. One screen pointed you to a
+"Scanner tab" that isn't a tab. And when you finished all 12 weeks, the app
+just told you to wander over to Settings instead of offering a button.
+
+**What changed:**
+Ten small fixes. The copy now tells the truth: the final onboarding screen has
+three honest versions depending on what actually happened; the fake reminder
+promise is gone; the wait estimate matches the real timeout ("up to a couple
+of minutes"). Dead ends became buttons: the Scanner-tab text is now a button
+that takes you to Settings, and the programme-complete screen got a real
+"Start Your Next Programme" button with a confirmation step (disabled with an
+explanation if your gym isn't set up). The welcome-back-from-a-break banner
+now only claims the session "accounts for the break" when that's true — if the
+session was planned before your break, it says so instead.
+
+**How it was checked:**
+Full build passed, the whole test suite ran, and the welcome-back banner logic
+got three new unit tests (short break, long break, pre-planned session).
+
+**Status:** waiting for review and merge as PR #337.
+
+---
+
 ## 2026-06-11 — The Progress tab got designed: your strength as a staircase (PR #336)
 
 **What happened (in plain words):**

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -47,6 +47,10 @@ struct ContentView: View {
     /// Shown once to users who already have a mesocycle loaded when updating to this build.
     @State private var showTrainingTimeMigrationNotice: Bool = false
 
+    /// Confirms "Start Your Next Programme" on the programme-complete screen
+    /// before triggering regeneration.
+    @State private var showNextProgrammeConfirmation: Bool = false
+
     // MARK: - Crash recovery
 
     /// Non-nil when a crash-sentinel is found in UserDefaults on launch, indicating an
@@ -504,8 +508,32 @@ struct ContentView: View {
                     Text("Programme Complete")
                         .font(.title2.bold())
                         .foregroundStyle(.white)
-                    Text("You've finished every session. Head to Settings to regenerate a new programme.")
+                    Text("You've finished every session.")
                         .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.45))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 40)
+                }
+                Button {
+                    showNextProgrammeConfirmation = true
+                } label: {
+                    Text("Start Your Next Programme")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(.white.opacity(confirmedProfile != nil ? 1.0 : 0.4))
+                        .padding(.horizontal, 28)
+                        .padding(.vertical, 12)
+                        .background(
+                            confirmedProfile != nil
+                                ? Color(red: 0.23, green: 0.56, blue: 1.00)
+                                : Color.white.opacity(0.08),
+                            in: Capsule()
+                        )
+                }
+                .disabled(confirmedProfile == nil)
+                .padding(.top, 8)
+                if confirmedProfile == nil {
+                    Text("Set up your gym in Settings to start a new programme")
+                        .font(.footnote)
                         .foregroundStyle(.white.opacity(0.45))
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 40)
@@ -520,7 +548,6 @@ struct ContentView: View {
                         .padding(.vertical, 12)
                         .background(.white.opacity(0.12), in: Capsule())
                 }
-                .padding(.top, 8)
                 Spacer()
             }
             .background(Color(red: 0.04, green: 0.04, blue: 0.06).ignoresSafeArea())
@@ -528,6 +555,15 @@ struct ContentView: View {
             .navigationBarTitleDisplayMode(.large)
             .toolbarBackground(Color(red: 0.04, green: 0.04, blue: 0.06), for: .navigationBar)
             .toolbarColorScheme(.dark, for: .navigationBar)
+            .alert("Start Your Next Programme?", isPresented: $showNextProgrammeConfirmation) {
+                Button("Cancel", role: .cancel) { }
+                Button("Start") {
+                    guard let profile = confirmedProfile else { return }
+                    Task { await regenerateProgram(gymProfile: profile) }
+                }
+            } message: {
+                Text("Generates a fresh 12-week programme. Your history is preserved.")
+            }
         }
     }
 

--- a/ProjectApex/Features/Onboarding/OnboardingView.swift
+++ b/ProjectApex/Features/Onboarding/OnboardingView.swift
@@ -438,12 +438,11 @@ struct OnboardingView: View {
                 stepHeader(
                     icon: "bell.badge.fill",
                     title: "Stay On Track",
-                    subtitle: "Allow notifications so the AI coach can alert you when your rest timer expires and remind you of upcoming sessions."
+                    subtitle: "Allow notifications so the AI coach can alert you when your rest timer expires."
                 )
 
                 VStack(spacing: 14) {
                     notifFeatureRow(icon: "timer", label: "Rest timer alerts — never lose track of your rest")
-                    notifFeatureRow(icon: "calendar.badge.clock", label: "Session reminders — train on schedule")
                 }
                 .padding(20)
                 .background(
@@ -632,7 +631,7 @@ struct OnboardingView: View {
                         .multilineTextAlignment(.center)
 
                     if isGenerating {
-                        Text("The AI coach is designing your 12-week periodized program.\nThis usually takes under a minute.")
+                        Text("The AI coach is designing your 12-week periodized program.\nThis can take up to a couple of minutes.")
                             .font(.system(size: 15, weight: .regular))
                             .foregroundStyle(.white.opacity(0.50))
                             .multilineTextAlignment(.center)
@@ -694,7 +693,16 @@ struct OnboardingView: View {
                             .multilineTextAlignment(.center)
 
                         let name = profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
-                        Text("Welcome, \(name.isEmpty ? "Athlete" : name). Your 12-week program is loaded. Head to the Program tab to review it, then start your first session.")
+                        let readyMessage: String = {
+                            if generationError != nil {
+                                return "Program generation didn't finish. You can generate it from the Program tab — your answers are saved."
+                            } else if scanSkipped {
+                                return "Almost there — add your gym equipment to unlock your program."
+                            } else {
+                                return "Welcome, \(name.isEmpty ? "Athlete" : name). Your 12-week program is loaded. Head to the Program tab to review it, then start your first session."
+                            }
+                        }()
+                        Text(readyMessage)
                             .font(.system(size: 16, weight: .regular))
                             .foregroundStyle(.white.opacity(0.55))
                             .multilineTextAlignment(.center)

--- a/ProjectApex/Features/Program/ProgramDayDetailView.swift
+++ b/ProjectApex/Features/Program/ProgramDayDetailView.swift
@@ -1222,7 +1222,7 @@ struct ProgramDayDetailView: View {
         ) {
             currentDay = generated
         } else {
-            sessionGenerationError = "Could not generate session. Check your API key and try again."
+            sessionGenerationError = "Couldn't generate the session. Check your connection and try again."
         }
     }
 }

--- a/ProjectApex/Features/Program/ProgramOverviewView.swift
+++ b/ProjectApex/Features/Program/ProgramOverviewView.swift
@@ -21,6 +21,7 @@ import SwiftUI
 struct ProgramOverviewView: View {
 
     @Environment(AppDependencies.self) private var deps
+    @Environment(\.switchToTab) private var switchToTab
 
     @Bindable var viewModel: ProgramViewModel
     /// The confirmed gym profile passed in from ContentView.
@@ -172,11 +173,13 @@ struct ProgramOverviewView: View {
                 .tint(Color(red: 0.23, green: 0.56, blue: 1.00))
                 .padding(.horizontal, 32)
             } else {
-                Text("Scan your gym in the Scanner tab to get started.")
-                    .font(.footnote)
-                    .foregroundStyle(.white.opacity(0.40))
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
+                Button(action: { switchToTab(3) }) {
+                    Text("Set up your gym in Settings")
+                        .font(.footnote)
+                        .foregroundStyle(Color(red: 0.23, green: 0.56, blue: 1.00))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 40)
+                }
             }
 
             Spacer()
@@ -239,7 +242,13 @@ struct ProgramOverviewView: View {
             }
 
             Button("Try Again") {
-                Task { await viewModel.loadProgram() }
+                Task {
+                    if let profile = gymProfile {
+                        await viewModel.generateMacroSkeleton(gymProfile: profile)
+                    } else {
+                        await viewModel.loadProgram()
+                    }
+                }
             }
             .buttonStyle(.borderedProminent)
             .tint(Color(red: 0.23, green: 0.56, blue: 1.00))

--- a/ProjectApex/Features/Workout/PreWorkoutView.swift
+++ b/ProjectApex/Features/Workout/PreWorkoutView.swift
@@ -370,12 +370,25 @@ struct PreWorkoutView: View {
 
     // MARK: - Welcome Back Banner (2.4A)
 
+    /// Pure message-selection for the welcome-back banner, extracted for unit testing.
+    /// A pending day's session hasn't been generated yet, so it genuinely will account
+    /// for the break; an already-generated session was planned before the break, so the
+    /// copy must not claim any break-aware adjustment.
+    static func welcomeBackMessage(days: Int, status: TrainingDayStatus) -> String {
+        switch status {
+        case .pending:
+            return days >= 28
+                ? "Welcome back — it's been \(days) days. Today is a recovery session with reduced volume to get you back on track."
+                : "Welcome back — it's been \(days) days. Today's session will account for the break."
+        default:
+            return "Welcome back — it's been \(days) days. This session was planned before your break — take it easy out there."
+        }
+    }
+
     private func welcomeBackBanner(days: Int) -> some View {
         let isReturnSession = days >= 28
         let amberColor = Color(red: 1.0, green: 0.65, blue: 0.0)
-        let message = isReturnSession
-            ? "Welcome back — it's been \(days) days. Today is a recovery session with reduced volume to get you back on track."
-            : "Welcome back — it's been \(days) days. We've adjusted today's session to ease back in."
+        let message = Self.welcomeBackMessage(days: days, status: trainingDay.status)
         return HStack(spacing: 12) {
             Image(systemName: isReturnSession ? "arrow.counterclockwise.circle.fill" : "hand.wave.fill")
                 .font(.system(size: 18, weight: .semibold))

--- a/ProjectApex/Features/Workout/RestTimerView.swift
+++ b/ProjectApex/Features/Workout/RestTimerView.swift
@@ -253,7 +253,7 @@ struct RestTimerView: View {
                 Image(systemName: "brain.head.profile.slash")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(Color(red: 1.0, green: 0.75, blue: 0.0))
-                Text(viewModel.fallbackDescription ?? "Coach offline — using plan defaults")
+                Text(viewModel.fallbackDescription ?? "Coach offline — using program defaults")
                     .font(.system(size: 13, weight: .medium))
                     .foregroundStyle(.white.opacity(0.55))
             } else {

--- a/ProjectApex/Settings/SettingsView.swift
+++ b/ProjectApex/Settings/SettingsView.swift
@@ -461,14 +461,15 @@ struct SettingsView: View {
         .presentationDragIndicator(.hidden)
     }
 
+    @ViewBuilder
     private var developerSection: some View {
+        #if DEBUG
         Section("Developer") {
-            #if DEBUG
             NavigationLink(destination: DeveloperSettingsView(onResetAll: onResetAll, programViewModel: programViewModel)) {
                 Label("Developer Settings", systemImage: "key.fill")
             }
-            #endif
         }
+        #endif
     }
 
     private var aboutSection: some View {

--- a/ProjectApexTests/HeavyReassessmentBannerCopyTests.swift
+++ b/ProjectApexTests/HeavyReassessmentBannerCopyTests.swift
@@ -61,3 +61,34 @@ struct HeavyReassessmentBannerCopyTests {
         #expect(HeavyReassessmentBannerCopy.title == "Your training has leveled up")
     }
 }
+
+// MARK: - Welcome-back banner copy (#318 U3)
+
+/// Verifies PreWorkoutView.welcomeBackMessage — the pure copy helper for the
+/// welcome-back banner. Pending days may claim break-aware adjustment (the
+/// session hasn't been generated yet); already-generated days must not.
+@Suite("WelcomeBackBannerCopy")
+struct WelcomeBackBannerCopyTests {
+
+    @Test("pending day under 28 days claims the session will account for the break")
+    func pendingUnder28Days() {
+        let message = PreWorkoutView.welcomeBackMessage(days: 15, status: .pending)
+        #expect(message.contains("Today's session will account for the break."))
+        #expect(message.contains("15 days"))
+    }
+
+    @Test("pending day at 28+ days keeps the stronger recovery-session variant")
+    func pendingAtLeast28Days() {
+        let message = PreWorkoutView.welcomeBackMessage(days: 30, status: .pending)
+        #expect(message.contains("Today is a recovery session with reduced volume"))
+    }
+
+    @Test("generated day claims no break-aware adjustment — session predates the break")
+    func generatedClaimsNoAdjustment() {
+        let message = PreWorkoutView.welcomeBackMessage(days: 30, status: .generated)
+        #expect(message.contains("This session was planned before your break — take it easy out there."))
+        #expect(!message.contains("account for the break"))
+        #expect(!message.contains("recovery session"))
+        #expect(!message.contains("adjusted"))
+    }
+}


### PR DESCRIPTION
Part of #318 — Unit U3 (copy fixes + small wiring, lowest-risk unit of the flow-audit fix campaign).

## What changed (one bullet per audit finding)

1. **OnboardingView `step6ReadyView`** — final-screen message now branches on the real outcome: success keeps "program is loaded"; scan skipped → "Almost there — add your gym equipment to unlock your program."; generation failed (reached via "Continue without a program") → "Program generation didn't finish. You can generate it from the Program tab — your answers are saved." `generationError` is not cleared on the continue path (verified — it stays the distinguishing signal).
2. **OnboardingView step 3 permissions** — removed the "Session reminders" promise and its feature row; grep confirmed no reminder-scheduling code exists anywhere in the app (only the rest-timer notification in RestTimerView). Subtitle keeps only the rest-timer rationale.
3. **OnboardingView generation-wait copy** — "usually takes under a minute" → "This can take up to a couple of minutes." (real timeout is 180s in ProgramGenerationService).
4. **ProgramOverviewView empty state** — dead "Scan your gym in the Scanner tab" text replaced with a button "Set up your gym in Settings" wired via `@Environment(\.switchToTab)` → `switchToTab(3)` (Settings confirmed tag 3 in ContentView).
5. **ProgramOverviewView `errorView`** — "Try Again" now retries `generateMacroSkeleton(gymProfile:)` when a gym profile exists, falls back to `loadProgram()` otherwise.
6. **ProgramDayDetailView** — "Check your API key…" → "Couldn't generate the session. Check your connection and try again."
7. **PreWorkoutView welcome-back banner** — message selection extracted into testable `static func welcomeBackMessage(days:status:)` branching on `trainingDay.status`: pending <28d → "Today's session will account for the break."; pending ≥28d keeps the stronger recovery-session variant; generated → "This session was planned before your break — take it easy out there." (no timing/adjustment claims). 3-case unit test added to the existing banner-copy test file (test target is not folder-synchronized).
8. **ContentView `programCompleteView`** — primary CTA "Start Your Next Programme" added, gated by a confirmation alert ("Generates a fresh 12-week programme. Your history is preserved.") that calls `regenerateProgram(gymProfile:)`. When `confirmedProfile == nil` (the no-op condition, verified at the call-site guard) the button renders disabled with caption "Set up your gym in Settings to start a new programme". Secondary "Go to Settings" link kept.
9. **SettingsView** — `Section("Developer")` moved entirely inside `#if DEBUG` (was rendering an empty section header in release).
10. **RestTimerView** — "plan defaults" → "program defaults".

Data contract: copy + wiring only. No schema, Edge Function, LLM-prompt, or persistence changes.

## Verification

- `xcodebuild build-for-testing` → exit=0
- Full test suite (`test` action) → exit 0, all green (including the new 3-case `WelcomeBackBannerCopy` suite; known live-LLM flake did not fail this run)
- Cross-cutting greps: no other occurrences of "plan defaults", "Scanner tab", "under a minute", or user-facing "session reminders" copy remain (one stale header *comment* in OnboardingView line 11 left untouched — comment, not user-facing copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)