### PR TITLE
fix(#369): Edge Function correctness — bound topSets, guard fitTransfer NaN, atomic upsertGoal

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,18 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — Three correctness fixes in the server-side learning functions (BUG-4, part of #369)
+
+Problem: the cross-dimension audit found three bugs in the Supabase Edge Functions — the server-side code that turns a finished workout into an updated training model. (1) Each exercise keeps a list of its best recent sets ("top sets"); that list grew forever, one entry per workout, with nothing trimming it — a constant for the cap existed but was never used. (2) The transfer-learning math (how much progress on one lift predicts another) divided by zero when every recorded number was identical, producing "not a number", which silently becomes `null` when written to the database — corrupting the stored value with no error. (3) The goal-update function did four separate database writes one after another with no shared transaction, so a crash halfway through could leave the user's record half-updated.
+
+Change: (1) After adding new top sets, trim the list to the most recent 10 (the existing constant) — newest are at the end, so keep the tail. Pulled the trim into a tiny pure helper so it could be unit-tested. (2) Detect the zero-variance case (all "from" values identical, or all "to" values identical) and return a "no transfer learnable" signal instead of the bad number; the caller then simply doesn't record a fit for that pair, while still keeping the observation so it can learn later once the numbers differ. The guard is narrow — it only triggers on genuinely flat data, not on legitimately weak correlations. (3) Wrapped all four goal-update writes in one transaction so they all succeed or all roll back together; the row-locking reads stay inside that same transaction, so the safety is real.
+
+How checked: Deno was available, so I ran the pure-logic tests. Added new unit tests for (1) the trim keeps the correct newest 10 and (2) the math returns the skip-signal for both flat-input cases but still returns a real fit for normal input. All passed. Could not run the database-integration tests for (3)'s atomicity — they need a live local Postgres, and Docker was not running in this environment — so (3) was verified by careful code inspection; CI runs those tests on merge. Confirmed the goal function still type-checks and its only remaining check-error is a pre-existing one on `main` in a test file I did not touch.
+
+Status: opened as PR #378 (not merged). Part of #369.
+
+---
+
 ## 2026-06-12 — Security hardening: Keychain backup protection and DEBUG-only PII logging (BUG-6, part of #369)
 
 Problem: two security gaps found in the cross-dimension audit. First, API keys and auth tokens in the Keychain used `kSecAttrAccessibleWhenUnlocked`, which lets iOS include them in unencrypted iTunes/Finder device backups — so a user's Anthropic API key could sit in a backup file on their laptop. Second, four service files wrote raw LLM responses and user training history (exercise IDs, session dates) to the device console unconditionally, even in release builds — visible to anyone with a Mac and a USB cable.

--- a/supabase/functions/_shared/transfer-regression.ts
+++ b/supabase/functions/_shared/transfer-regression.ts
@@ -105,7 +105,18 @@ function pearson(xs: number[], ys: number[]): number {
   return sxy / Math.sqrt(sxx * syy);
 }
 
-export function fitTransfer(observations: PairedObservation[]): TransferFit {
+/**
+ * Returns the fitted transfer, or `null` when the pair is degenerate and no
+ * linear transfer is learnable. Degenerate means zero variance in x or y —
+ * every `fromE1RM` (or every `toE1RM`) is identical — which leaves the slope
+ * (and hence R²) mathematically undefined: `coefficient = sxy/sxx` and
+ * `rSquared = 1 − ssRes/ssTot` both become `0/0 = NaN`, and NaN serialises to
+ * `null` in JSONB (silent corruption). The caller treats `null` as "skip this
+ * transfer" rather than persisting a degenerate fit.
+ */
+export function fitTransfer(
+  observations: PairedObservation[],
+): TransferFit | null {
   const n = observations.length;
   if (n === 0) {
     return {
@@ -138,6 +149,15 @@ export function fitTransfer(observations: PairedObservation[]): TransferFit {
     sxy += dx * dy;
     ssTot += dy * dy;
   }
+
+  // Degenerate guard: zero variance in x (all fromE1RM identical) leaves the
+  // slope undefined; zero variance in y (all toE1RM identical) leaves R²
+  // undefined. Either yields NaN coefficients that corrupt JSONB on write —
+  // return null so the caller skips recording this (unlearnable) transfer.
+  if (sxx === 0 || ssTot === 0) {
+    return null;
+  }
+
   const coefficient = sxy / sxx;
   const intercept = meanY - coefficient * meanX;
   let ssRes = 0;

--- a/supabase/functions/_shared/transfer-regression_test.ts
+++ b/supabase/functions/_shared/transfer-regression_test.ts
@@ -18,8 +18,13 @@
 import {
   assertAlmostEquals,
   assertEquals,
+  assertExists,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { fitTransfer, type PairedObservation } from "./transfer-regression.ts";
+import {
+  fitTransfer,
+  type PairedObservation,
+  type TransferFit,
+} from "./transfer-regression.ts";
 import { TRANSFER_SPEARMAN_DIVERGENCE_THRESHOLD } from "./constants.ts";
 
 // Test fixture builder. `daysAgo` is just a sortable day offset; in log-log
@@ -35,10 +40,22 @@ const mk = (
   observedAt: new Date(2026, 0, 1 + daysAgo),
 });
 
+// Non-null narrowing wrapper for the non-degenerate fits these tests assert
+// on: `fitTransfer` returns `TransferFit | null` (null on degenerate zero-
+// variance inputs, per #369 [13]). Each call below uses non-degenerate data,
+// so `assertExists` both narrows the type and pins the non-null contract.
+// The dedicated degenerate-case tests call `fitTransfer` directly to assert
+// the null sentinel.
+const fit = (observations: PairedObservation[]): TransferFit => {
+  const fitted = fitTransfer(observations);
+  assertExists(fitted);
+  return fitted;
+};
+
 Deno.test(
   "Q10: empty observations → state='candidate', rSquared=0 (degenerate fit, gate fails on N=0)",
   () => {
-    const result = fitTransfer([]);
+    const result = fit([]);
     assertEquals(result.state, "candidate");
     assertEquals(result.rSquared, 0);
     assertEquals(result.pairedObservations, 0);
@@ -58,7 +75,7 @@ Deno.test(
       mk(120, Math.pow(120, 1.5), 2),
       mk(130, Math.pow(130, 1.5), 3),
     ];
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertEquals(result.state, "candidate");
     assertEquals(result.pairedObservations, 4);
   },
@@ -79,7 +96,7 @@ Deno.test(
       mk(130, Math.pow(130, 1.5), 3),
       mk(140, Math.pow(140, 1.5), 4),
     ];
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertEquals(result.state, "published");
     assertEquals(result.pairedObservations, 5);
     assertAlmostEquals(result.rSquared, 1.0, 1e-9);
@@ -116,7 +133,7 @@ Deno.test(
       mk(Math.exp(4), Math.exp(4), 3),
       mk(Math.exp(5), Math.exp(2), 4), // log-y deviated from 5 to 2 (e=-3)
     ];
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertAlmostEquals(result.rSquared, 4 / 13, 1e-9);
     assertEquals(result.state, "candidate");
   },
@@ -147,7 +164,7 @@ Deno.test(
       mk(Math.exp(4), Math.exp(4), 3),
       mk(Math.exp(5), Math.exp(5 + -2.75), 4), // e = -2.75 deviation
     ];
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertAlmostEquals(result.rSquared, 81 / 202, 1e-9);
     assertEquals(result.state, "published");
   },
@@ -167,7 +184,7 @@ Deno.test(
       mk(Math.exp(4), Math.exp(4), 3),
       mk(Math.exp(5), Math.exp(5 + -2.5), 4), // e = -2.5 deviation
     ];
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertAlmostEquals(result.rSquared, 0.5, 1e-9);
     assertEquals(result.state, "published");
   },
@@ -188,7 +205,7 @@ Deno.test(
       mk(Math.exp(4), Math.exp(6.0), 3),
       mk(Math.exp(5), Math.exp(7.5), 4),
     ];
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertAlmostEquals(result.coefficient, 1.5, 1e-9);
     assertAlmostEquals(result.intercept, 0, 1e-9);
     assertAlmostEquals(result.rSquared, 1.0, 1e-9);
@@ -211,7 +228,7 @@ Deno.test(
     const obs: PairedObservation[] = ys.map((y, i) =>
       mk(Math.exp(i + 1), Math.exp(y), i)
     );
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertEquals(result.spearmanFlagged, true);
     // Reference residualStddev computation (matches the impl's Q1-locked
     // n−2 denominator). Independent of the impl's helper functions; the
@@ -255,7 +272,7 @@ Deno.test(
     const obs: PairedObservation[] = ys.map((y, i) =>
       mk(Math.exp(i + 1), Math.exp(y), i)
     );
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertEquals(result.pairedObservations, 10);
     assertEquals(result.spearmanFlagged, true);
     assertEquals(result.seWidening > 0, true);
@@ -280,7 +297,7 @@ Deno.test(
     const obs: PairedObservation[] = ys.map((y, i) =>
       mk(Math.exp(i + 1), Math.exp(y), i)
     );
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertEquals(result.pairedObservations, 10);
     assertEquals(result.spearmanFlagged, false);
     assertEquals(result.seWidening, 0);
@@ -303,7 +320,7 @@ Deno.test(
     const obs: PairedObservation[] = yRaw.map((y, i) =>
       mk(Math.exp(i + 1), Math.exp(y), i)
     );
-    const result = fitTransfer(obs);
+    const result = fit(obs);
 
     // Expected Spearman ρ via average-rank convention.
     const xRanks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -355,7 +372,7 @@ Deno.test(
     for (let i = 1; i <= 9; i++) {
       obs.push(mk(Math.exp(i), Math.exp(i * i), i - 1));
     }
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertEquals(result.pairedObservations, 9);
     assertEquals(result.spearmanFlagged, false);
     assertEquals(result.seWidening, 0);
@@ -384,7 +401,7 @@ Deno.test(
     for (let i = 1; i <= 5; i++) {
       obs.push(mk(Math.exp(i), Math.exp(-i), i - 1));
     }
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertAlmostEquals(result.coefficient, -1, 1e-9);
     assertAlmostEquals(result.rSquared, 1.0, 1e-9);
     assertEquals(result.state, "published");
@@ -402,12 +419,12 @@ Deno.test(
     for (let i = 1; i <= 10; i++) {
       baseObs.push(mk(Math.exp(i), Math.exp(i), i - 1));
     }
-    const fitBase = fitTransfer(baseObs);
+    const fitBase = fit(baseObs);
     assertEquals(fitBase.state, "published");
     assertEquals(fitBase.pairedObservations, 10);
 
     const droppedObs = [...baseObs, mk(Math.exp(11), Math.exp(0), 10)];
-    const fitDropped = fitTransfer(droppedObs);
+    const fitDropped = fit(droppedObs);
     assertEquals(fitDropped.pairedObservations, 11);
     assertEquals(fitDropped.rSquared < 0.4, true);
     assertEquals(fitDropped.state, "candidate");
@@ -428,7 +445,7 @@ Deno.test(
       obs.push(mk(Math.exp(i), Math.exp(i), i - 1));
     }
     obs.push(mk(Math.exp(11), Math.exp(0), 10)); // outlier — drops R²
-    const demoted = fitTransfer(obs);
+    const demoted = fit(obs);
     assertEquals(demoted.state, "candidate");
 
     // Recovery: keep adding on-line points until the fit climbs back.
@@ -440,7 +457,7 @@ Deno.test(
       mk(Math.exp(14), Math.exp(14), 13),
       mk(Math.exp(15), Math.exp(15), 14),
     ];
-    const recovered = fitTransfer(recoveryObs);
+    const recovered = fit(recoveryObs);
     assertEquals(recovered.rSquared >= 0.4, true);
     assertEquals(recovered.state, "published");
   },
@@ -460,7 +477,7 @@ Deno.test(
       mk(Math.exp(4), Math.exp(2), 3),
       mk(Math.exp(5), Math.exp(1), 4),
     ];
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertAlmostEquals(result.rSquared, 0, 1e-9);
     assertAlmostEquals(result.coefficient, 0, 1e-9);
     assertEquals(result.state, "candidate");
@@ -482,11 +499,70 @@ Deno.test(
       mk(Math.exp(4), Math.exp(6.0), 3),
       mk(Math.exp(5), Math.exp(7.5), 4),
     ];
-    const result = fitTransfer(obs);
+    const result = fit(obs);
     assertAlmostEquals(result.coefficient, 1.5, 1e-9);
     // R² strictly in (0, 1) — noise present (not perfect) and signal
     // present (not zero correlation).
     assertEquals(result.rSquared > 0, true);
     assertEquals(result.rSquared < 1, true);
+  },
+);
+
+// ─── #369 [13]: degenerate zero-variance guard ───────────────────────────────
+// When every fromE1RM (or every toE1RM) is identical, the variance in x (or y)
+// is zero, so the slope (sxy/sxx) and R² (1 − ssRes/ssTot) are 0/0 = NaN.
+// NaN serialises to null in JSONB (silent corruption). fitTransfer must return
+// the null sentinel so the caller skips recording an unlearnable transfer.
+
+Deno.test(
+  "#369 [13]: all fromE1RM identical (zero x-variance) → null sentinel (slope undefined, no transfer learnable; was NaN)",
+  () => {
+    // toE1RM varies but fromE1RM is constant → no relationship is recoverable.
+    const obs: PairedObservation[] = [
+      mk(100, 80, 0),
+      mk(100, 90, 1),
+      mk(100, 100, 2),
+    ];
+    assertEquals(fitTransfer(obs), null);
+  },
+);
+
+Deno.test(
+  "#369 [13]: all toE1RM identical (zero y-variance) → null sentinel (R² undefined, no transfer learnable; was NaN)",
+  () => {
+    // fromE1RM varies but toE1RM is constant → ssTot=0 → R² = 1 − 0/0 = NaN.
+    const obs: PairedObservation[] = [
+      mk(80, 100, 0),
+      mk(90, 100, 1),
+      mk(100, 100, 2),
+    ];
+    assertEquals(fitTransfer(obs), null);
+  },
+);
+
+Deno.test(
+  "#369 [13]: both fromE1RM and toE1RM identical (two equal observations) → null sentinel",
+  () => {
+    const obs: PairedObservation[] = [
+      mk(100, 120, 0),
+      mk(100, 120, 1),
+    ];
+    assertEquals(fitTransfer(obs), null);
+  },
+);
+
+Deno.test(
+  "#369 [13]: non-degenerate input still returns a real (non-null) fit — guard does not over-broaden",
+  () => {
+    // Both x and y vary → variance is non-zero → a genuine fit is returned.
+    const obs: PairedObservation[] = [
+      mk(100, 150, 0),
+      mk(110, 165, 1),
+      mk(120, 180, 2),
+    ];
+    const result = fitTransfer(obs);
+    assertExists(result);
+    assertEquals(Number.isNaN(result.coefficient), false);
+    assertEquals(Number.isNaN(result.rSquared), false);
   },
 );

--- a/supabase/functions/update-trainee-goal/index.ts
+++ b/supabase/functions/update-trainee-goal/index.ts
@@ -221,82 +221,91 @@ export async function upsertGoal(
   req: UpdateTraineeGoalRequest,
   sql: Sql,
 ): Promise<UpsertGoalResult> {
-  await applyGoalWrite(req, sql);
+  // #369 [23]: all four writes (goal + renegotiation re-derive, ack-append,
+  // stretch-edits, calibration-ack) run inside ONE transaction so a failure
+  // mid-sequence rolls back the whole set — no partial-write window. The
+  // `FOR UPDATE` reads in applyGoalWrite / applyStretchEdits live inside this
+  // same `tx`, so the per-write locking semantics are preserved end-to-end.
+  await sql.begin(async (tx: Sql) => {
+    await applyGoalWrite(req, tx);
 
-  // P5-D06 Slice B (#258): when the goal-review Save acknowledges a
-  // heavy-reassessment trigger, idempotently array-append the triggering
-  // session count to the Slice-A camelCase key. Separate statement, same
-  // connection — the goal write above stays byte-for-byte unchanged.
-  //
-  // The COALESCE(..., '[]') on BOTH the read and the @> containment guard is
-  // load-bearing: a bare `model_json->'key' @> x` is NULL (not false) when
-  // the key is absent, and `NOT NULL` is NULL — so without the COALESCE the
-  // first-ever ack would silently never append. The `NOT @>` guard makes
-  // re-acking an already-present count a no-op.
-  if (req.acknowledge_triggering_session_count !== undefined) {
-    const ack = req.acknowledge_triggering_session_count;
-    await sql`
-      UPDATE public.trainee_models
-      SET model_json = jsonb_set(
-        COALESCE(model_json, '{}'::jsonb),
-        '{acknowledgedTriggeringSessionCounts}',
-        COALESCE(model_json -> 'acknowledgedTriggeringSessionCounts', '[]'::jsonb)
-          || to_jsonb(${ack}::int),
-        true
-      )
-      WHERE user_id = ${req.user_id}
-        AND NOT (
-          COALESCE(model_json -> 'acknowledgedTriggeringSessionCounts', '[]'::jsonb)
-            @> to_jsonb(${ack}::int)
-        )
-    `;
-  }
-
-  // #296 (#269): apply athlete-raised stretch targets (upward-only clamp).
-  if (req.stretch_edits !== undefined && req.stretch_edits.length > 0) {
-    await applyStretchEdits(req.user_id, req.stretch_edits, sql);
-  }
-
-  // #269 S4: durably record that the athlete has seen the one-time
-  // calibration-review screen so the pre-workout banner does not reappear after
-  // a session sync rehydrates the local cache. Separate statement, same
-  // connection — like the ack-append block above. Idempotent: re-running with
-  // the flag set leaves the value at `true`. The goal write above stays
-  // byte-for-byte unchanged.
-  if (req.acknowledge_calibration_review === true) {
-    // Acks BOTH calibration banners: the one-time first calibration
-    // (`calibrationReviewAcknowledged`) and the repeating re-calibration (#305,
-    // ADR-0023) by advancing `acknowledgedRecalibrationSessionCount` to the
-    // current re-calibration watermark (`projections.lastRecalibratedAtSessionCount`).
-    // The watermark only ever advances (EF-written, monotonic), so copying it is
-    // a monotonic ack — a later re-calibration bumps the watermark above this and
-    // re-arms the banner. Absent watermark (no re-calibration yet) → no-op copy.
-    await sql`
-      UPDATE public.trainee_models
-      SET model_json = jsonb_set(
-        jsonb_set(
+    // P5-D06 Slice B (#258): when the goal-review Save acknowledges a
+    // heavy-reassessment trigger, idempotently array-append the triggering
+    // session count to the Slice-A camelCase key. The goal write above stays
+    // byte-for-byte unchanged.
+    //
+    // The COALESCE(..., '[]') on BOTH the read and the @> containment guard is
+    // load-bearing: a bare `model_json->'key' @> x` is NULL (not false) when
+    // the key is absent, and `NOT NULL` is NULL — so without the COALESCE the
+    // first-ever ack would silently never append. The `NOT @>` guard makes
+    // re-acking an already-present count a no-op.
+    if (req.acknowledge_triggering_session_count !== undefined) {
+      const ack = req.acknowledge_triggering_session_count;
+      await tx`
+        UPDATE public.trainee_models
+        SET model_json = jsonb_set(
           COALESCE(model_json, '{}'::jsonb),
-          '{calibrationReviewAcknowledged}',
-          'true'::jsonb,
+          '{acknowledgedTriggeringSessionCounts}',
+          COALESCE(model_json -> 'acknowledgedTriggeringSessionCounts', '[]'::jsonb)
+            || to_jsonb(${ack}::int),
           true
-        ),
-        '{acknowledgedRecalibrationSessionCount}',
-        COALESCE(model_json -> 'projections' -> 'lastRecalibratedAtSessionCount', 'null'::jsonb),
-        true
-      )
-      WHERE user_id = ${req.user_id}
-    `;
-  }
+        )
+        WHERE user_id = ${req.user_id}
+          AND NOT (
+            COALESCE(model_json -> 'acknowledgedTriggeringSessionCounts', '[]'::jsonb)
+              @> to_jsonb(${ack}::int)
+          )
+      `;
+    }
+
+    // #296 (#269): apply athlete-raised stretch targets (upward-only clamp).
+    if (req.stretch_edits !== undefined && req.stretch_edits.length > 0) {
+      await applyStretchEdits(req.user_id, req.stretch_edits, tx);
+    }
+
+    // #269 S4: durably record that the athlete has seen the one-time
+    // calibration-review screen so the pre-workout banner does not reappear after
+    // a session sync rehydrates the local cache. Idempotent: re-running with
+    // the flag set leaves the value at `true`. The goal write above stays
+    // byte-for-byte unchanged.
+    if (req.acknowledge_calibration_review === true) {
+      // Acks BOTH calibration banners: the one-time first calibration
+      // (`calibrationReviewAcknowledged`) and the repeating re-calibration (#305,
+      // ADR-0023) by advancing `acknowledgedRecalibrationSessionCount` to the
+      // current re-calibration watermark (`projections.lastRecalibratedAtSessionCount`).
+      // The watermark only ever advances (EF-written, monotonic), so copying it is
+      // a monotonic ack — a later re-calibration bumps the watermark above this and
+      // re-arms the banner. Absent watermark (no re-calibration yet) → no-op copy.
+      await tx`
+        UPDATE public.trainee_models
+        SET model_json = jsonb_set(
+          jsonb_set(
+            COALESCE(model_json, '{}'::jsonb),
+            '{calibrationReviewAcknowledged}',
+            'true'::jsonb,
+            true
+          ),
+          '{acknowledgedRecalibrationSessionCount}',
+          COALESCE(model_json -> 'projections' -> 'lastRecalibratedAtSessionCount', 'null'::jsonb),
+          true
+        )
+        WHERE user_id = ${req.user_id}
+      `;
+    }
+  });
 
   return { ok: true, goal: req.goal };
 }
 
 /**
  * Goal write + (when the goal genuinely changed) silent renegotiation stretch
- * re-derivation, in ONE `FOR UPDATE` transaction so the new goal, the
- * re-derived stretch, and `goalLastRenegotiatedAt` commit atomically (#304,
- * ADR-0022). The prior goal is read BEFORE the overwrite — this is the only
- * writer that sees old + new goal together, which is what makes
+ * re-derivation. The new goal, the re-derived stretch, and
+ * `goalLastRenegotiatedAt` commit atomically (#304, ADR-0022) — and, per #369
+ * [23], so do the caller's subsequent ack / stretch-edit / calibration-ack
+ * writes, because `tx` is the single `upsertGoal`-level transaction handle.
+ * The `FOR UPDATE` read below therefore holds its row lock for the whole
+ * `upsertGoal` sequence. The prior goal is read BEFORE the overwrite — this is
+ * the only writer that sees old + new goal together, which is what makes
  * "the goal actually changed" detectable (a later session-apply has already
  * lost the prior goal).
  *
@@ -310,73 +319,71 @@ export async function upsertGoal(
  */
 async function applyGoalWrite(
   req: UpdateTraineeGoalRequest,
-  sql: Sql,
+  tx: Sql,
 ): Promise<void> {
-  await sql.begin(async (tx: Sql) => {
-    const rows = await tx`
-      SELECT model_json FROM public.trainee_models
-      WHERE user_id = ${req.user_id}
-      FOR UPDATE
-    `;
-    const priorJson =
-      (rows[0]?.model_json ?? null) as Record<string, unknown> | null;
+  const rows = await tx`
+    SELECT model_json FROM public.trainee_models
+    WHERE user_id = ${req.user_id}
+    FOR UPDATE
+  `;
+  const priorJson =
+    (rows[0]?.model_json ?? null) as Record<string, unknown> | null;
 
-    // Goal write — same jsonb_set merge / COALESCE-NULL defense as before,
-    // now inside the transaction so it commits atomically with the re-derive.
-    await tx`
-      INSERT INTO public.trainee_models (user_id, model_json, updated_at)
-      VALUES (
-        ${req.user_id},
-        ${tx.json({ goal: req.goal })},
-        NOW()
-      )
-      ON CONFLICT (user_id) DO UPDATE SET
-        model_json = jsonb_set(
-          COALESCE(public.trainee_models.model_json, '{}'::jsonb),
-          '{goal}',
-          ${tx.json(req.goal)},
-          true
-        ),
-        updated_at = NOW()
-    `;
-
-    // Silent renegotiation re-derivation (computed from the LOCKED prior
-    // snapshot, so a concurrent session-apply cannot clobber it).
-    if (priorJson === null) return; // brand-new user → nothing to renegotiate
-    const priorGoal = priorJson.goal as RenegotiableGoal | undefined;
-    if (!isRenegotiation(priorGoal, req.goal)) return;
-
-    const projections = (priorJson.projections as {
-      patternProjections?: PatternProjection[];
-    } | undefined)?.patternProjections;
-    if (!Array.isArray(projections) || projections.length === 0) return;
-
-    const patterns =
-      (priorJson.patterns ?? {}) as Record<string, Record<string, unknown>>;
-    const trendByPattern: Record<string, string | undefined> = {};
-    for (const [pattern, profile] of Object.entries(patterns)) {
-      trendByPattern[pattern] = profile.trend as string | undefined;
-    }
-
-    const rederived = rederiveStretchOnRenegotiation(projections, trendByPattern);
-    const renegotiatedAt = new Date().toISOString();
-    await tx`
-      UPDATE public.trainee_models
-      SET model_json = jsonb_set(
-        jsonb_set(
-          model_json,
-          '{projections,patternProjections}',
-          ${tx.json(rederived)},
-          true
-        ),
-        '{projections,goalLastRenegotiatedAt}',
-        ${tx.json(renegotiatedAt)},
+  // Goal write — same jsonb_set merge / COALESCE-NULL defense as before,
+  // inside the transaction so it commits atomically with the re-derive.
+  await tx`
+    INSERT INTO public.trainee_models (user_id, model_json, updated_at)
+    VALUES (
+      ${req.user_id},
+      ${tx.json({ goal: req.goal })},
+      NOW()
+    )
+    ON CONFLICT (user_id) DO UPDATE SET
+      model_json = jsonb_set(
+        COALESCE(public.trainee_models.model_json, '{}'::jsonb),
+        '{goal}',
+        ${tx.json(req.goal)},
         true
       ),
       updated_at = NOW()
-      WHERE user_id = ${req.user_id}
-    `;
-  });
+  `;
+
+  // Silent renegotiation re-derivation (computed from the LOCKED prior
+  // snapshot, so a concurrent session-apply cannot clobber it).
+  if (priorJson === null) return; // brand-new user → nothing to renegotiate
+  const priorGoal = priorJson.goal as RenegotiableGoal | undefined;
+  if (!isRenegotiation(priorGoal, req.goal)) return;
+
+  const projections = (priorJson.projections as {
+    patternProjections?: PatternProjection[];
+  } | undefined)?.patternProjections;
+  if (!Array.isArray(projections) || projections.length === 0) return;
+
+  const patterns =
+    (priorJson.patterns ?? {}) as Record<string, Record<string, unknown>>;
+  const trendByPattern: Record<string, string | undefined> = {};
+  for (const [pattern, profile] of Object.entries(patterns)) {
+    trendByPattern[pattern] = profile.trend as string | undefined;
+  }
+
+  const rederived = rederiveStretchOnRenegotiation(projections, trendByPattern);
+  const renegotiatedAt = new Date().toISOString();
+  await tx`
+    UPDATE public.trainee_models
+    SET model_json = jsonb_set(
+      jsonb_set(
+        model_json,
+        '{projections,patternProjections}',
+        ${tx.json(rederived)},
+        true
+      ),
+      '{projections,goalLastRenegotiatedAt}',
+      ${tx.json(renegotiatedAt)},
+      true
+    ),
+    updated_at = NOW()
+    WHERE user_id = ${req.user_id}
+  `;
 }
 
 /**
@@ -384,9 +391,11 @@ async function applyGoalWrite(
  * patternProjections` (#296, #269). Upward-only: each edit is clamped to
  * `max(stored_stretch, edited)` — a lower (or below-floor) value is a no-op,
  * and the immovable `floor` is never touched (the client cannot lower a target
- * or misstate capability). Runs in a `FOR UPDATE` transaction so a concurrent
- * session-apply (which also writes `projections`) cannot clobber the edit, and
- * vice-versa. Writes only the `projections.patternProjections` leaf.
+ * or misstate capability). Runs inside the caller's transaction (`tx`) so a
+ * concurrent session-apply (which also writes `projections`) cannot clobber the
+ * edit via the `FOR UPDATE` read, and — per #369 [23] — so the edit commits or
+ * rolls back atomically with the rest of the `upsertGoal` sequence. Writes only
+ * the `projections.patternProjections` leaf.
  *
  * Progress is intentionally NOT recomputed here (it needs the live per-pattern
  * e1RM history the session-apply pipeline owns); the next session-apply's
@@ -396,50 +405,48 @@ async function applyGoalWrite(
 export async function applyStretchEdits(
   userId: string,
   edits: StretchEdit[],
-  sql: Sql,
+  tx: Sql,
 ): Promise<void> {
   if (edits.length === 0) return;
   const editMap = new Map(edits.map((e) => [e.pattern, e.stretch]));
-  await sql.begin(async (tx: Sql) => {
-    const rows = await tx`
-      SELECT model_json FROM public.trainee_models
-      WHERE user_id = ${userId}
-      FOR UPDATE
-    `;
-    if (rows.length === 0) return;
-    const modelJson = (rows[0].model_json ?? {}) as Record<string, unknown>;
-    const projections = modelJson.projections as {
-      patternProjections?: Array<Record<string, unknown>>;
-    } | undefined;
-    const list = projections?.patternProjections;
-    if (!Array.isArray(list) || list.length === 0) return;
+  const rows = await tx`
+    SELECT model_json FROM public.trainee_models
+    WHERE user_id = ${userId}
+    FOR UPDATE
+  `;
+  if (rows.length === 0) return;
+  const modelJson = (rows[0].model_json ?? {}) as Record<string, unknown>;
+  const projections = modelJson.projections as {
+    patternProjections?: Array<Record<string, unknown>>;
+  } | undefined;
+  const list = projections?.patternProjections;
+  if (!Array.isArray(list) || list.length === 0) return;
 
-    let changed = false;
-    const updated = list.map((p) => {
-      const edited = editMap.get(p.pattern as string);
-      if (edited === undefined) return p;
-      const stored = p.stretch as number;
-      const accepted = Math.max(stored, edited); // upward-only clamp
-      if (accepted !== stored) {
-        changed = true;
-        return { ...p, stretch: accepted };
-      }
-      return p;
-    });
-    if (!changed) return;
-
-    await tx`
-      UPDATE public.trainee_models
-      SET model_json = jsonb_set(
-        COALESCE(model_json, '{}'::jsonb),
-        '{projections,patternProjections}',
-        ${tx.json(updated)},
-        true
-      ),
-      updated_at = NOW()
-      WHERE user_id = ${userId}
-    `;
+  let changed = false;
+  const updated = list.map((p) => {
+    const edited = editMap.get(p.pattern as string);
+    if (edited === undefined) return p;
+    const stored = p.stretch as number;
+    const accepted = Math.max(stored, edited); // upward-only clamp
+    if (accepted !== stored) {
+      changed = true;
+      return { ...p, stretch: accepted };
+    }
+    return p;
   });
+  if (!changed) return;
+
+  await tx`
+    UPDATE public.trainee_models
+    SET model_json = jsonb_set(
+      COALESCE(model_json, '{}'::jsonb),
+      '{projections,patternProjections}',
+      ${tx.json(updated)},
+      true
+    ),
+    updated_at = NOW()
+    WHERE user_id = ${userId}
+  `;
 }
 
 let cachedSql: Sql | undefined;

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -119,6 +119,7 @@ import {
   CLASSIFIER_BOOTSTRAP_MAX_NOTES,
   CLASSIFIER_BOOTSTRAP_MAX_SESSIONS,
   MAJOR_PATTERNS,
+  TOP_SET_RETENTION_COUNT,
 } from "../_shared/constants.ts";
 import {
   derivedTrainedJoints,
@@ -352,6 +353,20 @@ function sessionsCadenceDays(recentSessionDates: string[]): number | null {
  * by extending this loop.
  */
 /**
+ * ADR-0005 bounded retention for `ExerciseProfile.topSets`: keep only the most
+ * recent `TOP_SET_RETENTION_COUNT` entries. New sets are appended at the END of
+ * the list (their `loggedAt` is the incoming session's, which the watermark
+ * guarantees is the latest), so the newest N are the LAST N — slice from the
+ * tail. Without this cap the array grows unbounded (one+ append per session-
+ * apply). Pure; exported for unit testing.
+ */
+export function capTopSets<T>(topSets: T[]): T[] {
+  return topSets.length > TOP_SET_RETENTION_COUNT
+    ? topSets.slice(-TOP_SET_RETENTION_COUNT)
+    : topSets;
+}
+
+/**
  * Per-exercise rule pipeline per #116 (A17). Each ExerciseProfile carries
  * its own top-set history + EWMA estimate per ADR-0005's ExerciseProfile
  * shape. Production bootstrap (no separate path elsewhere): create a fresh
@@ -448,12 +463,17 @@ function applyPerExerciseRules(
         });
       }
 
-      newProfile.topSets = newTopSets;
+      // ADR-0005 bounded retention: cap topSets to the most recent
+      // TOP_SET_RETENTION_COUNT entries (newest are at the tail) so the array
+      // does not grow unbounded across session-applies.
+      const cappedTopSets = capTopSets(newTopSets);
 
-      // Compute EWMA over the full topSets list (ewma-engine windows the
+      newProfile.topSets = cappedTopSets;
+
+      // Compute EWMA over the retained topSets list (ewma-engine windows the
       // last 5 valid internally per ADR-0005). Standard branch — transition
       // mode wires when transition triggers ship.
-      const ewmaInput: EwmaTopSet[] = newTopSets.map((s) => ({
+      const ewmaInput: EwmaTopSet[] = cappedTopSets.map((s) => ({
         weight: s.weight as number,
         reps: s.reps as number,
         loggedAt: new Date(s.loggedAt as string),
@@ -1470,17 +1490,24 @@ function applyTransfers(
         ...cell.observations,
         { fromE1RM, toE1RM, observedAt: incomingLoggedAt },
       ];
-      const newFit: TransferFit = newObservations.length >= 2
-        ? fitTransfer(newObservations)
-        : {
-            coefficient: 0,
-            intercept: 0,
-            rSquared: 0,
-            pairedObservations: newObservations.length,
-            spearmanFlagged: false,
-            seWidening: 0,
-            state: "candidate",
-          };
+      // A non-candidate placeholder for the no-fit branches: n<2 (sxx=0 →
+      // NaN) and the degenerate-variance case (fitTransfer returns null when
+      // every fromE1RM or every toE1RM is identical). Both keep the
+      // observation history accumulating while persisting a clean,
+      // non-NaN candidate fit — no transfer is learnable yet.
+      const candidatePlaceholder: TransferFit = {
+        coefficient: 0,
+        intercept: 0,
+        rSquared: 0,
+        pairedObservations: newObservations.length,
+        spearmanFlagged: false,
+        seWidening: 0,
+        state: "candidate",
+      };
+      const newFit: TransferFit =
+        (newObservations.length >= 2
+          ? fitTransfer(newObservations)
+          : null) ?? candidatePlaceholder;
       fromMap[toEx] = { observations: newObservations, fit: newFit };
       next[fromEx] = fromMap;
       rulesFired.add("transfer-regression");

--- a/supabase/functions/update-trainee-model/index_test.ts
+++ b/supabase/functions/update-trainee-model/index_test.ts
@@ -9,7 +9,8 @@
 //   deno test supabase/functions/update-trainee-model/index_test.ts
 
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { derivedTrainedSets, validateRequest } from "./index.ts";
+import { capTopSets, derivedTrainedSets, validateRequest } from "./index.ts";
+import { TOP_SET_RETENTION_COUNT } from "../_shared/constants.ts";
 
 const VALID_USER_ID = "11111111-1111-4111-8111-111111111111";
 const VALID_SESSION_ID = "22222222-2222-4222-8222-222222222222";
@@ -224,4 +225,43 @@ Deno.test("validateRequest_set_log_entry_null_returns_400", () => {
     throw new Error("expected error response");
   }
   assertEquals(result.error, "session_payload.set_logs[0] must be a JSON object");
+});
+
+// ─── #369 [12]: ExerciseProfile.topSets bounded retention (capTopSets) ───────
+// Without the cap, topSets grows by one+ append per session-apply and never
+// shrinks. capTopSets enforces ADR-0005's TOP_SET_RETENTION_COUNT, keeping the
+// most recent N (the tail, since new sets append at the end).
+
+Deno.test("capTopSets_under_count_returns_unchanged", () => {
+  // Fewer than the retention count → no truncation, same reference is fine.
+  const sets = Array.from({ length: TOP_SET_RETENTION_COUNT - 1 }, (_, i) => i);
+  assertEquals(capTopSets(sets), sets);
+});
+
+Deno.test("capTopSets_exactly_count_returns_unchanged", () => {
+  // Exactly the retention count is at the boundary, NOT over it → unchanged.
+  const sets = Array.from({ length: TOP_SET_RETENTION_COUNT }, (_, i) => i);
+  assertEquals(capTopSets(sets), sets);
+  assertEquals(capTopSets(sets).length, TOP_SET_RETENTION_COUNT);
+});
+
+Deno.test("capTopSets_over_count_keeps_newest_N_from_tail", () => {
+  // Append-order markers 0..N+4 (oldest..newest). After capping we must keep
+  // the NEWEST N — i.e. the last N markers — and drop the oldest 5.
+  const extra = 5;
+  const sets = Array.from(
+    { length: TOP_SET_RETENTION_COUNT + extra },
+    (_, i) => i,
+  );
+  const capped = capTopSets(sets);
+  assertEquals(capped.length, TOP_SET_RETENTION_COUNT);
+  // Newest N are markers [extra .. N+extra-1]; oldest `extra` are dropped.
+  const expected = Array.from(
+    { length: TOP_SET_RETENTION_COUNT },
+    (_, i) => i + extra,
+  );
+  assertEquals(capped, expected);
+  // Spot-check the ends: oldest dropped, newest retained.
+  assertEquals(capped[0], extra);
+  assertEquals(capped[capped.length - 1], TOP_SET_RETENTION_COUNT + extra - 1);
 });


### PR DESCRIPTION
Part of #369 (BUG-4, Edge Function correctness). Three confirmed findings in the Supabase Edge Functions. **Server-side Deno/TypeScript — the iOS xcodebuild does not cover these; verified with `deno test`.**

## [12] P2 — `ExerciseProfile.topSets` grew unbounded
`supabase/functions/update-trainee-model/index.ts` `applyPerExerciseRules` (~:463); constant `supabase/functions/_shared/constants.ts:46`.

`TOP_SET_RETENTION_COUNT` (10) was defined but never applied, so `topSets` grew one+ entry per session-apply forever. Fix: a pure `capTopSets` helper trims to the most recent N. New sets are appended at the **end** (their `loggedAt` is the incoming session's, which the watermark guarantees is the latest), so the newest N are the **last N** — `slice(-N)`. The capped list also feeds the EWMA input. 10 is 2× the EWMA window (5), so the cap never starves the estimate.

## [13] P2 — `fitTransfer` produced NaN on zero-variance input
`supabase/functions/_shared/transfer-regression.ts`; reachable from `applyTransfers` (`update-trainee-model/index.ts` ~:1490).

When every `fromE1RM` (or every `toE1RM`) is identical, `sxx === 0` (or `ssTot === 0`), so `coefficient = sxy/sxx` and `rSquared = 1 − ssRes/ssTot` are `0/0 = NaN` — and NaN serialises to `null` in JSONB (silent corruption). Fix: detect `sxx === 0 || ssTot === 0` and return `null` (sentinel: "no transfer learnable"). `fitTransfer`'s type is now `TransferFit | null`. `applyTransfers` treats `null` as skip-the-fit: it keeps the observation accumulating (so the pair can learn later once values differ) but persists a clean candidate placeholder instead of a NaN fit. The guard is **narrow** — only genuine zero x- or y-variance triggers it; the existing "uncorrelated pairs (Sxy=0, but x varies)" case still returns a real fit (R²=0, candidate), so legitimate weak transfers are not suppressed.

## [23] P3 — `upsertGoal` did four non-atomic writes
`supabase/functions/update-trainee-goal/index.ts` `upsertGoal` (~:220).

The four writes (goal + renegotiation re-derive, ack-append, stretch-edits, calibration-ack) ran as separate statements/transactions, leaving a partial-write window on mid-sequence failure. Fix: wrap the whole sequence in one `sql.begin(async (tx) => { ... })`; `applyGoalWrite` and `applyStretchEdits` now take the shared `tx` handle instead of opening their own `sql.begin`. The `FOR UPDATE` reads (the renegotiation re-derive read and the stretch-edit read) stay **inside** the single transaction, so the atomicity (and row-lock) is real. Every SQL statement is preserved byte-for-byte — only the transaction boundary moved.

## Verification (`deno test`, not xcodebuild)
`deno 2.7.14` was available. Pure suites run and pass:
- `supabase/functions/_shared/` — **376 passed / 0 failed** (incl. 4 new `#369 [13]` degenerate-case tests for `fitTransfer`)
- `supabase/functions/update-trainee-model/index_test.ts` — **17 passed / 0 failed** (incl. 3 new `capTopSets` retention tests)
- `supabase/functions/update-trainee-goal/index_test.ts` — **27 passed / 0 failed**

All four touched production/pure-test files `deno check` cleanly.

**Could not run:** the DB-integration tests (`orchestrator_test.ts` / `smoke_test.ts` for both functions) — they require a live local Postgres (`127.0.0.1:54322`) and Docker was not running in this environment. [23]'s atomicity is therefore verified by **code inspection**; CI runs those tests on merge. The goal `orchestrator_test.ts` has one **pre-existing** type-check error (`sql.json(partialJson)` at :83, present on `main`, in a test file not touched here) — my changes introduce no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)