### PR TITLE
fix(#369): Reset All clears the Supabase anon session (true-zero reset)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,22 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — The "reset app" button now actually gives you a fresh start (found from a gym-log crash)
+
+**What went wrong.** After the database lock went live (the auth work), I tried to start a workout and it wouldn't save — the app kept retrying and then gave up. The reason: turning on the lock gave my install a brand-new login id, but nothing ever created a matching row for that new id in the `users` table. Every save points back to that table, so the database rejected the workout. Onboarding is the *only* place that creates the `users` row, and my install had onboarded long ago, so it never re-ran.
+
+**Why it matters.** Since there's only one user right now (me), the clean fix is to wipe and start over from week one. But the in-app "Reset All App Data" button was written before the auth work — it cleared everything *except* the new login session. So a reset would quietly keep the same broken login, and you'd land right back in the same hole.
+
+**What I changed.** The reset button now also clears the saved login session (the access token, refresh token, expiry, and the login id). The next launch then signs in fresh, mints a new login id, and onboarding creates the matching `users` row for it — so saving works again. I also changed the confirmation message to tell you to quit and reopen the app before onboarding, because the fresh login only kicks in on the next launch.
+
+**How I checked.** Confirmed the four login keys are real, that nothing else in the app does an "identity wipe" that would need the same fix, and that the whole app still builds (BUILD SUCCEEDED). The old failed-and-parked workout in the local queue lives in the same storage the reset wipes, so it's gone after the reset too.
+
+**Follow-up filed.** The deeper fix — so this can never happen again to any future user — is a database trigger that creates the `users` row automatically the moment a new login is made, instead of relying on onboarding. Logged as a separate issue.
+
+**Status:** fix on branch, building green, PR to follow.
+
+---
+
 ## 2026-06-12 — Writing down what the auth work decided, so we don't forget (auth slice 6, docs — part of #369)
 
 **What this is.** Slices 1–5 of the auth/RLS workstream all shipped and the database lock is now live. This last slice is just paperwork: it writes down the decisions in a permanent record (ADR-0027) so future contributors understand why we went the way we did, and it fixes two older records that had an assumption that turned out to be wrong.

--- a/ProjectApex/Settings/DeveloperSettingsView.swift
+++ b/ProjectApex/Settings/DeveloperSettingsView.swift
@@ -584,6 +584,11 @@ struct DeveloperSettingsView: View {
     ///   1. All UserDefaults for this app's bundle domain (onboarding flags, scan-skipped flag, etc.)
     ///   2. GymFactStore weight-correction facts (UserDefaults-backed)
     ///   3. The userId Keychain entry so onboarding generates a fresh identity
+    ///   4. The Supabase anonymous-auth session (#369) — access/refresh tokens, expiry,
+    ///      and the persisted `auth.uid()`. Without this, `restoreFromKeychain()` re-pins
+    ///      the OLD identity on the next launch, so "reset" would not mint a fresh user and
+    ///      the freshly-onboarded `users` row would not match a brand-new `auth.uid()`.
+    ///      A new anonymous session (and uid) is minted on the next launch.
     ///   (API keys — anthropicAPIKey, openAIAPIKey, supabaseAnonKey — are intentionally preserved)
     @MainActor
     private func performResetAll() async {
@@ -598,9 +603,19 @@ struct DeveloperSettingsView: View {
         // 3. Remove the persisted userId so onboarding creates a fresh identity
         try? keychain.delete(.userId)
 
-        // Navigate to onboarding without a relaunch
+        // 4. Clear the persisted Supabase anonymous-auth session (#369) so the next launch
+        //    signs in fresh and mints a new auth.uid(). Otherwise the restored session
+        //    re-pins the old identity and the reset is not a true zero.
+        try? keychain.delete(.supabaseAccessToken)
+        try? keychain.delete(.supabaseRefreshToken)
+        try? keychain.delete(.supabaseSessionExpiry)
+        try? keychain.delete(.supabaseAuthUserId)
+
+        // Navigate to onboarding immediately; the fresh anon identity is established on the
+        // next launch (the in-memory auth session is only re-resolved at startup), so the
+        // banner tells the user to relaunch before onboarding.
         onResetAll?()
-        showBanner("All app data cleared.", isError: false)
+        showBanner("All app data cleared. Quit and reopen the app, then complete onboarding.", isError: false)
     }
 
     /// Clears onboarding flags and the cached program so re-running onboarding


### PR DESCRIPTION
## Why

Diagnosed from a real gym-session crash: starting a workout failed with

```
HTTP 409: 23503 — insert or update on "workout_sessions" violates FK
"workout_sessions_user_id_fkey" — Key is not present in table "users".
```

The #369 auth/RLS cutover mints a fresh `auth.uid()` per install, but the **only** code that inserts the matching `public.users` row is onboarding's one-shot best-effort `try? insert(..., table: "users")`. An install that already onboarded never re-runs it, so its new uid has no `users` row and every owner-scoped write FK-fails.

The clean recovery for the single-alpha-user case is wipe-and-restart. But the in-app **Reset All App Data** action predates the auth work — it cleared UserDefaults and the legacy `.userId` key but left the four Supabase session keys in the Keychain, so a reset re-pinned the **old** identity on relaunch and was not a true zero.

## What changed

`performResetAll()` now also deletes the four session keys:
`.supabaseAccessToken`, `.supabaseRefreshToken`, `.supabaseSessionExpiry`, `.supabaseAuthUserId`.

Next launch → fresh anon sign-in → new `auth.uid()` → onboarding provisions its `users` row (insert carries the JWT, so it passes the new RLS `WITH CHECK (id = auth.uid())`) → owned writes succeed.

Banner updated to tell the user to **quit + reopen** before onboarding, since the in-memory auth session is only re-resolved at startup (`onResetAll` just flips the UI; it doesn't relaunch).

## Verification

- Cross-cutting grep: the only two sites clearing all four session keys are now `performResetAll` and `SupabaseAuth.clearKeychain()` (logout). No other identity-wipe path has the gap.
- `xcodebuild ... build` → **BUILD SUCCEEDED**.
- The stale dead-lettered WAQ item is in UserDefaults-backed storage, which `removePersistentDomain` already wipes — so it clears on reset too.

## Follow-up

Durable root-cause fix — a `handle_new_user` trigger on `auth.users` that provisions the `public.users` row on every anon sign-up (canonical Supabase pattern; all profile columns are nullable so a bare `INSERT (id)` is valid) — filed separately. That removes the reliance on onboarding entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)