### PR TITLE
fix(#369): EF smoke test carries matching-sub JWT (unblocks deploy)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,18 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — Fix: the end-to-end smoke test now sends a login token (PR #387, part of #369)
+
+**Problem.** Slice 4 added the server-side ownership check (the function rejects a request whose login token doesn't match the body's user id). But the end-to-end "smoke" test for the trainee-model function fires a real HTTP request at the served function with **no** login token — so the new check correctly returned 401, the smoke test failed, and because CI's deploy step only runs when the Edge-Function tests pass, **the deploy was skipped and slice 4's check never actually went live.** (The slice-4 agent couldn't catch this — the smoke test needs a live local Postgres in Docker, which wasn't available, so it only ran the unit tests.)
+
+**What changed.** The smoke harness's shared `postWithRetry` helper now attaches an `Authorization: Bearer …` header carrying a token whose `sub` equals the request's `user_id` (the local serve runs with `--no-verify-jwt` and the code only decodes the token, so the signature is a placeholder). Both smoke cases now pass the ownership gate and reach the orchestrator.
+
+**How checked.** Verified the token the helper builds is accepted by slice 4's real `subFromAuthorization` decoder (extracts the matching `sub`). Can't run the full smoke test here (no Docker); CI runs it on merge — and a green Edge-Function-tests job is exactly what re-enables the deploy.
+
+**Status:** merged as PR #387. Unblocks the auto-deploy so slice 4's ownership check finally deploys.
+
+---
+
 ## 2026-06-12 — The server now checks it's really you before saving your data (auth slice 4, part of #369)
 
 **Problem.** Two of our server functions — the one that updates your trainee model after a workout, and the one that saves your goal — trusted the `user_id` written in the request body, no questions asked. That meant a logged-in person could put *someone else's* id in the body and write to that person's data (a classic "insecure direct object reference" hole). And we can't lean on the database's own row-level security to stop it here, because these functions connect with a super-privileged account that bypasses those row rules. So the function itself has to be the bouncer.

--- a/supabase/functions/update-trainee-model/smoke_test.ts
+++ b/supabase/functions/update-trainee-model/smoke_test.ts
@@ -38,12 +38,26 @@ const sql = postgres(DB_URL, { max: 4 });
  * window. Tests retry to absorb the flake — the underlying HTTP path is
  * the production target; the flake is local-dev / CI infrastructure.
  */
+// #369 slice 4 added a handler-level ownership check: the function decodes the
+// JWT `sub` from the Authorization header and rejects (401/403) when it doesn't
+// match the body `user_id`. The smoke harness serves with `--no-verify-jwt`, so
+// the signature is never checked — but the header must still be present and the
+// `sub` must match. Build a decode-only Bearer token carrying `sub = user_id`.
+function smokeAuthHeader(body: string): Record<string, string> {
+  const sub = (JSON.parse(body) as { user_id?: string }).user_id ?? "";
+  const payload = btoa(JSON.stringify({ sub }))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return {
+    Authorization: `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${payload}.smoke`,
+  };
+}
+
 async function postWithRetry(body: string, maxAttempts = 5): Promise<Response> {
   let lastRes: Response | undefined;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const res = await fetch(EDGE_FUNCTION_URL, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...smokeAuthHeader(body) },
       body,
     });
     if (res.status !== 502 && res.status !== 503 && res.status !== 504) {


### PR DESCRIPTION
Slice 4 (#385) added the EF ownership check, but the trainee-model **smoke test** POSTs with no Authorization header → the gate returns 401 → the **Edge-Function-tests CI job fails** → the deploy job (which `needs: [ef-test]`) is **skipped**, so slice 4's check never deployed. This makes `postWithRetry` attach a Bearer token whose `sub` equals the body `user_id` (serve uses `--no-verify-jwt`; the code only decodes, so the signature is a placeholder). Verified the token round-trips through slice 4's real `subFromAuthorization`. Merging this greens ef-test → re-enables the auto-deploy → slice 4's ownership check goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)