### PR TITLE
fix(#369): onboarding offers 2-day-per-week option (O-F11)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,18 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — Two-day-a-week lifters can now onboard honestly (PR #380, part of #369)
+
+**Problem.** The onboarding "days per week" picker only offered 3, 4, 5 and 6. Someone who trains twice a week had no honest option and was forced to claim 3 — even though the program engine fully supports 2-day weeks (the phase-advance math handles down to 1 day; the macro-plan prompt builds exactly as many days as you pick) and the redesign spec explicitly lists 2 / 3 / 4 / 5+.
+
+**What changed.** Added 2 to the picker (now 2/3/4/5/6). One-line, no option removed, so nothing regresses. This is the one onboarding item from the audit that's both cheap and not throwaway — the rest of the onboarding cluster is either already handled (the answer-wiring shipped earlier in #339) or belongs to the full onboarding rebuild (#362), and one finding turned out stale (height/age are now used by the coach, so they must NOT be removed).
+
+**How checked.** Build passed (build-exit=0). Pure picker-option change — can't affect other logic.
+
+**Status:** merged as PR #380.
+
+---
+
 ## 2026-06-12 — Manually-logged workouts now count toward your records (PR #379, part of #369)
 
 **Problem.** When you logged a past workout by hand, that session row was saved with no "status" value. But the code that finds your previous bests (for personal records and the "last time" line) filters sessions where `status` is not `"abandoned"` — and in a database, comparing a missing value to `"abandoned"` is itself "unknown", not "true", so those hand-logged sessions were silently skipped. Your manual entries never counted toward a PR or showed up as your last-time anchor.

--- a/ProjectApex/Features/Onboarding/OnboardingView.swift
+++ b/ProjectApex/Features/Onboarding/OnboardingView.swift
@@ -247,7 +247,12 @@ struct OnboardingView: View {
                                 .font(.system(size: 15, weight: .semibold))
                                 .foregroundStyle(.white.opacity(0.70))
                             HStack(spacing: 10) {
-                                ForEach([3, 4, 5, 6], id: \.self) { n in
+                                // #369 / O-F11: include 2 — the engine supports 2-day weeks
+                                // (phase-advance handles daysPerWeek≥1; the macro-plan prompt
+                                // takes any integer) and the onboarding spec lists 2/3/4/5+,
+                                // but the picker previously started at 3, so 2-day-per-week
+                                // users could not onboard honestly.
+                                ForEach([2, 3, 4, 5, 6], id: \.self) { n in
                                     Button {
                                         withAnimation(.spring(response: 0.28, dampingFraction: 0.80)) {
                                             profile.daysPerWeek = n


### PR DESCRIPTION
Part of #369 — the one cheap, non-throwaway onboarding-cluster fix. The days-per-week picker offered only 3/4/5/6, so a 2-day-per-week lifter couldn't onboard honestly — yet the engine supports 2-day weeks (phase-advance handles `daysPerWeek>=1`; the macro-plan prompt builds exactly `training_days_per_week` days) and the onboarding spec lists 2/3/4/5+. Adds 2 (now 2/3/4/5/6); no option removed.

The rest of the onboarding cluster is deferred to the #362 rebuild: O-F9 (notif timing) needs a replacement request point, O-F12 (goal/name ordering) is rebuild UX, durable mid-flow state shipped its cheap parts in #339, and O-F11's 'remove height/age' is now stale — those fields ARE consumed by the inference prompt, so removing them would regress weight calibration.

Build-verified (build-exit=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)