### PR TITLE
fix(#369): anon sign-in resilient to QUIC/HTTP3 stalls (retry + per-attempt timeout)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,20 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-12 — Sign-in no longer gives up too early on a good network (the real reason saves were failing)
+
+**What went wrong.** After the reset fix, saving a workout *still* failed — but for a new reason. On a perfectly good wifi, the app's anonymous sign-in (the thing that gets you a login) was timing out, so the app had no login at all. With no login, it fell back to a placeholder id and the database refused every save with a "row-level security" rejection. The console was full of `quic… max 5 reached` and "Operation timed out".
+
+**Why it was the app, not the wifi.** Earlier in the same run, a different request to the database *succeeded* — so the network was fine. The problem: the sign-in only waited **5 seconds**, tried **once**, and shared its connection with the rest of the app. iOS had learned the server supports a newer connection type (HTTP/3, "QUIC"), tried it for sign-in, and that handshake stalled. Five seconds wasn't enough to recover, so sign-in quit and the app carried on with no login.
+
+**What I changed.** Three small things in the sign-in code: (1) each attempt now gives up after 8 seconds of silence instead of hanging; (2) it **retries up to three times** — and a failed first try makes iOS drop back to the older, reliable connection type, so the retry goes through; (3) the overall wait went from 5 to 30 seconds. The longer wait is safe because sign-in runs in the background — it never freezes the app's screen; it only gives onboarding more time to get a login before it sets you up.
+
+**How I checked.** The whole app builds, and all 7 sign-in tests pass (the change doesn't affect the failure/timeout cases). The user spotted that this was a timing problem, not a wifi problem — they were right.
+
+**Status:** fix on branch, building green, tests green, PR to follow.
+
+---
+
 ## 2026-06-12 — The "reset app" button now actually gives you a fresh start (found from a gym-log crash)
 
 **What went wrong.** After the database lock went live (the auth work), I tried to start a workout and it wouldn't save — the app kept retrying and then gave up. The reason: turning on the lock gave my install a brand-new login id, but nothing ever created a matching row for that new id in the `users` table. Every save points back to that table, so the database rejected the workout. Onboarding is the *only* place that creates the `users` row, and my install had onboarded long ago, so it never re-ran.

--- a/ProjectApex/Services/SupabaseAuth.swift
+++ b/ProjectApex/Services/SupabaseAuth.swift
@@ -118,8 +118,18 @@ actor SupabaseAuth {
     private let session: URLSession
     private let keychain: KeychainService
     /// Hard ceiling on the first-resolution wait so a fresh launch can never
-    /// hang the app waiting on a slow/hung sign-in.
+    /// hang the app waiting on a slow/hung sign-in. Sized to allow a few bounded
+    /// sign-in attempts (see `signInAnonymouslyWithRetry`) — resolution runs in a
+    /// background Task (AppDependencies), so this never blocks the UI; it only
+    /// bounds how long onboarding's user-row provisioning waits for a session.
     private let signInTimeout: TimeInterval
+
+    /// Per-attempt inactivity timeout for a single GoTrue call. Kept short so a
+    /// stalled connection (e.g. an HTTP/3 / QUIC handshake that hangs on an
+    /// otherwise-healthy network) fails fast and the retry can force a fresh
+    /// connection that falls back to HTTP/2 over TCP, instead of burning the
+    /// whole ceiling on one hung request.
+    private let perAttemptTimeout: TimeInterval = 8
 
     private let decoder: JSONDecoder
     private static let logger = Logger(subsystem: "com.projectapex", category: "SupabaseAuth")
@@ -140,7 +150,7 @@ actor SupabaseAuth {
         anonKey: String,
         keychain: KeychainService = .shared,
         urlSession: URLSession = .shared,
-        signInTimeout: TimeInterval = 5
+        signInTimeout: TimeInterval = 30
     ) {
         self.baseURL = supabaseURL
         self.anonKey = anonKey
@@ -191,12 +201,7 @@ actor SupabaseAuth {
         let result = await withTaskGroup(of: SupabaseSession?.self) { group -> SupabaseSession? in
             group.addTask { [weak self] in
                 guard let self else { return nil }
-                do {
-                    return try await self.signInAnonymously()
-                } catch {
-                    await SupabaseAuth.log("anonymous sign-in failed; proceeding as anon", error)
-                    return nil
-                }
+                return await self.signInAnonymouslyWithRetry()
             }
             group.addTask {
                 try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
@@ -212,6 +217,27 @@ actor SupabaseAuth {
             SupabaseAuth.logger.log("anonymous sign-in timed out after \(timeout, privacy: .public)s; proceeding as anon")
         }
         return result
+    }
+
+    /// Anonymous sign-in with bounded retries. The first connection on a fresh
+    /// launch can stall on an HTTP/3 / QUIC handshake even when the network is
+    /// healthy (the PostgREST path having taught `URLSession.shared` that the
+    /// host speaks HTTP/3); each attempt is inactivity-bounded by
+    /// `perAttemptTimeout`, and a failed attempt makes URLSession mark HTTP/3
+    /// broken for the host, so the retry typically completes over HTTP/2/TCP.
+    /// Returns `nil` only after every attempt fails (caller falls back to anon).
+    private func signInAnonymouslyWithRetry(maxAttempts: Int = 3) async -> SupabaseSession? {
+        for attempt in 1...maxAttempts {
+            do {
+                return try await signInAnonymously()
+            } catch {
+                await SupabaseAuth.log("anonymous sign-in attempt \(attempt)/\(maxAttempts) failed", error)
+                if attempt < maxAttempts {
+                    try? await Task.sleep(nanoseconds: 500_000_000)  // 0.5s backoff
+                }
+            }
+        }
+        return nil
     }
 
     // MARK: - GoTrue calls
@@ -289,6 +315,10 @@ actor SupabaseAuth {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue(anonKey, forHTTPHeaderField: "apikey")
         request.httpBody = body
+        // Bound a single attempt so a stalled (e.g. QUIC-hung) connection fails
+        // fast and the caller's retry can force a fresh, TCP-fallback connection
+        // rather than hanging on URLSession's 60s default.
+        request.timeoutInterval = perAttemptTimeout
 
         let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else {


### PR DESCRIPTION
## Why

Follow-up to #389, from a second gym-session log. After a clean reset, saving a workout **still** failed — now with `403 / 42501 "violates row-level security policy"` and a `user_id` of the placeholder `00000000-…-0001`.

Root cause is app-side, not network (the user correctly pushed back on "it's your wifi"): earlier in the same run a PostgREST call **succeeded**, so the host was reachable. But anonymous sign-in ran a **single attempt** on `URLSession.shared` with a hard **5s** ceiling and no retry. Because the PostgREST path teaches `URLSession.shared` that the Supabase host advertises **HTTP/3**, sign-in attempted a **QUIC** connection that stalled (`quic_crypto_queue_append … max 5 reached`, repeated read timeouts), overran 5s, and gave up → no session → placeholder uid → RLS 403. Onboarding even generated an unsavable program.

## What changed (`SupabaseAuth`)

- **Per-attempt inactivity bound** (`request.timeoutInterval = 8`) so a stalled QUIC handshake fails fast instead of hanging on URLSession's 60s default.
- **`signInAnonymouslyWithRetry`** — up to 3 attempts, 0.5s backoff. A failed attempt makes URLSession mark HTTP/3 broken for the host, so the retry completes over HTTP/2/TCP.
- **Ceiling 5s → 30s.** Safe: first-resolution runs in a background `Task` (`AppDependencies.swift:132`), so it never blocks launch — it only bounds how long onboarding waits for a session before provisioning the `users` row.

## Verification

- `xcodebuild … build` → **BUILD SUCCEEDED**.
- `SupabaseAuthTests` → **7/7 pass**. The mock stub matcher is non-consuming (`.first { }`), so the added retries don't change the failure/timeout cases, and no test asserts an exact signup call-count.

## Follow-up (not in this PR)

Onboarding still *silently* proceeds to the placeholder if sign-in ultimately fails — under RLS that produces unsavable data. The durable fix is to gate onboarding/program-generation on a resolved session (surface "couldn't connect — retry") rather than fall through. Ties into #391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)