### PR TITLE
fix(#369): manual sessions count toward PR baselines (#10)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,18 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — Manually-logged workouts now count toward your records (PR #379, part of #369)
+
+**Problem.** When you logged a past workout by hand, that session row was saved with no "status" value. But the code that finds your previous bests (for personal records and the "last time" line) filters sessions where `status` is not `"abandoned"` — and in a database, comparing a missing value to `"abandoned"` is itself "unknown", not "true", so those hand-logged sessions were silently skipped. Your manual entries never counted toward a PR or showed up as your last-time anchor.
+
+**What changed.** The manual-log save now writes `status: "completed"` on the session row (it always set `completed: true`, but the queries filter on `status`, not that flag). A completed session passes the "not abandoned" filter, so manual workouts now contribute to PR baselines and last-time anchors like any normal session.
+
+**How checked.** Build passed (build-exit=0). The change is a single payload field on an additive struct, so it can't affect other logic; verified by the build plus the query semantics.
+
+**Status:** merged as PR #379.
+
+---
+
 ## 2026-06-12 — Three correctness fixes in the server-side learning functions (BUG-4, part of #369)
 
 Problem: the cross-dimension audit found three bugs in the Supabase Edge Functions — the server-side code that turns a finished workout into an updated training model. (1) Each exercise keeps a list of its best recent sets ("top sets"); that list grew forever, one entry per workout, with nothing trimming it — a constant for the cap existed but was never used. (2) The transfer-learning math (how much progress on one lift predicts another) divided by zero when every recorded number was identical, producing "not a number", which silently becomes `null` when written to the database — corrupting the stored value with no error. (3) The goal-update function did four separate database writes one after another with no shared transaction, so a crash halfway through could leave the user's record half-updated.

--- a/ProjectApex/Features/Workout/ManualSessionLogView.swift
+++ b/ProjectApex/Features/Workout/ManualSessionLogView.swift
@@ -347,7 +347,8 @@ struct ManualSessionLogView: View {
                 weekNumber: week.weekNumber,
                 dayType: day.dayLabel,
                 completed: true,
-                manuallyLogged: true
+                manuallyLogged: true,
+                status: "completed"   // #369 [10] — count toward PR baselines / last-time anchors
             )
             do {
                 try await deps.supabaseClient.insert(sessionPayload, table: "workout_sessions")
@@ -760,6 +761,12 @@ private struct ManualSessionPayload: Encodable {
     let dayType: String
     let completed: Bool
     let manuallyLogged: Bool
+    /// #369 [10]: a manually-logged session is a completed session. Without an
+    /// explicit status the row is inserted with status = NULL, and the PR-baseline
+    /// / last-performance queries filter `status != "abandoned"` — under which NULL
+    /// evaluates to NULL (not true), silently excluding manual sessions from PR
+    /// baselines and last-time anchors. Setting "completed" makes them count.
+    let status: String
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -770,6 +777,7 @@ private struct ManualSessionPayload: Encodable {
         case dayType        = "day_type"
         case completed
         case manuallyLogged = "manually_logged"
+        case status
     }
 }
 


### PR DESCRIPTION
Part of #369 — finding [10]. Manually-logged sessions were inserted with no `status`, so the PR-baseline and last-performance queries (`status != "abandoned"`) silently excluded them (`NULL != 'abandoned'` is NULL, not true). Now sets `status: "completed"` on the manual payload so hand-logged workouts contribute to personal records and last-time anchors like any normal session.

Build-verified (build-exit=0); the change is a single additive payload field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)