### PR TITLE
fix(#369): concurrency — finishSession idempotency, generation-guard for retry/swap/resume, atomic pullState

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,24 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — Four concurrency fixes in the live workout loop: no double-counting, no stale results, no torn reads (part of #369)
+
+Problem: the same cross-dimension audit (issue #369) found four subtle threading problems in the actor that runs a live workout and in the screen that reads from it. None of them showed up every time — they only bite when two things happen close together.
+
+1. Ending a session could run its wrap-up twice. The rest timer can fire "the session is over" at almost the same moment the user taps "end early". Both reached the same finish routine, and each one bumped the saved session count and queued a learning-update for the AI. So one workout could count as two. Fix: a one-way latch flipped the instant the finish routine starts — the second caller just returns. The latch is cleared whenever a brand-new session begins, so the next workout still counts.
+
+2. The "Retry" button could apply a stale answer. When the AI fails and the user taps Retry, the app asks again — but if the user moved on (finished a set, skipped, or swapped the exercise) while that retry was still in flight, the late answer used to overwrite the newer state. Fix: the retry now remembers which "generation" of the session it belongs to and throws its own answer away if the session has moved on, exactly like the normal inference path already did.
+
+3. Swapping an exercise (or resuming a paused session) didn't cancel the old in-flight answer. The app already had a "generation" counter that invalidates stale answers, but swap and resume never advanced it — so an answer meant for the old exercise could land on the new one. Fix: bump the counter at both points. (Judgment call on resume, documented in code + PR: bumping rather than resetting to zero catches the most common straggler — paused right as the first answer was coming back; a fully bulletproof version needs a wider change and is noted as deferred.)
+
+4. The live screen read the actor one field at a time — about nine separate hops. Between hops the actor could change, so the screen could show, say, a prescription from one moment next to a state from another. Fix: one method on the actor returns all the fields at once, so the screen always paints a single consistent moment.
+
+How checked: built clean (build-exit=0). Full suite green — 553 XCTest cases (543 passed, 0 failed, 10 skipped live-API/integration tests) plus 293 Swift Testing tests (0 failed). Four new tests: end-session runs its side effects once, the retry guard drops a stale result after a swap bumps the generation, the latch resets for the next session, and the one-hop snapshot matches the individual fields. The hard-to-reproduce timing races are pinned with deterministic latch/guard tests rather than flaky sleeps.
+
+Status: PR open, not yet merged. Part of #369.
+
+---
+
 ## 2026-06-12 — Five performance fixes: less CPU, less memory, fewer wasteful reads (PR #374, part of #369)
 
 Problem: a cross-dimension audit (issue #369) found five efficiency problems that were silently burning CPU and memory on every session.

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -59,6 +59,29 @@ nonisolated enum SessionState: Sendable, Equatable {
     }
 }
 
+// MARK: - WorkoutUISnapshot
+
+/// Atomic snapshot of every actor-isolated field `WorkoutViewModel.pullState()`
+/// needs to render the live session UI (#369 [20]). Returning all of these in ONE
+/// actor hop avoids the torn read that `pullState` previously produced by awaiting
+/// ~9 separate isolated properties — between hops the actor could advance, so the
+/// published `sessionState` and `currentPrescription` (etc.) could be from different
+/// instants. `lastPerformance` is the cached last-session set logs for the *live*
+/// exercise, resolved inside the actor so the liveExercise derivation is part of the
+/// same consistent snapshot.
+nonisolated struct WorkoutUISnapshot: Sendable {
+    let sessionState: SessionState
+    let currentPrescription: SetPrescription?
+    let currentFallbackReason: FallbackReason?
+    let restSecondsRemaining: Int
+    let restExpiresAt: Date?
+    let completedSets: [SetLog]
+    let inferenceRetryNeeded: Bool
+    let inferenceRetryReason: FallbackReason?
+    let pendingRetryExercise: PlannedExercise?
+    let lastPerformanceSets: [SetLog]?
+}
+
 // MARK: - WorkoutSessionManager
 
 /// Actor-isolated orchestrator for the full workout session lifecycle.
@@ -116,6 +139,13 @@ actor WorkoutSessionManager {
     /// Monotonically increasing generation counter. Incremented each completeSet().
     /// Inference results whose captured generation < inferenceGeneration are discarded.
     private var inferenceGeneration: Int = 0
+    /// Idempotency latch for finishSession (#369 [8]). Set the instant finishSession
+    /// begins so concurrent/duplicate end paths (endSession from the rest-timer Task
+    /// racing endSessionEarly from the UI) run the side effects — session-count
+    /// increment, trainee-model enqueue, completion PATCH — at most once.
+    /// Reset wherever a fresh session lifecycle begins (startSession / resumeSession /
+    /// resetToIdle).
+    private var isFinishingSession: Bool = false
     /// Running rest-timer Task reference so we can cancel it on early exit.
     private var restTimerTask: Task<Void, Never>?
 
@@ -232,6 +262,7 @@ actor WorkoutSessionManager {
         self.swapRecords = []
         self.inflightRequestCount = 0
         self.inferenceGeneration = 0
+        self.isFinishingSession = false   // #369 [8] — fresh session, latch cleared
 
         // FB-003: Read user biometrics from UserDefaults for WorkoutContext assembly.
         self.cachedUserProfile = Self.loadUserProfileFromDefaults()
@@ -652,6 +683,13 @@ actor WorkoutSessionManager {
         guard let exercise = pendingRetryExercise else { return false }
         let setNumber = pendingRetrySetNumber
 
+        // #369 [19] — capture the generation BEFORE the network/post-processing awaits.
+        // retryInference previously applied its result with no generation re-check, so a
+        // result that resolved AFTER a concurrent completeSet()/skip/swap advanced the
+        // session could clobber the newer state. Participate in the same guard discipline
+        // as handleInferenceResult: drop the result if the generation moved on.
+        let generation = inferenceGeneration
+
         // Clear failed state before retrying so UI shows "thinking" state
         currentFallbackReason = nil
         inferenceRetryNeeded = false
@@ -664,6 +702,10 @@ actor WorkoutSessionManager {
             // #318 U7: snap → clamp → marker — same shared post-processor as
             // handleInferenceResult (the only other live LLM path).
             rx = await postProcessPrescription(rx, for: exercise)
+            // #369 [19] — re-check the generation after the awaits (assembleWorkoutContext,
+            // prescribe, postProcessPrescription all suspend). If the session advanced in
+            // the meantime, this prescription is stale: drop it without mutating state.
+            guard generation == inferenceGeneration else { return false }
             if rx.safetyFlags.contains(.painReported) { rx.restSeconds = max(rx.restSeconds, 180) }
             currentPrescription = rx
             currentFallbackReason = nil
@@ -675,6 +717,9 @@ actor WorkoutSessionManager {
             sessionState = .active(exercise: exercise, setNumber: setNumber)
             return true
         case .fallback(let reason):
+            // #369 [19] — a stale fallback must not re-arm the retry sheet for a set the
+            // session has already moved past.
+            guard generation == inferenceGeneration else { return false }
             currentFallbackReason = reason
             inferenceRetryReason = reason
             inferenceRetryNeeded = true
@@ -872,7 +917,18 @@ actor WorkoutSessionManager {
         self.cachedWeeklyFatigue = nil
         self.cachedLastPerformance = [:]
         self.inflightRequestCount = 0
-        self.inferenceGeneration = 0
+        // #369 [21] — bump (not reset to 0) so any inference Task still in flight from
+        // BEFORE the pause is rejected by the generation guard when it returns. The actor
+        // is always idle here (resume guards on .idle, and the prior pause/end ran
+        // resetToIdle which left the counter at 0), so this advances 0 → 1. A pre-pause
+        // straggler that captured generation 0 (the common case: paused before/just as
+        // the first prescription landed) therefore no longer matches the resumed
+        // generation. NOTE: a straggler that captured a generation ≥ 1 deeper into the
+        // pre-pause session could still coincide with the resumed counter once it climbs
+        // there; fully closing that requires a lifetime-monotonic counter (never zeroed in
+        // resetToIdle) — deferred as a wider change. Documented in PR / report.
+        self.inferenceGeneration += 1
+        self.isFinishingSession = false   // #369 [8] — resumed session can end again
         self.inferenceRetryNeeded = false
         self.inferenceRetryReason = nil
         self.pendingRetryExercise = nil
@@ -985,6 +1041,7 @@ actor WorkoutSessionManager {
         swapRecords = []
         inflightRequestCount = 0
         inferenceGeneration = 0
+        isFinishingSession = false   // #369 [8] — clean slate for the next session
         currentPrescription = nil
         currentFallbackReason = nil
         inferenceRetryNeeded = false
@@ -1070,6 +1127,14 @@ actor WorkoutSessionManager {
         currentSetNumber = 1
         currentPrescription = nil
         inferenceRetryNeeded = false
+
+        // #369 [21] — bump the generation BEFORE firing inference for the swapped-in
+        // exercise. A swap changes "what we're inferring for" mid-session: an inference
+        // Task for the OLD exercise may still be in flight, having captured the prior
+        // generation. Bumping here means that stale result is rejected by the guard in
+        // handleInferenceResult when it returns, instead of clobbering the new
+        // exercise's prescription. Mirrors completeSet()/skipCurrentSet().
+        inferenceGeneration += 1
 
         // Embed a memory event so the AI learns about the swap
         let userId = sess.userId.uuidString
@@ -1532,6 +1597,36 @@ actor WorkoutSessionManager {
         cachedLastPerformance[exerciseId]
     }
 
+    /// #369 [20] — returns every field `WorkoutViewModel.pullState()` needs in ONE
+    /// actor hop, so the published UI state is internally consistent. The liveExercise
+    /// derivation (and its `lastPerformance` lookup) mirror the prior pullState logic
+    /// exactly — during .active/.resting the live exercise is the one in the state;
+    /// otherwise it is the pending-retry exercise (relevant during .preflight, where
+    /// the manual-fallback path targets pendingRetryExercise).
+    func uiSnapshot() -> WorkoutUISnapshot {
+        let liveExercise: PlannedExercise?
+        switch sessionState {
+        case .active(let exercise, _), .resting(let exercise, _):
+            liveExercise = exercise
+        default:
+            liveExercise = pendingRetryExercise
+        }
+        let lastPerformanceSets: [SetLog]? = liveExercise.flatMap { cachedLastPerformance[$0.exerciseId] }
+
+        return WorkoutUISnapshot(
+            sessionState: sessionState,
+            currentPrescription: currentPrescription,
+            currentFallbackReason: currentFallbackReason,
+            restSecondsRemaining: restSecondsRemaining,
+            restExpiresAt: restExpiresAt,
+            completedSets: completedSets,
+            inferenceRetryNeeded: inferenceRetryNeeded,
+            inferenceRetryReason: inferenceRetryReason,
+            pendingRetryExercise: pendingRetryExercise,
+            lastPerformanceSets: lastPerformanceSets
+        )
+    }
+
     /// Refreshes `cachedLastPerformance` for `exercise`. Called at session
     /// start and at EVERY exercise transition: next exercise in completeSet,
     /// skip into a new exercise, swapExercise, and resume.
@@ -1787,6 +1882,19 @@ actor WorkoutSessionManager {
     // MARK: - Session Termination
 
     private func finishSession(earlyExitReason: String?) async {
+        // #369 [8] — idempotency guard. endSession() (rest-timer Task, completeSet
+        // last-set, skip last-set, resume edge case) and endSessionEarly() can both
+        // reach here for the same session; the actor serialises them but each would
+        // otherwise run the full body, double-incrementing the session count and
+        // double-enqueueing the trainee-model update. Check-and-set on entry so the
+        // side effects run exactly once. The latch is cleared when a fresh session
+        // begins (startSession / resumeSession / resetToIdle).
+        guard !isFinishingSession else {
+            print("[WorkoutSessionManager] finishSession ignored — already finishing/finished")
+            return
+        }
+        isFinishingSession = true
+
         // Clear crash sentinel — session ending normally or via early exit.
         // pauseSession() overwrites this instead of clearing it.
         PausedSessionState.clear()

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -236,45 +236,27 @@ final class WorkoutViewModel {
     /// Pulls the latest actor state onto @MainActor properties.
     /// Safe to call from any context — awaits on the actor then updates self.
     func pullState() async {
-        let state = await manager.sessionState
-        let prescription = await manager.currentPrescription
-        let fallbackReason = await manager.currentFallbackReason
-        let restRemaining = await manager.restSecondsRemaining
-        let expiresAt = await manager.restExpiresAt
-        let sets = await manager.completedSets
-        let retryNeeded = await manager.inferenceRetryNeeded
-        let retryReason = await manager.inferenceRetryReason
-        let pendingExercise = await manager.pendingRetryExercise
+        // #369 [20] — single atomic actor hop. Previously this awaited ~9 separate
+        // isolated properties, so the actor could advance between hops and publish a
+        // torn snapshot (e.g. sessionState from one instant, currentPrescription from
+        // another). uiSnapshot() returns all of them — including the live exercise's
+        // last-session history — captured at one consistent instant. Behaviour is
+        // identical; only the read is now atomic.
+        let snapshot = await manager.uiSnapshot()
 
-        // Last-session history for the live exercise (#318 U7 / G-F6 + G-F1):
-        // powers the "Last time" line and the manual-fallback gating. During
-        // .preflight the retry exercise (if any) is the live one.
-        let liveExercise: PlannedExercise?
-        switch state {
-        case .active(let exercise, _), .resting(let exercise, _):
-            liveExercise = exercise
-        default:
-            liveExercise = pendingExercise
-        }
-        let lastPerformance: [SetLog]?
-        if let liveExercise {
-            lastPerformance = await manager.lastPerformance(for: liveExercise.exerciseId)
-        } else {
-            lastPerformance = nil
-        }
-
-        sessionState = state
-        currentPrescription = prescription
-        restSecondsRemaining = restRemaining
-        restExpiresAt = expiresAt
-        completedSets = sets
+        let fallbackReason = snapshot.currentFallbackReason
+        sessionState = snapshot.sessionState
+        currentPrescription = snapshot.currentPrescription
+        restSecondsRemaining = snapshot.restSecondsRemaining
+        restExpiresAt = snapshot.restExpiresAt
+        completedSets = snapshot.completedSets
         isAIOffline = fallbackReason != nil
         fallbackDescription = fallbackReason.map { Self.fallbackDescription(for: $0) }
         developerFallbackDescription = fallbackReason.map { Self.developerFallbackDescription(for: $0) }
-        showInferenceRetrySheet = retryNeeded
-        retryFailureDescription = retryReason.map { Self.retryDescription(for: $0) }
-        retryExercise = pendingExercise
-        lastPerformanceSets = lastPerformance
+        showInferenceRetrySheet = snapshot.inferenceRetryNeeded
+        retryFailureDescription = snapshot.inferenceRetryReason.map { Self.retryDescription(for: $0) }
+        retryExercise = snapshot.pendingRetryExercise
+        lastPerformanceSets = snapshot.lastPerformanceSets
     }
 
     /// Token for the currently-running polling task, so a second caller (e.g.

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -54,6 +54,70 @@ private struct DelayedLLMProvider: LLMProvider {
     }
 }
 
+/// Gated provider for deterministic generation-guard tests (#369 [19]). The first
+/// `complete()` call (startSession) throws so the manager lands in the pending-retry
+/// state with no flaky timing. The SECOND call (retryInference) parks on a
+/// continuation that the test resumes manually — letting the test advance the
+/// generation (via a reentrant actor call) WHILE the retry is suspended mid-await,
+/// then release it to verify the stale result is dropped by the guard.
+private final class GatedRetryProvider: LLMProvider, @unchecked Sendable {
+    let response: String
+    private let lock = NSLock()
+    private var callCount = 0
+    private var gateContinuation: CheckedContinuation<Void, Never>?
+    private var gateContinuationReadyContinuation: CheckedContinuation<Void, Never>?
+
+    init(response: String) { self.response = response }
+
+    /// Suspends until the retry call has actually parked on its gate.
+    func waitUntilRetryParked() async {
+        await withCheckedContinuation { (k: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            if gateContinuation != nil {
+                lock.unlock(); k.resume()
+            } else {
+                gateContinuationReadyContinuation = k; lock.unlock()
+            }
+        }
+    }
+
+    /// Releases the parked retry call so it can finish and return its response.
+    func releaseRetry() {
+        lock.lock()
+        let k = gateContinuation
+        gateContinuation = nil
+        lock.unlock()
+        k?.resume()
+    }
+
+    func complete(systemPrompt: String, userPayload: String) async throws -> String {
+        lock.lock()
+        callCount += 1
+        let n = callCount
+        lock.unlock()
+
+        if n == 1 {
+            // startSession inference — fail fast so we land in pending-retry.
+            throw LLMProviderError.httpError(statusCode: 401, body: "Invalid API key")
+        }
+
+        // ONLY the retry call (#2) is gated — park until the test releases it. Every
+        // later call (e.g. the swap's own inference, #3) returns immediately, so the
+        // gate is never overwritten and releaseRetry() is unambiguous.
+        guard n == 2 else { return response }
+
+        await withCheckedContinuation { (k: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            gateContinuation = k
+            let ready = gateContinuationReadyContinuation
+            gateContinuationReadyContinuation = nil
+            lock.unlock()
+            ready?.resume()
+        }
+        return response
+    }
+}
+
 // MARK: - Mock URLProtocol (always returns HTTP 201 — prevents real network calls and WAQ retry loops)
 
 private final class WSMAlwaysSucceedURLProtocol: URLProtocol, @unchecked Sendable {
@@ -779,6 +843,171 @@ final class WorkoutSessionManagerTests: XCTestCase {
 
         let logs = await manager.completedSets
         XCTAssertTrue(logs.isEmpty, "No SetLogs for an all-skipped session")
+    }
+
+    // MARK: #369 [8] — finishSession idempotency
+
+    /// Two end paths reaching finishSession for the same session (here endSession()
+    /// followed by endSessionEarly(), the rest-timer-Task-vs-UI race) must run the
+    /// side effects ONCE: the persistent session count increments by exactly 1.
+    /// Pre-fix, the second call re-ran the whole body, double-incrementing the count
+    /// (and double-enqueueing the trainee-model update).
+    func testFinishSession_isIdempotent_sessionCountIncrementsOnce() async throws {
+        let manager = makeManager()
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+
+        // finishSession writes UserProfileConstants.sessionCountKey on UserDefaults.standard.
+        // Snapshot the delta rather than the absolute value so the test is independent of
+        // any pre-existing count.
+        let key = UserProfileConstants.sessionCountKey
+        let before = UserDefaults.standard.integer(forKey: key)
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+        await manager.completeSet(actualReps: 5, rpeFelt: 7, intent: .top)
+
+        // First end path (the natural completion). Then a second, duplicate end path.
+        await manager.endSession()
+        await manager.endSessionEarly()
+
+        let after = UserDefaults.standard.integer(forKey: key)
+        XCTAssertEqual(
+            after - before, 1,
+            "finishSession must increment the session count exactly once across two end paths (#369 [8])"
+        )
+
+        // State is the single completed session — the second call did not corrupt it.
+        let state = await manager.sessionState
+        guard case .sessionComplete = state else {
+            XCTFail("Expected .sessionComplete after the (idempotent) double end, got \(state)")
+            return
+        }
+    }
+
+    /// A fresh session after a completed one must be able to finish again — the
+    /// idempotency latch is cleared on startSession, so it does not permanently
+    /// disable finishSession for the next session.
+    func testFinishSession_latchResetsForNextSession() async throws {
+        let manager = makeManager()
+        let key = UserProfileConstants.sessionCountKey
+        let before = UserDefaults.standard.integer(forKey: key)
+
+        // Session 1.
+        let day1 = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+        await manager.startSession(trainingDay: day1, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+        await manager.completeSet(actualReps: 5, rpeFelt: 7, intent: .top)
+        await manager.endSession()
+        await manager.resetToIdle()
+
+        // Session 2 — latch must have been cleared so this one also counts.
+        let day2 = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+        await manager.startSession(trainingDay: day2, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+        await manager.completeSet(actualReps: 5, rpeFelt: 7, intent: .top)
+        await manager.endSession()
+
+        let after = UserDefaults.standard.integer(forKey: key)
+        XCTAssertEqual(after - before, 2, "Two distinct sessions must each count once (latch resets per session)")
+    }
+
+    // MARK: #369 [19] — retryInference participates in the generation guard
+
+    /// A retry result that resolves AFTER the session has advanced (generation bumped
+    /// by a concurrent swap) must be DROPPED, not applied. The GatedRetryProvider parks
+    /// the retry mid-await; the test bumps the generation via swapExercise (a reentrant
+    /// actor call while the retry is suspended), then releases the retry. Pre-fix,
+    /// retryInference had no post-await generation re-check, so the stale prescription
+    /// clobbered the swapped-in state.
+    func testRetryInference_staleResultDroppedAfterGenerationBump() async throws {
+        let provider = GatedRetryProvider(response: prescriptionJSON(weightKg: 60.0))
+        let manager = makeManager(provider: provider)
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 2)
+
+        // startSession's inference fails (gated call #1) → pending-retry on exercise 0.
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+        let retryNeeded = await manager.inferenceRetryNeeded
+        XCTAssertTrue(retryNeeded, "Failed startSession inference should arm the retry")
+
+        // Launch the retry — it parks on the gate inside prescribe() (gated call #2).
+        let retryTask = Task { await manager.retryInference() }
+        await provider.waitUntilRetryParked()
+
+        // While the retry is suspended, advance the generation via a swap (reentrant
+        // actor call). The swap bumps inferenceGeneration, so the parked retry's
+        // captured generation is now stale.
+        let suggestion = ExerciseSwapService.ExerciseSuggestion(
+            exerciseId: "swapped_in",
+            name: "Swapped In",
+            equipmentRequired: "barbell",
+            suggestedWeightKg: 60.0,
+            suggestedReps: 8,
+            reasoning: "test"
+        )
+        await manager.swapExercise(suggestion: suggestion, reason: "test swap")
+
+        // Release the retry; its result is for the OLD generation and must be dropped.
+        provider.releaseRetry()
+        let applied = await retryTask.value
+        XCTAssertFalse(applied, "A stale retry result (generation bumped by swap) must report not-applied")
+
+        // The stale retry targeted exercise_0; if the guard failed it would have set
+        // sessionState = .active(exercise_0, ...). The swap moved the active context to
+        // "swapped_in", so the live exercise must NEVER be exercise_0. (The swap's own
+        // valid inference legitimately sets currentPrescription for "swapped_in".)
+        let state = await manager.sessionState
+        let liveExerciseId: String?
+        switch state {
+        case .active(let ex, _), .resting(let ex, _):
+            liveExerciseId = ex.exerciseId
+        default:
+            liveExerciseId = nil
+        }
+        if let liveExerciseId {
+            XCTAssertNotEqual(
+                liveExerciseId, day.exercises[0].exerciseId,
+                "Stale retry must not transition the session back to the pre-swap exercise (#369 [19])"
+            )
+        }
+    }
+
+    // MARK: #369 [20] — uiSnapshot returns a consistent set of fields
+
+    /// uiSnapshot() must return the same field values as the individual actor-isolated
+    /// properties at a quiescent moment (no torn read). This pins the snapshot's
+    /// field-mapping contract that pullState() now relies on.
+    func testUISnapshot_matchesIndividualFields() async throws {
+        let manager = makeManager()
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 2)
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        let snapshot = await manager.uiSnapshot()
+        let state = await manager.sessionState
+        let prescription = await manager.currentPrescription
+        let fallback = await manager.currentFallbackReason
+        let restRemaining = await manager.restSecondsRemaining
+        let expiresAt = await manager.restExpiresAt
+        let sets = await manager.completedSets
+        let retryNeeded = await manager.inferenceRetryNeeded
+        let pendingExercise = await manager.pendingRetryExercise
+
+        XCTAssertEqual(snapshot.sessionState, state)
+        XCTAssertEqual(snapshot.currentPrescription?.weightKg, prescription?.weightKg)
+        XCTAssertEqual(snapshot.restSecondsRemaining, restRemaining)
+        XCTAssertEqual(snapshot.restExpiresAt, expiresAt)
+        XCTAssertEqual(snapshot.completedSets.count, sets.count)
+        XCTAssertEqual(snapshot.inferenceRetryNeeded, retryNeeded)
+        XCTAssertEqual(snapshot.pendingRetryExercise?.exerciseId, pendingExercise?.exerciseId)
+        // currentFallbackReason is an enum without Equatable in scope here — compare nil-ness.
+        XCTAssertEqual(snapshot.currentFallbackReason == nil, fallback == nil)
+
+        // During .active the snapshot's lastPerformanceSets reflects the live exercise's
+        // cached history (nil here — no prior sessions in the test DB), proving the
+        // derivation runs inside the same atomic hop.
+        XCTAssertNil(snapshot.lastPerformanceSets, "No prior-session history in test → nil")
     }
 }
 


### PR DESCRIPTION
Part of #369 (BUG-2 — concurrency / actor safety). Four confirmed concurrency findings in `WorkoutSessionManager` and its view model. Live inference/session flow preserved exactly; surgical diffs.

## [8] P2 — `finishSession()` had no idempotency guard
`WorkoutSessionManager.swift` `finishSession(earlyExitReason:)`. Concurrent/duplicate end paths — `endSession()` (rest-timer Task, completeSet last-set, skip last-set, resume edge case) racing `endSessionEarly()` from the UI — each ran the full body, double-incrementing `UserProfileConstants.sessionCountKey` and double-enqueueing the trainee-model update.

**Mechanism:** an actor `Bool` latch `isFinishingSession`, checked-and-set at the top of `finishSession` (`guard !isFinishingSession else { return }; isFinishingSession = true`). Reset wherever a fresh session lifecycle begins — `startSession`, `resumeSession`, `resetToIdle`. The normal single-call path and the zero-set discard path are unchanged.

## [19] P3 — `retryInference()` applied its result without re-checking session state, bypassing the generation guard
`WorkoutSessionManager.swift` `retryInference()`. A stale retry result (resolved after a concurrent completeSet/skip/swap advanced the session) could clobber newer state.

**Fix:** capture `let generation = inferenceGeneration` before the awaits; after `postProcessPrescription` re-check `guard generation == inferenceGeneration else { return false }` before assigning `currentPrescription` / transitioning — mirroring the existing #318-U7 pattern in `handleInferenceResult`. The fallback branch is guarded too, so a stale failure doesn't re-arm the retry sheet for a set the session moved past.

## [21] P3 — `swapExercise()`/`resumeSession()` never bumped `inferenceGeneration`
`WorkoutSessionManager.swift` `swapExercise(suggestion:reason:)` and `resumeSession(...)`. `triggerInference` only *reads* the generation (correct — its callers establish it), but swap and resume changed the active inference context without advancing it, so a stale in-flight result wasn't rejected by the guard.

**Generation-bump reasoning:**
- **`swapExercise`** — `inferenceGeneration += 1` right after the per-exercise state reset and before `triggerInference` for the swapped-in exercise. A swap mid-active-session leaves the prior exercise's inference Task in flight with the current generation; bumping makes the guard in `handleInferenceResult` reject it instead of clobbering the new exercise's prescription. Unambiguous and complete — no reset sits between the bump and the stale task's return.
- **`resumeSession`** — changed `inferenceGeneration = 0` to `inferenceGeneration += 1`. The actor is always idle here (resume guards on `.idle`, and the preceding pause/end ran `resetToIdle`, leaving the counter at 0), so this advances 0 → 1. A pre-pause straggler that captured generation 0 (the common case — paused right as the first prescription was coming back; the same `manager` instance is reused across pause/resume and pause does *not* cancel in-flight inference Tasks) no longer matches the resumed generation. **Judgment call (documented in-code):** a straggler that captured a generation ≥ 1 deeper into the pre-pause session could still coincide once the resumed counter climbs there; fully closing that requires a lifetime-monotonic counter (never zeroed in `resetToIdle`), which is a wider change and is deferred. `completeSet`/`skipCurrentSet` already bump consistently — verified.

## [20] P3 — `WorkoutViewModel.pullState()` did a torn read across ~9 actor hops
`WorkoutViewModel.swift` `pullState()`. Awaiting `sessionState`, `currentPrescription`, etc. one property at a time let the actor advance between hops, publishing internally inconsistent UI state.

**Fix:** new `Sendable` struct `WorkoutUISnapshot` and an actor method `WorkoutSessionManager.uiSnapshot()` that returns every field `pullState` needs — including the live exercise's cached last-session history — in ONE hop. `pullState` consumes the snapshot. The liveExercise derivation moved into the actor verbatim. Behaviour identical, read now atomic.

## Tests (`WorkoutSessionManagerTests.swift`, registered)
- `testFinishSession_isIdempotent_sessionCountIncrementsOnce` — two end paths → session count +1 (not +2); state still `.sessionComplete`.
- `testFinishSession_latchResetsForNextSession` — two distinct sessions each count once (latch resets).
- `testRetryInference_staleResultDroppedAfterGenerationBump` — deterministic via a gated provider + actor reentrancy: the retry parks mid-await, a `swapExercise` bumps the generation, the released retry reports not-applied and never transitions the session back to the pre-swap exercise.
- `testUISnapshot_matchesIndividualFields` — snapshot fields equal the individual isolated-property reads at a quiescent moment.

The hard-to-reproduce timing races are pinned with deterministic latch/guard tests (gated provider, no flaky sleeps) per the task's guidance.

## Verification
- Build: `build-exit=0` (SourceKit false positives only).
- Full suite green: 553 XCTest (543 passed, 0 failed, 10 skipped = gated live-API/integration/cache-smoke) + 293 Swift Testing (0 failed). `TEST EXECUTE SUCCEEDED`.

Note: `WorkoutSessionManager.lastPerformance(for:)` is now unused by production code (its only caller, `pullState`, moved to the snapshot). Left in place rather than removed — flagging per surgical-changes discipline; happy to delete if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)