### PR TITLE
feat(#369): EF JWT sub==user_id ownership check — close the IDOR (auth slice 4)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,18 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — The server now checks it's really you before saving your data (auth slice 4, part of #369)
+
+**Problem.** Two of our server functions — the one that updates your trainee model after a workout, and the one that saves your goal — trusted the `user_id` written in the request body, no questions asked. That meant a logged-in person could put *someone else's* id in the body and write to that person's data (a classic "insecure direct object reference" hole). And we can't lean on the database's own row-level security to stop it here, because these functions connect with a super-privileged account that bypasses those row rules. So the function itself has to be the bouncer.
+
+**What changed.** Before either function does any database work, it now reads the login token the platform already verified, pulls out the user id baked into that token, and checks it matches the `user_id` in the request body. If they don't match, it refuses (403). If there's no token, or the token is garbled, or it has no user id, it also refuses (fail-closed, 401) — it never quietly lets the write through. The token-reading logic lives in one small shared helper so both functions use exactly the same check. We only *read* the id from the token, we don't re-check its signature — the platform already did that.
+
+**How checked.** Added unit tests for the shared helper (14) covering the good decode and every fail-closed case, plus four handler tests on each function (mismatch → 403, no token → 401, garbled token → 401, matching id → passes the gate). All pass. The existing tests still pass: shared helpers 390, model validator 21, goal validator 31. The database-integration tests can't run here (they need a local Postgres in Docker, which is down — they failed with connection-refused as expected and will run on CI when merged). Did NOT turn on row-level security, add migrations, touch the app, or deploy — those are other slices / the orchestrator's job.
+
+**Status:** opened as PR (see below); NOT merged, NOT deployed.
+
+---
+
 ## 2026-06-12 — The app now uses your real login identity instead of a stand-in (auth slice 3, part of #369)
 
 **Problem.** Until now every install used the same hardcoded placeholder id (`…0001`) or a random one minted at onboarding to tag all your data. Earlier in this auth work (slice 1) the app started quietly logging itself in anonymously at launch, which gives it a real, stable identity — but nothing was using that identity yet. For the upcoming security lock (slice 5, which will only let you read rows that are tagged with *your* id), the data has to be keyed to that real login id, not the placeholder.

--- a/supabase/functions/_shared/jwt-owner.ts
+++ b/supabase/functions/_shared/jwt-owner.ts
@@ -1,0 +1,91 @@
+// Project Apex — JWT-`sub` ownership check (#369, auth/RLS slice 4, ADR-0027).
+//
+// Both Edge Functions connect via the privileged `SUPABASE_DB_URL` (the
+// `postgres` role, which has BYPASSRLS), so RLS does NOT protect the EF write
+// path — the function must enforce ownership itself. This is the IDOR fix:
+// the handlers trust the caller identity derived HERE (the verified JWT's
+// `sub`), not the `user_id` in the request body.
+//
+// The Supabase platform has ALREADY verified the JWT signature (verify-jwt is
+// ON for these functions — we do NOT pass `--no-verify-jwt`). So this helper
+// only DECODES the payload to read `sub`; it does NOT re-verify the signature.
+//
+// Fail closed: a missing Authorization header, a malformed JWT, or a
+// missing/empty `sub` all yield a rejection, never a silent pass.
+
+/** Outcome of deriving the caller's `sub` from the request. Discriminated. */
+export type OwnerCheck =
+  | { ok: true }
+  | { ok: false; status: number; error: string };
+
+/**
+ * base64url-decode a single JWT segment to its UTF-8 string. base64url uses
+ * `-`/`_` for `+`/`/` and may omit `=` padding — normalise both, then `atob`.
+ * Throws on invalid base64 (caller treats a throw as "malformed JWT").
+ */
+function decodeSegment(segment: string): string {
+  const b64 = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+  const binary = atob(padded);
+  // atob yields a Latin-1 string; re-decode the bytes as UTF-8 so non-ASCII
+  // claim values survive. `sub` is a UUID (ASCII) here, but decode honestly.
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+/**
+ * Extract the `sub` claim from a `Bearer <jwt>` Authorization header value by
+ * DECODING (not verifying) the JWT payload. Returns the trimmed `sub`, or
+ * `null` when the header is absent/not-Bearer, the JWT is malformed, or `sub`
+ * is missing/non-string/empty. A `null` return is the fail-closed signal.
+ */
+export function subFromAuthorization(
+  authorization: string | null,
+): string | null {
+  if (!authorization) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(authorization.trim());
+  if (!match) return null;
+  const parts = match[1].split(".");
+  if (parts.length !== 3) return null; // not a header.payload.signature JWT
+  let payload: unknown;
+  try {
+    payload = JSON.parse(decodeSegment(parts[1]));
+  } catch {
+    return null; // undecodable / non-JSON payload
+  }
+  if (typeof payload !== "object" || payload === null) return null;
+  const sub = (payload as Record<string, unknown>).sub;
+  if (typeof sub !== "string" || sub.length === 0) return null;
+  return sub;
+}
+
+/**
+ * Gate a privileged write on caller ownership: the JWT `sub` (verified by the
+ * platform, decoded here) MUST equal the body `user_id`. Returns `{ ok: true }`
+ * only when they match; otherwise a fail-closed rejection:
+ *   - 401 when no usable credential is present (missing header, malformed JWT,
+ *     or missing/empty `sub`) — the caller never proved who they are;
+ *   - 403 when a `sub` was derived but it does not match the body `user_id`
+ *     (the caller is authenticated but is not the resource owner — IDOR).
+ */
+export function checkOwnership(
+  req: Request,
+  bodyUserId: string,
+): OwnerCheck {
+  const sub = subFromAuthorization(req.headers.get("Authorization"));
+  if (sub === null) {
+    return {
+      ok: false,
+      status: 401,
+      error: "missing or malformed Authorization bearer token",
+    };
+  }
+  if (sub !== bodyUserId) {
+    return {
+      ok: false,
+      status: 403,
+      error: "authenticated user is not the owner of this resource",
+    };
+  }
+  return { ok: true };
+}

--- a/supabase/functions/_shared/jwt-owner_test.ts
+++ b/supabase/functions/_shared/jwt-owner_test.ts
@@ -1,0 +1,117 @@
+// Project Apex — unit tests for the JWT-`sub` ownership check (#369, slice 4).
+//
+// The helper DECODES (never verifies) the JWT payload, so the tests build
+// fake-but-well-formed tokens: header.payload.signature, where the payload
+// base64url-encodes the claims and the signature is an arbitrary dummy (the
+// code never touches it). The platform owns signature verification (verify-jwt
+// is ON); these tests pin the decode + fail-closed contract.
+//
+// Run locally:
+//   deno test --allow-all supabase/functions/_shared/jwt-owner_test.ts
+
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { checkOwnership, subFromAuthorization } from "./jwt-owner.ts";
+
+const OWNER = "11111111-1111-4111-8111-111111111111";
+const OTHER = "22222222-2222-4222-8222-222222222222";
+
+/** base64url-encode a UTF-8 string (no `=` padding, `-`/`_` alphabet). */
+function b64url(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** Build a fake-but-well-formed JWT carrying `claims` in the payload segment. */
+function fakeJwt(claims: Record<string, unknown>): string {
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = b64url(JSON.stringify(claims));
+  return `${header}.${payload}.dummy-signature-not-verified`;
+}
+
+function bearer(token: string): Request {
+  return new Request("https://example.test/", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+// ─── subFromAuthorization: happy decode ──────────────────────────────────────
+
+Deno.test("subFromAuthorization: decodes sub from a well-formed bearer token", () => {
+  assertEquals(subFromAuthorization(`Bearer ${fakeJwt({ sub: OWNER })}`), OWNER);
+});
+
+Deno.test("subFromAuthorization: ignores other claims, returns only sub", () => {
+  const token = fakeJwt({ sub: OWNER, role: "authenticated", exp: 9999999999 });
+  assertEquals(subFromAuthorization(`Bearer ${token}`), OWNER);
+});
+
+// ─── subFromAuthorization: fail-closed (null) cases ──────────────────────────
+
+Deno.test("subFromAuthorization: null when header absent", () => {
+  assertEquals(subFromAuthorization(null), null);
+});
+
+Deno.test("subFromAuthorization: null when scheme is not Bearer", () => {
+  assertEquals(subFromAuthorization(`Basic ${fakeJwt({ sub: OWNER })}`), null);
+});
+
+Deno.test("subFromAuthorization: null when JWT has wrong segment count", () => {
+  assertEquals(subFromAuthorization("Bearer not.a.valid.jwt.here"), null);
+  assertEquals(subFromAuthorization("Bearer onlyonesegment"), null);
+});
+
+Deno.test("subFromAuthorization: null when payload is not valid base64/JSON", () => {
+  assertEquals(subFromAuthorization("Bearer aaa.!!!notbase64!!!.bbb"), null);
+});
+
+Deno.test("subFromAuthorization: null when sub claim is missing", () => {
+  assertEquals(subFromAuthorization(`Bearer ${fakeJwt({ role: "x" })}`), null);
+});
+
+Deno.test("subFromAuthorization: null when sub is empty string", () => {
+  assertEquals(subFromAuthorization(`Bearer ${fakeJwt({ sub: "" })}`), null);
+});
+
+Deno.test("subFromAuthorization: null when sub is non-string", () => {
+  assertEquals(subFromAuthorization(`Bearer ${fakeJwt({ sub: 42 })}`), null);
+});
+
+// ─── checkOwnership: the gate the handlers call ──────────────────────────────
+
+Deno.test("checkOwnership: ok when sub === body user_id", () => {
+  const result = checkOwnership(bearer(fakeJwt({ sub: OWNER })), OWNER);
+  assertEquals(result.ok, true);
+});
+
+Deno.test("checkOwnership: 403 when sub !== body user_id (IDOR)", () => {
+  const result = checkOwnership(bearer(fakeJwt({ sub: OTHER })), OWNER);
+  assertEquals(result.ok, false);
+  if (result.ok) return;
+  assertEquals(result.status, 403);
+});
+
+Deno.test("checkOwnership: 401 when Authorization header absent", () => {
+  const req = new Request("https://example.test/", { method: "POST" });
+  const result = checkOwnership(req, OWNER);
+  assertEquals(result.ok, false);
+  if (result.ok) return;
+  assertEquals(result.status, 401);
+});
+
+Deno.test("checkOwnership: 401 when JWT is malformed", () => {
+  const req = bearer("garbage-not-a-jwt");
+  const result = checkOwnership(req, OWNER);
+  assertEquals(result.ok, false);
+  if (result.ok) return;
+  assertEquals(result.status, 401);
+});
+
+Deno.test("checkOwnership: 401 when sub is missing from an otherwise-valid JWT", () => {
+  const result = checkOwnership(bearer(fakeJwt({ role: "authenticated" })), OWNER);
+  assertEquals(result.ok, false);
+  if (result.ok) return;
+  assertEquals(result.status, 401);
+});

--- a/supabase/functions/update-trainee-goal/index.ts
+++ b/supabase/functions/update-trainee-goal/index.ts
@@ -31,6 +31,7 @@
 
 import postgres from "postgres";
 import { MAJOR_PATTERNS } from "../_shared/constants.ts";
+import { checkOwnership } from "../_shared/jwt-owner.ts";
 import type { PatternProjection } from "../_shared/calibration-projection.ts";
 import {
   isRenegotiation,
@@ -478,6 +479,17 @@ export async function handleRequest(req: Request): Promise<Response> {
   const validated = validateRequest(body);
   if ("error" in validated) {
     return jsonResponse({ error: validated.error }, 400);
+  }
+
+  // #369 (slice 4, ADR-0027): close the IDOR. The EF connects as `postgres`
+  // (BYPASSRLS) via SUPABASE_DB_URL, so RLS cannot protect this write path —
+  // enforce ownership here. The caller is the verified JWT `sub` (platform
+  // verified the signature; we only decode it); reject when it doesn't match
+  // the body `user_id`. Runs BEFORE getSql so a rejected caller never touches
+  // the DB.
+  const ownership = checkOwnership(req, validated.user_id);
+  if (!ownership.ok) {
+    return jsonResponse({ error: ownership.error }, ownership.status);
   }
 
   let sql: Sql;

--- a/supabase/functions/update-trainee-goal/index_test.ts
+++ b/supabase/functions/update-trainee-goal/index_test.ts
@@ -9,9 +9,10 @@
 //   deno test supabase/functions/update-trainee-goal/index_test.ts
 
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { validateRequest } from "./index.ts";
+import { handleRequest, validateRequest } from "./index.ts";
 
 const VALID_USER_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_USER_ID = "22222222-2222-4222-8222-222222222222";
 const VALID_GOAL = {
   statement: "Hypertrophy (muscle size)",
   focusAreas: [],
@@ -263,4 +264,81 @@ Deno.test("validateRequest_ack_calibration_review_nonBoolean_returns_400", () =>
   );
   if (!("error" in result)) throw new Error("expected error");
   assertEquals(result.error.includes("acknowledge_calibration_review"), true);
+});
+
+// ─── #369 slice 4: handleRequest JWT-`sub` ownership check (closes the IDOR) ──
+//
+// The handler derives the caller from the verified JWT `sub` (decode-only; the
+// platform verifies the signature) and rejects when it doesn't match the body
+// `user_id`. The reject paths return BEFORE getSql, so no DB is needed. A
+// fake-but-well-formed JWT (header.payload.signature; payload base64url-encodes
+// the claims; dummy signature) drives every case.
+
+function b64url(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fakeJwt(sub: string): string {
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = b64url(JSON.stringify({ sub, role: "authenticated" }));
+  return `${header}.${payload}.dummy-signature-not-verified`;
+}
+
+function postRequest(
+  body: Record<string, unknown>,
+  authorization?: string,
+): Request {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (authorization !== undefined) headers.Authorization = authorization;
+  return new Request("https://example.test/update-trainee-goal", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function validBody(): Record<string, unknown> {
+  return { user_id: VALID_USER_ID, goal: VALID_GOAL };
+}
+
+Deno.test("handleRequest_sub_mismatch_returns_403", async () => {
+  // Authenticated as OTHER, but body claims VALID_USER_ID → IDOR → 403.
+  const res = await handleRequest(
+    postRequest(validBody(), `Bearer ${fakeJwt(OTHER_USER_ID)}`),
+  );
+  assertEquals(res.status, 403);
+});
+
+Deno.test("handleRequest_missing_authorization_returns_401", async () => {
+  const res = await handleRequest(postRequest(validBody()));
+  assertEquals(res.status, 401);
+});
+
+Deno.test("handleRequest_malformed_jwt_returns_401", async () => {
+  const res = await handleRequest(
+    postRequest(validBody(), "Bearer garbage-not-a-jwt"),
+  );
+  assertEquals(res.status, 401);
+});
+
+Deno.test("handleRequest_sub_match_passes_ownership_gate", async () => {
+  // sub === body.user_id → the gate lets it through. With no SUPABASE_DB_URL
+  // set in the unit-test env, getSql throws and the handler returns 500 — which
+  // proves the request PASSED the ownership gate (it is neither 403 nor 401).
+  // The 200 happy path is covered by the DB-integration tests (orchestrator).
+  const prior = Deno.env.get("SUPABASE_DB_URL");
+  Deno.env.delete("SUPABASE_DB_URL");
+  try {
+    const res = await handleRequest(
+      postRequest(validBody(), `Bearer ${fakeJwt(VALID_USER_ID)}`),
+    );
+    await res.body?.cancel();
+    assertEquals(res.status !== 403 && res.status !== 401, true);
+    assertEquals(res.status, 500);
+  } finally {
+    if (prior !== undefined) Deno.env.set("SUPABASE_DB_URL", prior);
+  }
 });

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -135,6 +135,7 @@ import {
 import { LLMPermanentError, LLMTransientError } from "../_shared/llm-retry.ts";
 import { backfillPatternConfidence } from "../_shared/pattern-confidence-backfill.ts";
 import { backfillPatternSessionCount } from "../_shared/pattern-session-count-backfill.ts";
+import { checkOwnership } from "../_shared/jwt-owner.ts";
 
 export interface UpdateTraineeModelRequest {
   user_id: string;
@@ -2501,6 +2502,17 @@ export async function handleRequest(req: Request): Promise<Response> {
   const validated = validateRequest(body);
   if ("error" in validated) {
     return jsonResponse({ error: validated.error }, 400);
+  }
+
+  // #369 (slice 4, ADR-0027): close the IDOR. The EF connects as `postgres`
+  // (BYPASSRLS) via SUPABASE_DB_URL, so RLS cannot protect this write path —
+  // enforce ownership here. The caller is the verified JWT `sub` (platform
+  // verified the signature; we only decode it); reject when it doesn't match
+  // the body `user_id`. Runs BEFORE getSql so a rejected caller never touches
+  // the DB.
+  const ownership = checkOwnership(req, validated.user_id);
+  if (!ownership.ok) {
+    return jsonResponse({ error: ownership.error }, ownership.status);
   }
 
   let sql: Sql;

--- a/supabase/functions/update-trainee-model/index_test.ts
+++ b/supabase/functions/update-trainee-model/index_test.ts
@@ -9,11 +9,17 @@
 //   deno test supabase/functions/update-trainee-model/index_test.ts
 
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { capTopSets, derivedTrainedSets, validateRequest } from "./index.ts";
+import {
+  capTopSets,
+  derivedTrainedSets,
+  handleRequest,
+  validateRequest,
+} from "./index.ts";
 import { TOP_SET_RETENTION_COUNT } from "../_shared/constants.ts";
 
 const VALID_USER_ID = "11111111-1111-4111-8111-111111111111";
 const VALID_SESSION_ID = "22222222-2222-4222-8222-222222222222";
+const OTHER_USER_ID = "33333333-3333-4333-8333-333333333333";
 
 function baseRequest(payloadOverrides: Record<string, unknown> = {}) {
   return {
@@ -264,4 +270,85 @@ Deno.test("capTopSets_over_count_keeps_newest_N_from_tail", () => {
   // Spot-check the ends: oldest dropped, newest retained.
   assertEquals(capped[0], extra);
   assertEquals(capped[capped.length - 1], TOP_SET_RETENTION_COUNT + extra - 1);
+});
+
+// ─── #369 slice 4: handleRequest JWT-`sub` ownership check (closes the IDOR) ──
+//
+// The handler derives the caller from the verified JWT `sub` (decode-only; the
+// platform verifies the signature) and rejects when it doesn't match the body
+// `user_id`. The reject paths return BEFORE getSql, so no DB is needed. A
+// fake-but-well-formed JWT (header.payload.signature; payload base64url-encodes
+// the claims; dummy signature) drives every case.
+
+function b64url(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fakeJwt(sub: string): string {
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = b64url(JSON.stringify({ sub, role: "authenticated" }));
+  return `${header}.${payload}.dummy-signature-not-verified`;
+}
+
+function postRequest(
+  body: Record<string, unknown>,
+  authorization?: string,
+): Request {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (authorization !== undefined) headers.Authorization = authorization;
+  return new Request("https://example.test/update-trainee-model", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function validBody(): Record<string, unknown> {
+  return {
+    user_id: VALID_USER_ID,
+    session_id: VALID_SESSION_ID,
+    session_payload: {},
+  };
+}
+
+Deno.test("handleRequest_sub_mismatch_returns_403", async () => {
+  // Authenticated as OTHER, but body claims VALID_USER_ID → IDOR → 403.
+  const res = await handleRequest(
+    postRequest(validBody(), `Bearer ${fakeJwt(OTHER_USER_ID)}`),
+  );
+  assertEquals(res.status, 403);
+});
+
+Deno.test("handleRequest_missing_authorization_returns_401", async () => {
+  const res = await handleRequest(postRequest(validBody()));
+  assertEquals(res.status, 401);
+});
+
+Deno.test("handleRequest_malformed_jwt_returns_401", async () => {
+  const res = await handleRequest(
+    postRequest(validBody(), "Bearer garbage-not-a-jwt"),
+  );
+  assertEquals(res.status, 401);
+});
+
+Deno.test("handleRequest_sub_match_passes_ownership_gate", async () => {
+  // sub === body.user_id → the gate lets it through. With no SUPABASE_DB_URL
+  // set in the unit-test env, getSql throws and the handler returns 500 — which
+  // proves the request PASSED the ownership gate (it is neither 403 nor 401).
+  // The 200 happy path is covered by the DB-integration tests (orchestrator).
+  const prior = Deno.env.get("SUPABASE_DB_URL");
+  Deno.env.delete("SUPABASE_DB_URL");
+  try {
+    const res = await handleRequest(
+      postRequest(validBody(), `Bearer ${fakeJwt(VALID_USER_ID)}`),
+    );
+    await res.body?.cancel();
+    assertEquals(res.status !== 403 && res.status !== 401, true);
+    assertEquals(res.status, 500);
+  } finally {
+    if (prior !== undefined) Deno.env.set("SUPABASE_DB_URL", prior);
+  }
 });


### PR DESCRIPTION
Part of #369 — auth/RLS workstream slice 4 of 6. Closes the IDOR: both EFs now derive the caller from the verified JWT `sub` and reject (403) when it doesn't match the body `user_id`. The EF connects as `postgres` (BYPASSRLS), so RLS can't protect this path — the function enforces ownership itself. Must land after slice 3 (client now sends `body.user_id = auth.uid()` = JWT sub). Not deployed by this PR.

## What changed
- New `supabase/functions/_shared/jwt-owner.ts`: `subFromAuthorization` decodes (does NOT verify — the platform already did, verify-jwt is ON) the JWT payload to read `sub`; `checkOwnership(req, bodyUserId)` returns `{ ok: true }` only when `sub === bodyUserId`, else a fail-closed rejection.
- Both `handleRequest`s gate on `checkOwnership` after `validateRequest` and **before** `getSql`, so a rejected caller never touches the DB.

## Fail-closed contract
- `sub !== body.user_id` → **403** (authenticated but not the owner — the IDOR case).
- Missing Authorization header / non-Bearer / malformed JWT / missing or empty `sub` → **401** (caller never proved who they are).
- `sub === body.user_id` → proceeds to the existing `applySession` / `upsertGoal` logic unchanged.

## Tests (deno)
- `_shared/jwt-owner_test.ts`: 14 tests (happy decode + every fail-closed case).
- Each `index_test.ts`: +4 handler tests (403 mismatch, 401 missing token, 401 malformed token, matched-sub passes the gate).
- Existing suites still green: `_shared` 390, model validator 21, goal validator 31.
- DB-integration tests (`orchestrator_test.ts` / `smoke_test.ts`) need a local Postgres (Docker) — down in this env, failed with `ECONNREFUSED 127.0.0.1:54322` as expected; they run on CI on merge.

## Scope
No RLS enabled, no migrations, no iOS changes, business logic of `applySession`/`upsertGoal` untouched (only gated behind the check). Not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)