### PR TITLE
feat(#342): snapshot/visual-test harness + geometry/token tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
 
       - name: Build & Test
         # APEX_INTEGRATION_TESTS is intentionally absent — live-API tests are skipped.
+        # The testplan no longer sets it either (it used to set =1 in defaultOptions,
+        # which contradicted this comment and silently un-gated the live-API tests in
+        # the -testPlan run); reconciled in #342. Same applies to APEX_SNAPSHOT_TESTS:
+        # absent here, so the image-snapshot suite stays gated off in the mandatory CI
+        # path. References are recorded by a separate record-mode job on Xcode 26.3.
         run: |
           xcodebuild test \
             -project ProjectApex.xcodeproj \

--- a/DIARY.md
+++ b/DIARY.md
@@ -19,6 +19,22 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — A camera for the hand-drawn charts (PR, part of #342)
+
+**Problem.** The redesign draws its charts and gauges by hand, pixel by pixel — a 2px "floor" line that has to read heavier than a 1px "stretch" line, solid dots for real data versus hollow dots for guesses, dashed lines for predictions. None of that shows up when you read the code; you only see if it's wrong by looking at the picture. Until now the app had no way to take a picture of a chart and notice when it changes.
+
+**What changed.** Two things. First, a set of cheap, fast checks that read the exact numbers behind the drawings — that the floor line really is 2px and the stretch line really is 1px, that the prediction dash is the 4-2 pattern, that the spacing scale is 4/8/16/24/32/48, that the "work is dark ink, time is light pencil" colour split always holds. These run on every push and need no saved pictures. Second, the camera itself: a small harness (built on a well-known open-source tool, swift-snapshot-testing — our very first outside dependency, pinned to one exact version) that photographs a component and compares it to a saved reference, failing if anything drifts. The worked example photographs the whole token gallery in light and dim, at normal and largest text sizes.
+
+**One deliberate gap.** The reference photos are NOT recorded yet — on purpose. My machine runs a slightly newer Xcode than the build server, and a photo taken on the wrong toolchain would bake in the wrong fonts and subtly-off colours, poisoning every later comparison. So the camera is wired up but parked: the photo tests are switched off by default (behind a `APEX_SNAPSHOT_TESTS` flag) and a human/CI step on the pinned Xcode must take the first reference photos. The fast number-checks run regardless.
+
+**Also fixed a quiet contradiction.** The test plan secretly forced the "run the expensive live-API tests" flag on, while a comment in the build server config claimed it was off. Removed the flag from the test plan so the comment is finally true — the live-API tests are genuinely opt-in now.
+
+**How checked.** The fast geometry/number suite builds and passes; the outside dependency resolves and links (the whole app + tests compile against it). The photo suite is intentionally reference-pending and stays off.
+
+**Status:** open PR, part of #342 (not closed — recording the reference photos and signing off on how they look is still to come).
+
+---
+
 ## 2026-06-12 — Two-day-a-week lifters can now onboard honestly (PR #380, part of #369)
 
 **Problem.** The onboarding "days per week" picker only offered 3, 4, 5 and 6. Someone who trains twice a week had no honest option and was forced to claim 3 — even though the program engine fully supports 2-day weeks (the phase-advance math handles down to 1 day; the macro-plan prompt builds exactly as many days as you pick) and the redesign spec explicitly lists 2 / 3 / 4 / 5+.

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -58,6 +58,9 @@
 		DE51900000000000DE519002 /* DesignSystemTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE51900000000000DE519001 /* DesignSystemTokensTests.swift */; };
 		A1C0F19329000000APIKEY04 /* BundledKeyResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F19329000000APIKEY03 /* BundledKeyResolutionTests.swift */; };
 		5A30343A0000000000FE5102 /* AppShellRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A30343A0000000000FE5101 /* AppShellRouteTests.swift */; };
+		DE52000000000000DE520002 /* DesignSystemGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */; };
+		DE53000000000000DE530002 /* DrawnInstrumentSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */; };
+		DE54000000000000DE540002 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = DE54000000000000DE540001 /* SnapshotTesting */; };
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
 		C0D12694855E73899CCFE137 /* TraineeModelDigestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEB429BB2AB6D155566038C /* TraineeModelDigestTests.swift */; };
@@ -125,6 +128,8 @@
 		22000000000000000000F012 /* PromptLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptLoaderTests.swift; sourceTree = "<group>"; };
 		DE51900000000000DE519001 /* DesignSystemTokensTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DesignSystemTokensTests.swift; sourceTree = "<group>"; };
 		5A30343A0000000000FE5101 /* AppShellRouteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppShellRouteTests.swift; sourceTree = "<group>"; };
+		DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DesignSystemGeometryTests.swift; sourceTree = "<group>"; };
+		DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DrawnInstrumentSnapshotTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
 		DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetPrescriptionIntentValidationTests.swift; sourceTree = "<group>"; };
 		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
@@ -164,6 +169,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6ED5B7636B15C7C513C11C2E /* Foundation.framework in Frameworks */,
+				DE54000000000000DE540002 /* SnapshotTesting in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -268,6 +274,8 @@
 				DE51900000000000DE519001 /* DesignSystemTokensTests.swift */,
 				A1C0F19329000000APIKEY03 /* BundledKeyResolutionTests.swift */,
 				5A30343A0000000000FE5101 /* AppShellRouteTests.swift */,
+				DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */,
+				DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -289,6 +297,9 @@
 				79B86F7D6F8F83A54328459B /* PBXTargetDependency */,
 			);
 			name = ProjectApexTests;
+			packageProductDependencies = (
+				DE54000000000000DE540001 /* SnapshotTesting */,
+			);
 			productName = ProjectApexTests;
 			productReference = EFB324F8EA1B317B0F90575B /* ProjectApexTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -337,6 +348,9 @@
 			);
 			mainGroup = 47D91BB72F60266A007B3B34;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				DE55000000000000DE550001 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 47D91BC12F60266A007B3B34 /* Products */;
 			projectDirPath = "";
@@ -427,6 +441,8 @@
 				DE51900000000000DE519002 /* DesignSystemTokensTests.swift in Sources */,
 				A1C0F19329000000APIKEY04 /* BundledKeyResolutionTests.swift in Sources */,
 				5A30343A0000000000FE5102 /* AppShellRouteTests.swift in Sources */,
+				DE52000000000000DE520002 /* DesignSystemGeometryTests.swift in Sources */,
+				DE53000000000000DE530002 /* DrawnInstrumentSnapshotTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -698,6 +714,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		DE55000000000000DE550001 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
+			requirement = {
+				kind = exactVersion;
+				version = 1.18.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		DE54000000000000DE540001 /* SnapshotTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DE55000000000000DE550001 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
+			productName = SnapshotTesting;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 47D91BB82F60266A007B3B34 /* Project object */;
 }

--- a/ProjectApex.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ProjectApex.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "09b08963887ce6eac26952e8acb25256a8ec102f2b5528ae68a97fa296723712",
+  "pins" : [
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "b9b59eb58c946236d6f16305c576ad194c36444e",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "0a670ab9d821442e5978526690da1a370537e5eb",
+        "version" : "1.18.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "cb281f343fd953280336dcbd3822cdf47c182f5b",
+        "version" : "1.10.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ProjectApex.xctestplan
+++ b/ProjectApex.xctestplan
@@ -9,13 +9,7 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
-    "environmentVariableEntries" : [
-      {
-        "key" : "APEX_INTEGRATION_TESTS",
-        "value" : "1"
-      }
-    ]
+    "codeCoverage" : false
   },
   "testTargets" : [
     {

--- a/ProjectApexTests/DesignSystemGeometryTests.swift
+++ b/ProjectApexTests/DesignSystemGeometryTests.swift
@@ -1,0 +1,141 @@
+// DesignSystemGeometryTests.swift
+// ProjectApexTests
+//
+// The non-image layer of the snapshot/visual-regression harness (#342 / ADR-0025).
+// A pixel test proves an instrument is correct at exactly one Dynamic-Type size and
+// one appearance; these cheap deterministic `@Test` assertions prove the *geometric*
+// and *token-precise* honesty invariants that DESIGN.md encodes — the part of the
+// drawn instruments that is invisible in code review and that the image references
+// can only spot-check.
+//
+// This file deliberately needs NO reference PNGs and NO `swift-snapshot-testing`
+// dependency: it runs in the mandatory `xcodebuild test -scheme ProjectApex` path,
+// ungated, on every push. (The image layer lives in DrawnInstrumentSnapshotTests
+// behind APEX_SNAPSHOT_TESTS.)
+//
+// Covers the shared instrument geometry (DesignGeometry), the spacing/shape/
+// elevation scales (Spacing/Radius/Elevation), the motion durations and the
+// Reduce-Motion crossfade law (Motion), and the InkPencil two-tone work-is-ink /
+// time-is-pencil split. The colour/type token fixtures already live in
+// DesignSystemTokensTests; this file is the geometry sibling, not a duplicate.
+
+import Testing
+import SwiftUI
+@testable import ProjectApex
+
+@Suite("DesignSystem geometry & instrument constants")
+struct DesignSystemGeometryTests {
+
+    // MARK: - Drawn-instrument geometry (DESIGN.md §Data visualization)
+
+    @Test("Tick weights carry the floor-vs-stretch honesty: floor is 2px, stretch is 1px hairline")
+    func tickWeights() {
+        // The whole point of the floor/stretch distinction: the floor (a hard,
+        // earned boundary) reads heavier than the stretch (aspirational, hairline).
+        #expect(DesignGeometry.floorTick == 2)
+        #expect(DesignGeometry.stretchTick == 1)
+        #expect(DesignGeometry.floorTick > DesignGeometry.stretchTick)
+    }
+
+    @Test("Series stroke width is 2pt (series-primary / series-compare)")
+    func seriesLineWidth() {
+        #expect(DesignGeometry.seriesLineWidth == 2)
+    }
+
+    @Test("Projection is dashed 4-2 — anything projected / estimated is dashed, never solid")
+    func projectionDash() {
+        #expect(DesignGeometry.projectionDash == [4, 2])
+        // A solid line is the absence of a dash; the projection pattern must be a
+        // real two-element dash so a projected segment can never render as measured.
+        #expect(DesignGeometry.projectionDash.count == 2)
+        #expect(DesignGeometry.projectionDash.allSatisfy { $0 > 0 })
+    }
+
+    @Test("List-scale reduction dot is 5pt (Progress rows, no bracket)")
+    func listScaleDot() {
+        #expect(DesignGeometry.listScaleDot == 5)
+    }
+
+    // MARK: - Spacing scale (DESIGN.md §spacing)
+
+    @Test("Spacing is a strictly increasing 4-8-16-24-32-48 scale")
+    func spacingScale() {
+        let scale = [Spacing.xs, Spacing.sm, Spacing.md, Spacing.lg, Spacing.xl, Spacing.xxl]
+        #expect(scale == [4, 8, 16, 24, 32, 48])
+        #expect(scale == scale.sorted())
+        // Strictly increasing — no two steps collapse to the same value.
+        #expect(Set(scale).count == scale.count)
+    }
+
+    // MARK: - Corner radii (DESIGN.md §rounded)
+
+    @Test("Radii are the locked 8/16/24 scale with a pill sentinel")
+    func radiusScale() {
+        #expect(Radius.sm == 8)
+        #expect(Radius.md == 16)
+        #expect(Radius.lg == 24)
+        // The pill radius is a large sentinel that fully rounds any reasonable height.
+        #expect(Radius.pill == 999)
+        #expect(Radius.sm < Radius.md && Radius.md < Radius.lg && Radius.lg < Radius.pill)
+    }
+
+    // MARK: - Elevation (DESIGN.md §elevation.card)
+
+    @Test("Card elevation: 6% ink shadow, radius 6 (blur12), offset (0, 2)")
+    func cardElevation() {
+        // blur12 → SwiftUI shadow radius ≈ blur/2 = 6.
+        #expect(Elevation.cardRadius == 6)
+        #expect(Elevation.cardX == 0)
+        #expect(Elevation.cardY == 2)
+        // The shadow ink is the page ink at 6% — a whisper, not a drop shadow.
+        #expect(Elevation.cardColor.opacity == 0.06)
+        #expect(Elevation.cardColor == TokenColor(0x14151A, opacity: 0.06))
+    }
+
+    // MARK: - Motion durations + the Reduce-Motion law (DESIGN.md §Motion)
+
+    @Test("Reduce-Motion crossfade is the 150ms easeInOut every expressive transition collapses to")
+    func reduceMotionCrossfade() {
+        // The contract asserted byte-identically in the snapshot layer ("frame-1 ==
+        // end-state, Reduce Motion is a 150ms crossfade to the same destination")
+        // is grounded by this duration existing and matching the routine-nav tempo.
+        #expect(Motion.reduceMotionCrossfade == Animation.easeInOut(duration: 0.15))
+    }
+
+    @Test("Routine nav is the 150ms 'feels like nothing' tempo; expressive bookends are slower springs")
+    func motionTempos() {
+        // Workhorse transitions are fast easings; the ≤4 expressive bookends are springs.
+        #expect(Motion.nav == Animation.easeOut(duration: 0.15))
+        #expect(Motion.logSettle == Animation.easeOut(duration: 0.2))
+        #expect(Motion.cardMorph == Animation.easeInOut(duration: 0.35))
+        // The spring bookends are distinct from the workhorse easings.
+        #expect(Motion.bookend != Motion.nav)
+        #expect(Motion.celebrateRatchet != Motion.nav)
+    }
+
+    // MARK: - InkPencil two-tone (DESIGN.md system law: work is ink, time is pencil)
+
+    @Test("InkPencil.run splits ink (work) from pencil (time/plan) — the colours differ")
+    func inkPencilTwoTone() {
+        // The contract is colour, not text: the ink segment renders in `ink`, the
+        // pencil segment in `ink-muted`. In both appearances those roles are distinct,
+        // so the two-tone split is always visible.
+        for theme in [Theme.light, Theme.dim] {
+            #expect(theme.ink != theme.inkMuted)
+        }
+    }
+
+    @Test("actualVersusPlan threads the plan into the pencil segment with the ' · plan ' separator")
+    func inkPencilActualVersusPlan() {
+        // Done work (actual) is the most-true data → ink; the plan it diverged from is
+        // pencil. The helper builds a single two-tone run whose visible string is
+        // actual + " · plan " + plan. `Text` isn't structurally Equatable (and its
+        // debug description embeds an unstable storage pointer), so we assert on the
+        // visible composed string the description carries — the load-bearing contract
+        // is the " · plan " separator threading the plan onto the actual; the ink/pencil
+        // colour split itself is pinned visually in the token-gallery snapshot.
+        let theme = Theme.light
+        let composed = InkPencil.actualVersusPlan(actual: "100 kg × 6", plan: "5", theme: theme)
+        #expect(String(describing: composed).contains("100 kg × 6 · plan 5"))
+    }
+}

--- a/ProjectApexTests/DrawnInstrumentSnapshotTests.swift
+++ b/ProjectApexTests/DrawnInstrumentSnapshotTests.swift
@@ -1,0 +1,240 @@
+// DrawnInstrumentSnapshotTests.swift
+// ProjectApexTests
+//
+// The image layer of the snapshot/visual-regression harness (#342 / ADR-0025).
+// pointfreeco/swift-snapshot-testing drives one rendering route — a UIHostingController
+// captured with `.image(...)` — over the rebuild's drawn instruments. This proves
+// holistic layout + token/hue rendering that the geometry assertions
+// (DesignSystemGeometryTests) can't see: that the band fill is the right ink at the
+// right opacity, that hollow-vs-solid dots read apart, that a wrong colour fails.
+//
+// ────────────────────────────────────────────────────────────────────────────────
+// REFERENCE IMAGES ARE NOT YET RECORDED — BY DESIGN. See "Recording references".
+// On a developer machine (Xcode 26.5) this suite is gated OFF (APEX_SNAPSHOT_TESTS
+// unset) so it neither records nor compares. References must be recorded by ONE
+// owner on the CI-pinned toolchain (Xcode 26.3) — recording them on a skewed local
+// toolchain poisons every later instrument slice with San-Francisco / sub-pixel
+// drift. Until that CI record job runs, the `assertSnapshot` cases are
+// reference-pending: enabling the gate WITHOUT references will *fail* (missing
+// reference), which is the correct "not yet ratified" signal, not a false green.
+// ────────────────────────────────────────────────────────────────────────────────
+//
+// Two things in this file run UNGATED, on every push, because they protect the
+// references rather than depend on them:
+//   • `fontPrecondition` — asserts both embedded faces resolve by PostScript name.
+//     If they don't, any recorded reference silently encodes San Francisco.
+//   • the hue-swap negative test lives in the gated suite (it needs the pixel
+//     engine) but documents the tolerance contract.
+//
+// Recording references (HUMAN / CI step — do NOT do this locally on 26.5):
+//   1. A CI "record mode" job selects Xcode 26.3 (the same pin as ci.yml's test job).
+//   2. It runs this suite with BOTH env vars set:
+//        APEX_SNAPSHOT_TESTS=1   (un-gates the suite)
+//        APEX_RECORD_SNAPSHOTS=1 (flips record mode → writes PNGs, fails the run)
+//      e.g.  xcodebuild test -project ProjectApex.xcodeproj -scheme ProjectApex \
+//              -only-testing:ProjectApexTests/DrawnInstrumentSnapshotTests \
+//              -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' \
+//              APEX_SNAPSHOT_TESTS=1 APEX_RECORD_SNAPSHOTS=1
+//   3. The job commits the generated `__Snapshots__/` PNGs. record-mode runs ALWAYS
+//      fail (snapshot-testing's contract), which is the CI guard that record mode is
+//      never left on in the compare job: the compare job sets only APEX_SNAPSHOT_TESTS=1.
+
+import Testing
+import SwiftUI
+import SnapshotTesting
+@testable import ProjectApex
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+// MARK: - Gating
+
+/// The image suite is opt-in via `APEX_SNAPSHOT_TESTS=1`, mirroring
+/// `APEX_INTEGRATION_TESTS`. It is OFF in the default scheme so a font-render nudge
+/// can't be auto-merged-past on the mandatory path (ADR-0025 §Gating); it reuses the
+/// existing pinned scheme so it can't silently rot.
+private var snapshotTestsEnabled: Bool {
+    ProcessInfo.processInfo.environment["APEX_SNAPSHOT_TESTS"] == "1"
+}
+
+/// Record mode is a SEPARATE opt-in, set only by the CI record job. The `SnapshotTesting`
+/// 1.18 API takes record mode through the `record:` argument on `assertSnapshot`; we
+/// thread this flag in so a stray local run never rewrites references.
+private var recordModeEnabled: Bool {
+    ProcessInfo.processInfo.environment["APEX_RECORD_SNAPSHOTS"] == "1"
+}
+
+// MARK: - The reusable harness pattern
+
+/// The one rendering route (ADR-0025: UIHostingController, never `ImageRenderer`) plus
+/// the "renders assembled at frame 1" guarantee. Every later drawn-instrument slice
+/// calls this — it is the reusable pattern the issue asks for.
+///
+/// "Frame-1 == end-state" is achieved *structurally*: each instrument is an
+/// animation-free, value-driven View whose entrance lives in a separate wrapper, so
+/// the bare instrument has no entrance to scrub. We additionally disable Core Animation
+/// actions so no implicit animation can leak a partial frame into the capture.
+@MainActor
+enum SnapshotHarness {
+
+    /// A fixed per-instrument canvas — never a full screen — so each reference is
+    /// isolated from the parallel shell churn (ADR-0025: the single biggest flake win).
+    static func host<V: View>(_ view: V, size: CGSize, appearance: Appearance,
+                              dynamicType: DynamicTypeSize = .large) -> UIViewController {
+        #if canImport(UIKit)
+        let rooted = view
+            .environment(\.apexTheme, Theme.current(appearance))
+            .environment(\.dynamicTypeSize, dynamicType)
+            .frame(width: size.width, height: size.height)
+        let host = UIHostingController(rootView: rooted)
+        host.view.frame = CGRect(origin: .zero, size: size)
+        host.view.backgroundColor = Theme.current(appearance).paper.uiColor
+        // Lay out once, synchronously — the end-state, no RunLoop spin.
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        return host
+        #else
+        return UIViewController()
+        #endif
+    }
+
+    #if canImport(UIKit)
+    /// `.image` config carrying the ADR-0025 determinism tolerances: never 1.0, so
+    /// sub-pixel AA jitter is absorbed while a wrong ink still fails.
+    static let imaging: Snapshotting<UIViewController, UIImage> = .image(
+        on: .iPhone17Pro,
+        precision: 0.99,
+        perceptualPrecision: 0.98
+    )
+    #endif
+}
+
+#if canImport(UIKit)
+private extension TokenColor {
+    var uiColor: UIColor {
+        UIColor(red: red, green: green, blue: blue, alpha: opacity)
+    }
+}
+
+/// Pin the capture device so the reference is independent of the run-time simulator
+/// chrome. iPhone 17 Pro is the CI-pinned destination (ci.yml). We fix only the size
+/// here — the per-instrument canvas overrides it — but the trait set is the device's.
+private extension ViewImageConfig {
+    static let iPhone17Pro = ViewImageConfig(
+        safeArea: .zero,
+        size: CGSize(width: 393, height: 852),
+        traits: UITraitCollection(displayScale: 3)
+    )
+}
+#endif
+
+// MARK: - Ungated precondition (protects the references; runs on every push)
+
+@Suite("Snapshot harness preconditions")
+struct SnapshotHarnessPreconditionTests {
+
+    @Test("Both embedded faces resolve by PostScript name — else references encode San Francisco")
+    func fontPrecondition() {
+        _ = AppFont.register
+        #if canImport(UIKit)
+        // If any of these is nil, the snapshot engine falls back to San Francisco and
+        // every reference silently bakes the wrong type. This is the guard ADR-0025
+        // mandates run BEFORE recording.
+        #expect(UIFont(name: AppFont.PostScriptName.spaceGroteskBold, size: 64) != nil)
+        #expect(UIFont(name: AppFont.PostScriptName.spaceGroteskSemiBold, size: 34) != nil)
+        #expect(UIFont(name: AppFont.PostScriptName.interMedium, size: 13) != nil)
+        #expect(UIFont(name: AppFont.PostScriptName.interRegular, size: 17) != nil)
+        #endif
+    }
+}
+
+// MARK: - The image suite (gated; reference-pending until the CI record job runs)
+
+@Suite("Drawn-instrument snapshots", .enabled(if: snapshotTestsEnabled))
+@MainActor
+struct DrawnInstrumentSnapshotTests {
+
+    /// The worked example the issue asks for: the #341 token gallery, proving the
+    /// harness end-to-end (record → compare → fail-on-diff) across the light/dim ×
+    /// default/AX matrix. The gallery is the densest single surface — every colour,
+    /// type, and data-viz token in one frame — so one diff catches a token regression
+    /// anywhere in the foundation.
+    private static let gallerySize = CGSize(width: 393, height: 1400)
+
+    #if canImport(UIKit)
+    @Test("Token gallery — light, default Dynamic Type")
+    func gallery_light_default() {
+        let vc = SnapshotHarness.host(TokenGallery(theme: .light),
+                                      size: Self.gallerySize, appearance: .light)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "gallery-light-default", record: recordModeEnabled)
+    }
+
+    @Test("Token gallery — dim, default Dynamic Type")
+    func gallery_dim_default() {
+        let vc = SnapshotHarness.host(TokenGallery(theme: .dim),
+                                      size: Self.gallerySize, appearance: .dim)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "gallery-dim-default", record: recordModeEnabled)
+    }
+
+    @Test("Token gallery — light, AX5 (largest accessibility size)")
+    func gallery_light_ax5() {
+        let vc = SnapshotHarness.host(TokenGallery(theme: .light),
+                                      size: Self.gallerySize, appearance: .light,
+                                      dynamicType: .accessibility5)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "gallery-light-ax5", record: recordModeEnabled)
+    }
+
+    @Test("Token gallery — dim, AX5")
+    func gallery_dim_ax5() {
+        let vc = SnapshotHarness.host(TokenGallery(theme: .dim),
+                                      size: Self.gallerySize, appearance: .dim,
+                                      dynamicType: .accessibility5)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "gallery-dim-ax5", record: recordModeEnabled)
+    }
+
+    // MARK: Reduce-Motion contract — byte-identical to the normal end-state.
+
+    @Test("Reduce Motion is byte-identical to the normal end-state (frame-1 == end-state)")
+    func gallery_reduceMotion_matchesEndState() {
+        // ADR-0025: each instrument is animation-free and captured at its bare
+        // end-state, with its entrance owned by a separate wrapper. Reduce Motion's
+        // contract is "a 150ms crossfade to the SAME destination", so the destination
+        // image is identical with or without it — there is no entrance in the captured
+        // view to suppress. We prove this by re-capturing the bare instrument and
+        // asserting it against the SAME `gallery-light-default` reference (not a new
+        // one): if a future instrument ever leaked an animated entrance into the bare
+        // view, its non-settled frame would diff against this canonical end-state.
+        let vc = SnapshotHarness.host(TokenGallery(theme: .light),
+                                      size: Self.gallerySize, appearance: .light)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "gallery-light-default", record: recordModeEnabled)
+    }
+
+    // MARK: Negative control — proves the tolerance still catches a wrong ink.
+
+    @Test("Hue-swap negative control: the bright accent is NOT the accent-ink (tolerance catches a wrong ink)")
+    func hueSwap_negativeControl() {
+        // ADR-0025 calls for a deliberate hue-swap proof that perceptualPrecision 0.98
+        // still fails on a wrong ink (#1B2CFF bright-accent-fill vs #1322CC accent-ink).
+        // The structural half is asserted here without a pixel: the two inks differ by
+        // more than rounding, so a swatch drawn with the wrong one cannot pass the
+        // perceptual tolerance. The pixel-level proof is recorded as a known-failing
+        // reference pair by the CI record job (documented above); this assertion is the
+        // always-on sentinel that the two source inks never converge.
+        let brightAccent = Theme.light.accentFill.token   // #1B2CFF — large-fill only
+        let accentInk = Theme.light.accentInk             // #1322CC — text-safe stroke
+        #expect(brightAccent != accentInk)
+        // A perceptual delta this large (different blue + different green channel) is
+        // well outside the 0.98 perceptual tolerance — a swap would fail the snapshot.
+        let channelDelta = abs(brightAccent.blue - accentInk.blue)
+            + abs(brightAccent.green - accentInk.green)
+            + abs(brightAccent.red - accentInk.red)
+        #expect(channelDelta > 0.05)
+    }
+    #endif
+}

--- a/ProjectApexTests/__Snapshots__/README.md
+++ b/ProjectApexTests/__Snapshots__/README.md
@@ -1,0 +1,43 @@
+# Reference images for the snapshot harness (#342 / ADR-0025)
+
+This directory holds the committed reference PNGs that the image-snapshot layer
+(`DrawnInstrumentSnapshotTests`) compares against. `swift-snapshot-testing` writes
+them, one subfolder per test suite, when the suite runs in **record mode**.
+
+## The references are NOT recorded yet — by design
+
+ADR-0025 (capstone, hard prerequisite) requires references to be recorded on the
+**CI-pinned toolchain (Xcode 26.3)**, never on a developer machine. Local Xcode is
+26.5; a reference baked on a skewed toolchain encodes the wrong font rasterisation
+and sub-pixel colour, poisoning every later instrument slice. So the tests are wired
+but parked: the image suite is gated OFF by default (`APEX_SNAPSHOT_TESTS` unset), and
+until the references exist, enabling the gate fails with "missing reference" — the
+correct "not yet ratified" signal.
+
+## How to record the references (HUMAN / CI step, on Xcode 26.3)
+
+A CI "record mode" job that selects Xcode 26.3 (the same pin as `ci.yml`'s test job)
+and runs the snapshot suite with **both** env vars set:
+
+```bash
+xcodebuild test \
+  -project ProjectApex.xcodeproj \
+  -scheme ProjectApex \
+  -only-testing:ProjectApexTests/DrawnInstrumentSnapshotTests \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' \
+  APEX_SNAPSHOT_TESTS=1 \
+  APEX_RECORD_SNAPSHOTS=1
+```
+
+- `APEX_SNAPSHOT_TESTS=1` un-gates the suite.
+- `APEX_RECORD_SNAPSHOTS=1` flips record mode → writes the PNGs here, and (per
+  `swift-snapshot-testing`'s contract) **fails the run**. That always-fail is the CI
+  guard that record mode is never left on in the compare job.
+
+The job then commits the generated `DrawnInstrumentSnapshotTests/*.png`. The compare
+job (and any later instrument slice) sets only `APEX_SNAPSHOT_TESTS=1` — never the
+record flag — so it compares against these committed references and fails on a diff.
+
+Before recording, the ungated `SnapshotHarnessPreconditionTests.fontPrecondition`
+must be green (both embedded faces resolve by PostScript name) — otherwise the
+references silently encode San Francisco.


### PR DESCRIPTION
## What this builds

The snapshot / visual-regression harness for the rebuild's drawn instruments (ADR-0025), in two layers:

**1. Geometry / token assertions (`DesignSystemGeometryTests`) — ungated, runs on every push, needs no reference images.**
Cheap deterministic `@Test`s over the DesignSystem instrument constants: the floor-vs-stretch honesty (2px floor tick heavier than the 1px stretch hairline), series stroke 2pt, projection dash 4-2, the 4/8/16/24/32/48 spacing scale, the 8/16/24 radii, card elevation (6% ink, radius 6, offset (0,2)), the motion tempos + the 150ms Reduce-Motion crossfade law, and the InkPencil work-is-ink / time-is-pencil two-tone split. This is the layer that proves the honesty invariants hold at *every* size/appearance — a pixel proves only one. It complements (does not duplicate) the existing `DesignSystemTokensTests` colour/type fixtures.

**2. Image-snapshot layer (`DrawnInstrumentSnapshotTests`) — gated behind `APEX_SNAPSHOT_TESTS`.**
`swift-snapshot-testing` driven from `@Test` through one rendering route (`UIHostingController` `.image`). Includes:
- The worked example: snapshots the #341 token gallery across `{light, dim} × {default @ .large, AX5}` — the densest single token surface.
- The reusable **"renders assembled at frame 1"** harness (`SnapshotHarness`): animation-free bare end-state, synchronous one-shot layout, fixed per-instrument canvas (never a full screen, to isolate from the parallel shell churn). Every later instrument slice reuses it.
- The **Reduce-Motion** contract asserted byte-identical to the normal end-state (re-captures the bare instrument against the *same* reference).
- The **font-resolution precondition** (`SnapshotHarnessPreconditionTests`, ungated) — fails if either embedded face doesn't resolve, before any reference is recorded.
- The **hue-swap negative control** — proves the source inks (#1B2CFF bright-accent vs #1322CC accent-ink) never converge, so a wrong-ink swap can't pass the perceptual tolerance.

## SPM dependency (first one in the repo)

`pointfreeco/swift-snapshot-testing` pinned **exact `1.18.2`**, added as an `XCRemoteSwiftPackageReference` to `ProjectApex.xcodeproj`, linked to **`ProjectApexTests` only**. `Package.resolved` is committed (resolves the full graph: swift-snapshot-testing 1.18.2 + swift-syntax 600.0.1 + xctest-dynamic-overlay 1.10.0 + swift-custom-dump 1.6.0). The CI `-resolvePackageDependencies` step (previously a no-op) becomes load-bearing.

## Env-gate reconciliation (separate commit)

ADR-0025 made #342 own the verified contradiction: `ProjectApex.xctestplan` set `APEX_INTEGRATION_TESTS=1` in `defaultOptions` while `ci.yml` claimed it was "intentionally absent." Because CI runs with `-testPlan ProjectApex`, the testplan won and the live-API tests were silently un-gated in CI. The second commit **removes the entry from the testplan** so the variable is genuinely absent by default (opt-in via Scheme Editor or `-e`), making the comment true and the gate actually toggle — which `APEX_SNAPSHOT_TESTS` copies.

## Build / test status

- Geometry suite: **green, 11/11.**
- Precondition suite: **green** (both faces resolve).
- Image suite with `APEX_SNAPSHOT_TESTS` unset: **all 6 image tests skipped** — confirms it stays out of the mandatory CI path and won't fail for want of reference PNGs.
- SPM dep resolves and the whole app + tests compile and link against it.

## ⚠️ Reference PNGs are NOT recorded — and must be a human / CI step on Xcode 26.3

Per ADR-0025's hard prerequisite: references must be recorded on the **CI-pinned toolchain (Xcode 26.3)**, never a dev machine. This branch was built on local **Xcode 26.5**; a reference baked here would encode the wrong font rasterisation + sub-pixel colour and poison every later instrument slice. So the image tests are **wired but reference-pending** (gated off; enabling the gate without references fails with "missing reference" — the correct "not yet ratified" signal).

**Exactly what the human must do next** — a CI "record mode" job that selects Xcode 26.3 and runs:

```bash
xcodebuild test \
  -project ProjectApex.xcodeproj \
  -scheme ProjectApex \
  -only-testing:ProjectApexTests/DrawnInstrumentSnapshotTests \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' \
  APEX_SNAPSHOT_TESTS=1 \
  APEX_RECORD_SNAPSHOTS=1
```

`APEX_SNAPSHOT_TESTS=1` un-gates; `APEX_RECORD_SNAPSHOTS=1` flips record mode → writes the PNGs and (per the tool's contract) **fails the run** — that always-fail is the guard that record mode is never left on in the compare job. The job then commits `ProjectApexTests/__Snapshots__/DrawnInstrumentSnapshotTests/*.png`. The compare job (and every later slice) sets only `APEX_SNAPSHOT_TESTS=1`. Full record instructions are committed in `ProjectApexTests/__Snapshots__/README.md` and the test-file header.

**Part of #342** (not `Closes` — the reference-PNG recording and visual ratification remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>