### PR TITLE
feat(#369): enable RLS + owner policies on core tables; fix gym_profiles policy (auth slice 5)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,20 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — The database now hides everyone else's data from you (auth slice 5 — the gate-flip, part of #369)
+
+**Problem.** This is the keystone of the auth work. Up to now the database had *no* lock on the core tables — workouts, programs, your trainee model, your user row, and your set logs were all readable and writable by any logged-in client, because "row-level security" (the database's own per-user filter) was switched off on them. The two tables that *did* have it on were either fine (the memory embeddings) or wide open anyway (gym profiles had an "anon full access" rule that let everyone see everything). Slices 1–4 set up real per-user identities and made the server functions check them; this slice finally turns the database lock itself.
+
+**What changed.** One forward migration (plus its documentation-only reverse). It (1) turns on row-level security for the five unprotected tables; (2) adds an "owner access" rule to each that says, in effect, *you can only see and only write rows tagged with your own login id* — both the read side (USING) and the write side (WITH CHECK), so a client can't even sneak in a row owned by someone else; for set logs (which have no owner column of their own) ownership is traced through the workout session they belong to; for the user table the row's own id is the owner; and (3) replaces the gym-profiles "everyone sees everything" rule with the same owner-only rule. No changes to who's granted access at the coarse level — once these id-based rules are on, the anonymous role matches no rows anyway, so the old grants are harmless. The server functions keep working because they connect with the privileged account that skips these rules and do their own id check (from slice 4).
+
+**How checked.** SQL review against the baseline schema only — I could not run it against a database here (the local Postgres in Docker is down; `supabase db lint` / `migration list` both failed with connection-refused, as expected). I read the exact current table, column, and policy names out of the baseline and confirmed every "drop the old rule" line names the real existing rule verbatim, the owner columns are right, and the paren-balanced SQL matches the baseline's style. I also checked the reverse migration exactly undoes the forward one (turns the lock back off on those five tables, drops the new rules, and restores the original gym-profiles "anon full access" rule). Touched only the two migration files and this diary — no app code, no server functions, no other files.
+
+**Heads-up for whoever merges this:** merging runs `db push` in CI, which **turns the lock on in production** — this is the live data-visibility flip. Any rows still tagged with the old placeholder id (not a real login id) become invisible to everyone; that's the accepted alpha data-wipe, and clients must already be on the slice-3 build (which tags data with the real login id) for their data to remain visible.
+
+**Status:** opened as PR (see below); NOT merged, NOT deployed — the gate-flip is the orchestrator's call.
+
+---
+
 ## 2026-06-12 — The server now checks it's really you before saving your data (auth slice 4, part of #369)
 
 **Problem.** Two of our server functions — the one that updates your trainee model after a workout, and the one that saves your goal — trusted the `user_id` written in the request body, no questions asked. That meant a logged-in person could put *someone else's* id in the body and write to that person's data (a classic "insecure direct object reference" hole). And we can't lean on the database's own row-level security to stop it here, because these functions connect with a super-privileged account that bypasses those row rules. So the function itself has to be the bouncer.

--- a/docs/migrations/down/20260612020101_enable_rls_owner_policies.sql
+++ b/docs/migrations/down/20260612020101_enable_rls_owner_policies.sql
@@ -1,0 +1,54 @@
+-- Reverse of 20260612020101_enable_rls_owner_policies.sql
+--
+-- supabase db push is forward-only; this file is for manual operator use
+-- (psql -f) when rolling back the RLS gate-flip from auth slice 5 (#369).
+-- Documentation only; not auto-applied.
+--
+-- Restores the exact pre-migration state:
+--   * DISABLE RLS on the five tables the forward migration enabled it on
+--     (workout_sessions, programs, trainee_models, users, set_logs).
+--   * DROP the new FOR ALL owner policies.
+--   * Restore the original USING-only "owner access" policies on programs and
+--     set_logs (the forward migration replaced these with FOR ALL variants).
+--   * Restore the original gym_profiles "anon full access" USING(true) policy
+--     (gym_profiles keeps RLS enabled — the baseline had it on).
+--
+-- WARNING: re-disabling RLS re-exposes every row to the anon grants. Only run
+-- this if you are deliberately rolling back per-user data isolation.
+
+
+-- 1. Drop the new FOR ALL owner policies.
+
+DROP POLICY IF EXISTS "workout_sessions: owner access" ON "public"."workout_sessions";
+DROP POLICY IF EXISTS "programs: owner access" ON "public"."programs";
+DROP POLICY IF EXISTS "trainee_models: owner access" ON "public"."trainee_models";
+DROP POLICY IF EXISTS "users: owner access" ON "public"."users";
+DROP POLICY IF EXISTS "set_logs: owner access" ON "public"."set_logs";
+DROP POLICY IF EXISTS "owner access" ON "public"."gym_profiles";
+
+
+-- 2. Disable RLS on the five tables the forward migration enabled it on.
+--    (gym_profiles is intentionally left RLS-enabled — that matches the baseline.)
+
+ALTER TABLE "public"."workout_sessions" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."programs" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."trainee_models" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."users" DISABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."set_logs" DISABLE ROW LEVEL SECURITY;
+
+
+-- 3. Restore the original USING-only "owner access" policies on programs and
+--    set_logs (the forward migration replaced these). These are inert while RLS
+--    is disabled above, but restoring them returns the schema to its exact
+--    pre-migration shape.
+
+CREATE POLICY "programs: owner access" ON "public"."programs" USING (("user_id" = "auth"."uid"()));
+
+CREATE POLICY "set_logs: owner access" ON "public"."set_logs" USING (("session_id" IN ( SELECT "workout_sessions"."id"
+   FROM "public"."workout_sessions"
+  WHERE ("workout_sessions"."user_id" = "auth"."uid"()))));
+
+
+-- 4. Restore the original gym_profiles "anon full access" USING(true) policy.
+
+CREATE POLICY "anon full access" ON "public"."gym_profiles" USING (true) WITH CHECK (true);

--- a/supabase/migrations/20260612020101_enable_rls_owner_policies.sql
+++ b/supabase/migrations/20260612020101_enable_rls_owner_policies.sql
@@ -1,0 +1,67 @@
+-- Reverse migration: docs/migrations/down/20260612020101_enable_rls_owner_policies.sql
+-- (documentation only; not auto-applied by `supabase db push`)
+--
+-- Auth/RLS workstream slice 5 (#369, ADR-0027) — the gate-flip.
+--
+-- Enables Row Level Security on the five core owner-scoped tables that were
+-- still RLS-off (workout_sessions, programs, trainee_models, users, set_logs),
+-- and installs FOR ALL owner policies with BOTH USING and WITH CHECK so a client
+-- can neither read nor INSERT rows it does not own. Replaces the pre-existing
+-- USING-only "owner access" policies on programs and set_logs (which had no
+-- WITH CHECK, so they could not constrain writes). Also replaces the
+-- gym_profiles "anon full access" USING(true) policy with a real owner policy.
+--
+-- No GRANT changes: with auth.uid()-keyed policies the anon role (NULL uid)
+-- matches no rows, so the existing anon grants are inert under RLS. Edge
+-- Functions connect as postgres (BYPASSRLS) and enforce ownership via the
+-- slice-4 JWT check, so they are unaffected.
+--
+-- Idempotent: ENABLE ROW LEVEL SECURITY is a no-op if already on, and every
+-- CREATE POLICY is preceded by DROP POLICY IF EXISTS.
+
+
+-- 1. Enable RLS on the five tables currently missing it.
+
+ALTER TABLE "public"."workout_sessions" ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE "public"."programs" ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE "public"."trainee_models" ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE "public"."users" ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE "public"."set_logs" ENABLE ROW LEVEL SECURITY;
+
+
+-- 2. Owner-scoped FOR ALL policies (USING + WITH CHECK).
+
+DROP POLICY IF EXISTS "workout_sessions: owner access" ON "public"."workout_sessions";
+CREATE POLICY "workout_sessions: owner access" ON "public"."workout_sessions" FOR ALL USING (("user_id" = "auth"."uid"())) WITH CHECK (("user_id" = "auth"."uid"()));
+
+-- programs had a pre-existing USING-only "programs: owner access" policy; replace it.
+DROP POLICY IF EXISTS "programs: owner access" ON "public"."programs";
+CREATE POLICY "programs: owner access" ON "public"."programs" FOR ALL USING (("user_id" = "auth"."uid"())) WITH CHECK (("user_id" = "auth"."uid"()));
+
+DROP POLICY IF EXISTS "trainee_models: owner access" ON "public"."trainee_models";
+CREATE POLICY "trainee_models: owner access" ON "public"."trainee_models" FOR ALL USING (("user_id" = "auth"."uid"())) WITH CHECK (("user_id" = "auth"."uid"()));
+
+-- users is keyed on its PK (no user_id column; id IS the user id).
+DROP POLICY IF EXISTS "users: owner access" ON "public"."users";
+CREATE POLICY "users: owner access" ON "public"."users" FOR ALL USING (("id" = "auth"."uid"())) WITH CHECK (("id" = "auth"."uid"()));
+
+-- set_logs has no user_id; ownership is via session_id -> workout_sessions.user_id.
+-- Replace the pre-existing USING-only "set_logs: owner access" subquery policy,
+-- keeping the subquery shape and adding the matching WITH CHECK.
+DROP POLICY IF EXISTS "set_logs: owner access" ON "public"."set_logs";
+CREATE POLICY "set_logs: owner access" ON "public"."set_logs" FOR ALL USING (("session_id" IN ( SELECT "workout_sessions"."id"
+   FROM "public"."workout_sessions"
+  WHERE ("workout_sessions"."user_id" = "auth"."uid"())))) WITH CHECK (("session_id" IN ( SELECT "workout_sessions"."id"
+   FROM "public"."workout_sessions"
+  WHERE ("workout_sessions"."user_id" = "auth"."uid"()))));
+
+
+-- 3. Fix gym_profiles: replace the "anon full access" USING(true) policy with a
+--    real owner policy. (gym_profiles already has RLS enabled in the baseline.)
+
+DROP POLICY IF EXISTS "anon full access" ON "public"."gym_profiles";
+CREATE POLICY "owner access" ON "public"."gym_profiles" FOR ALL USING (("user_id" = "auth"."uid"())) WITH CHECK (("user_id" = "auth"."uid"()));


### PR DESCRIPTION
Part of #369 — auth/RLS workstream slice 5 of 6 (the gate-flip). Enables RLS + `FOR ALL USING/WITH CHECK (user_id = auth.uid())` owner policies on workout_sessions/programs/trainee_models/users(id)/set_logs(subquery), and replaces gym_profiles' `USING(true)` with an owner policy. **Merging this runs `db push` in CI → RLS goes live on prod**; existing placeholder-keyed rows become invisible (accepted alpha data-wipe); clients must be on the slice-3 build (auth.uid() identity). EFs keep working (postgres/BYPASSRLS + slice-4 JWT check). No grant changes (anon grants inert under RLS).

### What's in the migration
- `ENABLE ROW LEVEL SECURITY` on the 5 tables still missing it: `workout_sessions`, `programs`, `trainee_models`, `users`, `set_logs` (idempotent; `gym_profiles`/`memory_embeddings` already had it).
- New `FOR ALL` owner policies with **both** USING and WITH CHECK (the WITH CHECK blocks INSERTing a row you don't own). `users` keyed on its PK (`id = auth.uid()`); `set_logs` traces ownership through `session_id → workout_sessions.user_id`.
- Each `CREATE POLICY` preceded by `DROP POLICY IF EXISTS "<exact baseline name>"` → idempotent + forward-safe. The pre-existing USING-only `programs: owner access` and `set_logs: owner access` policies are cleanly replaced with the FOR ALL variants.
- `gym_profiles`: drops the `anon full access` `USING(true)` policy, adds an `owner access` policy.

### Deferred (not in this PR)
- **Grant-narrowing** (defense-in-depth): the existing `anon` grants are left as-is. Under these `auth.uid()`-keyed policies the anon role (NULL `auth.uid()`) matches no rows, so the grants are inert — narrowing them is a separate follow-up.

### Verification
- **Not applied against a DB** — no local Postgres here (Docker down; `supabase db lint`/`migration list` fail with connection-refused). Verified by SQL review against the baseline `20260506091314_remote_schema.sql` only: exact table/column/policy names, paren-balanced SQL, baseline style.
- Reverse migration (`docs/migrations/down/<same-filename>.sql`, doc-only) exactly inverts: DISABLE RLS on the 5 tables, DROP the new policies, restore the original USING-only `programs`/`set_logs` policies and the `gym_profiles` `anon full access` `USING(true)` policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)