### PR TITLE
fix(#318): banner dismissal semantics — durable, event-fingerprinted dismissals

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,43 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-11 — Dismissed banners now stay dismissed — and come back only when there's genuinely something new (PR #366)
+
+**What happened (in plain words):**
+The last item from the #318 flow audit. The pre-workout screen shows little
+notice cards — "welcome back after your break", "you've leveled up", "your
+targets are ready". Each has an × to dismiss it. But the app only remembered
+that × in short-term memory: leave the screen and come back, and the same
+card you just closed was back again. Worse, the app didn't remember *which*
+news you dismissed — so it couldn't tell "same old card again" apart from
+"actually, something new happened". Separately, on app launch two pop-ups
+(crash recovery and a one-time programme notice) could try to appear at the
+same moment; the system quietly drops one, and the dropped notice was marked
+as "already shown" — so you'd never see it at all.
+
+**What changed:**
+Dismissing a card now writes down exactly which event you dismissed — keyed
+to solid facts like "the session date that caused the break" or "the
+session count when you leveled up", never to wobbly numbers. The card stays
+gone across screens and app restarts, and only returns when the underlying
+event genuinely changes (a new break, a new level-up, a re-calibration).
+The × is still just a local "not now" — saving from the review screens
+remains the real acknowledgement. And at launch, crash recovery now goes
+first: the programme notice politely waits for the next launch instead of
+being silently swallowed. The bigger banner-queue redesign stays parked as
+issue #327.
+
+**How it was checked:**
+Six new unit tests cover the dismissal memory directly — shows when nothing
+is dismissed, stays hidden for the same event, re-arms for a new one, each
+banner independent — all against a throwaway settings store so real
+settings are never touched. Full build passed and the whole test suite ran
+green — zero failures (the live-API test stays gated off).
+
+**Status:** merged as PR #366 — the #318 audit campaign closes with this one.
+
+---
+
 ## 2026-06-11 — The coach can no longer prescribe weights that don't exist, or jumps that don't make sense (PR #365)
 
 **What happened (in plain words):**

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -170,22 +170,19 @@ struct ContentView: View {
                 )
             }
 
-            // One-time migration notice: show once when an existing user first launches
-            // the build that introduced training-time programme progression.
-            let migrationKey = "training_time_migration_v1_shown"
-            if !showOnboarding && !UserDefaults.standard.bool(forKey: migrationKey) {
-                UserDefaults.standard.set(true, forKey: migrationKey)
-                showTrainingTimeMigrationNotice = true
-            }
-
             // Crash recovery check — detect sessions that were interrupted by a kill.
             // PausedSessionState is written at session start and updated every set, so
             // if it's present here the session was never properly ended or explicitly paused.
             // Skip during onboarding (no session has ever run).
+            // Evaluated FIRST (J-F7 / #318): two alerts arming in the same .task pass
+            // collide — SwiftUI silently drops one — so the migration notice below only
+            // arms when no crash-recovery alert won this launch.
+            var crashAlertArmed = false
             if !showOnboarding {
                 if let saved = PausedSessionState.load() {
                     crashRecoveryState = saved
                     showCrashRecoveryAlert = true
+                    crashAlertArmed = true
                 } else if PausedSessionState.repairPending {
                     // UserDefaults data was present but corrupt (key migration failure or
                     // incompatible struct change). Query Supabase for a paused row so the
@@ -197,8 +194,20 @@ struct ContentView: View {
                     if let repaired = PausedSessionState.load() {
                         crashRecoveryState = repaired
                         showCrashRecoveryAlert = true
+                        crashAlertArmed = true
                     }
                 }
+            }
+
+            // One-time migration notice: show once when an existing user first launches
+            // the build that introduced training-time programme progression. Suppressed
+            // when the crash-recovery alert won — and the shown-flag is set ONLY when
+            // the notice actually presents, so a suppressed notice isn't silently
+            // consumed and still shows on the next launch (J-F7 / #318).
+            let migrationKey = "training_time_migration_v1_shown"
+            if !showOnboarding && !crashAlertArmed && !UserDefaults.standard.bool(forKey: migrationKey) {
+                UserDefaults.standard.set(true, forKey: migrationKey)
+                showTrainingTimeMigrationNotice = true
             }
         }
         .alert("Unfinished Workout", isPresented: $showCrashRecoveryAlert) {

--- a/ProjectApex/Features/Workout/BannerDismissals.swift
+++ b/ProjectApex/Features/Workout/BannerDismissals.swift
@@ -1,0 +1,89 @@
+// Features/Workout/BannerDismissals.swift
+// ProjectApex — #318 (finding J-F7, fix-now parts)
+//
+// Durable, event-fingerprinted dismissal state for the pre-workout banners.
+//
+// Before #318 the welcome-back, heavy-reassessment, and calibration banners
+// were dismissed via transient @State Bool flags: dismissal was forgotten on
+// every view rebuild, and a dismissal didn't track WHICH event it dismissed.
+//
+// This helper stores, per banner, the fingerprint of the event that was
+// dismissed (UserDefaults-backed). A banner shows only when its current event
+// fingerprint differs from the stored dismissed one; dismissing writes the
+// current fingerprint. Fingerprints are STABLE keys (date strings / session
+// counts — never formatting-unstable floats), so:
+//
+//   • welcome-back re-arms when a NEW last-session date produces a gap,
+//   • heavy-reassessment re-arms when a NEW global-phase-advance fires
+//     (new triggeringSessionCount),
+//   • calibration re-arms when the watermark pair moves — i.e. on
+//     re-calibration (#305 semantics).
+//
+// The X (dismiss) writes NO durable server-side ack — sheet-save remains the
+// only durable-ack path. The full banner-queue redesign is deferred to #327.
+
+import Foundation
+
+struct BannerDismissals {
+
+    /// The three pre-workout banners with locally-dismissable X buttons.
+    /// (The first-session banner has no X and is not tracked here.)
+    enum Banner: String, CaseIterable {
+        case welcomeBack       = "banner_dismissed_welcome_back"
+        case heavyReassessment = "banner_dismissed_heavy_reassessment"
+        case calibrationReview = "banner_dismissed_calibration_review"
+    }
+
+    private let defaults: UserDefaults
+
+    /// `defaults` is injectable so tests run against an ephemeral suite and
+    /// never pollute `.standard`.
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// True when the banner should show: no dismissal stored yet, or the
+    /// current event fingerprint differs from the dismissed one.
+    func shouldShow(_ banner: Banner, fingerprint: String) -> Bool {
+        defaults.string(forKey: banner.rawValue) != fingerprint
+    }
+
+    /// Records that the user dismissed the banner for the given event.
+    func dismiss(_ banner: Banner, fingerprint: String) {
+        defaults.set(fingerprint, forKey: banner.rawValue)
+    }
+
+    // MARK: - Fingerprint builders (pure; stable keys only)
+
+    /// Keyed on the last-session date that produced the gap — the raw
+    /// `workout_sessions.session_date` string ("yyyy-MM-dd") of the most
+    /// recent completed session. A newer last session ⇒ a new fingerprint ⇒
+    /// a later ≥14-day gap re-arms the banner.
+    static func welcomeBackFingerprint(lastSessionDateKey: String) -> String {
+        "last_session:\(lastSessionDateKey)"
+    }
+
+    /// Keyed on `HeavyReassessmentSignal.triggeringSessionCount` (equal to
+    /// `TraineeModel.lastGlobalPhaseAdvanceFiredAtSessionCount`) — stable, and
+    /// it mirrors how the durable ack is keyed in
+    /// `acknowledgedTriggeringSessionCounts`. A later GPA fire carries a new
+    /// count ⇒ the banner re-arms.
+    static func heavyReassessmentFingerprint(triggeringSessionCount: Int) -> String {
+        "gpa_fired_at:\(triggeringSessionCount)"
+    }
+
+    /// Keyed on the existing watermark pair
+    /// (`ProjectionState.calibrationReviewFiredAt`,
+    /// `ProjectionState.lastRecalibratedAtSessionCount`). The date is reduced
+    /// to whole epoch seconds (Int) — never a formatted float — and the
+    /// floor/stretch target values are deliberately NOT part of the key.
+    /// Re-calibration moves the watermark ⇒ the banner re-arms (#305).
+    static func calibrationFingerprint(
+        calibrationReviewFiredAt: Date?,
+        lastRecalibratedAtSessionCount: Int?
+    ) -> String {
+        let firedAt = calibrationReviewFiredAt.map { String(Int($0.timeIntervalSince1970)) } ?? "none"
+        let recalAt = lastRecalibratedAtSessionCount.map(String.init) ?? "none"
+        return "calibration_fired_at:\(firedAt)|recalibrated_at:\(recalAt)"
+    }
+}

--- a/ProjectApex/Features/Workout/PreWorkoutView.swift
+++ b/ProjectApex/Features/Workout/PreWorkoutView.swift
@@ -45,6 +45,9 @@ struct PreWorkoutView: View {
     /// Days since the user's last completed session — nil means first-ever session.
     /// Drives the welcome-back banner when the gap is ≥ 14 days (2.4A).
     var daysSinceLastSession: Int? = nil
+    /// Raw `session_date` string ("yyyy-MM-dd") of that last completed session —
+    /// the stable key for the welcome-back banner's dismissal fingerprint (J-F7).
+    var lastSessionDateKey: String? = nil
     /// Heavy-reassessment signal (#258). When present (and not locally dismissed),
     /// shows the level-up banner naming recently-advanced patterns. Nil → no banner.
     var heavyReassessmentSignal: HeavyReassessmentSignal? = nil
@@ -58,6 +61,12 @@ struct PreWorkoutView: View {
     /// Called when the user taps "Review targets" on the calibration banner (#269).
     /// Wired to the read-only calibration screen. Default no-op.
     var onReviewCalibration: () -> Void = {}
+    /// Watermark pair backing the calibration banner's dismissal fingerprint
+    /// (J-F7): `ProjectionState.calibrationReviewFiredAt` and
+    /// `ProjectionState.lastRecalibratedAtSessionCount`. Re-calibration moves
+    /// the watermark, which re-arms a dismissed banner (#305 semantics).
+    var calibrationWatermarkFiredAt: Date? = nil
+    var calibrationWatermarkRecalibratedAtSessionCount: Int? = nil
     /// Called when the user taps "Skip this session". Defers this day without recording
     /// any session data — the next pending non-skipped day becomes the active session.
     var onSkipSession: (() -> Void)? = nil
@@ -75,9 +84,15 @@ struct PreWorkoutView: View {
 
     // MARK: - Private state
     @State private var showSkipConfirmation: Bool = false
-    @State private var welcomeBackBannerDismissed: Bool = false
-    @State private var heavyReassessmentBannerDismissed: Bool = false
-    @State private var calibrationBannerDismissed: Bool = false
+    /// Durable, event-fingerprinted dismissal store for the three dismissable
+    /// banners (J-F7 / #318). Replaces the transient per-banner Bool flags —
+    /// a dismissal now survives view rebuilds and is keyed to the event it
+    /// dismissed, re-arming only when the underlying event genuinely changes.
+    private let bannerDismissals = BannerDismissals()
+    /// Banners dismissed during this view's lifetime. The durable store is the
+    /// source of truth across rebuilds; this set exists only so an X-tap
+    /// triggers an immediate SwiftUI re-render.
+    @State private var locallyDismissedBanners: Set<BannerDismissals.Banner> = []
     /// Set true once the user taps "Generate Session". Combined with the day still being
     /// pending and generation no longer in progress, this surfaces the inline failure
     /// line — generateDaySession restores .loaded silently on error (amendment 2.2).
@@ -102,12 +117,15 @@ struct PreWorkoutView: View {
                         // Precedence (#269): the calibration banner takes priority; the
                         // heavy-reassessment banner shows only when the calibration banner
                         // is not currently shown.
-                        if let calibration = calibrationReviewSignal, !calibrationBannerDismissed {
+                        if let calibration = calibrationReviewSignal,
+                           showsBanner(.calibrationReview, fingerprint: calibrationFingerprint) {
                             calibrationReviewBanner(calibration)
-                        } else if let signal = heavyReassessmentSignal, !heavyReassessmentBannerDismissed {
+                        } else if let signal = heavyReassessmentSignal,
+                                  showsBanner(.heavyReassessment, fingerprint: heavyReassessmentFingerprint(signal)) {
                             heavyReassessmentBanner(signal)
                         }
-                        if let days = daysSinceLastSession, days >= 14, !welcomeBackBannerDismissed {
+                        if let days = daysSinceLastSession, days >= 14,
+                           showsBanner(.welcomeBack, fingerprint: welcomeBackFingerprint) {
                             welcomeBackBanner(days: days)
                         }
                         sessionInfoCard
@@ -368,6 +386,39 @@ struct PreWorkoutView: View {
         )
     }
 
+    // MARK: - Banner dismissal semantics (J-F7 / #318)
+
+    /// True when the banner should render: not dismissed during this view's
+    /// lifetime (the set drives the immediate re-render on X-tap) and the
+    /// current event fingerprint differs from the durably dismissed one (the
+    /// store drives persistence across view rebuilds).
+    private func showsBanner(_ banner: BannerDismissals.Banner, fingerprint: String) -> Bool {
+        !locallyDismissedBanners.contains(banner)
+            && bannerDismissals.shouldShow(banner, fingerprint: fingerprint)
+    }
+
+    /// Writes the current event fingerprint durably. No server-side ack —
+    /// sheet-save remains the only durable-ack path.
+    private func dismissBanner(_ banner: BannerDismissals.Banner, fingerprint: String) {
+        bannerDismissals.dismiss(banner, fingerprint: fingerprint)
+        locallyDismissedBanners.insert(banner)
+    }
+
+    private var welcomeBackFingerprint: String {
+        BannerDismissals.welcomeBackFingerprint(lastSessionDateKey: lastSessionDateKey ?? "")
+    }
+
+    private func heavyReassessmentFingerprint(_ signal: HeavyReassessmentSignal) -> String {
+        BannerDismissals.heavyReassessmentFingerprint(triggeringSessionCount: signal.triggeringSessionCount)
+    }
+
+    private var calibrationFingerprint: String {
+        BannerDismissals.calibrationFingerprint(
+            calibrationReviewFiredAt: calibrationWatermarkFiredAt,
+            lastRecalibratedAtSessionCount: calibrationWatermarkRecalibratedAtSessionCount
+        )
+    }
+
     // MARK: - Welcome Back Banner (2.4A)
 
     /// Pure message-selection for the welcome-back banner, extracted for unit testing.
@@ -399,7 +450,7 @@ struct PreWorkoutView: View {
                 .fixedSize(horizontal: false, vertical: true)
             Spacer(minLength: 0)
             Button {
-                welcomeBackBannerDismissed = true
+                dismissBanner(.welcomeBack, fingerprint: welcomeBackFingerprint)
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 11, weight: .semibold))
@@ -449,7 +500,7 @@ struct PreWorkoutView: View {
             }
             Spacer(minLength: 0)
             Button {
-                heavyReassessmentBannerDismissed = true
+                dismissBanner(.heavyReassessment, fingerprint: heavyReassessmentFingerprint(signal))
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 11, weight: .semibold))
@@ -499,7 +550,7 @@ struct PreWorkoutView: View {
             }
             Spacer(minLength: 0)
             Button {
-                calibrationBannerDismissed = true
+                dismissBanner(.calibrationReview, fingerprint: calibrationFingerprint)
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 11, weight: .semibold))

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -39,6 +39,9 @@ struct WorkoutView: View {
     /// Days since the user's last completed session — nil on first-ever session.
     /// Used by PreWorkoutView to show the welcome-back banner after a long gap.
     @State private var daysSinceLastSession: Int? = nil
+    /// Raw `session_date` string ("yyyy-MM-dd") of that last completed session —
+    /// the stable key for the welcome-back banner's dismissal fingerprint (J-F7).
+    @State private var lastSessionDateKey: String? = nil
     /// Heavy-reassessment signal derived from the cached trainee model (#258).
     /// Drives the level-up banner in PreWorkoutView. Nil when no model / out of
     /// the cooldown window / acknowledged.
@@ -51,6 +54,11 @@ struct WorkoutView: View {
     /// Drives the one-time targets banner in PreWorkoutView. Nil when no model /
     /// review not fired / already acknowledged.
     @State private var calibrationReviewSignal: CalibrationReviewSignal? = nil
+    /// Watermark pair backing the calibration banner's durable dismissal
+    /// fingerprint (J-F7): re-calibration moves the watermark, re-arming a
+    /// dismissed banner (#305 semantics).
+    @State private var calibrationWatermarkFiredAt: Date? = nil
+    @State private var calibrationWatermarkRecalibratedAtSessionCount: Int? = nil
     /// True while the read-only calibration-review screen is presented from the
     /// banner CTA (#269). On dismiss the signal is re-derived; acknowledging the
     /// screen sets calibrationReviewAcknowledged, so the banner then disappears.
@@ -156,6 +164,9 @@ struct WorkoutView: View {
                 formatter.locale = Locale(identifier: "en_US_POSIX")
                 if let date = formatter.date(from: row.sessionDate) {
                     daysSinceLastSession = Calendar.current.dateComponents([.day], from: date, to: Date()).day
+                    // Stable dismissal key for the welcome-back banner (J-F7) —
+                    // the raw date string, never the day count (which changes daily).
+                    lastSessionDateKey = row.sessionDate
                 }
             }
 
@@ -167,6 +178,12 @@ struct WorkoutView: View {
             // Calibration-review signal for the pre-workout one-time targets banner (#269).
             // Same cached-digest path. Nil model / not-fired / acknowledged → nil → no banner.
             calibrationReviewSignal = await deps.traineeModelService.digest()?.calibrationReviewSignal
+
+            // Watermark pair backing the calibration banner's durable dismissal
+            // fingerprint (J-F7). Same cached-digest path.
+            let watermark = await deps.traineeModelService.digest()?.projections
+            calibrationWatermarkFiredAt = watermark?.calibrationReviewFiredAt
+            calibrationWatermarkRecalibratedAtSessionCount = watermark?.lastRecalibratedAtSessionCount
 
             guard let vm = viewModel else { return }
 
@@ -351,6 +368,7 @@ struct WorkoutView: View {
                 completedDayCount: completedDayCount,
                 totalDayCount: totalDayCount,
                 daysSinceLastSession: daysSinceLastSession,
+                lastSessionDateKey: lastSessionDateKey,
                 heavyReassessmentSignal: heavyReassessmentSignal,
                 onReviewGoals: {
                     showGoalReview = true
@@ -359,6 +377,8 @@ struct WorkoutView: View {
                 onReviewCalibration: {
                     showCalibrationReview = true
                 },
+                calibrationWatermarkFiredAt: calibrationWatermarkFiredAt,
+                calibrationWatermarkRecalibratedAtSessionCount: calibrationWatermarkRecalibratedAtSessionCount,
                 onSkipSession: onSkipSession,
                 onBack: onBack,
                 onCloseToTab0: onCloseToTab0,

--- a/ProjectApexTests/HeavyReassessmentBannerCopyTests.swift
+++ b/ProjectApexTests/HeavyReassessmentBannerCopyTests.swift
@@ -92,3 +92,123 @@ struct WelcomeBackBannerCopyTests {
         #expect(!message.contains("adjusted"))
     }
 }
+
+// MARK: - Banner dismissal semantics (#318 U8 / J-F7)
+
+/// Verifies BannerDismissals — the durable, event-fingerprinted dismissal
+/// store behind the pre-workout banners' X buttons. Every case runs against
+/// an ephemeral injected UserDefaults suite; `.standard` is never touched.
+@Suite("BannerDismissals")
+struct BannerDismissalsTests {
+
+    /// Runs `body` against a uniquely-named UserDefaults suite, then wipes it.
+    private func withEphemeralDefaults(_ body: (UserDefaults) -> Void) {
+        let suiteName = "BannerDismissalsTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(defaults)
+    }
+
+    // MARK: Welcome-back (keyed on the last-session date that produced the gap)
+
+    @Test("welcome-back: shows with no stored dismissal, hides after dismissing the same last-session date")
+    func welcomeBackDismissalSticks() {
+        withEphemeralDefaults { defaults in
+            let store = BannerDismissals(defaults: defaults)
+            let fp = BannerDismissals.welcomeBackFingerprint(lastSessionDateKey: "2026-05-20")
+            #expect(store.shouldShow(.welcomeBack, fingerprint: fp))
+            store.dismiss(.welcomeBack, fingerprint: fp)
+            #expect(!store.shouldShow(.welcomeBack, fingerprint: fp))
+        }
+    }
+
+    @Test("welcome-back: re-arms when a NEW last-session date produces the gap")
+    func welcomeBackReArmsOnNewLastSessionDate() {
+        withEphemeralDefaults { defaults in
+            let store = BannerDismissals(defaults: defaults)
+            store.dismiss(
+                .welcomeBack,
+                fingerprint: BannerDismissals.welcomeBackFingerprint(lastSessionDateKey: "2026-05-20")
+            )
+            let newGap = BannerDismissals.welcomeBackFingerprint(lastSessionDateKey: "2026-06-10")
+            #expect(store.shouldShow(.welcomeBack, fingerprint: newGap))
+        }
+    }
+
+    // MARK: Heavy reassessment (keyed on triggeringSessionCount)
+
+    @Test("heavy-reassessment: hides after dismissal, re-arms on a NEW triggeringSessionCount")
+    func heavyReassessmentReArmsOnNewTrigger() {
+        withEphemeralDefaults { defaults in
+            let store = BannerDismissals(defaults: defaults)
+            let fired18 = BannerDismissals.heavyReassessmentFingerprint(triggeringSessionCount: 18)
+            #expect(store.shouldShow(.heavyReassessment, fingerprint: fired18))
+            store.dismiss(.heavyReassessment, fingerprint: fired18)
+            #expect(!store.shouldShow(.heavyReassessment, fingerprint: fired18))
+            // A later GPA fire carries a new triggering count → banner re-arms.
+            let fired24 = BannerDismissals.heavyReassessmentFingerprint(triggeringSessionCount: 24)
+            #expect(store.shouldShow(.heavyReassessment, fingerprint: fired24))
+        }
+    }
+
+    // MARK: Calibration (keyed on the watermark pair, #305 semantics)
+
+    @Test("calibration: hides after dismissal, re-arms when the watermark pair moves (re-calibration)")
+    func calibrationReArmsOnWatermarkMove() {
+        withEphemeralDefaults { defaults in
+            let store = BannerDismissals(defaults: defaults)
+            let firedAt = Date(timeIntervalSince1970: 1_780_000_000)
+            let firstCalibration = BannerDismissals.calibrationFingerprint(
+                calibrationReviewFiredAt: firedAt,
+                lastRecalibratedAtSessionCount: nil
+            )
+            #expect(store.shouldShow(.calibrationReview, fingerprint: firstCalibration))
+            store.dismiss(.calibrationReview, fingerprint: firstCalibration)
+            #expect(!store.shouldShow(.calibrationReview, fingerprint: firstCalibration))
+            // Re-calibration moves the watermark (same firedAt, new recal count) → re-arms.
+            let recalibrated = BannerDismissals.calibrationFingerprint(
+                calibrationReviewFiredAt: firedAt,
+                lastRecalibratedAtSessionCount: 24
+            )
+            #expect(store.shouldShow(.calibrationReview, fingerprint: recalibrated))
+        }
+    }
+
+    @Test("calibration fingerprint is a stable function of the watermark pair — nil components stay distinct")
+    func calibrationFingerprintIsStable() {
+        let firedAt = Date(timeIntervalSince1970: 1_780_000_000)
+        // Same inputs → same fingerprint (deterministic key, no unstable formatting).
+        #expect(
+            BannerDismissals.calibrationFingerprint(calibrationReviewFiredAt: firedAt, lastRecalibratedAtSessionCount: 12)
+                == BannerDismissals.calibrationFingerprint(calibrationReviewFiredAt: firedAt, lastRecalibratedAtSessionCount: 12)
+        )
+        // Each component of the pair moving changes the fingerprint.
+        let base = BannerDismissals.calibrationFingerprint(calibrationReviewFiredAt: firedAt, lastRecalibratedAtSessionCount: nil)
+        #expect(base != BannerDismissals.calibrationFingerprint(calibrationReviewFiredAt: nil, lastRecalibratedAtSessionCount: nil))
+        #expect(base != BannerDismissals.calibrationFingerprint(calibrationReviewFiredAt: firedAt, lastRecalibratedAtSessionCount: 12))
+    }
+
+    // MARK: Independence
+
+    @Test("dismissing one banner never hides another")
+    func bannersDismissIndependently() {
+        withEphemeralDefaults { defaults in
+            let store = BannerDismissals(defaults: defaults)
+            store.dismiss(
+                .welcomeBack,
+                fingerprint: BannerDismissals.welcomeBackFingerprint(lastSessionDateKey: "2026-05-20")
+            )
+            #expect(store.shouldShow(
+                .heavyReassessment,
+                fingerprint: BannerDismissals.heavyReassessmentFingerprint(triggeringSessionCount: 18)
+            ))
+            #expect(store.shouldShow(
+                .calibrationReview,
+                fingerprint: BannerDismissals.calibrationFingerprint(
+                    calibrationReviewFiredAt: Date(timeIntervalSince1970: 1_780_000_000),
+                    lastRecalibratedAtSessionCount: nil
+                )
+            ))
+        }
+    }
+}


### PR DESCRIPTION
Part of #318 — **the final unit of the flow-audit fix campaign**. Closes #318.

Fixes finding **J-F7** (fix-now parts only; the full banner-queue redesign stays deferred to #327).

## What changed

**Durable, event-fingerprinted banner dismissals (`PreWorkoutView`)**
- New `BannerDismissals` helper (UserDefaults-backed, injectable suite) replaces the three transient `@State` dismissal flags. A dismissal now survives view rebuilds and is keyed to the *event* it dismissed, re-arming only when that event genuinely changes:
  - **welcome-back** → keyed on the last completed session's raw `session_date` string (stable; not the day count, which changes daily).
  - **heavy-reassessment** → keyed on `HeavyReassessmentSignal.triggeringSessionCount` (mirrors the durable-ack key).
  - **calibration** → keyed on the watermark pair `(calibrationReviewFiredAt, lastRecalibratedAtSessionCount)`, reduced to whole epoch seconds + Int — never a formatting-unstable float. Re-calibration moves the watermark → the banner re-arms (#305 semantics).
- The X is still a local "not now" only — it writes **no** durable server-side ack; sheet-save remains the only acknowledgement path. The first-session banner is untouched.

**Launch alert ordering (`ContentView` `.task`)**
- The crash-recovery sentinel is now evaluated **first**. The training-time migration notice arms — and sets its `training_time_migration_v1_shown` flag — **only** when no crash-recovery alert won this launch. Previously both armed in one pass and SwiftUI silently dropped one, marking the dropped notice as "shown" so it never appeared.

## How it was checked
- `xcodebuild build-for-testing` → exit 0.
- Full `ProjectApexTests` suite → 0 failures (live-API integration test stays gated off via `APEX_INTEGRATION_TESTS`).
- Six new `BannerDismissalsTests` (Swift Testing, ephemeral UserDefaults suite): shows when nothing dismissed; stays hidden for the same fingerprint; re-arms on a new fingerprint per banner; fingerprint stability; banner independence. Existing banner-copy tests stay green.

Data contract: UserDefaults only — no schema, Edge Function, or prompt changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
