### PR TITLE
feat(#369): bundle Supabase anon key + extend launch gate (auth slice 2)

### DIFF
--- a/APIKeys.xcconfig
+++ b/APIKeys.xcconfig
@@ -13,5 +13,6 @@
 //   then replace REPLACE_ME in APIKeys.local.xcconfig with the real sk-ant- key.
 
 ANTHROPIC_API_KEY = REPLACE_ME
+SUPABASE_ANON_KEY = REPLACE_ME
 
 #include? "APIKeys.local.xcconfig"

--- a/APIKeys.xcconfig.example
+++ b/APIKeys.xcconfig.example
@@ -1,23 +1,26 @@
-// APIKeys.xcconfig.example — TEMPLATE for the LOCAL bundled alpha key (#329).
+// APIKeys.xcconfig.example — TEMPLATE for LOCAL bundled alpha keys (#329, #369).
 //
 // HOW TO USE (one step):
 //   cp APIKeys.xcconfig.example APIKeys.local.xcconfig
-//   then replace REPLACE_ME with the real alpha Anthropic key (starts with "sk-ant-").
+//   then replace the REPLACE_ME placeholders with the real keys.
 //
-// APIKeys.local.xcconfig is .gitignored — the real key NEVER gets committed. This
-// template (with its placeholder) and the committed APIKeys.xcconfig (which only
-// sets the placeholder default and optionally includes the local file) are the
+// APIKeys.local.xcconfig is .gitignored — real keys NEVER get committed. This
+// template (with its placeholders) and the committed APIKeys.xcconfig (which only
+// sets the placeholder defaults and optionally includes the local file) are the
 // only copies in source control.
 //
 // Mechanism: the app target's build configs use APIKeys.xcconfig as their
 // baseConfigurationReference; APIKeys.xcconfig does `#include? "APIKeys.local.xcconfig"`,
-// so this file's value overrides the placeholder when present. The result is
-// surfaced into the generated Info.plist via INFOPLIST_KEY_APEXAnthropicAPIKey =
-// $(ANTHROPIC_API_KEY) and read at runtime by BundledAPIKey.anthropic. When this
-// file is absent (clean checkout, CI without the secret), the value stays at the
-// placeholder and the app resolves the key to nil — never a compile error.
-//
-// One key covers both failing onboarding steps: the gym scan (VisionAPIService)
-// and program generation both read the same .anthropicAPIKey Keychain entry.
+// so this file's values override the placeholders when present. The results are
+// surfaced into Info.plist via ${VARIABLE} expansion and read at runtime by
+// BundledAPIKey. When this file is absent (clean checkout, CI without the keys),
+// the values stay at the placeholder and the app resolves them to nil — never a
+// compile error, always the honest needs-setup gate.
 
+// Anthropic API key (starts with "sk-ant-"). Used by VisionAPIService and program
+// generation. One key covers both failing onboarding steps.
 ANTHROPIC_API_KEY = REPLACE_ME
+
+// Supabase anon key (#369 slice 2). Public client credential — safe to ship in
+// the bundle. Required for a fresh install to reach Supabase at all.
+SUPABASE_ANON_KEY = REPLACE_ME

--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,18 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — A fresh install can now reach Supabase (auth slice 2, PR TBD)
+
+Problem: a clean install had no Supabase anon key, so the SupabaseClient was created with an empty string and any network call to Supabase would fail. The Anthropic key already had a bundled-key mechanism (PR #368), but the Supabase anon key did not.
+
+Change: mirrored the existing Anthropic bundling pattern for the Supabase anon key. Added `APEXSupabaseAnonKey` to Info.plist expanded from a new `SUPABASE_ANON_KEY` build variable in the xcconfig files. Added `BundledAPIKey.supabaseAnon()` and `SupabaseAnonKeyResolver` (same Keychain-first precedence as the Anthropic resolver). AppDependencies now resolves the anon key through the resolver instead of a bare Keychain lookup, seeding it into the Keychain on first run. The launch gate in ContentView was extended from "AI key required" to "both keys required" — either missing triggers NeedsSetupView.
+
+How checked: built with no real key in place (build-exit=0). Ran the full test suite — all 23 tests in BundledKeyResolutionTests passed (9 new tests for the Supabase path). One pre-existing timing flake in AIInferenceServiceTests unrelated to this change.
+
+Status: PR open, not yet merged. Closes #329 (both keys now bundleable so a fresh install can complete onboarding end-to-end).
+
+---
+
 ## 2026-06-12 — The app now quietly signs in behind the scenes (PR #372)
 
 **The problem (in plain words):**

--- a/Info.plist
+++ b/Info.plist
@@ -26,6 +26,15 @@
 	<key>APEXAnthropicAPIKey</key>
 	<string>${ANTHROPIC_API_KEY}</string>
 
+	<!-- Bundled Supabase anon key (#369 slice 2). ${SUPABASE_ANON_KEY} is expanded from
+	     the build setting (APIKeys.xcconfig -> optional APIKeys.local.xcconfig) during
+	     Info.plist processing. The anon key is a public client credential but goes through
+	     the same placeholder mechanism for consistency. Read at runtime by
+	     BundledAPIKey.supabaseAnon. With no real key configured it stays "REPLACE_ME",
+	     treated as nil -> the needs-setup launch gate. -->
+	<key>APEXSupabaseAnonKey</key>
+	<string>${SUPABASE_ANON_KEY}</string>
+
 	<!-- Standard bundle identity. With GENERATE_INFOPLIST_FILE off these are not
 	     auto-injected, so they are declared here and expanded from the existing
 	     build settings (brace ${...} syntax). -->

--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -84,6 +84,10 @@ final class AppDependencies {
     /// onboarding start and die mid-gym-scan with a raw HTTP error.
     let hasResolvableAIKey: Bool
 
+    /// True when a Supabase anon key was resolvable at launch (Keychain or bundled
+    /// build-time key). False on a fresh install with no key baked in (#369 slice 2).
+    let hasResolvableSupabaseKey: Bool
+
     // MARK: Init
 
     init() {
@@ -101,8 +105,17 @@ final class AppDependencies {
         let keychain = KeychainService.shared
         self.keychainService = keychain
 
-        // 2. Supabase — needs its anon key from Keychain; URL comes from Config
-        let supabaseAnonKey = (try? keychain.retrieve(.supabaseAnonKey)) ?? ""
+        // 2. Supabase — needs its anon key; URL comes from Config.
+        // Precedence (#369 slice 2): existing Keychain value → bundled build-time key
+        // (seeded into the Keychain) → nil. A fresh install with a bundled key behaves
+        // exactly like a dev install that entered the key via Developer Settings.
+        let resolvedSupabaseAnonKey = SupabaseAnonKeyResolver.resolve(
+            retrieve: { try? keychain.retrieve(.supabaseAnonKey) },
+            store: { try? keychain.store($0, for: .supabaseAnonKey) },
+            bundled: { BundledAPIKey.supabaseAnon() }
+        )
+        self.hasResolvableSupabaseKey = resolvedSupabaseAnonKey != nil
+        let supabaseAnonKey = resolvedSupabaseAnonKey ?? ""
         let client = SupabaseClient(supabaseURL: Config.supabaseURL, anonKey: supabaseAnonKey)
         self.supabaseClient = client
 

--- a/ProjectApex/App/BundledAPIKey.swift
+++ b/ProjectApex/App/BundledAPIKey.swift
@@ -1,39 +1,34 @@
 // BundledAPIKey.swift
 // ProjectApex — App Layer
 //
-// Resolves the build-time alpha Anthropic key that ships in the app bundle so a
-// FRESH INSTALL can complete onboarding (#329 / O-F1). Before this, the only way
-// to populate the Anthropic Keychain entry was the DEBUG-only DeveloperSettingsView,
-// which sits behind the onboarding gate — so a clean install died with raw HTTP
-// errors mid-gym-scan.
+// Resolves build-time keys that ship in the app bundle so a FRESH INSTALL can
+// reach external services (#329 / O-F1, #369 slice 2).
 //
 // Mechanism (no secret in git):
-//   APIKeys.local.xcconfig (gitignored) defines ANTHROPIC_API_KEY; the committed
-//   APIKeys.xcconfig optionally includes it and otherwise holds the placeholder.
-//   The build expands ${ANTHROPIC_API_KEY} into Info.plist (key APEXAnthropicAPIKey),
-//   and this type reads it back at runtime. When the local file is absent (clean
-//   checkout / CI), the value stays the placeholder and `anthropic` returns nil —
-//   never a compile error.
-//
-// One key, two consumers: the gym scan (VisionAPIService) and program generation
-// both read the same `.anthropicAPIKey` Keychain entry, so seeding this one value
-// unblocks both failing onboarding steps.
+//   APIKeys.local.xcconfig (gitignored) defines the real values; the committed
+//   APIKeys.xcconfig optionally includes it and otherwise holds the placeholders.
+//   The build expands the variables into Info.plist, and this type reads them
+//   back at runtime. When the local file is absent (clean checkout / CI), the
+//   values stay at the placeholder and the accessors return nil — never a compile
+//   error.
 
 import Foundation
 
-/// Reads the build-time bundled Anthropic key from the app's Info dictionary.
+/// Reads build-time bundled API keys from the app's Info dictionary.
 ///
 /// `lookup` is injectable so tests can stand in a fake Info.plist without touching
 /// the real bundle. Production callers use the default, which reads `Bundle.main`.
 enum BundledAPIKey {
 
-    /// The Info.plist key the build configuration writes `$(ANTHROPIC_API_KEY)` into.
-    static let infoPlistKey = "APEXAnthropicAPIKey"
-
     /// Placeholder shipped in `APIKeys.xcconfig.example`. Treated as "no key" so a
     /// developer who copied the template but never filled it in still hits the gate
     /// rather than sending `REPLACE_ME` to the API.
     static let placeholder = "REPLACE_ME"
+
+    // MARK: - Anthropic
+
+    /// The Info.plist key the build configuration writes `$(ANTHROPIC_API_KEY)` into.
+    static let infoPlistKey = "APEXAnthropicAPIKey"
 
     /// The resolved bundled Anthropic key, or `nil` when none was baked into the build.
     ///
@@ -42,7 +37,29 @@ enum BundledAPIKey {
     static func anthropic(
         lookup: (String) -> Any? = { Bundle.main.object(forInfoDictionaryKey: $0) }
     ) -> String? {
-        guard let raw = lookup(infoPlistKey) as? String else { return nil }
+        resolve(key: infoPlistKey, lookup: lookup)
+    }
+
+    // MARK: - Supabase anon key
+
+    /// The Info.plist key the build configuration writes `$(SUPABASE_ANON_KEY)` into.
+    static let supabaseAnonInfoPlistKey = "APEXSupabaseAnonKey"
+
+    /// The resolved bundled Supabase anon key, or `nil` when none was baked into the build.
+    ///
+    /// The anon key is a public client credential (safe to ship in the bundle), but it
+    /// goes through the same placeholder mechanism as the Anthropic key for consistency
+    /// so a fresh checkout without a local override never sends a dummy value.
+    static func supabaseAnon(
+        lookup: (String) -> Any? = { Bundle.main.object(forInfoDictionaryKey: $0) }
+    ) -> String? {
+        resolve(key: supabaseAnonInfoPlistKey, lookup: lookup)
+    }
+
+    // MARK: - Private
+
+    private static func resolve(key: String, lookup: (String) -> Any?) -> String? {
+        guard let raw = lookup(key) as? String else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, trimmed != placeholder else { return nil }
         return trimmed

--- a/ProjectApex/App/SupabaseAnonKeyResolver.swift
+++ b/ProjectApex/App/SupabaseAnonKeyResolver.swift
@@ -1,0 +1,48 @@
+// SupabaseAnonKeyResolver.swift
+// ProjectApex — App Layer
+//
+// Single source of truth for "which Supabase anon key does this install use, and
+// is there one at all?" (#369 slice 2).
+//
+// Precedence (mirrors AnthropicKeyResolver, locked by the issue):
+//   1. Keychain value      — the dev path (DeveloperSettingsView) stays working untouched.
+//   2. Bundled Info.plist  — the alpha key baked into the build; seeded into the
+//                            Keychain so the rest of the app reads it the usual way.
+//   3. nil                 — no key anywhere → the launch gate (NeedsSetupView).
+//
+// Factored out of AppDependencies.init so the precedence logic is unit-testable
+// with injected Keychain + bundled lookups (no real Keychain, no real bundle).
+
+import Foundation
+
+enum SupabaseAnonKeyResolver {
+
+    /// Resolves the Supabase anon key using the locked precedence, seeding the bundled
+    /// key into the Keychain on the fallback path so every existing consumer keeps
+    /// reading `.supabaseAnonKey` from the Keychain exactly as before.
+    ///
+    /// - Parameters:
+    ///   - retrieve: Reads the current Keychain value for `.supabaseAnonKey`.
+    ///   - store: Writes a value into the Keychain for `.supabaseAnonKey` (used to
+    ///            seed the bundled key). Failures are swallowed — a seed failure
+    ///            must not crash launch; the caller still receives the resolved key.
+    ///   - bundled: Returns the build-time bundled key, or nil when none was baked in.
+    /// - Returns: The resolved key, or `nil` when neither source supplies one.
+    static func resolve(
+        retrieve: () -> String?,
+        store: (String) -> Void,
+        bundled: () -> String?
+    ) -> String? {
+        // 1. Existing Keychain value wins — never overwrite the dev-entered key.
+        if let existing = retrieve(), !existing.isEmpty {
+            return existing
+        }
+        // 2. Bundled key — seed it into the Keychain, then use it.
+        if let bundledKey = bundled(), !bundledKey.isEmpty {
+            store(bundledKey)
+            return bundledKey
+        }
+        // 3. Nothing anywhere.
+        return nil
+    }
+}

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -75,11 +75,12 @@ struct ContentView: View {
     @State private var navigateToPausedDayDetail: Bool = false
 
     var body: some View {
-        // Honest launch gate (#329 / O-F1): when no AI key is resolvable — neither
-        // in the Keychain nor bundled into the build — show the "needs setup" screen
-        // instead of letting onboarding start and die mid-gym-scan. No-op when a key
-        // is present: the normal onboarding/app path below is completely untouched.
-        if deps.hasResolvableAIKey {
+        // Honest launch gate (#329 / O-F1, #369 slice 2): when either required key is
+        // missing — neither in the Keychain nor bundled into the build — show the
+        // "needs setup" screen instead of letting onboarding start and die mid-gym-scan
+        // or mid-Supabase call. No-op when both keys are present: the normal
+        // onboarding/app path below is completely untouched.
+        if deps.hasResolvableAIKey && deps.hasResolvableSupabaseKey {
             mainContent
         } else {
             NeedsSetupView()

--- a/ProjectApexTests/BundledKeyResolutionTests.swift
+++ b/ProjectApexTests/BundledKeyResolutionTests.swift
@@ -1,10 +1,11 @@
 // BundledKeyResolutionTests.swift
 // ProjectApexTests
 //
-// Covers the fresh-install key path (#329 / O-F1):
-//   • BundledAPIKey — reads the build-time Info.plist key; empty / placeholder → nil.
+// Covers the fresh-install key path (#329 / O-F1, #369 slice 2):
+//   • BundledAPIKey — reads the build-time Info.plist keys; empty / placeholder → nil.
 //   • AnthropicKeyResolver — precedence Keychain → bundled (seeded) → nil.
-//   • Gate predicate — nil key → gate shown; key present → gate not shown.
+//   • SupabaseAnonKeyResolver — same precedence, mirrored.
+//   • Gate predicate — missing either key → gate shown; both present → gate not shown.
 //
 // The Keychain and Info.plist lookups are injected as closures, so no test touches
 // the real Keychain or the real app bundle.
@@ -43,6 +44,34 @@ final class BundledKeyResolutionTests: XCTestCase {
         var requestedKey: String?
         _ = BundledAPIKey.anthropic(lookup: { requestedKey = $0; return nil })
         XCTAssertEqual(requestedKey, BundledAPIKey.infoPlistKey)
+    }
+
+    // MARK: - BundledAPIKey.supabaseAnon
+
+    func test_bundledSupabaseKey_realValue_returnsTrimmedValue() {
+        let key = BundledAPIKey.supabaseAnon(lookup: { _ in "  eyJhbGc.real-anon-key  " })
+        XCTAssertEqual(key, "eyJhbGc.real-anon-key")
+    }
+
+    func test_bundledSupabaseKey_missingEntry_returnsNil() {
+        let key = BundledAPIKey.supabaseAnon(lookup: { _ in nil })
+        XCTAssertNil(key)
+    }
+
+    func test_bundledSupabaseKey_emptyString_returnsNil() {
+        let key = BundledAPIKey.supabaseAnon(lookup: { _ in "" })
+        XCTAssertNil(key)
+    }
+
+    func test_bundledSupabaseKey_untouchedPlaceholder_returnsNil() {
+        let key = BundledAPIKey.supabaseAnon(lookup: { _ in BundledAPIKey.placeholder })
+        XCTAssertNil(key)
+    }
+
+    func test_bundledSupabaseKey_readsTheExpectedInfoPlistKey() {
+        var requestedKey: String?
+        _ = BundledAPIKey.supabaseAnon(lookup: { requestedKey = $0; return nil })
+        XCTAssertEqual(requestedKey, BundledAPIKey.supabaseAnonInfoPlistKey)
     }
 
     // MARK: - AnthropicKeyResolver precedence
@@ -93,28 +122,78 @@ final class BundledKeyResolutionTests: XCTestCase {
         XCTAssertNil(stored, "Nothing to seed when there is no bundled key.")
     }
 
-    // MARK: - Gate predicate
+    // MARK: - SupabaseAnonKeyResolver precedence
 
-    /// The launch gate keys off the same nil-ness the resolver produces:
-    /// `hasResolvableAIKey = resolved != nil`. These two cases pin that mapping.
-
-    func test_gatePredicate_keyPresent_gateNotShown() {
-        let resolved = AnthropicKeyResolver.resolve(
-            retrieve: { nil },
-            store: { _ in },
-            bundled: { "sk-ant-bundled" }
+    func test_supabaseResolve_keychainPresent_usesKeychain_andDoesNotSeed() {
+        var stored: String?
+        let resolved = SupabaseAnonKeyResolver.resolve(
+            retrieve: { "eyJhbGc.keychain-anon-key" },
+            store: { stored = $0 },
+            bundled: { "eyJhbGc.bundled-anon-key" }
         )
-        let hasResolvableAIKey = resolved != nil
-        XCTAssertTrue(hasResolvableAIKey, "A resolvable key must NOT trigger the needs-setup gate.")
+        XCTAssertEqual(resolved, "eyJhbGc.keychain-anon-key", "Keychain value must win over bundled.")
+        XCTAssertNil(stored, "An existing Keychain key must never be overwritten.")
     }
 
-    func test_gatePredicate_noKey_gateShown() {
-        let resolved = AnthropicKeyResolver.resolve(
+    func test_supabaseResolve_keychainEmpty_bundledPresent_usesAndSeedsBundled() {
+        var stored: String?
+        let resolved = SupabaseAnonKeyResolver.resolve(
             retrieve: { nil },
-            store: { _ in },
+            store: { stored = $0 },
+            bundled: { "eyJhbGc.bundled-anon-key" }
+        )
+        XCTAssertEqual(resolved, "eyJhbGc.bundled-anon-key", "Bundled key must be used when Keychain is empty.")
+        XCTAssertEqual(stored, "eyJhbGc.bundled-anon-key", "Bundled key must be seeded into the Keychain.")
+    }
+
+    func test_supabaseResolve_keychainEmptyString_bundledPresent_usesAndSeedsBundled() {
+        var stored: String?
+        let resolved = SupabaseAnonKeyResolver.resolve(
+            retrieve: { "" },
+            store: { stored = $0 },
+            bundled: { "eyJhbGc.bundled-anon-key" }
+        )
+        XCTAssertEqual(resolved, "eyJhbGc.bundled-anon-key")
+        XCTAssertEqual(stored, "eyJhbGc.bundled-anon-key")
+    }
+
+    func test_supabaseResolve_bothAbsent_returnsNil_andDoesNotSeed() {
+        var stored: String?
+        let resolved = SupabaseAnonKeyResolver.resolve(
+            retrieve: { nil },
+            store: { stored = $0 },
             bundled: { nil }
         )
-        let hasResolvableAIKey = resolved != nil
-        XCTAssertFalse(hasResolvableAIKey, "No resolvable key MUST trigger the needs-setup gate.")
+        XCTAssertNil(resolved, "No key anywhere → nil.")
+        XCTAssertNil(stored, "Nothing to seed when there is no bundled key.")
+    }
+
+    // MARK: - Gate predicate
+
+    /// The launch gate requires BOTH keys: `hasResolvableAIKey && hasResolvableSupabaseKey`.
+    /// These cases pin that combined predicate.
+
+    func test_gatePredicate_bothKeysPresent_gateNotShown() {
+        let ai = AnthropicKeyResolver.resolve(retrieve: { nil }, store: { _ in }, bundled: { "sk-ant-bundled" })
+        let supa = SupabaseAnonKeyResolver.resolve(retrieve: { nil }, store: { _ in }, bundled: { "eyJhbGc.bundled" })
+        XCTAssertTrue(ai != nil && supa != nil, "Both keys present must NOT trigger the gate.")
+    }
+
+    func test_gatePredicate_aiKeyMissing_gateShown() {
+        let ai = AnthropicKeyResolver.resolve(retrieve: { nil }, store: { _ in }, bundled: { nil })
+        let supa = SupabaseAnonKeyResolver.resolve(retrieve: { nil }, store: { _ in }, bundled: { "eyJhbGc.bundled" })
+        XCTAssertFalse(ai != nil && supa != nil, "Missing AI key MUST trigger the gate.")
+    }
+
+    func test_gatePredicate_supabaseKeyMissing_gateShown() {
+        let ai = AnthropicKeyResolver.resolve(retrieve: { nil }, store: { _ in }, bundled: { "sk-ant-bundled" })
+        let supa = SupabaseAnonKeyResolver.resolve(retrieve: { nil }, store: { _ in }, bundled: { nil })
+        XCTAssertFalse(ai != nil && supa != nil, "Missing Supabase anon key MUST trigger the gate.")
+    }
+
+    func test_gatePredicate_bothKeysMissing_gateShown() {
+        let ai = AnthropicKeyResolver.resolve(retrieve: { nil }, store: { _ in }, bundled: { nil })
+        let supa = SupabaseAnonKeyResolver.resolve(retrieve: { nil }, store: { _ in }, bundled: { nil })
+        XCTAssertFalse(ai != nil && supa != nil, "Both keys missing MUST trigger the gate.")
     }
 }


### PR DESCRIPTION
Part of #369 — auth/RLS workstream slice 2 of 6. Bundles the Supabase anon key (mirrors PR #368's Anthropic mechanism) so a fresh install can reach Supabase, and extends the honest launch gate. **Closes #329** (a fresh install can now complete onboarding end-to-end; data-isolation under RLS is still slice 5, and the build should not be distributed to a cohort until RLS lands). No RLS or user-id changes this slice.

## What changed

- `Info.plist` — new `APEXSupabaseAnonKey` entry, expanded from `${SUPABASE_ANON_KEY}` at build time (same mechanism as `APEXAnthropicAPIKey`)
- `APIKeys.xcconfig` + `APIKeys.xcconfig.example` — new `SUPABASE_ANON_KEY = REPLACE_ME` placeholder; developers fill it in `APIKeys.local.xcconfig` (gitignored)
- `BundledAPIKey.swift` — `supabaseAnon()` accessor mirroring `anthropic()`; shared private `resolve(key:lookup:)` helper extracted
- `SupabaseAnonKeyResolver.swift` — new file, Keychain → bundled → nil precedence, identical shape to `AnthropicKeyResolver`
- `AppDependencies.swift` — Supabase anon key now resolved through `SupabaseAnonKeyResolver` (with Keychain seeding); `hasResolvableSupabaseKey` property added
- `ContentView.swift` — gate condition extended: `hasResolvableAIKey && hasResolvableSupabaseKey` (either missing → `NeedsSetupView`)
- `BundledKeyResolutionTests.swift` — 9 new test cases covering `BundledAPIKey.supabaseAnon`, `SupabaseAnonKeyResolver` precedence, and the updated combined gate predicate

## Test results

build-exit=0 (no real key present). 538 passed / 1 failed (pre-existing timing flake: `AIInferenceServiceTests.test_networkFailure_urlError_returnsFallbackLLMProviderError`) / 10 skipped (live-API tests). All 23 `BundledKeyResolutionTests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)