### PR TITLE
feat(#343): 3-tab shell bootstrap (Today/Train/Progress) — dormant strangler seam

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -103,6 +103,42 @@ all — this build-time key is the alpha-stage stopgap.
 
 ---
 
+## 2026-06-12 — Built the new 3-tab layout, but kept it switched off (PR #370)
+
+**What happened (in plain words):**
+The redesign moves the app from four bottom tabs (Program, Workout, Progress,
+Settings) to three — **Today, Train, Progress** — with Settings tucked into a corner
+button instead of a tab. I built that new three-tab layout in code, drawn in the
+redesign's own colours and fonts (yesterday's building blocks), with a little corner
+gear for settings.
+
+The important part: it's **switched off by default**. The app still runs the old
+four-tab screen exactly as before. There's a single on/off switch in the code, set
+to "off". That's on purpose — turning it on means moving some delicate plumbing (the
+first-time setup screen, crash recovery, and "resume a paused workout"), and that
+deserves its own careful, separately-tested step later. So this slice lays the new
+layout down next to the old one without disturbing any of that plumbing.
+
+A few things worth calling out simply:
+- The new bottom bar follows the design rule: each tab's icon is quiet ink normally
+  and turns ink-blue + filled-in only for the tab you're on.
+- One tab (Progress) already shows its real screen; Today and Train show a simple
+  honest placeholder for now — and nobody sees these yet, because the whole thing is
+  switched off.
+- There's a small translator so the app's existing "jump to that tab" buttons keep
+  working unchanged once the new layout is eventually switched on.
+
+**How I made sure it works:**
+I wrote five small tests for the translator first, and they all pass. The whole app
+still builds cleanly with no warnings, and I confirmed I didn't touch the old main
+screen at all.
+
+**Status:** Opened pull request #370 (part of issue #343). Switched off, so nothing
+changes for the user yet — waiting on your review before it merges. Turning it on
+(and moving the delicate plumbing) is a later step.
+
+---
+
 ## 2026-06-11 — The new look's building blocks now exist in code (PR #367)
 
 **What happened (in plain words):**

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		22000000000000000000F011 /* PromptLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22000000000000000000F012 /* PromptLoaderTests.swift */; };
 		DE51900000000000DE519002 /* DesignSystemTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE51900000000000DE519001 /* DesignSystemTokensTests.swift */; };
 		A1C0F19329000000APIKEY04 /* BundledKeyResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F19329000000APIKEY03 /* BundledKeyResolutionTests.swift */; };
+		5A30343A0000000000FE5102 /* AppShellRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A30343A0000000000FE5101 /* AppShellRouteTests.swift */; };
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
 		C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */; };
@@ -123,6 +124,7 @@
 		A1540154CAFE0154CAFE0022 /* CalibrationReviewStretchPayloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CalibrationReviewStretchPayloadTests.swift; sourceTree = "<group>"; };
 		22000000000000000000F012 /* PromptLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptLoaderTests.swift; sourceTree = "<group>"; };
 		DE51900000000000DE519001 /* DesignSystemTokensTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DesignSystemTokensTests.swift; sourceTree = "<group>"; };
+		5A30343A0000000000FE5101 /* AppShellRouteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppShellRouteTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
 		DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetPrescriptionIntentValidationTests.swift; sourceTree = "<group>"; };
 		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
@@ -265,6 +267,7 @@
 				22000000000000000000F012 /* PromptLoaderTests.swift */,
 				DE51900000000000DE519001 /* DesignSystemTokensTests.swift */,
 				A1C0F19329000000APIKEY03 /* BundledKeyResolutionTests.swift */,
+				5A30343A0000000000FE5101 /* AppShellRouteTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -423,6 +426,7 @@
 				22000000000000000000F011 /* PromptLoaderTests.swift in Sources */,
 				DE51900000000000DE519002 /* DesignSystemTokensTests.swift in Sources */,
 				A1C0F19329000000APIKEY04 /* BundledKeyResolutionTests.swift in Sources */,
+				5A30343A0000000000FE5102 /* AppShellRouteTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/AppShell.swift
+++ b/ProjectApex/AppShell.swift
@@ -1,0 +1,238 @@
+// AppShell.swift
+// ProjectApex
+//
+// The Phase 3 UI-overhaul shell: the locked 3-tab navigation — Today / Train /
+// Progress — with settings in a corner, not a tab (ui-overhaul-spec.md §2).
+//
+// A strangler-fig sibling root to the frozen `ContentView` (ADR-0026), selected by
+// one compile-time constant in `ProjectApexApp`. This slice (#343) lands the shell
+// behind `useNewShell = false`: built, wired, and unit-tested, but NOT yet the live
+// root — so `ContentView` keeps owning the onboarding gate, crash-recovery, the
+// paused-session resume, and the `ProgramViewModel` lifecycle (ADR-0026
+// "machinery-last"). Each surface is a code-as-switch `@ViewBuilder`; a per-surface
+// slice swaps in its real screen later. The legacy raw-Int `switchToTab` contract
+// is preserved by a pure translation layer (`ShellRoute`) so the existing
+// feature-view call sites stay byte-identical.
+//
+// All chrome reads #341 design tokens (ADR-0024) — no hardcoded colors here.
+
+import SwiftUI
+
+// MARK: - Tabs
+
+/// The three locked tabs (ui-overhaul-spec.md §2), in bar order. Settings is
+/// deliberately *not* a case — it lives in a corner affordance, not the tab bar.
+enum ApexTab: CaseIterable, Identifiable {
+    case today, train, progress
+
+    var id: Self { self }
+
+    /// Tab-bar label — also the VoiceOver name.
+    var title: String {
+        switch self {
+        case .today: "Today"
+        case .train: "Train"
+        case .progress: "Progress"
+        }
+    }
+
+    /// SF Symbol base name. The bar applies the *filled* variant to the selected
+    /// tab (DESIGN.md §Iconography: "Filled variant only for the selected tab").
+    var symbol: String {
+        switch self {
+        case .today: "sun.max"
+        case .train: "dumbbell"
+        case .progress: "chart.line.uptrend.xyaxis"
+        }
+    }
+}
+
+// MARK: - Legacy switchToTab bridge
+
+/// Translation of the frozen `ContentView` raw-Int `switchToTab` contract
+/// (0 = Program, 1 = Workout, 2 = Progress, 3 = Settings) into a shell action.
+///
+/// ADR-0026 keeps the Int contract so the two live feature-view call sites
+/// (`switchToTab(1)` "Continue Workout" → live loop, `switchToTab(3)` → Settings)
+/// stay byte-identical. The mapping is pure, so a wrong route is a caught test
+/// failure, not a silent in-app mis-navigation. (Migrating the callers to a typed
+/// `ApexTab` is the close-out move, deferred to #363.)
+enum ShellRoute: Equatable {
+    /// Switch the bar to a tab.
+    case select(ApexTab)
+    /// The live-loop entry — a pushed/covered surface, not a tab
+    /// (ADR-0026 / splash-today.md: the loop "rises through" Start, off-tab).
+    case presentLiveLoop
+    /// The settings corner sheet.
+    case presentSettings
+
+    static func from(legacyTab index: Int) -> ShellRoute {
+        switch index {
+        case 0: .select(.train)      // Program → Train owns the program/calendar now
+        case 1: .presentLiveLoop     // Workout → the live-loop entry
+        case 2: .select(.progress)   // Progress → Progress
+        case 3: .presentSettings     // Settings → the corner sheet
+        default: .select(.today)     // unknown index → home (the safe no-op-spirited default)
+        }
+    }
+}
+
+// MARK: - Shell
+
+struct AppShell: View {
+
+    @Environment(\.apexTheme) private var theme
+    @Environment(AppDependencies.self) private var deps
+
+    @State private var selection: ApexTab = .today
+    @State private var showSettings = false
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            theme.paper.color.ignoresSafeArea()
+
+            // Active surface — code-as-switch routing (ADR-0026 (a)).
+            surface(for: selection)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            tabBar
+        }
+        // Settings leaves the tab bar for a corner gear (ADR-0026 (b)).
+        .overlay(alignment: .topTrailing) { settingsButton }
+        .sheet(isPresented: $showSettings) { settingsSheet }
+        // Preserve the frozen raw-Int `switchToTab` contract via the pure bridge,
+        // so the existing feature-view call sites need no edit (ADR-0026 (c)).
+        .environment(\.switchToTab) { legacyTab in
+            switch ShellRoute.from(legacyTab: legacyTab) {
+            case .select(let tab): selection = tab
+            // Interim: the live-loop host is lifted in a later, tested slice
+            // (machinery-last); route to Today, which owns Start, until then.
+            case .presentLiveLoop: selection = .today
+            case .presentSettings: showSettings = true
+            }
+        }
+    }
+
+    // MARK: Routing — code-as-switch
+
+    /// "Is this surface built?" is the literal presence of its real view's
+    /// constructor here (ADR-0026 (a)). Progress re-homes its real screen now
+    /// (it needs only `deps`). Today and Train depend on the `ProgramViewModel`
+    /// lifecycle that machinery-last keeps in `ContentView`, so they show an
+    /// honest interim until their per-surface slice lifts that machinery.
+    @ViewBuilder
+    private func surface(for tab: ApexTab) -> some View {
+        switch tab {
+        case .today:
+            InterimSurface(
+                title: "Today",
+                note: "The coach/home surface lands in the Today slice."
+            )
+        case .train:
+            InterimSurface(
+                title: "Train",
+                note: "The program surface re-homes here in the Train slice."
+            )
+        case .progress:
+            ProgressTabView(
+                supabaseClient: deps.supabaseClient,
+                userId: deps.resolvedUserId,
+                traineeModelService: deps.traineeModelService
+            )
+        }
+    }
+
+    // MARK: Tab bar (DESIGN.md §Iconography — ink default, accent-ink + filled when selected)
+
+    private var tabBar: some View {
+        HStack(spacing: 0) {
+            ForEach(ApexTab.allCases) { tab in
+                tabButton(tab)
+            }
+        }
+        .padding(.top, Spacing.sm)
+        .background(alignment: .top) {
+            theme.surface.color
+                .ignoresSafeArea(edges: .bottom)
+                .overlay(alignment: .top) {
+                    theme.hairline.color.frame(height: 1)   // full-bleed top rule
+                }
+        }
+    }
+
+    private func tabButton(_ tab: ApexTab) -> some View {
+        let isSelected = tab == selection
+        return Button {
+            selection = tab
+        } label: {
+            VStack(spacing: Spacing.xs) {
+                Image(systemName: tab.symbol)
+                    .symbolVariant(isSelected ? .fill : .none)
+                    .font(.system(size: 22, weight: .medium))   // §Iconography medium weight
+                Text(tab.title)
+                    .apexFont(.label)
+            }
+            .foregroundStyle(isSelected ? theme.accentInk.color : theme.ink.color)
+            .frame(maxWidth: .infinity)
+            .padding(.bottom, Spacing.xs)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(tab.title)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+
+    // MARK: Settings corner
+
+    private var settingsButton: some View {
+        Button {
+            showSettings = true
+        } label: {
+            Image(systemName: "gearshape")
+                .font(.system(size: 20, weight: .medium))
+                .foregroundStyle(theme.accentInk.color)   // interactive → accent-ink
+                .padding(Spacing.md)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Settings")
+    }
+
+    private var settingsSheet: some View {
+        // Interim: the real settings root is a private member of the frozen
+        // `ContentView` (no standalone screen to reuse), so it re-homes here in a
+        // later slice. The corner affordance + sheet mechanics are wired now.
+        InterimSurface(
+            title: "Settings",
+            note: "The settings surface re-homes here in a later slice."
+        )
+    }
+}
+
+// MARK: - Interim surface
+
+/// An honest interim for a surface whose real screen (and the machinery it needs)
+/// lands in a later per-surface slice. The shell is dormant in #343
+/// (`useNewShell = false`), so this is compile-time scaffold that no user sees
+/// until each surface's slice swaps in its real screen.
+private struct InterimSurface: View {
+    @Environment(\.apexTheme) private var theme
+    let title: String
+    let note: String
+
+    var body: some View {
+        ZStack {
+            theme.paper.color.ignoresSafeArea()
+            VStack(spacing: Spacing.sm) {
+                Text(title)
+                    .apexFont(.display)
+                    .foregroundStyle(theme.ink.color)
+                Text(note)
+                    .apexFont(.body)
+                    .foregroundStyle(theme.inkMuted.color)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(Spacing.lg)
+        }
+    }
+}

--- a/ProjectApex/AppShell.swift
+++ b/ProjectApex/AppShell.swift
@@ -88,29 +88,27 @@ struct AppShell: View {
     @State private var showSettings = false
 
     var body: some View {
-        ZStack(alignment: .bottom) {
-            theme.paper.color.ignoresSafeArea()
-
-            // Active surface — code-as-switch routing (ADR-0026 (a)).
-            surface(for: selection)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-            tabBar
-        }
-        // Settings leaves the tab bar for a corner gear (ADR-0026 (b)).
-        .overlay(alignment: .topTrailing) { settingsButton }
-        .sheet(isPresented: $showSettings) { settingsSheet }
-        // Preserve the frozen raw-Int `switchToTab` contract via the pure bridge,
-        // so the existing feature-view call sites need no edit (ADR-0026 (c)).
-        .environment(\.switchToTab) { legacyTab in
-            switch ShellRoute.from(legacyTab: legacyTab) {
-            case .select(let tab): selection = tab
-            // Interim: the live-loop host is lifted in a later, tested slice
-            // (machinery-last); route to Today, which owns Start, until then.
-            case .presentLiveLoop: selection = .today
-            case .presentSettings: showSettings = true
+        // Active surface — code-as-switch routing (ADR-0026 (a)).
+        surface(for: selection)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(theme.paper.color.ignoresSafeArea())
+            // The bar reserves its own space and propagates a bottom inset into
+            // child scroll views, so surface content never renders behind it.
+            .safeAreaInset(edge: .bottom, spacing: 0) { tabBar }
+            // Settings leaves the tab bar for a corner gear (ADR-0026 (b)).
+            .overlay(alignment: .topTrailing) { settingsButton }
+            .sheet(isPresented: $showSettings) { settingsSheet }
+            // Preserve the frozen raw-Int `switchToTab` contract via the pure bridge,
+            // so the existing feature-view call sites need no edit (ADR-0026 (c)).
+            .environment(\.switchToTab) { legacyTab in
+                switch ShellRoute.from(legacyTab: legacyTab) {
+                case .select(let tab): selection = tab
+                // Interim: the live-loop host is lifted in a later, tested slice
+                // (machinery-last); route to Today, which owns Start, until then.
+                case .presentLiveLoop: selection = .today
+                case .presentSettings: showSettings = true
+                }
             }
-        }
     }
 
     // MARK: Routing — code-as-switch

--- a/ProjectApex/ProjectApexApp.swift
+++ b/ProjectApex/ProjectApexApp.swift
@@ -13,6 +13,13 @@ struct ProjectApexApp: App {
     @State private var deps = AppDependencies()
     @Environment(\.scenePhase) private var scenePhase
 
+    /// Strangler entry seam (ADR-0026): the new 3-tab `AppShell` is selected by a
+    /// single compile-time constant. #343 lands it `false` — the shell is built,
+    /// wired, and unit-tested but not yet the live root, so the frozen `ContentView`
+    /// keeps owning onboarding, crash-recovery, and the paused-session resume
+    /// (machinery-last). Flip to `true` once that machinery is lifted (close-out #363).
+    private let useNewShell = false
+
     init() {
         // Register the embedded design-system fonts at launch (ADR-0024 — runtime
         // Core Text registration, not the Info.plist UIAppFonts build-setting key).
@@ -21,9 +28,15 @@ struct ProjectApexApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environment(deps)
-                .apexThemeRoot()
+            Group {
+                if useNewShell {
+                    AppShell()
+                } else {
+                    ContentView()
+                }
+            }
+            .environment(deps)
+            .apexThemeRoot()
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {

--- a/ProjectApexTests/AppShellRouteTests.swift
+++ b/ProjectApexTests/AppShellRouteTests.swift
@@ -1,0 +1,43 @@
+// AppShellRouteTests.swift
+// ProjectApexTests
+//
+// The legacy raw-Int `switchToTab` contract (frozen ContentView: 0 = Program,
+// 1 = Workout, 2 = Progress, 3 = Settings) is preserved across the new 3-tab
+// shell by a pure translation layer, `ShellRoute` (#343 / ADR-0026). In the app a
+// wrong mapping is a silent mis-route, not a crash — so the bridge is pinned here:
+// the two live feature-view call sites (`switchToTab(1)` "Continue Workout" and
+// `switchToTab(3)` "Settings") and the remaining indices each resolve to their
+// intended shell action.
+
+import Testing
+@testable import ProjectApex
+
+@Suite("AppShell legacy switchToTab bridge")
+struct AppShellRouteTests {
+
+    @Test("Workout (1) → the live-loop entry — the 'Continue Workout' call site")
+    func workoutRoutesToLiveLoop() {
+        #expect(ShellRoute.from(legacyTab: 1) == .presentLiveLoop)
+    }
+
+    @Test("Settings (3) → the settings corner sheet — the second live call site")
+    func settingsRoutesToSheet() {
+        #expect(ShellRoute.from(legacyTab: 3) == .presentSettings)
+    }
+
+    @Test("Program (0) → Train — the program surface's home in the new nav")
+    func programRoutesToTrain() {
+        #expect(ShellRoute.from(legacyTab: 0) == .select(.train))
+    }
+
+    @Test("Progress (2) → Progress")
+    func progressRoutesToProgress() {
+        #expect(ShellRoute.from(legacyTab: 2) == .select(.progress))
+    }
+
+    @Test("An unknown index falls back to Today and never traps")
+    func unknownRoutesToToday() {
+        #expect(ShellRoute.from(legacyTab: 99) == .select(.today))
+        #expect(ShellRoute.from(legacyTab: -1) == .select(.today))
+    }
+}


### PR DESCRIPTION
## What this lands

The **bootstrap slice** of the Phase 3 UI overhaul's 3-tab shell, built as a strangler-fig per **ADR-0026**. A new sibling root `AppShell.swift` renders the locked 3-tab nav (**Today / Train / Progress**, settings in a corner) styled entirely with #341 design tokens, selected by a single compile-time seam in `ProjectApexApp`:

```swift
private let useNewShell = false   // #343 lands it dormant
…
if useNewShell { AppShell() } else { ContentView() }
```

**Dormant by decision (HITL):** `useNewShell = false`, so `ContentView` stays the live root and is **frozen** — onboarding, crash-recovery, and the paused-session resume keep working untouched (ADR-0026 *machinery-last*; *single-root invariant* — the two roots are never both mounted, never embedded). A later 1-line flip activates the shell once that machinery is lifted.

## Delivered

- `AppShell.swift` (new) — 3-tab token-styled shell: custom bottom bar (`ink` default, `accent-ink` + **filled** SF Symbol when selected, per DESIGN.md §Iconography), settings **corner gear** → sheet, code-as-switch `@ViewBuilder` routing. No hardcoded colors.
- **`ShellRoute`** — pure `Int → shell action` bridge preserving the frozen raw-`Int` `switchToTab` contract (`1 → live-loop`, `3 → settings`), so the two live feature-view call sites (`ProgramOverviewView` `switchToTab(3)`, `ProgramDayDetailView` `switchToTab(1)`) stay **byte-identical**. Verified by grep that those are the only two external call sites (ADR-0026's premise).
- Surfaces: **Progress** re-homes its real `ProgressTabView` now (needs only `deps`). **Today / Train** show an honest interim — both depend on the `ProgramViewModel` lifecycle that machinery-last keeps in `ContentView`, so their real screens land with each per-surface slice. (Since the shell is dormant, no user sees the interim.)
- VoiceOver: each tab labelled + `.isSelected`; the settings gear has a "Settings" label.
- `AppShellRouteTests.swift` (new) — 5-test Swift Testing suite pinning the bridge mapping.

## Deferred (not in this slice)

- **Activation** of the shell (`useNewShell = true`) + lifting onboarding / crash-recovery / paused-resume / `ProgramViewModel` out of frozen `ContentView` — a dedicated, tested machinery-lift slice.
- Real **Today** and **Train** screens (their per-surface slices).
- Real **settings** root re-home (today it's a private member of frozen `ContentView`; no standalone screen to reuse).
- The `switchToTab` → typed-`ApexTab` migration + `ContentView` deletion — the close-out (#363).

## Verification

- `xcodebuild test … -only-testing:ProjectApexTests/AppShellRouteTests` → **TEST SUCCEEDED**, 5/5 pass. Whole app + test target compile (so `AppShell` + the seam compile); no warnings (incl. no unreachable-code warning on the dormant branch).
- `ContentView.swift` **untouched** (git-confirmed). Only shared-file edits: the one-line seam in `ProjectApexApp.swift` + 4 `project.pbxproj` test-target entries (app files auto-sync via the synchronized root group).

## Issue linkage

**Part of #343** — intentionally *not* `Closes #343`: this is the dormant bootstrap, so the shell isn't the live root yet and #343's live-behavior criteria aren't met until the activation slice. Leaving #343 open to track that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
