### PR TITLE
feat(#369): Supabase anonymous-auth session foundation (auth slice 1)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,45 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — The app now quietly signs in behind the scenes (PR #372)
+
+**The problem (in plain words):**
+Right now the app talks to our database using one shared "house key" (the anon key)
+— there's no notion of *this particular person* being signed in. Before we can lock
+data down so each person only sees their own, the app first needs to get its own
+private sign-in token. This is the first small step of that bigger job: get the
+token, but change nothing anyone can see yet.
+
+**What changed:**
+On launch the app now asks our auth service for an anonymous sign-in — like getting
+a wristband at the door without giving your name. It tucks the resulting token away
+safely (in the iPhone's secure Keychain) and uses it on its database calls. Next
+time you open the app it reuses the same wristband instead of grabbing a new one, so
+you stay the same "person" across launches. The token also quietly refreshes itself
+when it's about to expire.
+
+Crucially, this is built to fail softly. If the sign-in can't happen — for example
+because we haven't flipped the "allow anonymous sign-ins" switch on the dashboard
+yet, or the network is slow — the app shrugs and carries on exactly as it does today
+with the shared house key. It never blocks the app waiting. So nothing about how the
+app behaves changes in this step: it still reads and writes the same data the same
+way. We did NOT switch over which user-id the app uses, and we did NOT turn on the
+per-person data locks — those are deliberately later steps.
+
+**How it was checked:**
+Wrote tests that fake the auth server (no real network): a successful sign-in saves
+the token and sets it; a relaunch with a saved token reuses it without signing in
+again; a rejected sign-in leaves things on the old shared-key behavior without
+crashing or hanging; and the token-refresh / retry-after-expiry path works. Full app
+test suite still green (532 ran, 0 failures, 10 skipped — the usual live-API ones
+that need real credentials). The build is clean.
+
+**Status:** Done on branch `feat/369-auth-slice1-anon-session`, PR #372. Not
+merged. Live end-to-end sign-in still needs the dashboard's Anonymous provider turned
+on; until then the app correctly runs on the old shared-key path.
+
+---
+
 ## 2026-06-12 — A brand-new install can now get past the front door (PR #368)
 
 **The problem (in plain words):**

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		47DFECFD2F72C1FC006F4B62 /* ExerciseLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DFECFC2F72C1FC006F4B62 /* ExerciseLibraryTests.swift */; };
 		47DFED092F99B001006F4B62 /* AnthropicProviderCachingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47DFED082F99B001006F4B62 /* AnthropicProviderCachingTests.swift */; };
 		47E356CB2F61BA7300C69CD6 /* SupabaseClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356CA2F61BA7300C69CD6 /* SupabaseClientTests.swift */; };
+		369A00012F61BA7300C69CD6 /* SupabaseAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 369A00002F61BA7300C69CD6 /* SupabaseAuthTests.swift */; };
 		47E356CF2F61BFCF00C69CD6 /* EquipmentMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356CE2F61BFCF00C69CD6 /* EquipmentMergerTests.swift */; };
 		47E356DA2F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356D92F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift */; };
 		47E356DC2F61D07B00C69CD6 /* GymFactStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E356DB2F61D07B00C69CD6 /* GymFactStoreTests.swift */; };
@@ -100,6 +101,7 @@
 		47DFECFC2F72C1FC006F4B62 /* ExerciseLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseLibraryTests.swift; sourceTree = "<group>"; };
 		47DFED082F99B001006F4B62 /* AnthropicProviderCachingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicProviderCachingTests.swift; sourceTree = "<group>"; };
 		47E356CA2F61BA7300C69CD6 /* SupabaseClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClientTests.swift; sourceTree = "<group>"; };
+		369A00002F61BA7300C69CD6 /* SupabaseAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseAuthTests.swift; sourceTree = "<group>"; };
 		47E356CE2F61BFCF00C69CD6 /* EquipmentMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquipmentMergerTests.swift; sourceTree = "<group>"; };
 		47E356D92F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultWeightIncrementsTests.swift; sourceTree = "<group>"; };
 		47E356DB2F61D07B00C69CD6 /* GymFactStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymFactStoreTests.swift; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				47D91CC22F61AADC007B3B34 /* AIInferenceServiceTests.swift */,
 				47DFED082F99B001006F4B62 /* AnthropicProviderCachingTests.swift */,
 				47E356CA2F61BA7300C69CD6 /* SupabaseClientTests.swift */,
+				369A00002F61BA7300C69CD6 /* SupabaseAuthTests.swift */,
 				47E356CE2F61BFCF00C69CD6 /* EquipmentMergerTests.swift */,
 				47E356D92F61D06100C69CD6 /* DefaultWeightIncrementsTests.swift */,
 				47E356DB2F61D07B00C69CD6 /* GymFactStoreTests.swift */,
@@ -384,6 +387,7 @@
 				47C5C1AF2F62A64E0005F99E /* WriteAheadQueueTests.swift in Sources */,
 				474B848D2F67D31C001E0879 /* MacroPlanServiceDayCountTests.swift in Sources */,
 				47E356CB2F61BA7300C69CD6 /* SupabaseClientTests.swift in Sources */,
+				369A00012F61BA7300C69CD6 /* SupabaseAuthTests.swift in Sources */,
 				47D91CA42F619741007B3B34 /* KeychainServiceTests.swift in Sources */,
 				47C5C1BA2F62C0550005F99E /* SpeechServiceTests.swift in Sources */,
 				47D91CC12F61A9E7007B3B34 /* WorkoutContextAssemblyTests.swift in Sources */,

--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -22,6 +22,9 @@ final class AppDependencies {
 
     let keychainService: KeychainService
     let supabaseClient: SupabaseClient
+    /// GoTrue anonymous-auth session owner (#369 slice 1). Additive: sets the
+    /// client's JWT; does not repoint resolvedUserId or enable RLS this slice.
+    let supabaseAuth: SupabaseAuth
     let healthKitService: HealthKitService
     let memoryService: MemoryService
     let speechService: SpeechService
@@ -102,6 +105,26 @@ final class AppDependencies {
         let supabaseAnonKey = (try? keychain.retrieve(.supabaseAnonKey)) ?? ""
         let client = SupabaseClient(supabaseURL: Config.supabaseURL, anonKey: supabaseAnonKey)
         self.supabaseClient = client
+
+        // 2b. Supabase Auth (GoTrue) — #369 slice 1. Additive only: establishes
+        // an anonymous session and sets the client's JWT. resolvedUserId is NOT
+        // repointed and RLS is still off, so behavior is unchanged this slice.
+        // A stored session restores instantly; a fresh launch signs in anonymously
+        // in the background and falls back to the anon key on failure/timeout.
+        let auth = SupabaseAuth(supabaseURL: Config.supabaseURL, anonKey: supabaseAnonKey)
+        self.supabaseAuth = auth
+        // Wire the refresh/401-retry hooks so authed requests stay valid.
+        Task {
+            await client.setRefreshHooks(
+                refreshIfNeeded: { await auth.validAccessToken() },
+                forceRefresh: { await auth.forceRefreshAccessToken() }
+            )
+            // Resolve the first session (restore-or-sign-in), then set the JWT.
+            // Bounded internally so this can never hang. nil → stays on anon key.
+            if let session = await auth.awaitFirstResolution() {
+                await client.setAuthToken(session.accessToken)
+            }
+        }
 
         // 3. HealthKit — no dependencies
         self.healthKitService = HealthKitService()

--- a/ProjectApex/Security/KeychainService.swift
+++ b/ProjectApex/Security/KeychainService.swift
@@ -38,6 +38,15 @@ enum KeychainKey: String, CaseIterable {
     case supabaseAnonKey  = "com.projectapex.keychain.supabaseAnonKey"
     /// Stable user identifier (UUID string) persisted between app reinstalls.
     case userId           = "com.projectapex.keychain.userId"
+    /// Supabase Auth (GoTrue) access token (JWT) for the current session.
+    case supabaseAccessToken  = "com.projectapex.keychain.supabaseAccessToken"
+    /// Supabase Auth refresh token used to mint a fresh access token.
+    case supabaseRefreshToken = "com.projectapex.keychain.supabaseRefreshToken"
+    /// Access-token expiry as a Unix-epoch seconds string (e.g. "1718200000").
+    case supabaseSessionExpiry = "com.projectapex.keychain.supabaseSessionExpiry"
+    /// The GoTrue `user.id` (UUID string) of the authenticated session. This is
+    /// the auth subject; it is NOT yet wired to `resolvedUserId` (later slice).
+    case supabaseAuthUserId   = "com.projectapex.keychain.supabaseAuthUserId"
 }
 
 // MARK: - KeychainError

--- a/ProjectApex/Services/SupabaseAuth.swift
+++ b/ProjectApex/Services/SupabaseAuth.swift
@@ -1,0 +1,354 @@
+// SupabaseAuth.swift
+// ProjectApex — Services
+//
+// Hand-rolled Supabase Auth (GoTrue) REST client. Mirrors the hand-rolled style
+// of `SupabaseClient` rather than pulling in the supabase-swift SPM dependency.
+//
+// Slice 1 of the auth/RLS workstream (#369). PURELY ADDITIVE: this establishes
+// an anonymous GoTrue session and surfaces its access token (JWT) so the
+// SupabaseClient can send `Authorization: Bearer <jwt>`. It does NOT repoint the
+// app's user id (`AppDependencies.resolvedUserId` is unchanged) and RLS is still
+// off, so every read/write works whether or not a session is established.
+//
+// Degradation contract (critical): if anonymous sign-in fails (e.g. the
+// dashboard Anonymous provider is not enabled yet → non-2xx) or times out, we
+// log it and proceed with NO session. SupabaseClient then falls back to today's
+// anon-key behavior. The readiness gate (`awaitFirstResolution`) must NEVER
+// block the app or a test indefinitely.
+//
+// GoTrue endpoints used (all relative to Config.supabaseURL):
+//   POST /auth/v1/signup                              — anonymous sign-up
+//   POST /auth/v1/token?grant_type=refresh_token      — refresh
+//   POST /auth/v1/logout                              — logout
+//
+// Security: token values are never logged.
+
+import Foundation
+import OSLog
+
+// MARK: - SupabaseSession
+
+/// A resolved GoTrue session. Persisted to the Keychain so a relaunch restores
+/// the same anonymous user (a fresh anonymous sign-up would mint a NEW uid and
+/// orphan the previous user's data).
+struct SupabaseSession: Equatable, Sendable {
+    let accessToken: String
+    let refreshToken: String
+    /// Absolute access-token expiry.
+    let expiresAt: Date
+    /// The GoTrue `user.id`.
+    let userId: UUID
+
+    /// True when the access token is within `leeway` of expiry (or already past).
+    func isNearExpiry(now: Date = Date(), leeway: TimeInterval = 60) -> Bool {
+        now.addingTimeInterval(leeway) >= expiresAt
+    }
+}
+
+// MARK: - SupabaseAuthError
+
+enum SupabaseAuthError: LocalizedError {
+    case httpError(statusCode: Int)
+    case decodingError
+    case invalidURL
+    case noRefreshToken
+
+    var errorDescription: String? {
+        switch self {
+        case .httpError(let code): return "GoTrue HTTP \(code)"
+        case .decodingError:        return "GoTrue response could not be decoded"
+        case .invalidURL:           return "Could not construct a GoTrue request URL"
+        case .noRefreshToken:       return "No refresh token available"
+        }
+    }
+}
+
+// MARK: - GoTrue wire shapes
+
+/// GoTrue token response shape (signup, refresh). `expires_at` is preferred
+/// (absolute epoch seconds); `expires_in` (seconds-from-now) is the fallback.
+private struct GoTrueTokenResponse: Decodable {
+    let accessToken: String
+    let refreshToken: String
+    let expiresAt: Int?
+    let expiresIn: Int?
+    let user: GoTrueUser
+
+    struct GoTrueUser: Decodable {
+        let id: UUID
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken  = "access_token"
+        case refreshToken = "refresh_token"
+        case expiresAt    = "expires_at"
+        case expiresIn    = "expires_in"
+        case user
+    }
+
+    func session(now: Date = Date()) -> SupabaseSession {
+        let expiry: Date
+        if let expiresAt {
+            expiry = Date(timeIntervalSince1970: TimeInterval(expiresAt))
+        } else if let expiresIn {
+            expiry = now.addingTimeInterval(TimeInterval(expiresIn))
+        } else {
+            // GoTrue access tokens default to a 1-hour lifetime.
+            expiry = now.addingTimeInterval(3600)
+        }
+        return SupabaseSession(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            expiresAt: expiry,
+            userId: user.id
+        )
+    }
+}
+
+// MARK: - SupabaseAuth
+
+/// Actor that owns the GoTrue session lifecycle: restore-or-sign-in on launch,
+/// refresh near expiry, logout. Persists the session in the Keychain.
+actor SupabaseAuth {
+
+    // MARK: - Dependencies
+
+    private let baseURL: URL
+    private let anonKey: String
+    private let session: URLSession
+    private let keychain: KeychainService
+    /// Hard ceiling on the first-resolution wait so a fresh launch can never
+    /// hang the app waiting on a slow/hung sign-in.
+    private let signInTimeout: TimeInterval
+
+    private let decoder: JSONDecoder
+    private static let logger = Logger(subsystem: "com.projectapex", category: "SupabaseAuth")
+
+    // MARK: - State
+
+    private(set) var currentSession: SupabaseSession?
+
+    /// The single in-flight first-resolution task (sign-in or restore). All
+    /// callers of `awaitFirstResolution` await this one task; it always
+    /// completes (success → session; failure/timeout → nil) and never throws.
+    private var firstResolution: Task<SupabaseSession?, Never>?
+
+    // MARK: - Init
+
+    init(
+        supabaseURL: URL,
+        anonKey: String,
+        keychain: KeychainService = .shared,
+        urlSession: URLSession = .shared,
+        signInTimeout: TimeInterval = 5
+    ) {
+        self.baseURL = supabaseURL
+        self.anonKey = anonKey
+        self.keychain = keychain
+        self.session = urlSession
+        self.signInTimeout = signInTimeout
+
+        let dec = JSONDecoder()
+        self.decoder = dec
+    }
+
+    // MARK: - Launch resolution
+
+    /// Kicks off (once) the first session resolution: restore from Keychain if a
+    /// stored session exists, otherwise anonymous sign-in. Returns immediately;
+    /// callers await the result via `awaitFirstResolution`. Idempotent.
+    func startResolution() {
+        guard firstResolution == nil else { return }
+        firstResolution = Task { [weak self] in
+            guard let self else { return nil }
+            return await self.resolveFirstSession()
+        }
+    }
+
+    /// Awaits the first session resolution, bounded so it can never hang. A
+    /// restored session resolves instantly; a fresh launch resolves on sign-in
+    /// return or `signInTimeout`, then falls through to `nil` (anon behavior).
+    ///
+    /// Returns the resolved session, or `nil` when resolution failed/timed out
+    /// (the caller should proceed with no auth token = today's anon-key path).
+    func awaitFirstResolution() async -> SupabaseSession? {
+        startResolution()
+        guard let firstResolution else { return nil }
+        return await firstResolution.value
+    }
+
+    /// Restore-or-sign-in, with a timeout guard on the network path. Never throws.
+    private func resolveFirstSession() async -> SupabaseSession? {
+        // 1. Restore a stored session instantly (no network) if present.
+        if let restored = restoreFromKeychain() {
+            currentSession = restored
+            return restored
+        }
+
+        // 2. Fresh launch → anonymous sign-in, bounded by signInTimeout so a
+        //    hung/slow endpoint (or an unreachable network) can't block launch.
+        let timeout = signInTimeout
+        let result = await withTaskGroup(of: SupabaseSession?.self) { group -> SupabaseSession? in
+            group.addTask { [weak self] in
+                guard let self else { return nil }
+                do {
+                    return try await self.signInAnonymously()
+                } catch {
+                    await SupabaseAuth.log("anonymous sign-in failed; proceeding as anon", error)
+                    return nil
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                return nil
+            }
+            // First task to finish wins; cancel the rest.
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+
+        if result == nil {
+            SupabaseAuth.logger.log("anonymous sign-in timed out after \(timeout, privacy: .public)s; proceeding as anon")
+        }
+        return result
+    }
+
+    // MARK: - GoTrue calls
+
+    /// `POST /auth/v1/signup` with an anonymous body. Persists + caches on success.
+    func signInAnonymously() async throws -> SupabaseSession {
+        // GoTrue treats a signup with no email/password as an anonymous sign-up.
+        let body = Data("{}".utf8)
+        let response = try await postToken(path: "/auth/v1/signup", query: nil, body: body)
+        let newSession = response.session()
+        persist(newSession)
+        currentSession = newSession
+        return newSession
+    }
+
+    /// `POST /auth/v1/token?grant_type=refresh_token`. Persists + caches on success.
+    @discardableResult
+    func refresh() async throws -> SupabaseSession {
+        guard let refreshToken = currentSession?.refreshToken
+            ?? (try? keychain.retrieve(.supabaseRefreshToken)).flatMap({ $0 }) else {
+            throw SupabaseAuthError.noRefreshToken
+        }
+        let body = try JSONSerialization.data(withJSONObject: ["refresh_token": refreshToken])
+        let response = try await postToken(
+            path: "/auth/v1/token",
+            query: [URLQueryItem(name: "grant_type", value: "refresh_token")],
+            body: body
+        )
+        let newSession = response.session()
+        persist(newSession)
+        currentSession = newSession
+        return newSession
+    }
+
+    /// `POST /auth/v1/logout`. Clears the persisted + cached session regardless
+    /// of the server response (best-effort sign-out).
+    func logout() async {
+        if let token = currentSession?.accessToken {
+            if let url = makeURL(path: "/auth/v1/logout", query: nil) {
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.setValue(anonKey, forHTTPHeaderField: "apikey")
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                _ = try? await session.data(for: request)
+            }
+        }
+        clearKeychain()
+        currentSession = nil
+    }
+
+    // MARK: - Token-for-request helpers (used by SupabaseClient refresh hook)
+
+    /// Returns a valid (non-near-expiry) access token, refreshing first if
+    /// needed. Returns `nil` when there is no session or refresh fails — the
+    /// caller then proceeds with the anon key (no auth token).
+    func validAccessToken() async -> String? {
+        guard let current = currentSession else { return nil }
+        guard current.isNearExpiry() else { return current.accessToken }
+        return try? await refresh().accessToken
+    }
+
+    /// Forces a refresh and returns the fresh access token, or `nil` on failure.
+    /// Used by the 401-retry path.
+    func forceRefreshAccessToken() async -> String? {
+        try? await refresh().accessToken
+    }
+
+    // MARK: - Networking
+
+    private func postToken(path: String, query: [URLQueryItem]?, body: Data) async throws -> GoTrueTokenResponse {
+        guard let url = makeURL(path: path, query: query) else { throw SupabaseAuthError.invalidURL }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(anonKey, forHTTPHeaderField: "apikey")
+        request.httpBody = body
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw SupabaseAuthError.httpError(statusCode: 0)
+        }
+        guard (200...299).contains(http.statusCode) else {
+            throw SupabaseAuthError.httpError(statusCode: http.statusCode)
+        }
+        do {
+            return try decoder.decode(GoTrueTokenResponse.self, from: data)
+        } catch {
+            throw SupabaseAuthError.decodingError
+        }
+    }
+
+    private func makeURL(path: String, query: [URLQueryItem]?) -> URL? {
+        guard var components = URLComponents(
+            url: baseURL.appendingPathComponent(path),
+            resolvingAgainstBaseURL: false
+        ) else { return nil }
+        components.queryItems = query
+        return components.url
+    }
+
+    // MARK: - Keychain persistence
+
+    private func restoreFromKeychain() -> SupabaseSession? {
+        guard
+            let access = (try? keychain.retrieve(.supabaseAccessToken)) ?? nil, !access.isEmpty,
+            let refresh = (try? keychain.retrieve(.supabaseRefreshToken)) ?? nil, !refresh.isEmpty,
+            let expiryString = (try? keychain.retrieve(.supabaseSessionExpiry)) ?? nil,
+            let expirySeconds = TimeInterval(expiryString),
+            let userIdString = (try? keychain.retrieve(.supabaseAuthUserId)) ?? nil,
+            let userId = UUID(uuidString: userIdString)
+        else { return nil }
+        return SupabaseSession(
+            accessToken: access,
+            refreshToken: refresh,
+            expiresAt: Date(timeIntervalSince1970: expirySeconds),
+            userId: userId
+        )
+    }
+
+    private func persist(_ s: SupabaseSession) {
+        try? keychain.store(s.accessToken, for: .supabaseAccessToken)
+        try? keychain.store(s.refreshToken, for: .supabaseRefreshToken)
+        try? keychain.store(String(Int(s.expiresAt.timeIntervalSince1970)), for: .supabaseSessionExpiry)
+        try? keychain.store(s.userId.uuidString, for: .supabaseAuthUserId)
+    }
+
+    private func clearKeychain() {
+        try? keychain.delete(.supabaseAccessToken)
+        try? keychain.delete(.supabaseRefreshToken)
+        try? keychain.delete(.supabaseSessionExpiry)
+        try? keychain.delete(.supabaseAuthUserId)
+    }
+
+    // MARK: - Logging (never logs token values)
+
+    private static func log(_ message: String, _ error: Error) {
+        logger.error("\(message, privacy: .public): \(error.localizedDescription, privacy: .public)")
+    }
+}

--- a/ProjectApex/Services/SupabaseClient.swift
+++ b/ProjectApex/Services/SupabaseClient.swift
@@ -107,6 +107,30 @@ actor SupabaseClient {
     /// request instead of (not in addition to) the anon key.
     var authToken: String?
 
+    /// Sets the auth token from outside the actor (e.g. AppDependencies once a
+    /// GoTrue session resolves). Slice 1 (#369).
+    func setAuthToken(_ token: String?) {
+        self.authToken = token
+    }
+
+    // MARK: - Auth refresh hooks (#369, slice 1)
+
+    /// Returns a valid (non-near-expiry) access token, refreshing first if
+    /// needed. Wired to `SupabaseAuth` by AppDependencies; `nil` when no session
+    /// (→ anon-key behavior). Both hooks update `authToken` via their return.
+    private var refreshIfNeeded: (@Sendable () async -> String?)?
+    /// Forces a token refresh after a 401; returns the fresh token or `nil`.
+    private var forceRefresh: (@Sendable () async -> String?)?
+
+    /// Installs the GoTrue refresh hooks. Called once after a session resolves.
+    func setRefreshHooks(
+        refreshIfNeeded: @escaping @Sendable () async -> String?,
+        forceRefresh: @escaping @Sendable () async -> String?
+    ) {
+        self.refreshIfNeeded = refreshIfNeeded
+        self.forceRefresh = forceRefresh
+    }
+
     // MARK: - Private helpers
 
     private let session: URLSession
@@ -500,16 +524,55 @@ actor SupabaseClient {
 
     /// Performs a request and returns the response body on success.
     /// Throws `SupabaseError.httpError` on non-2xx responses.
+    ///
+    /// Auth (#369, slice 1): when a GoTrue session is wired, the access token is
+    /// refreshed *before* the request if it is near expiry, and on a 401 the
+    /// token is refreshed once and the request retried. With no session wired
+    /// these hooks are nil and behavior is unchanged (anon-key path).
     private func performReturningData(_ request: URLRequest) async throws -> Data {
+        var request = request
+
+        // Pre-flight refresh if the access token is near expiry.
+        if let refreshIfNeeded, let fresh = await refreshIfNeeded() {
+            authToken = fresh
+            stampAuthorization(on: &request)
+        }
+
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw SupabaseError.httpError(statusCode: 0, body: "Non-HTTP response")
         }
+
+        // On 401, refresh once and retry the request a single time.
+        if http.statusCode == 401, let forceRefresh, let fresh = await forceRefresh() {
+            authToken = fresh
+            stampAuthorization(on: &request)
+            let (retryData, retryResponse) = try await session.data(for: request)
+            guard let retryHTTP = retryResponse as? HTTPURLResponse else {
+                throw SupabaseError.httpError(statusCode: 0, body: "Non-HTTP response")
+            }
+            guard (200...299).contains(retryHTTP.statusCode) else {
+                let body = String(data: retryData, encoding: .utf8) ?? "<non-UTF8 body>"
+                throw SupabaseError.httpError(statusCode: retryHTTP.statusCode, body: body)
+            }
+            return retryData
+        }
+
         guard (200...299).contains(http.statusCode) else {
             let body = String(data: data, encoding: .utf8) ?? "<non-UTF8 body>"
             throw SupabaseError.httpError(statusCode: http.statusCode, body: body)
         }
         return data
+    }
+
+    /// Re-stamps the `Authorization` header on an already-built request after a
+    /// token change. Mirrors the Bearer priority in `baseRequest`.
+    private func stampAuthorization(on request: inout URLRequest) {
+        if let token = authToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        } else {
+            request.setValue("Bearer \(anonKey)", forHTTPHeaderField: "Authorization")
+        }
     }
 
     /// Performs a PATCH request that already carries `Prefer: return=representation`

--- a/ProjectApexTests/SupabaseAuthTests.swift
+++ b/ProjectApexTests/SupabaseAuthTests.swift
@@ -1,0 +1,362 @@
+// SupabaseAuthTests.swift
+// ProjectApexTests — #369 auth slice 1
+//
+// Unit tests for the hand-rolled GoTrue client (SupabaseAuth) and the
+// SupabaseClient token-refresh / 401-retry path. All network calls are mocked
+// via URLProtocol; nothing here hits the live Supabase project.
+//
+// Coverage:
+//   1. Anonymous sign-in success → session persisted to Keychain + token set.
+//   2. Stored-session restore on launch → no signup call; token from Keychain.
+//   3. Sign-in failure (non-2xx) → no crash, no hang, session stays nil.
+//   4. Refresh on near-expiry; 401 → refresh once and retry.
+
+import XCTest
+@testable import ProjectApex
+
+// MARK: - Path-routing URLProtocol mock
+
+/// Routes responses by URL path prefix so GoTrue (signup/token/logout) and
+/// PostgREST requests can be stubbed independently within one URLSession.
+final class GoTrueMockURLProtocol: URLProtocol {
+
+    struct Stub {
+        let statusCode: Int
+        let data: Data
+    }
+
+    /// Keyed by a substring of the request path. First match wins.
+    static var stubs: [(match: String, stub: Stub)] = []
+    /// Recorded request paths in order, for "no signup call" assertions.
+    static var recordedPaths: [String] = []
+    /// Recorded Authorization header values in order (for retry assertions).
+    static var recordedAuthHeaders: [String] = []
+
+    static func reset() {
+        stubs = []
+        recordedPaths = []
+        recordedAuthHeaders = []
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let path = request.url?.path ?? ""
+        GoTrueMockURLProtocol.recordedPaths.append(path)
+        GoTrueMockURLProtocol.recordedAuthHeaders.append(
+            request.value(forHTTPHeaderField: "Authorization") ?? ""
+        )
+
+        let match = GoTrueMockURLProtocol.stubs.first { path.contains($0.match) }
+        let stub = match?.stub ?? Stub(statusCode: 404, data: Data())
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: stub.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Helpers
+
+private func makeMockSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [GoTrueMockURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+/// A throwaway KeychainService scoped to a per-test service name so tests never
+/// touch the real app Keychain namespace and don't collide with each other.
+private func makeScopedKeychain() -> KeychainService {
+    KeychainService(serviceName: "com.projectapex.tests.auth.\(UUID().uuidString)")
+}
+
+private func clearAuthKeys(_ keychain: KeychainService) {
+    try? keychain.delete(.supabaseAccessToken)
+    try? keychain.delete(.supabaseRefreshToken)
+    try? keychain.delete(.supabaseSessionExpiry)
+    try? keychain.delete(.supabaseAuthUserId)
+}
+
+/// Builds a GoTrue token JSON body with an absolute `expires_at`.
+private func tokenJSON(
+    access: String,
+    refresh: String,
+    expiresAt: Int,
+    userId: UUID = UUID()
+) -> Data {
+    let dict: [String: Any] = [
+        "access_token": access,
+        "refresh_token": refresh,
+        "expires_at": expiresAt,
+        "user": ["id": userId.uuidString]
+    ]
+    return try! JSONSerialization.data(withJSONObject: dict)
+}
+
+private let testURL = URL(string: "https://test.supabase.co")!
+
+// MARK: - SupabaseAuthTests
+
+final class SupabaseAuthTests: XCTestCase {
+
+    override func tearDown() {
+        GoTrueMockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    // MARK: 1. Anonymous sign-in success
+
+    func test_signInAnonymously_success_persistsSessionAndReturnsToken() async throws {
+        let keychain = makeScopedKeychain()
+        clearAuthKeys(keychain)
+        let uid = UUID()
+        GoTrueMockURLProtocol.reset()
+        GoTrueMockURLProtocol.stubs = [
+            ("/auth/v1/signup", .init(
+                statusCode: 200,
+                data: tokenJSON(access: "access-1", refresh: "refresh-1",
+                                expiresAt: Int(Date().timeIntervalSince1970) + 3600,
+                                userId: uid)
+            ))
+        ]
+
+        let auth = SupabaseAuth(
+            supabaseURL: testURL, anonKey: "anon",
+            keychain: keychain, urlSession: makeMockSession()
+        )
+
+        let session = try await auth.signInAnonymously()
+
+        XCTAssertEqual(session.accessToken, "access-1")
+        XCTAssertEqual(session.userId, uid)
+        // Persisted to the Keychain.
+        XCTAssertEqual(try keychain.retrieve(.supabaseAccessToken), "access-1")
+        XCTAssertEqual(try keychain.retrieve(.supabaseRefreshToken), "refresh-1")
+        XCTAssertEqual(try keychain.retrieve(.supabaseAuthUserId), uid.uuidString)
+        clearAuthKeys(keychain)
+    }
+
+    func test_awaitFirstResolution_freshLaunch_signsInAndSetsToken() async throws {
+        let keychain = makeScopedKeychain()
+        clearAuthKeys(keychain)
+        GoTrueMockURLProtocol.reset()
+        GoTrueMockURLProtocol.stubs = [
+            ("/auth/v1/signup", .init(
+                statusCode: 200,
+                data: tokenJSON(access: "fresh-access", refresh: "r",
+                                expiresAt: Int(Date().timeIntervalSince1970) + 3600)
+            ))
+        ]
+
+        let auth = SupabaseAuth(
+            supabaseURL: testURL, anonKey: "anon",
+            keychain: keychain, urlSession: makeMockSession()
+        )
+
+        let resolved = await auth.awaitFirstResolution()
+        XCTAssertEqual(resolved?.accessToken, "fresh-access")
+        XCTAssertTrue(GoTrueMockURLProtocol.recordedPaths.contains { $0.contains("/auth/v1/signup") })
+        clearAuthKeys(keychain)
+    }
+
+    // MARK: 2. Stored-session restore
+
+    func test_awaitFirstResolution_restoresStoredSession_noSignupCall() async throws {
+        let keychain = makeScopedKeychain()
+        let uid = UUID()
+        let futureExpiry = Int(Date().timeIntervalSince1970) + 3600
+        try keychain.store("stored-access", for: .supabaseAccessToken)
+        try keychain.store("stored-refresh", for: .supabaseRefreshToken)
+        try keychain.store(String(futureExpiry), for: .supabaseSessionExpiry)
+        try keychain.store(uid.uuidString, for: .supabaseAuthUserId)
+
+        GoTrueMockURLProtocol.reset()
+        // No stubs registered: any network call would 404. Restore must not call out.
+
+        let auth = SupabaseAuth(
+            supabaseURL: testURL, anonKey: "anon",
+            keychain: keychain, urlSession: makeMockSession()
+        )
+
+        let resolved = await auth.awaitFirstResolution()
+        XCTAssertEqual(resolved?.accessToken, "stored-access")
+        XCTAssertEqual(resolved?.userId, uid)
+        XCTAssertTrue(
+            GoTrueMockURLProtocol.recordedPaths.isEmpty,
+            "Restore must not hit the network; got \(GoTrueMockURLProtocol.recordedPaths)."
+        )
+        clearAuthKeys(keychain)
+    }
+
+    // MARK: 3. Sign-in failure degrades gracefully
+
+    func test_awaitFirstResolution_signInFailure_returnsNil_noHang() async throws {
+        let keychain = makeScopedKeychain()
+        clearAuthKeys(keychain)
+        GoTrueMockURLProtocol.reset()
+        GoTrueMockURLProtocol.stubs = [
+            // Anonymous provider not enabled → 422 (or any non-2xx).
+            ("/auth/v1/signup", .init(statusCode: 422,
+                data: Data(#"{"error":"anonymous sign-ins disabled"}"#.utf8)))
+        ]
+
+        let auth = SupabaseAuth(
+            supabaseURL: testURL, anonKey: "anon",
+            keychain: keychain, urlSession: makeMockSession(),
+            signInTimeout: 5
+        )
+
+        let resolved = await auth.awaitFirstResolution()
+        XCTAssertNil(resolved, "Non-2xx sign-in must resolve to nil (anon behavior), not throw or hang.")
+        let stored = try keychain.retrieve(.supabaseAccessToken)
+        XCTAssertNil(stored, "Failed sign-in must not persist any token.")
+        clearAuthKeys(keychain)
+    }
+
+    func test_awaitFirstResolution_timesOut_returnsNil() async throws {
+        let keychain = makeScopedKeychain()
+        clearAuthKeys(keychain)
+        GoTrueMockURLProtocol.reset()
+        // No stub for signup AND a tiny timeout — but to deterministically force
+        // the timeout branch we use a hanging URLProtocol that never completes.
+        let hangingSession = makeHangingSession()
+
+        let auth = SupabaseAuth(
+            supabaseURL: testURL, anonKey: "anon",
+            keychain: keychain, urlSession: hangingSession,
+            signInTimeout: 0.2
+        )
+
+        let start = Date()
+        let resolved = await auth.awaitFirstResolution()
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertNil(resolved, "A hung sign-in must time out to nil.")
+        XCTAssertLessThan(elapsed, 3.0, "Timeout must bound the wait well under the 5s default.")
+        clearAuthKeys(keychain)
+    }
+
+    // MARK: 4. Refresh + 401 retry
+
+    func test_validAccessToken_refreshesWhenNearExpiry() async throws {
+        let keychain = makeScopedKeychain()
+        clearAuthKeys(keychain)
+        GoTrueMockURLProtocol.reset()
+        // Sign-in returns an already-expired token, refresh returns a fresh one.
+        GoTrueMockURLProtocol.stubs = [
+            ("/auth/v1/signup", .init(
+                statusCode: 200,
+                data: tokenJSON(access: "expiring", refresh: "refresh-x",
+                                expiresAt: Int(Date().timeIntervalSince1970) - 10)
+            )),
+            ("/auth/v1/token", .init(
+                statusCode: 200,
+                data: tokenJSON(access: "refreshed", refresh: "refresh-y",
+                                expiresAt: Int(Date().timeIntervalSince1970) + 3600)
+            ))
+        ]
+
+        let auth = SupabaseAuth(
+            supabaseURL: testURL, anonKey: "anon",
+            keychain: keychain, urlSession: makeMockSession()
+        )
+        _ = try await auth.signInAnonymously()
+
+        let token = await auth.validAccessToken()
+        XCTAssertEqual(token, "refreshed", "Near-expiry token must be refreshed before use.")
+        XCTAssertTrue(GoTrueMockURLProtocol.recordedPaths.contains { $0.contains("/auth/v1/token") })
+        clearAuthKeys(keychain)
+    }
+
+    func test_supabaseClient_401_refreshesOnceAndRetries() async throws {
+        // Drive the SupabaseClient refresh/401-retry path directly. The first
+        // PostgREST GET returns 401; the forceRefresh hook hands back a new
+        // token; the retry succeeds.
+        GoTrueMockURLProtocol.reset()
+        var rest401Served = false
+        // Custom stub logic: the rest endpoint returns 401 the first time, 200 after.
+        final class Counting: URLProtocol {
+            static var restCallCount = 0
+            override class func canInit(with request: URLRequest) -> Bool { true }
+            override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+            override func startLoading() {
+                let path = request.url?.path ?? ""
+                let status: Int
+                let body: Data
+                if path.contains("/rest/v1/") {
+                    Counting.restCallCount += 1
+                    if Counting.restCallCount == 1 {
+                        status = 401; body = Data(#"{"message":"JWT expired"}"#.utf8)
+                    } else {
+                        status = 200; body = Data("[]".utf8)
+                    }
+                } else {
+                    status = 404; body = Data()
+                }
+                let resp = HTTPURLResponse(url: request.url!, statusCode: status,
+                                           httpVersion: "HTTP/1.1",
+                                           headerFields: ["Content-Type": "application/json"])!
+                client?.urlProtocol(self, didReceive: resp, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: body)
+                client?.urlProtocolDidFinishLoading(self)
+            }
+            override func stopLoading() {}
+        }
+        Counting.restCallCount = 0
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [Counting.self]
+        let restSession = URLSession(configuration: config)
+
+        let client = SupabaseClient(supabaseURL: testURL, anonKey: "anon", urlSession: restSession)
+        await client.setAuthToken("stale-token")
+        let counter = ForceRefreshCounter()
+        await client.setRefreshHooks(
+            refreshIfNeeded: { nil }, // not near expiry from the client's POV
+            forceRefresh: {
+                await counter.increment()
+                return "new-token"
+            }
+        )
+
+        struct Row: Decodable {}
+        let rows: [Row] = try await client.fetch(Row.self, table: "workout_sessions")
+        XCTAssertEqual(rows.count, 0, "Retry must succeed and decode the empty array.")
+        let calls = await counter.count
+        XCTAssertEqual(calls, 1, "401 must trigger exactly one forced refresh.")
+        XCTAssertEqual(Counting.restCallCount, 2, "Request must be retried exactly once after 401.")
+        _ = rest401Served
+    }
+
+    // MARK: - Hanging session helper (for timeout test)
+
+    private func makeHangingSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [HangingURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+}
+
+/// Thread-safe counter for the 401-retry force-refresh assertion (lets the
+/// @Sendable hook mutate shared state without data-race warnings).
+actor ForceRefreshCounter {
+    private(set) var count = 0
+    func increment() { count += 1 }
+}
+
+/// A URLProtocol that never completes its load — used to deterministically
+/// exercise the sign-in timeout branch.
+final class HangingURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() { /* intentionally never finishes */ }
+    override func stopLoading() {}
+}


### PR DESCRIPTION
Part of #369 — auth/RLS workstream slice 1 of 6. Additive only: establishes the anon-auth session + JWT; does not repoint user IDs or enable RLS. Degrades to anon-key behavior if the dashboard Anonymous provider is not yet enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)