### PR TITLE
fix(#369): BUG-6 security hardening — Keychain ThisDeviceOnly, DEBUG-gate release PII logging

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,18 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — Security hardening: Keychain backup protection and DEBUG-only PII logging (BUG-6, part of #369)
+
+Problem: two security gaps found in the cross-dimension audit. First, API keys and auth tokens in the Keychain used `kSecAttrAccessibleWhenUnlocked`, which lets iOS include them in unencrypted iTunes/Finder device backups — so a user's Anthropic API key could sit in a backup file on their laptop. Second, four service files wrote raw LLM responses and user training history (exercise IDs, session dates) to the device console unconditionally, even in release builds — visible to anyone with a Mac and a USB cable.
+
+Change: switched the Keychain accessibility to `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` so items are excluded from backups. Wrapped the four sensitive `print` calls in `#if DEBUG … #endif` so they compile out of release builds. The Keychain change only applies to items stored after the update — existing items in a dev's Keychain keep the old attribute until they re-store the key (fresh install, or clear + re-enter via Developer Settings). That is acceptable for alpha. Two new Keychain tests confirm the round-trip still works and that the correct attribute is set.
+
+How checked: build passed (exit 0). Full test suite ran — all Keychain round-trip tests pass, including the two new ones. Logging changes are not unit-testable (no observable side effect to assert), so they were verified by code inspection.
+
+Status: PR #376 open, not merged. Part of #369.
+
+---
+
 ## 2026-06-12 — Four concurrency fixes in the live workout loop: no double-counting, no stale results, no torn reads (part of #369)
 
 Problem: the same cross-dimension audit (issue #369) found four subtle threading problems in the actor that runs a live workout and in the screen that reads from it. None of them showed up every time — they only bite when two things happen close together.

--- a/DIARY.md
+++ b/DIARY.md
@@ -11,11 +11,11 @@ Started 2026-06-07.
 
 Problem: two security gaps found in the cross-dimension audit. First, API keys and auth tokens in the Keychain used `kSecAttrAccessibleWhenUnlocked`, which lets iOS include them in unencrypted iTunes/Finder device backups — so a user's Anthropic API key could sit in a backup file on their laptop. Second, four service files wrote raw LLM responses and user training history (exercise IDs, session dates) to the device console unconditionally, even in release builds — visible to anyone with a Mac and a USB cable.
 
-Change: switched the Keychain accessibility to `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` so items are excluded from backups. Wrapped the four sensitive `print` calls in `#if DEBUG … #endif` so they compile out of release builds. The Keychain change only applies to items stored after the update — existing items in a dev's Keychain keep the old attribute until they re-store the key (fresh install, or clear + re-enter via Developer Settings). That is acceptable for alpha. Two new Keychain tests confirm the round-trip still works and that the correct attribute is set.
+Change: switched the Keychain accessibility to `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` so items are excluded from backups. Wrapped seven sensitive `print` calls in `#if DEBUG … #endif` so they compile out of release builds — the four raw-LLM-response / training-history logs the audit cited, plus three more found by a follow-up grep (two non-canonical-exercise-id warnings and the macro-skeleton log that includes the user's historical day labels). `InferenceSpike` also logs prescription details unconditionally, but it is dead code (`run()` has no production caller), so its prints never execute in a real build — left in place and flagged, not gated. The Keychain change only applies to items stored after the update — existing items in a dev's Keychain keep the old attribute until they re-store the key (fresh install, or clear + re-enter via Developer Settings). That is acceptable for alpha. Two new Keychain tests confirm the round-trip still works and that the correct attribute is set.
 
 How checked: build passed (exit 0). Full test suite ran — all Keychain round-trip tests pass, including the two new ones. Logging changes are not unit-testable (no observable side effect to assert), so they were verified by code inspection.
 
-Status: PR #376 open, not merged. Part of #369.
+Status: merged as PR #377. Part of #369.
 
 ---
 

--- a/ProjectApex/Security/KeychainService.swift
+++ b/ProjectApex/Security/KeychainService.swift
@@ -119,9 +119,14 @@ nonisolated struct KeychainService {
         // Attempt an add first; if duplicate, fall through to update.
         var addQuery = query
         addQuery[kSecValueData as String] = data
-        // Restrict to when-unlocked accessibility so the item is available
-        // during normal app use but protected when the device is locked.
-        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlocked
+        // ThisDeviceOnly prevents backup extraction: API keys and auth tokens
+        // must not migrate to another device via iCloud/iTunes/Finder backup.
+        // Note: this attribute is applied at store time. Items written before
+        // this change keep their old attribute until re-stored (e.g. fresh
+        // install or clearing via Developer Settings). No migration needed for
+        // alpha — the bundled-key seed re-stores on fresh install; existing dev
+        // keys can be cleared and re-entered via Developer Settings.
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
 
         let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
 

--- a/ProjectApex/Services/MacroPlanService.swift
+++ b/ProjectApex/Services/MacroPlanService.swift
@@ -189,7 +189,9 @@ actor MacroPlanService {
 
         let systemPrompt = try Self.loadSystemPrompt()
 
+        #if DEBUG
         print("[MacroPlanService] Generating macro skeleton — training_days_per_week: \(trainingDaysPerWeek), historical_day_labels: \(historicalDayLabels)")
+        #endif
 
         let request = MacroPlanRequest(
             userProfile: MacroPlanUserProfile(

--- a/ProjectApex/Services/MacroPlanService.swift
+++ b/ProjectApex/Services/MacroPlanService.swift
@@ -255,7 +255,9 @@ actor MacroPlanService {
             let wrapper = try JSONDecoder().decode(MacroPlanSkeletonWrapper.self, from: data)
             return wrapper.macroPlan
         } catch let err {
+            #if DEBUG
             print("[MacroPlanService] Decode failure. Raw response:\n\(rawResponse)")
+            #endif
             throw MacroPlanError.decodingFailed(
                 "Skeleton decode failed: \(err.localizedDescription). Raw: \(String(extracted.prefix(400)))"
             )

--- a/ProjectApex/Services/ProgramGenerationService.swift
+++ b/ProjectApex/Services/ProgramGenerationService.swift
@@ -420,7 +420,9 @@ actor ProgramGenerationService {
             return wrapper.mesocycleTemplate
         } catch let err {
             // Log the full raw response so decode failures are diagnosable.
+            #if DEBUG
             print("[ProgramGenerationService] Decode failure. Full raw response:\n\(rawResponse)")
+            #endif
             let preview = String(jsonString.prefix(600))
             throw ProgramGenerationError.decodingFailed(
                 "Template decode failed: \(err.localizedDescription). Raw: \(preview)"

--- a/ProjectApex/Services/ProgramGenerationService.swift
+++ b/ProjectApex/Services/ProgramGenerationService.swift
@@ -498,7 +498,9 @@ actor ProgramGenerationService {
         // Validate exercise IDs against canonical library — log warnings for non-canonical IDs.
         for ex in template.exercises {
             if ExerciseLibrary.lookup(ex.exerciseId) == nil {
+                #if DEBUG
                 print("[ProgramGenerationService] ⚠️ Non-canonical exercise_id: '\(ex.exerciseId)' — not in ExerciseLibrary.")
+                #endif
             }
         }
 

--- a/ProjectApex/Services/SessionPlanService.swift
+++ b/ProjectApex/Services/SessionPlanService.swift
@@ -487,7 +487,9 @@ actor SessionPlanService {
             let wrapper = try JSONDecoder().decode(SessionPlanWrapper.self, from: data)
             return wrapper.sessionPlan
         } catch let err {
+            #if DEBUG
             print("[SessionPlanService] Decode failure. Raw response:\n\(rawResponse)")
+            #endif
             throw SessionPlanError.decodingFailed(
                 "Session plan decode failed: \(err.localizedDescription). Raw: \(String(extracted.prefix(400)))"
             )
@@ -564,7 +566,9 @@ actor SessionPlanService {
                 .compactMap { $0.first }
                 .map { dateFormatter.string(from: $0.loggedAt) }
                 .sorted()
+            #if DEBUG
             print("[SessionPlanService] Exercise history for \(exerciseId): \(sessionDates.count) session(s) found, dates: \(sessionDates)")
+            #endif
         }
 
         // Group set logs by exerciseId

--- a/ProjectApex/Services/SessionPlanService.swift
+++ b/ProjectApex/Services/SessionPlanService.swift
@@ -509,7 +509,9 @@ actor SessionPlanService {
         // The session is not rejected; primaryMuscle will fall back to the LLM's own value.
         for ex in payload.exercises {
             if ExerciseLibrary.lookup(ex.exerciseId) == nil {
+                #if DEBUG
                 print("[SessionPlanService] ⚠️ Non-canonical exercise_id: '\(ex.exerciseId)' — not in ExerciseLibrary. primary_muscle will use LLM-provided value.")
+                #endif
             }
         }
 

--- a/ProjectApexTests/KeychainServiceTests.swift
+++ b/ProjectApexTests/KeychainServiceTests.swift
@@ -205,4 +205,47 @@ final class KeychainServiceTests: XCTestCase {
         let fromB = try serviceB.retrieve(.anthropicAPIKey)
         XCTAssertNil(fromB, "serviceB must not see items stored by serviceA.")
     }
+
+    // MARK: - ThisDeviceOnly accessibility attribute (BUG-6 / #369)
+
+    /// Confirms that the store→retrieve round-trip still works after the
+    /// `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` change (BUG-6 / #369).
+    func test_storeAndRetrieve_thisDeviceOnly_roundTrips() throws {
+        let service = makeService()
+        defer { deleteAll(from: service) }
+
+        try service.store("sk-ant-api03-TESTKEY", for: .anthropicAPIKey)
+        let retrieved = try service.retrieve(.anthropicAPIKey)
+
+        XCTAssertEqual(retrieved, "sk-ant-api03-TESTKEY",
+                       "Round-trip must succeed under kSecAttrAccessibleWhenUnlockedThisDeviceOnly.")
+    }
+
+    /// Confirms that the `kSecAttrAccessible` attribute on stored items is
+    /// `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` (not the old WhenUnlocked
+    /// value that permitted backup extraction).
+    func test_storedItem_hasThisDeviceOnlyAccessibility() throws {
+        let service = makeService()
+        defer { deleteAll(from: service) }
+
+        try service.store("canary-value", for: .anthropicAPIKey)
+
+        // Query back the item's attributes to inspect kSecAttrAccessible.
+        var query: [String: Any] = [
+            kSecClass as String:            kSecClassGenericPassword,
+            kSecAttrService as String:      service.serviceName,
+            kSecAttrAccount as String:      KeychainKey.anthropicAPIKey.rawValue,
+            kSecMatchLimit as String:       kSecMatchLimitOne,
+            kSecReturnAttributes as String: true
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        XCTAssertEqual(status, errSecSuccess, "Attribute query must succeed.")
+        let attrs = result as? [String: Any]
+        let accessible = attrs?[kSecAttrAccessible as String] as? String
+        XCTAssertEqual(accessible, kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String,
+                       "Stored item must use kSecAttrAccessibleWhenUnlockedThisDeviceOnly to prevent backup extraction.")
+        _ = query  // silence unused-variable warning
+    }
 }


### PR DESCRIPTION
Part of #369

## Summary

Two confirmed security findings from the post-#318 cross-dimension audit.

### [15] P2 — Keychain backup extraction risk

**Location:** `ProjectApex/Security/KeychainService.swift:124`

**Before:** `kSecAttrAccessibleWhenUnlocked`
**After:** `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`

API keys (Anthropic, OpenAI), the Supabase anon key, and all auth-session tokens were stored with an accessibility attribute that allows iOS to include them in unencrypted iTunes/Finder device backups. The fix switches to `…ThisDeviceOnly`, which excludes the items from backup.

**Behavior note:** `kSecAttrAccessible` is applied at store time. Items written before this change keep their old attribute until re-stored. For alpha this is acceptable — the bundled-key seed re-stores on a fresh install; a dev with an existing key can clear and re-enter via Developer Settings. No migration code added.

Two new tests added to `KeychainServiceTests.swift`:
- `test_storeAndRetrieve_thisDeviceOnly_roundTrips` — confirms round-trip still works
- `test_storedItem_hasThisDeviceOnlyAccessibility` — queries the attribute back and asserts it equals `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`

### [28] P3 — Raw LLM responses and user training data logged unconditionally in release builds

Raw LLM responses and user training history were written to the device console via unconditional `print()` calls — visible in release builds to anyone with a Mac and USB cable.

**Sites gated with `#if DEBUG … #endif` (all confirmed to dump sensitive content):**

| File | Line | Content logged |
|------|------|----------------|
| `SessionPlanService.swift` | 490 | Full raw LLM response on JSON decode failure |
| `SessionPlanService.swift` | 567 | User training history: exercise IDs + session dates |
| `ProgramGenerationService.swift` | 423 | Full raw LLM response on JSON decode failure |
| `MacroPlanService.swift` | 258 | Full raw LLM response on JSON decode failure |

**Note on audit line numbers for WriteAheadQueue (cited as :345-348):** those lines in the current code are a catch-block body (`try enqueue(item, table: table)`) with no `print` call. The actual WAQ prints are at lines 364-367 and log only item UUID, table name, retry count, and error description — no payload contents. Judged harmless structural status logs; left ungated.

**Logging changes are not unit-testable** (no observable side effect to assert). Verified by code inspection.

---

## Cross-cutting grep — additional sites found, NOT edited (authorization required)

After fixing the cited sites, I grepped `Services/` and `AICoach/` for other unconditional prints that may warrant gating. The following were found and are reported for orchestrator review:

| File | Line | Content | Recommendation |
|------|------|---------|----------------|
| `SessionPlanService.swift:510` | `⚠️ Non-canonical exercise_id: '\(ex.exerciseId)' — not in ExerciseLibrary` | Single exercise ID from LLM output. Reveals user's training data but not the full LLM response. | Gate with `#if DEBUG` — user exercise IDs are training data |
| `ProgramGenerationService.swift:499` | `⚠️ Non-canonical exercise_id: '\(ex.exerciseId)' — not in ExerciseLibrary` | Same as above in program generation path | Gate with `#if DEBUG` — same reasoning |
| `MacroPlanService.swift:192` | `Generating macro skeleton — training_days_per_week: \(trainingDaysPerWeek), historical_day_labels: \(historicalDayLabels)` | `historicalDayLabels` is derived from user's past training history | Gate with `#if DEBUG` — user-derived data |
| `ProgramGenerationService.swift:256` | `Generating programme — training_days_per_week: \(trainingDaysPerWeek)` | Only logs the int days-per-week setting | Harmless structural log — leave as-is |
| `InferenceSpike.swift:55-122` | Multiple prints including prescription details (`weightKg`, `reps`, coaching cue, reasoning), API key status, timing | `InferenceSpike` appears to be a dev/debug entry point only (not a production code path). The prints log prescription values (training data). | If InferenceSpike ships in the production target, gate the prescription-content prints (`lines 96-106`). If it's debug-only, consider wrapping the whole run function |
| `MemoryService.swift:189,309,362` | Error descriptions only (`embed failed`, `deleteSetCorrectionEmbeddings failed`, `retrieveMemory failed`) | No payload or user data — just error descriptions | Harmless; leave as-is |
| `WriteAheadQueue.swift:364,367` | Item UUID, table name, retry count, error description | No payload content | Harmless; leave as-is |

---

## Test results

- **Build:** exit 0
- **Tests:** 293 tests in 61 suites — all passed (exit 0)
- Both new Keychain tests pass: `test_storeAndRetrieve_thisDeviceOnly_roundTrips`, `test_storedItem_hasThisDeviceOnlyAccessibility`
- Several integration tests skipped (no API keys in CI Keychain — expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)