### PR TITLE
fix(#318): live-loop quick wins — real streak id, rest-alert notice, rest polish, post-workout PRs

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,45 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-11 — Rest screen polish and the workout summary finally celebrates real records (PR #347)
+
+**What happened (in plain words):**
+Four small lies and rough edges in the live workout loop, all found by the
+big #318 audit. The gym streak was always computed for a fake placeholder
+user, so once real sign-ins existed, your streak could be someone else's —
+or nobody's. The rest screen promised a "rest is over" alert even when you
+had turned notifications off, and said nothing about it. Its skip button was
+so faint and small it was easy to miss and easy to fumble. The countdown
+showed raw seconds ("150") instead of the "2:30" a human expects. And the
+end-of-workout summary had a personal-records section that the screen knew
+how to draw — but the data side always sent an empty list, so it never,
+ever appeared.
+
+**What changed:**
+The streak now uses the real signed-in user. The rest screen quietly tells
+you when rest alerts can't fire because notifications are off (one muted
+line, no nagging, no buttons). The skip button is brighter and has a proper
+finger-sized tap area, and the countdown now reads minutes:seconds. And the
+summary now computes real personal records: for each exercise it compares
+your best estimated one-rep max from today's top sets (3–10 reps only)
+against your history under the same rule, using the same formula the rest
+of the app already uses. One honest detail: if you've never done an
+exercise before, there's no baseline — so no record is claimed. First time
+doing something is not a "new record", it's just a first time. The history
+lookup runs alongside the existing end-of-workout save, so finishing a
+workout is not a second slower; and if the lookup fails, the summary simply
+shows no records rather than blocking.
+
+**How it was checked:**
+The record-computing piece is a pure function, so four tests pin it down: a
+genuine record, no record when you didn't beat your best, no record when
+there's no history, and reps outside 3–10 being ignored on both sides. Full
+build passed and the whole suite ran green — 757 tests, 0 failures.
+
+**Status:** waiting for review and merge as PR #347.
+
+---
+
 ## 2026-06-11 — Logging a set got honest: no forced effort rating, zero reps allowed, and you can skip (PR #340)
 
 **What happened (in plain words):**

--- a/ProjectApex/Features/Workout/RestTimerView.swift
+++ b/ProjectApex/Features/Workout/RestTimerView.swift
@@ -53,6 +53,10 @@ struct RestTimerView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
 
+    /// True when notification permission is denied — the background
+    /// "rest complete" alert cannot fire, so we surface a quiet notice (G-F5).
+    @State private var notificationsDenied: Bool = false
+
     // MARK: - Body
 
     var body: some View {
@@ -123,6 +127,15 @@ struct RestTimerView: View {
 
                 Spacer()
 
+                // Rest-alert disabled notice (G-F5) — display-only, shown when
+                // notification permission is denied.
+                if notificationsDenied {
+                    Text("Rest alerts are off — enable notifications in iOS Settings.")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.38))
+                        .padding(.bottom, 12)
+                }
+
                 // Skip rest button
                 skipButton
                     .padding(.bottom, 48)
@@ -165,6 +178,11 @@ struct RestTimerView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Your progress so far will be saved. You can review your partial session summary.")
+        }
+        .task {
+            // Check notification authorization once per appearance (G-F5).
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            notificationsDenied = settings.authorizationStatus == .denied
         }
         .onAppear {
             // Seed total duration from plan default or AI prescription if already present
@@ -215,18 +233,12 @@ struct RestTimerView: View {
                 .rotationEffect(.degrees(-90))
                 .animation(.linear(duration: 1.0), value: ringProgress)
 
-            // Countdown number
-            VStack(spacing: 4) {
-                Text(countdownDisplay)
-                    .font(.system(size: 80, weight: .ultraLight, design: .rounded).monospacedDigit())
-                    .foregroundStyle(.white)
-                    .contentTransition(.numericText())
-                    .animation(.linear(duration: 0.3), value: viewModel.restSecondsRemaining)
-
-                Text("seconds")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.35))
-            }
+            // Countdown number (m:ss — the "seconds" caption no longer applies)
+            Text(countdownDisplay)
+                .font(.system(size: 80, weight: .ultraLight, design: .rounded).monospacedDigit())
+                .foregroundStyle(.white)
+                .contentTransition(.numericText())
+                .animation(.linear(duration: 0.3), value: viewModel.restSecondsRemaining)
         }
         .scaleEffect(prescriptionJustArrived ? 1.03 : 1.0)
         .animation(.spring(response: 0.45, dampingFraction: 0.70), value: prescriptionJustArrived)
@@ -343,10 +355,12 @@ struct RestTimerView: View {
                     .font(.system(size: 13, weight: .bold))
                     .tracking(1.0)
             }
-            .foregroundStyle(.white.opacity(0.28))
+            .foregroundStyle(.white.opacity(0.55))
             .padding(.horizontal, 20)
             .padding(.vertical, 10)
             .background(.white.opacity(0.04), in: Capsule())
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
         }
     }
 
@@ -375,7 +389,7 @@ struct RestTimerView: View {
     }
 
     private var countdownDisplay: String {
-        "\(viewModel.restSecondsRemaining)"
+        viewModel.formattedRestTime
     }
 
     private func weightString(_ kg: Double) -> String {

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -1463,6 +1463,97 @@ actor WorkoutSessionManager {
         )
     }
 
+    // MARK: - Personal Records (#318 U6 / G-F12)
+
+    /// Fetches the user's historical top-intent set logs for PR comparison.
+    /// Two-step query mirroring `fetchWeeklyFatigue` — set_logs has no
+    /// user_id column, so resolve the user's recent non-abandoned sessions
+    /// first, then fetch their set_logs filtered to `intent = top`. The
+    /// current session is excluded so the baseline never includes the sets
+    /// just logged (they may already be flushed via the WAQ).
+    /// Best-effort: any failure returns empty history, which suppresses all
+    /// PR claims (no baseline ⇒ no claim) — never blocks the summary.
+    private func fetchHistoricalTopSets(userId: UUID?, excludingSessionId: UUID?) async -> [SetLog] {
+        guard let userId else { return [] }
+        do {
+            struct SessionIdRow: Decodable { let id: UUID }
+            var sessionFilters = [
+                Filter(column: "user_id", op: .eq,  value: userId.uuidString),
+                Filter(column: "status",  op: .neq, value: "abandoned")
+            ]
+            if let excludingSessionId {
+                sessionFilters.append(Filter(column: "id", op: .neq, value: excludingSessionId.uuidString))
+            }
+            let sessionRows: [SessionIdRow] = try await supabase.fetch(
+                SessionIdRow.self,
+                table: "workout_sessions",
+                filters: sessionFilters,
+                order: "session_date.desc",
+                limit: 50,
+                select: "id"
+            )
+            guard !sessionRows.isEmpty else { return [] }
+            let sessionIds = sessionRows.map { $0.id.uuidString }.joined(separator: ",")
+            return try await supabase.fetch(
+                SetLog.self,
+                table: "set_logs",
+                filters: [
+                    Filter(column: "session_id", op: .in, value: "(\(sessionIds))"),
+                    Filter(column: "intent",     op: .eq, value: SetIntent.top.rawValue)
+                ]
+            )
+        } catch {
+            print("[WorkoutSessionManager] fetchHistoricalTopSets failed (\(error.localizedDescription)) — treating as empty history")
+            return []
+        }
+    }
+
+    /// Pure PR computation. Per exercise: the session-best e1RM over the
+    /// session's top sets with reps in 3...10, compared against the
+    /// historical-best e1RM under the same rule. e1RM uses the existing
+    /// Epley estimate (`weight × (1 + reps/30)`) shared with the in-session
+    /// PR memory event and ProgressViewModel.
+    ///
+    /// Suppression rule: an exercise with ZERO historical top sets produces
+    /// NO entry — `PersonalRecord.previousBest` is non-optional, and a
+    /// first-ever session must not fabricate a "PR" against a 0.0 baseline.
+    static func computePersonalRecords(
+        sessionSets: [SetLog],
+        historicalSets: [SetLog],
+        exercises: [PlannedExercise]
+    ) -> [PersonalRecord] {
+        func e1RM(_ log: SetLog) -> Double {
+            log.weightKg * (1.0 + Double(log.repsCompleted) / 30.0)
+        }
+        func isCandidate(_ log: SetLog) -> Bool {
+            log.intent == .top && (3...10).contains(log.repsCompleted)
+        }
+
+        let namesById = Dictionary(
+            exercises.map { ($0.exerciseId, $0.name) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let historicalCandidates = historicalSets.filter(isCandidate)
+
+        var records: [PersonalRecord] = []
+        for (exerciseId, sets) in Dictionary(grouping: sessionSets.filter(isCandidate), by: \.exerciseId) {
+            // No historical baseline ⇒ no claim ⇒ no entry (suppression rule).
+            guard let previousBest = historicalCandidates
+                .filter({ $0.exerciseId == exerciseId })
+                .map(e1RM).max()
+            else { continue }
+            guard let sessionBest = sets.map(e1RM).max(), sessionBest > previousBest else { continue }
+            records.append(PersonalRecord(
+                exerciseId: exerciseId,
+                exerciseName: namesById[exerciseId] ?? exerciseId,
+                previousBest: previousBest,
+                newBest: sessionBest,
+                metric: .estimatedOneRM
+            ))
+        }
+        return records.sorted { $0.exerciseName < $1.exerciseName }
+    }
+
     // MARK: - Session Termination
 
     private func finishSession(earlyExitReason: String?) async {
@@ -1473,6 +1564,14 @@ actor WorkoutSessionManager {
 
         restTimerTask?.cancel()
         restTimerTask = nil
+
+        // PR history fetch (#318 U6 / G-F12) runs CONCURRENTLY with the WAQ
+        // flush below so it adds no extra await to the summary gate. A failed
+        // fetch resolves to empty history → personalRecords: [].
+        async let historicalTopSets = fetchHistoricalTopSets(
+            userId: session?.userId,
+            excludingSessionId: session?.id
+        )
 
         // Flush WAQ before PATCH so all set_logs are in Supabase before the session row
         // is marked completed. Mirrors pauseSession() and abandonSession() exactly.
@@ -1502,11 +1601,19 @@ actor WorkoutSessionManager {
         } else {
             sessionDuration = 0
         }
+        // Real PR detection (#318 U6 / G-F12): session-best e1RM vs the
+        // historical best over top sets with 3–10 reps. The history fetch was
+        // started concurrently with the WAQ flush above.
+        let personalRecords = Self.computePersonalRecords(
+            sessionSets: completedSets,
+            historicalSets: await historicalTopSets,
+            exercises: trainingDay?.exercises ?? []
+        )
         let summary = SessionSummary(
             totalVolumeKg: totalVolume,
             setsCompleted: completedSets.count,
             setsPlanned: totalPlanned,
-            personalRecords: [],    // PR detection is a P4 deliverable
+            personalRecords: personalRecords,
             aiAdjustmentCount: completedSets.filter { $0.aiPrescribed != nil }.count,
             notableNotes: sessionNotes.map(\.rawTranscript),
             earlyExitReason: earlyExitReason,

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -133,8 +133,7 @@ struct WorkoutView: View {
                 viewModel = WorkoutViewModel(manager: deps.workoutSessionManager)
             }
             // Fetch streak from GymStreakService (non-blocking — neutral fallback on error).
-            // userId is a placeholder for MVP; auth is wired in a future phase.
-            streak = await deps.gymStreakService.computeStreak(userId: AppDependencies.placeholderUserId)
+            streak = await deps.gymStreakService.computeStreak(userId: deps.resolvedUserId)
 
             // Fetch days-since-last-session for the welcome-back banner in PreWorkoutView.
             // One-row query: most recent completed session ordered desc. Nil = first-ever session.
@@ -224,7 +223,7 @@ struct WorkoutView: View {
                 // and the next PreWorkoutView both show the updated value.
                 Task {
                     streak = await deps.gymStreakService.computeStreak(
-                        userId: AppDependencies.placeholderUserId
+                        userId: deps.resolvedUserId
                     )
                 }
             }

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -916,3 +916,105 @@ private func makeDelayManager() -> WorkoutSessionManager {
         writeAheadQueue: waq
     )
 }
+
+// MARK: - ComputePersonalRecordsTests (#318 U6 / G-F12)
+
+/// Tests for the pure `WorkoutSessionManager.computePersonalRecords`.
+/// Rule under test: per exercise, session-best e1RM (Epley, weight × (1 + reps/30))
+/// over top sets with reps in 3...10, vs the historical best under the same rule.
+/// No historical baseline ⇒ no entry (PersonalRecord.previousBest is non-optional).
+final class ComputePersonalRecordsTests: XCTestCase {
+
+    private func makeSet(
+        exerciseId: String = "exercise_0",
+        weightKg: Double,
+        reps: Int,
+        intent: SetIntent? = .top
+    ) -> SetLog {
+        SetLog(
+            id: UUID(),
+            sessionId: UUID(),
+            exerciseId: exerciseId,
+            setNumber: 1,
+            weightKg: weightKg,
+            repsCompleted: reps,
+            rpeFelt: 8,
+            rirEstimated: 2,
+            aiPrescribed: nil,
+            loggedAt: Date(),
+            primaryMuscle: nil,
+            intent: intent,
+            completionFlags: []
+        )
+    }
+
+    func test_genuinePR_producesRecordWithCorrectValues() {
+        // Historical best: 100 kg × 5 → e1RM 116.667. Session best: 105 kg × 5 → 122.5.
+        let records = WorkoutSessionManager.computePersonalRecords(
+            sessionSets: [makeSet(weightKg: 105, reps: 5)],
+            historicalSets: [makeSet(weightKg: 100, reps: 5)],
+            exercises: makeTrainingDay().exercises
+        )
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].exerciseId, "exercise_0")
+        XCTAssertEqual(records[0].exerciseName, "Exercise 0")
+        XCTAssertEqual(records[0].previousBest, 100.0 * (1.0 + 5.0 / 30.0), accuracy: 0.0001)
+        XCTAssertEqual(records[0].newBest, 105.0 * (1.0 + 5.0 / 30.0), accuracy: 0.0001)
+        XCTAssertEqual(records[0].metric, .estimatedOneRM)
+    }
+
+    func test_noPR_whenSessionBestDoesNotExceedHistoricalBest() {
+        // Equal e1RM (strict > required) and lower e1RM both produce no record.
+        let equalRecords = WorkoutSessionManager.computePersonalRecords(
+            sessionSets: [makeSet(weightKg: 100, reps: 5)],
+            historicalSets: [makeSet(weightKg: 100, reps: 5)],
+            exercises: makeTrainingDay().exercises
+        )
+        XCTAssertTrue(equalRecords.isEmpty)
+
+        let lowerRecords = WorkoutSessionManager.computePersonalRecords(
+            sessionSets: [makeSet(weightKg: 95, reps: 5)],
+            historicalSets: [makeSet(weightKg: 100, reps: 5)],
+            exercises: makeTrainingDay().exercises
+        )
+        XCTAssertTrue(lowerRecords.isEmpty)
+    }
+
+    func test_suppressed_whenExerciseHasZeroHistoricalTopSets() {
+        // exercise_1 has NO history — a huge session best must NOT fabricate a
+        // PR against a 0.0 baseline. exercise_0 has a baseline and a real PR.
+        let records = WorkoutSessionManager.computePersonalRecords(
+            sessionSets: [
+                makeSet(exerciseId: "exercise_0", weightKg: 105, reps: 5),
+                makeSet(exerciseId: "exercise_1", weightKg: 200, reps: 5)
+            ],
+            historicalSets: [makeSet(exerciseId: "exercise_0", weightKg: 100, reps: 5)],
+            exercises: makeTrainingDay().exercises
+        )
+        XCTAssertEqual(records.count, 1)
+        XCTAssertFalse(records.contains { $0.exerciseId == "exercise_1" })
+        XCTAssertEqual(records[0].exerciseId, "exercise_0")
+    }
+
+    func test_repsOutside3to10_excludedFromBothSessionAndHistoricalBests() {
+        // Session: 200 kg × 2 (excluded, below range) + 100 kg × 5 (valid → 116.667).
+        // History: 180 kg × 12 (excluded, above range) + 90 kg × 5 (valid → 105).
+        // If exclusion failed on either side, the result would differ:
+        // history 180×12 → e1RM 252 would swallow the PR; session 200×2 → 213.3
+        // would inflate newBest.
+        let records = WorkoutSessionManager.computePersonalRecords(
+            sessionSets: [
+                makeSet(weightKg: 200, reps: 2),
+                makeSet(weightKg: 100, reps: 5)
+            ],
+            historicalSets: [
+                makeSet(weightKg: 180, reps: 12),
+                makeSet(weightKg: 90, reps: 5)
+            ],
+            exercises: makeTrainingDay().exercises
+        )
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records[0].previousBest, 90.0 * (1.0 + 5.0 / 30.0), accuracy: 0.0001)
+        XCTAssertEqual(records[0].newBest, 100.0 * (1.0 + 5.0 / 30.0), accuracy: 0.0001)
+    }
+}


### PR DESCRIPTION
Part of #318 (unit U6 of the fix campaign).

## What this fixes

**G-F4 — streak uses the real user id.** The two real call sites in `WorkoutView.swift` (initial `.task` fetch and the post-completion re-fetch) now pass `deps.resolvedUserId` instead of `AppDependencies.placeholderUserId`. The third audit hit (`ProgramOverviewView.swift`) is inside a `#Preview` block and is intentionally untouched.

**G-F5 (auth-check part) — rest-alert disabled notice.** `RestTimerView` now queries `UNUserNotificationCenter.current().notificationSettings()`; when `authorizationStatus == .denied` it renders one muted line: "Rest alerts are off — enable notifications in iOS Settings." Display-only — no settings deeplink, no scheduling.

**G-F10 — rest-control polish.** Skip button: `.frame(minHeight: 44)` + `.contentShape(Rectangle())`, opacity 0.28 → 0.55. Countdown now renders the existing (previously unused) `viewModel.formattedRestTime` (m:ss). The "seconds" caption under the number was removed because it no longer applies to a m:ss display.

**G-F12 — real post-workout PRs.** `finishSession` no longer hardcodes `personalRecords: []`. A pure `static func computePersonalRecords(sessionSets:historicalSets:exercises:)` compares, per exercise, the session-best e1RM over top-intent sets with reps in 3...10 against the historical best under the same rule. e1RM reuses the existing Epley estimate `weightKg * (1.0 + reps / 30.0)`.
- **Suppression rule:** an exercise with zero historical top sets produces no entry — `PersonalRecord.previousBest` is non-optional, so a first-ever session must not fabricate a "PR" against a 0.0 baseline.
- **History fetch:** two-step query mirroring `fetchWeeklyFatigue` (recent non-abandoned sessions by user → their `set_logs` with `intent=eq.top`; `set_logs` has no `user_id` column), excludes the current session id, runs **concurrently** with the WAQ flush via `async let`, and degrades to empty history (→ `[]`) on any failure — never blocks the summary.
- No schema/EF/prompt change: the summary JSONB is unconstrained and `PostWorkoutSummaryView` already renders a populated array.

## Tests

4 new cases in `ComputePersonalRecordsTests` (registered file `WorkoutSessionManagerTests.swift`): genuine PR with correct previousBest/newBest, no PR when session best ≤ historical best, suppression with zero historical top sets, and the 3–10 rep gate on both sides.

## Verification

- `xcodebuild build-for-testing` → exit=0
- Full test suite: 757 tests, 747 passed, 0 failed, 10 skipped (the `APEX_INTEGRATION_TESTS`-gated live tests). The known flake did not fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)