### PR TITLE
fix(#318): honest set logging — optional RPE, 0-rep floor, skip-set

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,44 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-11 — Logging a set got honest: no forced effort rating, zero reps allowed, and you can skip (PR #340)
+
+**What happened (in plain words):**
+The set-logging sheet quietly made things up. The "how hard was it?" picker
+came pre-set to "On Target", so if you never touched it the app recorded an
+effort rating you never gave. The rep counter refused to go below 1, so a
+failed lift — zero reps, real and useful information — could not be recorded
+truthfully. And there was no way to skip a set at all: if you weren't going
+to do it, your only options were lying about it or ending the workout.
+
+**What changed:**
+Three things. The effort picker now starts empty and is clearly marked
+optional — pick one if you want, skip it if you don't, and nothing gets
+invented either way. The rep counter now goes down to zero, and a zero-rep
+set can no longer be celebrated as a personal record. And the menu on the
+active set screen has a new "Skip Set" item: it moves you straight to the
+next set (no rest timer, nothing written down for the skipped one), and if
+you skip everything, the session is thrown away instead of being saved empty.
+
+Fixing skip surfaced a sneaky bug: the app decided "was that the last set?"
+by counting the sets it had written down. A skipped set writes nothing down,
+so after a skip the count lagged and the coach would prescribe a phantom
+extra set. Both the skip path and the normal path now ask "what set number
+are we on?" instead of counting receipts.
+
+**How it was checked:**
+The phantom-set test was written first and watched to fail against the old
+counting logic, then the fix turned it green. Full build passed and the whole
+suite ran green — 743 tests, 0 failures. Seven new tests: the empty-by-default
+effort picker, the database row leaving the effort field properly blank,
+skip advancing without writing anything or resting, skip-then-complete
+advancing to the next exercise with no phantom set, and an all-skipped
+session being discarded.
+
+**Status:** waiting for review and merge as PR #340.
+
+---
+
 ## 2026-06-11 — Your onboarding answers finally reach the coach (PR #339)
 
 **What happened (in plain words):**

--- a/ProjectApex/Features/Workout/ActiveSetView.swift
+++ b/ProjectApex/Features/Workout/ActiveSetView.swift
@@ -230,6 +230,11 @@ struct ActiveSetView: View {
                 .accessibilityHint("Shows the planned exercises and what you've logged so far")
                 Menu {
                     Button {
+                        viewModel.onSkipSet()
+                    } label: {
+                        Label("Skip Set", systemImage: "forward.end")
+                    }
+                    Button {
                         viewModel.requestExerciseSwap()
                     } label: {
                         Label("Swap Exercise", systemImage: "arrow.triangle.2.circlepath")
@@ -955,8 +960,11 @@ struct ActiveSetView: View {
     private func commitSetComplete(_ state: SetCompletionFormState) {
         guard state.canSubmit, let chosenIntent = state.resolvedIntent else { return }
         showRepConfirmation = false
-        // Map 0/1/2 picker to a rough RPE value: too easy = 5, on target = 7, too hard = 9
-        let rpeValue: Int = [5, 7, 9][state.rpeFelt]
+        // Map 0/1/2 picker to a rough RPE value: too easy = 5, on target = 7, too hard = 9.
+        // RPE is optional (#318 / U5, G-F2): nil when the user didn't pick —
+        // the downstream chain to the SetLog encode is Int?-tolerant and
+        // persists rpe_felt as NULL.
+        let rpeValue = state.rpeFelt.map { [5, 7, 9][$0] }
         viewModel.onSetComplete(
             actualReps: state.actualReps,
             rpeFelt: rpeValue,
@@ -1032,7 +1040,8 @@ struct RepRPEIntentConfirmationSheet: View {
                     HStack(spacing: 24) {
                         Button {
                             UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                            if formState.actualReps > 1 { formState.actualReps -= 1 }
+                            // Floor is 0 (#318 / U5): a failed/zero rep is honest data.
+                            if formState.actualReps > 0 { formState.actualReps -= 1 }
                         } label: {
                             Image(systemName: "minus.circle.fill")
                                 .font(.system(size: 36))
@@ -1058,17 +1067,25 @@ struct RepRPEIntentConfirmationSheet: View {
                     }
                 }
 
-                // RPE/RIR felt — 3-option segmented picker
+                // RPE/RIR felt — 3-option segmented picker.
+                // Optional with NO preselected value (#318 / U5, G-F2): the
+                // selection is Int? starting nil, so no segment is highlighted
+                // until the user actively picks one.
                 VStack(spacing: 10) {
-                    Text("How hard was it?")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(.white.opacity(0.50))
-                        .tracking(0.5)
+                    HStack(spacing: 6) {
+                        Text("How hard was it?")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.50))
+                            .tracking(0.5)
+                        Text("· Optional")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.30))
+                    }
 
-                    Picker("RPE felt", selection: $formState.rpeFelt) {
-                        Text("Too Easy").tag(0)
-                        Text("On Target").tag(1)
-                        Text("Too Hard").tag(2)
+                    Picker("RPE felt (optional)", selection: $formState.rpeFelt) {
+                        Text("Too Easy").tag(Int?.some(0))
+                        Text("On Target").tag(Int?.some(1))
+                        Text("Too Hard").tag(Int?.some(2))
                     }
                     .pickerStyle(.segmented)
                 }

--- a/ProjectApex/Features/Workout/SetCompletionFormState.swift
+++ b/ProjectApex/Features/Workout/SetCompletionFormState.swift
@@ -39,7 +39,10 @@ struct SetCompletionFormState: Equatable {
 
     /// 0 = too easy, 1 = on target, 2 = too hard. Mapped to RPE 5/7/9 at
     /// commit time (matches the existing ActiveSetView mapping).
-    var rpeFelt: Int
+    /// Optional with NO preselected value (#318 / U5, G-F2): nil means the
+    /// user chose not to report — rpe_felt persists as NULL, never a
+    /// fabricated default.
+    var rpeFelt: Int?
 
     // MARK: - Intent (Slice 6 redesign)
 
@@ -94,7 +97,7 @@ struct SetCompletionFormState: Equatable {
     ///     on whether the picker is the only path (freestyle: yes;
     ///     AI-prescribed: hidden behind the "Did something different?"
     ///     affordance).
-    init(actualReps: Int, rpeFelt: Int = 1, prescribedIntent: SetIntent?) {
+    init(actualReps: Int, rpeFelt: Int? = nil, prescribedIntent: SetIntent?) {
         self.actualReps = actualReps
         self.rpeFelt = rpeFelt
         self.prescribedIntent = prescribedIntent

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -351,47 +351,12 @@ actor WorkoutSessionManager {
         try? await writeAheadQueue.enqueue(setPayload, table: "set_logs")
         print("[WAQ] Enqueued set_log — session_id: \(session.id), set: \(setNumber), exercise: \(exercise.name), weight: \(currentPrescription?.weightKg ?? 0)kg, reps: \(actualReps)")
 
-        // Determine whether this was the last set for this exercise
-        let setsForExercise = completedSets.filter { $0.exerciseId == exercise.exerciseId }.count
-        let isLastSetForExercise = setsForExercise >= exercise.sets
-
-        if isLastSetForExercise {
-            // Archive this exercise's sets into session history
-            sessionHistoryToday.append(buildExerciseHistoryItem(for: exercise))
-            exerciseIndex += 1
-            currentSetNumber = 1
-        } else {
-            currentSetNumber = setNumber + 1
-        }
-
-        // Update crash sentinel so crash recovery reflects the latest set/exercise position.
-        if let day = trainingDay {
-            PausedSessionState(
-                sessionId: session.id,
-                trainingDayId: day.id,
-                weekId: weekId,
-                weekNumber: session.weekNumber,
-                exerciseIndex: exerciseIndex,
-                currentSetNumber: currentSetNumber,
-                dayType: session.dayType,
-                programId: session.programId,
-                userId: session.userId,
-                pausedAt: Date()
-            ).save()
-        }
-
-        // Determine next exercise and set number
-        let exercises = trainingDay?.exercises ?? []
-        let nextExercise: PlannedExercise?
-        let nextSetNumber: Int
-
-        if isLastSetForExercise {
-            nextExercise = exercises.indices.contains(exerciseIndex) ? exercises[exerciseIndex] : nil
-            nextSetNumber = 1
-        } else {
-            nextExercise = exercise
-            nextSetNumber = currentSetNumber
-        }
+        // Determine whether this was the last set for this exercise and
+        // advance position. SET-NUMBER-based, shared with skipCurrentSet()
+        // (#318 / U5): counting SetLogs lags reality after a skip (a skipped
+        // set writes no SetLog) and would prescribe a phantom extra set.
+        let (isLastSetForExercise, nextExercise, nextSetNumber) =
+            advancePosition(after: exercise, setNumber: setNumber)
 
         // 2. Transition to resting (or end session immediately if this was the last set)
         let planRestSeconds = currentPrescription?.restSeconds ?? exercise.restSeconds
@@ -467,6 +432,97 @@ actor WorkoutSessionManager {
             } else {
                 inflightRequestCount -= 1
             }
+        }
+    }
+
+    /// Skips the current set without logging it (#318 / U5, G-F7).
+    ///
+    /// Advances exactly like completeSet() but writes NO SetLog, NO WAQ entry,
+    /// NO memory event, and takes NO rest period: state moves straight to
+    /// .active for the next set (ActiveSetView renders the thinking indicator
+    /// while currentPrescription is nil) and inference fires immediately.
+    /// Skipping the last set of the last exercise ends the session; a session
+    /// where EVERY set was skipped is then discarded by finishSession's
+    /// zero-set guard (completedSets.isEmpty → .idle, nothing persisted).
+    func skipCurrentSet() async {
+        guard case .active(let exercise, let setNumber) = sessionState,
+              session != nil else { return }
+
+        // Invalidate any in-flight inference aimed at the skipped set —
+        // same reentrancy discipline as completeSet().
+        inferenceGeneration += 1
+
+        let (isLastSetForExercise, nextExercise, nextSetNumber) =
+            advancePosition(after: exercise, setNumber: setNumber)
+
+        currentPrescription = nil   // ActiveSetView shows the thinking indicator
+
+        guard let next = nextExercise else {
+            // Skipped the last set of the last exercise — end the session.
+            await endSession()
+            return
+        }
+
+        if isLastSetForExercise {
+            // Moving to a new exercise — refresh RAG memory (mirrors
+            // completeSet's last-set branch; the sessionHistoryToday archive
+            // already happened inside advancePosition).
+            cachedRAGMemory = await fetchRAGMemory(for: next)
+        }
+
+        // No rest after a skip — go straight to the next set and fire inference.
+        sessionState = .active(exercise: next, setNumber: nextSetNumber)
+        await triggerInference(for: next, setNumber: nextSetNumber)
+    }
+
+    /// Shared advancement tail for completeSet()/skipCurrentSet() (#318 / U5).
+    ///
+    /// Last-set determination is SET-NUMBER-based (`setNumber >= exercise.sets`),
+    /// NOT SetLog-count-based: a skipped set writes no SetLog, so counting logs
+    /// lags reality after a skip and would prescribe a phantom extra set.
+    ///
+    /// Advances exerciseIndex/currentSetNumber, archives the finished exercise
+    /// into sessionHistoryToday on the last set, and refreshes the crash
+    /// sentinel. Returns the position to move to next — a nil nextExercise
+    /// (only possible when isLastSetForExercise) means the session is over.
+    private func advancePosition(
+        after exercise: PlannedExercise,
+        setNumber: Int
+    ) -> (isLastSetForExercise: Bool, nextExercise: PlannedExercise?, nextSetNumber: Int) {
+        let isLastSetForExercise = setNumber >= exercise.sets
+
+        if isLastSetForExercise {
+            // Archive this exercise's sets into session history
+            sessionHistoryToday.append(buildExerciseHistoryItem(for: exercise))
+            exerciseIndex += 1
+            currentSetNumber = 1
+        } else {
+            currentSetNumber = setNumber + 1
+        }
+
+        // Update crash sentinel so crash recovery reflects the latest set/exercise position.
+        if let session, let day = trainingDay {
+            PausedSessionState(
+                sessionId: session.id,
+                trainingDayId: day.id,
+                weekId: weekId,
+                weekNumber: session.weekNumber,
+                exerciseIndex: exerciseIndex,
+                currentSetNumber: currentSetNumber,
+                dayType: session.dayType,
+                programId: session.programId,
+                userId: session.userId,
+                pausedAt: Date()
+            ).save()
+        }
+
+        // Determine next exercise and set number
+        let exercises = trainingDay?.exercises ?? []
+        if isLastSetForExercise {
+            let next = exercises.indices.contains(exerciseIndex) ? exercises[exerciseIndex] : nil
+            return (true, next, 1)
+        } else {
+            return (false, exercise, currentSetNumber)
         }
     }
 
@@ -1187,6 +1243,14 @@ actor WorkoutSessionManager {
                 }
                 // If rest still running, do nothing — onRestTimerExpired() handles it.
             }
+        case .active:
+            // Post-skip path (#318 / U5): skipCurrentSet() moves straight to
+            // .active with a nil prescription. On success the prescription was
+            // applied above and the card appears; on failure surface the retry
+            // sheet now — there is no rest timer on this path to defer to.
+            if currentPrescription == nil && currentFallbackReason != nil {
+                inferenceRetryNeeded = true
+            }
         default:
             break
         }
@@ -1598,6 +1662,9 @@ actor WorkoutSessionManager {
     /// (Cross-session PR detection is a P4 deliverable; this covers within-session PRs.)
     private func emitPRMemoryEventIfNeeded(for log: SetLog, exercise: PlannedExercise) {
         guard let sess = session else { return }
+        // A 0-rep set (failed attempt) must never emit a PR event (#318 / U5):
+        // weight × (1 + 0/30) still exceeds a 0.0 priorBest on the first set.
+        guard log.repsCompleted > 0 else { return }
         let currentEstimated1RM = log.weightKg * (1.0 + Double(log.repsCompleted) / 30.0)
         let priorBest = completedSets
             .filter { $0.exerciseId == exercise.exerciseId && $0.id != log.id }

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -135,6 +135,19 @@ final class WorkoutViewModel {
         }
     }
 
+    /// Called when the user taps "Skip Set" in the overflow menu (#318 / U5,
+    /// G-F7). Mirrors onSetComplete's task shape — reuses the isCompletingSet
+    /// flag so a skip and a complete can't race each other.
+    func onSkipSet() {
+        guard !isCompletingSet else { return }
+        isCompletingSet = true
+        Task {
+            await manager.skipCurrentSet()
+            await pullState()
+            isCompletingSet = false
+        }
+    }
+
     /// Submits a voice note transcript to the session.
     func onAddVoiceNote(transcript: String, exerciseId: String) {
         Task {

--- a/ProjectApexTests/SetCompletionFormStateTests.swift
+++ b/ProjectApexTests/SetCompletionFormStateTests.swift
@@ -177,6 +177,30 @@ final class SetCompletionFormStateTests: XCTestCase {
                        "Freestyle never has isDeviation=true regardless of selection.")
     }
 
+    // MARK: - Optional RPE (#318 / U5, G-F2)
+
+    /// RPE is truly optional: no preselected value. The prior shape defaulted
+    /// to 1 ("On Target"), silently fabricating an RPE for users who never
+    /// touched the picker.
+    func test_rpeFelt_defaultsToNil_noPreselectedValue() {
+        let state = SetCompletionFormState(actualReps: 8, prescribedIntent: .top)
+        XCTAssertNil(state.rpeFelt,
+                     "RPE must have NO preselected value (G-F2).")
+        XCTAssertTrue(state.canSubmit,
+                      "A nil RPE must not block submission — the gate is intent-only.")
+    }
+
+    func test_rpeFelt_nil_freestyleGateStillIntentOnly() {
+        var state = SetCompletionFormState(actualReps: 8, prescribedIntent: nil)
+        XCTAssertNil(state.rpeFelt)
+        XCTAssertFalse(state.canSubmit,
+                       "Freestyle stays blocked on intent, regardless of RPE.")
+        state.selectIntent(.warmup)
+        XCTAssertTrue(state.canSubmit,
+                      "Picking an intent opens the gate with RPE still nil.")
+        XCTAssertNil(state.rpeFelt, "Picking an intent must not fabricate an RPE.")
+    }
+
     // MARK: - Completion flags
 
     func test_completionFlags_emptyByDefault() {

--- a/ProjectApexTests/SetLogPayloadEncoderTests.swift
+++ b/ProjectApexTests/SetLogPayloadEncoderTests.swift
@@ -115,6 +115,33 @@ final class SetLogPayloadEncoderTests: XCTestCase {
         assertSetLogRowShape(dict, expectedIntent: .backoff)
     }
 
+    /// Optional RPE (#318 / U5, G-F2): rpe_felt is nullable in the schema. A
+    /// set logged without an RPE pick must encode with the key ABSENT
+    /// (JSONEncoder omits nil optionals), which PostgREST stores as NULL —
+    /// not 0, not a fabricated default. Same for the derived rir_estimated.
+    func test_setLogPayload_nilRPE_omitsRpeFeltAndRirEstimated() throws {
+        let log = SetLog(
+            id: UUID(),
+            sessionId: UUID(),
+            exerciseId: "barbell_bench_press",
+            setNumber: 2,
+            weightKg: 100.0,
+            repsCompleted: 5,
+            rpeFelt: nil,
+            rirEstimated: nil,
+            aiPrescribed: nil,
+            loggedAt: Date(timeIntervalSince1970: 1_781_524_800),
+            primaryMuscle: "pectoralis_major",
+            intent: nil
+        )
+        let dict = try encodeToDict(SetLogPayload(from: log, intent: .top))
+        assertSetLogRowShape(dict, expectedIntent: .top)
+        XCTAssertNil(dict["rpe_felt"],
+                     "nil RPE must be omitted from the payload (→ NULL), never defaulted")
+        XCTAssertNil(dict["rir_estimated"],
+                     "nil RIR must be omitted from the payload (→ NULL)")
+    }
+
     // MARK: - ManualSetLogPayload (freestyle manual log)
 
     func test_manualSetLogPayload_topIntent_serialisesIntentAndLocalDate() throws {

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -686,6 +686,100 @@ final class WorkoutSessionManagerTests: XCTestCase {
             "Resuming a day with no remaining sets must abort to .idle (corrected J-F2)"
         )
     }
+
+    // MARK: #318 / U5 — skip set (G-F7): advancement must be set-number-based
+
+    /// The bug-catcher (critic amendment): a SKIPPED set writes no SetLog, so
+    /// SetLog-count-based last-set determination lags reality. Skip set 1 of 2,
+    /// then complete set 2 → the manager must advance to the NEXT exercise,
+    /// not prescribe a phantom set 3 of the same exercise.
+    func testSkipSet_thenCompleteSet_advancesExerciseCorrectly() async throws {
+        let manager = makeManager()
+        let day = makeTrainingDay(exerciseCount: 2, setsPerExercise: 2)
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // Skip set 1 of exercise 0 → straight to .active set 2 (no rest, no SetLog).
+        await manager.skipCurrentSet()
+        let afterSkip = await manager.sessionState
+        guard case .active(let skipEx, let skipN) = afterSkip else {
+            XCTFail("Expected .active after skip, got \(afterSkip)")
+            return
+        }
+        XCTAssertEqual(skipEx.exerciseId, day.exercises[0].exerciseId)
+        XCTAssertEqual(skipN, 2, "Skip must advance to set 2 of the same exercise")
+
+        // Let the post-skip inference land so completeSet has a prescription.
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        // Complete set 2 — the exercise's LAST set (sets == 2; 1 skipped + 1 completed).
+        await manager.completeSet(actualReps: 8, rpeFelt: 7, intent: .top)
+
+        // The last-set branch flashes .exerciseComplete then rests for the NEXT
+        // exercise. Count-based logic sees only 1 SetLog (< 2 planned sets) and
+        // wrongly schedules a phantom set 3 of exercise 0 instead.
+        let after = await manager.sessionState
+        guard case .resting(let nextEx, let nextN) = after else {
+            XCTFail("Expected .resting after the exercise's last set, got \(after)")
+            return
+        }
+        XCTAssertEqual(
+            nextEx.exerciseId, day.exercises[1].exerciseId,
+            "After skip+complete (2 of 2 sets addressed) the manager must advance to exercise 1 — a phantom extra set means last-set determination is still SetLog-count-based"
+        )
+        XCTAssertEqual(nextN, 1, "Next exercise starts at set 1")
+
+        let logs = await manager.completedSets
+        XCTAssertEqual(logs.count, 1, "Only the completed set produces a SetLog")
+    }
+
+    /// Skip writes NO SetLog and advances within the exercise with NO rest.
+    func testSkipSet_advancesWithoutSetLogOrRest() async throws {
+        let manager = makeManager()
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 3)
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        await manager.skipCurrentSet()
+
+        let state = await manager.sessionState
+        guard case .active(let ex, let n) = state else {
+            XCTFail("Skip must go straight to .active (no rest period), got \(state)")
+            return
+        }
+        XCTAssertEqual(ex.exerciseId, day.exercises[0].exerciseId)
+        XCTAssertEqual(n, 2, "Skip advances to the next set number")
+
+        let logs = await manager.completedSets
+        XCTAssertTrue(logs.isEmpty, "A skipped set must not produce a SetLog")
+        let rest = await manager.restSecondsRemaining
+        XCTAssertEqual(rest, 0, "No rest period after a skip")
+    }
+
+    /// A session where EVERY set was skipped has zero SetLogs — finishSession's
+    /// zero-set guard must discard it (→ .idle), never persist a completion.
+    func testAllSetsSkipped_sessionIsDiscarded() async throws {
+        let manager = makeManager()
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 2)
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        await manager.skipCurrentSet()   // set 1 of 2
+        await manager.skipCurrentSet()   // set 2 of 2 — last set of last exercise → endSession
+
+        let state = await manager.sessionState
+        if case .sessionComplete = state {
+            XCTFail("An all-skipped session must not complete with a summary")
+            return
+        }
+        XCTAssertEqual(state, .idle, "Zero-set guard must discard the all-skipped session")
+
+        let logs = await manager.completedSets
+        XCTAssertTrue(logs.isEmpty, "No SetLogs for an all-skipped session")
+    }
 }
 
 // MARK: - Body-capturing URLProtocol (#171 — inspect the PATCH payload)


### PR DESCRIPTION
Part of #318 (fix-campaign unit U5; findings G-F2, G-F7).

## What

1. **Optional RPE — no preselection.** `SetCompletionFormState.rpeFelt` is now `Int?` defaulting to `nil`. The segmented picker starts with no segment selected and carries a "· Optional" label. `commitSetComplete` maps via `state.rpeFelt.map { [5,7,9][$0] }`; the downstream chain (`onSetComplete` → `completeSet` → `SetLog` → `SetLogPayload`) was verified `Int?`-tolerant end-to-end, so `rpe_felt` persists as NULL (key omitted from the encode) instead of a fabricated "On Target" 7. `rir_estimated` follows via the existing `.map`.

2. **Zero-rep floor.** Reps stepper floor 1 → 0 — a failed/zero rep is honest data (`reps_completed` is NOT NULL with no CHECK; 0 is storable). `emitPRMemoryEventIfNeeded` is now guarded on `repsCompleted > 0` so a 0-rep set can't emit a within-session PR event (weight × (1 + 0/30) would beat a 0.0 priorBest on a first set).

3. **Skip Set.** New overflow-menu item → `WorkoutViewModel.onSkipSet()` → `WorkoutSessionManager.skipCurrentSet()`. Advances exactly like `completeSet` but writes **no SetLog, no WAQ entry, no memory event, and takes no rest** — state goes straight to `.active` for the next set (thinking indicator shows until the prescription lands) and inference fires immediately. Skipping the last set of the last exercise calls `endSession()`; an all-skipped session is discarded by `finishSession`'s existing zero-set guard (`completedSets.isEmpty` → `.idle`, no PATCH, no summary, no trainee-model enqueue).

## The phantom-set bug (critic amendment)

Last-set determination was SetLog-count-based (`completedSets.filter{…}.count >= exercise.sets`). A skipped set writes no SetLog, so the count lags reality and the manager prescribed a phantom extra set after any skip. Both `completeSet` and `skipCurrentSet` now share a set-number-based tail, `advancePosition(after:setNumber:)` (`setNumber >= exercise.sets`), which also archives `sessionHistoryToday` and refreshes the crash sentinel on both paths. `handleInferenceResult` gains a `.active` case so a failed post-skip inference surfaces the retry sheet (the post-skip path has no rest timer to defer to).

TDD: `testSkipSet_thenCompleteSet_advancesExerciseCorrectly` was written first and failed red against the count-based logic (phantom set 3 of exercise_0 instead of exercise_1 set 1), then went green with the fix.

## Record-don't-fix note (0-rep NM timestamps)

A 0-rep top/backoff set still bumps NM-stimulus timestamps in the EF pipeline. That is defensible — a failed heavy attempt is real neuromuscular stress — so it is deliberately left as-is. (The e1RM/EWMA validity gate requires reps 3..10 and `prescription-accuracy.ts` excludes reps < 1, so a 0-rep set cannot pollute capability or accuracy stats.)

## Tests

- `WorkoutSessionManagerTests`: `testSkipSet_thenCompleteSet_advancesExerciseCorrectly` (the bug-catcher, red→green), `testSkipSet_advancesWithoutSetLogOrRest`, `testAllSetsSkipped_sessionIsDiscarded`
- `SetCompletionFormStateTests`: `test_rpeFelt_defaultsToNil_noPreselectedValue`, `test_rpeFelt_nil_freestyleGateStillIntentOnly`
- `SetLogPayloadEncoderTests`: `test_setLogPayload_nilRPE_omitsRpeFeltAndRirEstimated`

## Verification

- `xcodebuild build-for-testing` → exit=0
- Full suite: **743 passed, 0 failed, 10 skipped** (skips are the `APEX_INTEGRATION_TESTS`-gated live-API tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)