### PR TITLE
feat(#369): repoint resolvedUserId to auth.uid(); onboarding writes users.id = auth.uid() (auth slice 3)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,18 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — The app now uses your real login identity instead of a stand-in (auth slice 3, part of #369)
+
+**Problem.** Until now every install used the same hardcoded placeholder id (`…0001`) or a random one minted at onboarding to tag all your data. Earlier in this auth work (slice 1) the app started quietly logging itself in anonymously at launch, which gives it a real, stable identity — but nothing was using that identity yet. For the upcoming security lock (slice 5, which will only let you read rows that are tagged with *your* id), the data has to be keyed to that real login id, not the placeholder.
+
+**What changed.** Two things. (1) The single place the app asks "who am I?" now answers with the real anonymous-login id (read instantly from where slice 1 saved it), falling back to the old placeholder only in the brief moment on a brand-new install before the background login finishes — that fallback is safe right now because the security lock is still off, and it goes away for good once slice 5 lands. (2) Onboarding now writes your user row tagged with that real login id (and skips writing the row entirely if the login somehow hasn't finished yet, rather than saving a row under the placeholder that the security lock would later orphan). Pulled the "who am I?" logic into a small, separately-testable helper so the priority order is pinned down by unit tests.
+
+**How checked.** Build passed (build-exit=0). Added six unit tests for the identity helper (real id wins over the placeholder and over the older mirror; placeholder only when nothing else exists; onboarding refuses to write under the placeholder) — all pass. Full suite: 561 run, 10 skipped (the live-API tests, off by default), 1 failure — and that one is the known network-timeout flake unrelated to this change; it passed on its own when re-run. Did NOT turn on the security lock or touch any server functions or migrations — that's later slices.
+
+**Status:** opened as PR (see below); NOT merged, awaiting review.
+
+---
+
 ## 2026-06-12 — Two-day-a-week lifters can now onboard honestly (PR #380, part of #369)
 
 **Problem.** The onboarding "days per week" picker only offered 3, 4, 5 and 6. Someone who trains twice a week had no honest option and was forced to claim 3 — even though the program engine fully supports 2-day weeks (the phase-advance math handles down to 1 day; the macro-plan prompt builds exactly as many days as you pick) and the redesign spec explicitly lists 2 / 3 / 4 / 5+.

--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -62,16 +62,18 @@ final class AppDependencies {
     /// Matches the hardcoded UUID used in WorkoutSessionManager for session creation.
     static let placeholderUserId = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
 
-    /// Returns the user UUID stored in Keychain if available, falling back to
-    /// the MVP placeholder. Use this for all Supabase writes and AI calls so
-    /// that real user IDs flow through automatically once onboarding has run.
+    /// The app's user identity for all Supabase writes and AI calls. As of #369
+    /// slice 3 this is the anonymous-auth `auth.uid()` slice 1 persists to
+    /// `.supabaseAuthUserId`, read synchronously so this stays a sync property.
+    ///
+    /// First-launch race: on a fresh install the async anon sign-in may not have
+    /// completed the first time this is read, so the resolver falls back to the
+    /// `.userId` onboarding mirror and finally the placeholder. That fallback is
+    /// safe THIS slice only because RLS is still off (placeholder-keyed reads
+    /// work); it goes vestigial once RLS lands (slice 5) + slice 1's readiness
+    /// gate guarantees a session before any RLS-gated read. See `UserIdentityResolver`.
     var resolvedUserId: UUID {
-        if let stored = try? keychainService.retrieve(.userId),
-           !stored.isEmpty,
-           let uuid = UUID(uuidString: stored) {
-            return uuid
-        }
-        return Self.placeholderUserId
+        UserIdentityResolver.resolve(keychain: keychainService, placeholder: Self.placeholderUserId)
     }
 
     // MARK: Private: Stored Anthropic key for re-init

--- a/ProjectApex/App/UserIdentityResolver.swift
+++ b/ProjectApex/App/UserIdentityResolver.swift
@@ -1,0 +1,55 @@
+// UserIdentityResolver.swift
+// ProjectApex — App Layer
+//
+// #369 auth slice 3. Pure (Keychain-injectable) resolution of the app's user
+// identity. Extracted from `AppDependencies.resolvedUserId` and the onboarding
+// user-insert so the precedence is deterministically testable with a scoped
+// `KeychainService` (the `GenerationUserProfile.assemble` extraction precedent).
+//
+// THE REPOINT (slice 3): the app's identity is now the anonymous-auth
+// `auth.uid()` established by slice 1, read synchronously from the persisted
+// `.supabaseAuthUserId` Keychain entry. RLS is STILL OFF this slice, so the
+// transitional fallback below is safe — old placeholder-keyed data still reads.
+
+import Foundation
+
+enum UserIdentityResolver {
+
+    /// Resolves the user UUID for all Supabase writes and AI calls, in priority
+    /// order:
+    ///
+    ///   1. `.supabaseAuthUserId` — the anonymous-auth `auth.uid()` slice 1
+    ///      persists once a session is established. This is the identity slice 5's
+    ///      `users` RLS policy (`id = auth.uid()`) will match.
+    ///   2. `.userId` — the onboarding mirror. Kept as a secondary so an install
+    ///      that minted a `.userId` before slice 1 (or before its session has
+    ///      restored mid-launch) keeps reading its existing id rather than the
+    ///      placeholder. Onboarding now writes `auth.uid()` here too, so the two
+    ///      keys converge for fresh installs.
+    ///   3. `placeholderUserId` — the TRANSITIONAL first-launch fallback. On a
+    ///      fresh install the async anon sign-in may not have completed the first
+    ///      time this is read; the placeholder keeps reads working in that window.
+    ///      This is safe ONLY because RLS is off this slice (the fallback reads
+    ///      succeed). It becomes vestigial once RLS lands (slice 5) + slice 1's
+    ///      readiness gate guarantees a session before any RLS-gated read.
+    static func resolve(keychain: KeychainService, placeholder: UUID) -> UUID {
+        if let authUid = nonEmptyUUID(keychain, .supabaseAuthUserId) { return authUid }
+        if let mirrored = nonEmptyUUID(keychain, .userId) { return mirrored }
+        return placeholder
+    }
+
+    /// The id onboarding writes to the `public.users` row (and the `.userId`
+    /// mirror): the resolved identity ONLY when it is the real auth uid. Returns
+    /// `nil` when no auth session has resolved yet — the caller must then skip the
+    /// `users` insert rather than persist a placeholder-keyed row that slice 5's
+    /// RLS policy would later orphan.
+    static func onboardingUserId(keychain: KeychainService, placeholder: UUID) -> UUID? {
+        let resolved = resolve(keychain: keychain, placeholder: placeholder)
+        return resolved == placeholder ? nil : resolved
+    }
+
+    private static func nonEmptyUUID(_ keychain: KeychainService, _ key: KeychainKey) -> UUID? {
+        guard let stored = (try? keychain.retrieve(key)) ?? nil, !stored.isEmpty else { return nil }
+        return UUID(uuidString: stored)
+    }
+}

--- a/ProjectApex/Features/Onboarding/OnboardingView.swift
+++ b/ProjectApex/Features/Onboarding/OnboardingView.swift
@@ -14,8 +14,11 @@
 //   6 — Ready confirmation         → dismisses to Program tab
 //
 // First-run detection: KeychainService.retrieve(.userId) == nil
-// On completion: UUID written to Keychain.userId; onboardingCompleted stored
-// in UserDefaults so subsequent launches skip this view immediately.
+// On completion (#369 slice 3): the anonymous-auth `auth.uid()` is written to
+// Keychain.userId (mirroring the auth subject, not a fresh UUID()); the
+// public.users row is keyed to that same uid so slice 5's RLS policy matches.
+// onboardingCompleted is stored in UserDefaults so subsequent launches skip
+// this view immediately.
 
 import SwiftUI
 import UserNotifications
@@ -922,29 +925,29 @@ struct OnboardingView: View {
     /// without a Supabase round-trip during active sessions (FB-003).
     private func persistUserIfNeeded() async {
         let keychain = deps.keychainService
-        // If userId is already stored, nothing to do for the Keychain+Supabase write —
-        // but still persist any updated biometrics to UserDefaults.
-        let isNewUser: Bool
-        if let existing = try? keychain.retrieve(.userId), !existing.isEmpty {
-            isNewUser = false
-        } else {
-            isNewUser = true
-        }
 
-        let userId: UUID
-        if isNewUser {
-            userId = UUID()
-            try? keychain.store(userId.uuidString, for: .userId)
-        } else {
-            userId = deps.resolvedUserId
-        }
-
-        // Persist biometrics to UserDefaults for fast in-session access.
+        // Persist biometrics to UserDefaults for fast in-session access. These are
+        // not identity-keyed, so they are written regardless of session state.
         UserDefaults.standard.set(profile.bodyweightKg, forKey: UserProfileConstants.bodyweightKgKey)
         UserDefaults.standard.set(profile.heightCm, forKey: UserProfileConstants.heightCmKey)
         UserDefaults.standard.set(profile.age, forKey: UserProfileConstants.ageKey)
         UserDefaults.standard.set(profile.trainingAge.rawValue, forKey: UserProfileConstants.trainingAgeKey)
         UserDefaults.standard.set(profile.primaryGoal.rawValue, forKey: UserProfileConstants.primaryGoalKey)
+
+        // #369 slice 3: the `users` row's id MUST be the anonymous-auth
+        // `auth.uid()` so slice 5's RLS policy (`id = auth.uid()`) will match.
+        // The session is established at launch (slice 1); onboarding runs after,
+        // so await the slice-1 readiness to make sure the uid has resolved before
+        // we read it. If it still hasn't (sign-in failed/timed out), skip the
+        // insert and the `.userId` mirror — do NOT write a placeholder-keyed row
+        // that slice 5's RLS would orphan; the next onboarding run retries.
+        _ = await deps.supabaseAuth.awaitFirstResolution()
+        guard let userId = UserIdentityResolver.onboardingUserId(
+            keychain: keychain,
+            placeholder: AppDependencies.placeholderUserId
+        ) else { return }
+        // Mirror the auth uid into `.userId` (first-run signal + secondary read).
+        try? keychain.store(userId.uuidString, for: .userId)
 
         // Best-effort upsert into users table — failure is non-fatal for onboarding.
         let nameStr = profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/ProjectApex/Security/KeychainService.swift
+++ b/ProjectApex/Security/KeychainService.swift
@@ -44,8 +44,9 @@ enum KeychainKey: String, CaseIterable {
     case supabaseRefreshToken = "com.projectapex.keychain.supabaseRefreshToken"
     /// Access-token expiry as a Unix-epoch seconds string (e.g. "1718200000").
     case supabaseSessionExpiry = "com.projectapex.keychain.supabaseSessionExpiry"
-    /// The GoTrue `user.id` (UUID string) of the authenticated session. This is
-    /// the auth subject; it is NOT yet wired to `resolvedUserId` (later slice).
+    /// The GoTrue `user.id` (UUID string) of the authenticated session — the
+    /// `auth.uid()`. As of #369 slice 3 this is the primary source for
+    /// `AppDependencies.resolvedUserId` (the app's user identity).
     case supabaseAuthUserId   = "com.projectapex.keychain.supabaseAuthUserId"
 }
 

--- a/ProjectApexTests/SupabaseAuthTests.swift
+++ b/ProjectApexTests/SupabaseAuthTests.swift
@@ -360,3 +360,112 @@ final class HangingURLProtocol: URLProtocol {
     override func startLoading() { /* intentionally never finishes */ }
     override func stopLoading() {}
 }
+
+// MARK: - UserIdentityResolver (#369 slice 3: repoint resolvedUserId to auth.uid())
+
+/// Locks the identity-resolution precedence that `AppDependencies.resolvedUserId`
+/// and onboarding's user-insert both delegate to. Uses a per-test scoped
+/// `KeychainService` so the Keychain state is injected deterministically.
+final class UserIdentityResolverTests: XCTestCase {
+
+    private let placeholder = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+
+    private func makeScopedKeychain() -> KeychainService {
+        KeychainService(serviceName: "com.projectapex.tests.identity.\(UUID().uuidString)")
+    }
+
+    private func clearIdentityKeys(_ keychain: KeychainService) {
+        try? keychain.delete(.supabaseAuthUserId)
+        try? keychain.delete(.userId)
+    }
+
+    // MARK: resolve — auth uid is the primary source
+
+    func test_resolve_returnsAuthUid_whenSessionExists() throws {
+        let keychain = makeScopedKeychain()
+        clearIdentityKeys(keychain)
+        let authUid = UUID()
+        try keychain.store(authUid.uuidString, for: .supabaseAuthUserId)
+
+        let resolved = UserIdentityResolver.resolve(keychain: keychain, placeholder: placeholder)
+
+        XCTAssertEqual(resolved, authUid,
+            "resolvedUserId must be the persisted auth.uid() when a session exists")
+        clearIdentityKeys(keychain)
+    }
+
+    func test_resolve_authUid_winsOverUserIdMirror() throws {
+        let keychain = makeScopedKeychain()
+        clearIdentityKeys(keychain)
+        let authUid = UUID()
+        let mirrored = UUID()
+        try keychain.store(authUid.uuidString, for: .supabaseAuthUserId)
+        try keychain.store(mirrored.uuidString, for: .userId)
+
+        let resolved = UserIdentityResolver.resolve(keychain: keychain, placeholder: placeholder)
+
+        XCTAssertEqual(resolved, authUid,
+            "the auth uid takes precedence over the .userId mirror")
+        clearIdentityKeys(keychain)
+    }
+
+    // MARK: resolve — first-launch fallback
+
+    func test_resolve_fallsBackToPlaceholder_whenNoSessionAndNoMirror() {
+        let keychain = makeScopedKeychain()
+        clearIdentityKeys(keychain)
+
+        let resolved = UserIdentityResolver.resolve(keychain: keychain, placeholder: placeholder)
+
+        XCTAssertEqual(resolved, placeholder,
+            "with no auth uid and no .userId, the transitional placeholder is the fallback")
+        clearIdentityKeys(keychain)
+    }
+
+    func test_resolve_fallsBackToUserIdMirror_whenNoAuthUidYet() throws {
+        // A pre-slice-1 install (or mid-launch before the session restores) that
+        // already minted a .userId keeps reading it rather than the placeholder.
+        let keychain = makeScopedKeychain()
+        clearIdentityKeys(keychain)
+        let mirrored = UUID()
+        try keychain.store(mirrored.uuidString, for: .userId)
+
+        let resolved = UserIdentityResolver.resolve(keychain: keychain, placeholder: placeholder)
+
+        XCTAssertEqual(resolved, mirrored,
+            "with no auth uid but an existing .userId, the mirror is the fallback (not placeholder)")
+        clearIdentityKeys(keychain)
+    }
+
+    // MARK: onboardingUserId — never the placeholder
+
+    func test_onboardingUserId_isAuthUid_whenSessionExists() throws {
+        let keychain = makeScopedKeychain()
+        clearIdentityKeys(keychain)
+        let authUid = UUID()
+        try keychain.store(authUid.uuidString, for: .supabaseAuthUserId)
+
+        let onboardingId = UserIdentityResolver.onboardingUserId(
+            keychain: keychain, placeholder: placeholder
+        )
+
+        XCTAssertEqual(onboardingId, authUid,
+            "onboarding writes users.id = auth.uid() so slice 5's RLS policy matches")
+        clearIdentityKeys(keychain)
+    }
+
+    func test_onboardingUserId_isNil_whenNoSessionYet() {
+        // The guard that prevents writing a placeholder-keyed users row: with no
+        // resolved identity, onboarding must skip the insert (returns nil).
+        let keychain = makeScopedKeychain()
+        clearIdentityKeys(keychain)
+
+        let onboardingId = UserIdentityResolver.onboardingUserId(
+            keychain: keychain, placeholder: placeholder
+        )
+
+        XCTAssertNil(onboardingId,
+            "no auth session yet → onboarding must NOT write a placeholder-keyed users row")
+        clearIdentityKeys(keychain)
+    }
+}


### PR DESCRIPTION
Part of #369 — auth/RLS workstream slice 3 of 6. Repoints user identity to the anonymous auth.uid(); onboarding writes users.id = auth.uid() so slice 5's RLS users policy matches. RLS still OFF this slice (old data still reads; safe to ship alone). Transitional placeholder fallback for the first-launch window (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)