### PR TITLE
fix(#369): GoTrue on a dedicated HTTP/2 session (fixes QUIC sign-in stall) + sign-in diagnostics

### DIFF
--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -126,7 +126,21 @@ final class AppDependencies {
         // repointed and RLS is still off, so behavior is unchanged this slice.
         // A stored session restores instantly; a fresh launch signs in anonymously
         // in the background and falls back to the anon key on failure/timeout.
-        let auth = SupabaseAuth(supabaseURL: Config.supabaseURL, anonKey: supabaseAnonKey)
+        // GoTrue gets its OWN ephemeral URLSession rather than URLSession.shared.
+        // The shared session, once the PostgREST path teaches it the host advertises
+        // HTTP/3, attempts QUIC for sign-in; on some networks that handshake stalls
+        // and the launch sign-in times out with no session (→ placeholder uid →
+        // RLS 403 on every owned write). A fresh ephemeral session carries no cached
+        // Alt-Svc, so its first request negotiates HTTP/2 over TCP — which the server
+        // serves fine. waitsForConnectivity rides out a brief connectivity drop.
+        let authSessionConfig = URLSessionConfiguration.ephemeral
+        authSessionConfig.waitsForConnectivity = true
+        authSessionConfig.timeoutIntervalForRequest = 15
+        let auth = SupabaseAuth(
+            supabaseURL: Config.supabaseURL,
+            anonKey: supabaseAnonKey,
+            urlSession: URLSession(configuration: authSessionConfig)
+        )
         self.supabaseAuth = auth
         // Wire the refresh/401-retry hooks so authed requests stay valid.
         Task {

--- a/ProjectApex/Services/SupabaseAuth.swift
+++ b/ProjectApex/Services/SupabaseAuth.swift
@@ -191,9 +191,11 @@ actor SupabaseAuth {
     private func resolveFirstSession() async -> SupabaseSession? {
         // 1. Restore a stored session instantly (no network) if present.
         if let restored = restoreFromKeychain() {
+            print("[SupabaseAuth] restored persisted session — uid: \(restored.userId)")
             currentSession = restored
             return restored
         }
+        print("[SupabaseAuth] no stored session — starting fresh anonymous sign-in")
 
         // 2. Fresh launch → anonymous sign-in, bounded by signInTimeout so a
         //    hung/slow endpoint (or an unreachable network) can't block launch.
@@ -214,6 +216,7 @@ actor SupabaseAuth {
         }
 
         if result == nil {
+            print("[SupabaseAuth] first-resolution returned NO session after \(timeout)s ceiling — proceeding as anon (placeholder)")
             SupabaseAuth.logger.log("anonymous sign-in timed out after \(timeout, privacy: .public)s; proceeding as anon")
         }
         return result
@@ -229,14 +232,18 @@ actor SupabaseAuth {
     private func signInAnonymouslyWithRetry(maxAttempts: Int = 3) async -> SupabaseSession? {
         for attempt in 1...maxAttempts {
             do {
-                return try await signInAnonymously()
+                let session = try await signInAnonymously()
+                print("[SupabaseAuth] anonymous sign-in succeeded on attempt \(attempt)/\(maxAttempts) — uid: \(session.userId)")
+                return session
             } catch {
+                print("[SupabaseAuth] anonymous sign-in attempt \(attempt)/\(maxAttempts) FAILED: \(error.localizedDescription) — \(error)")
                 await SupabaseAuth.log("anonymous sign-in attempt \(attempt)/\(maxAttempts) failed", error)
                 if attempt < maxAttempts {
                     try? await Task.sleep(nanoseconds: 500_000_000)  // 0.5s backoff
                 }
             }
         }
+        print("[SupabaseAuth] anonymous sign-in EXHAUSTED all \(maxAttempts) attempts — no session (app falls back to placeholder; owned writes will RLS-403)")
         return nil
     }
 


### PR DESCRIPTION
## Definitive diagnosis

Hit the live endpoint directly — `POST https://…supabase.co/auth/v1/signup` with `{}` and the anon key → **HTTP/2 200** with a valid `is_anonymous: true` session in 211ms. So the server, anon key, and anonymous provider are healthy and **not** rate-limited.

The failure is **client-side**: on device, the launch sign-in stalls on an **HTTP/3 (QUIC)** handshake (`quic_crypto_queue_append … max 5 reached`, repeated read timeouts) → resolves to no session → placeholder uid `00000000-…-0001` → `403 / 42501` RLS on every owned write. `URLSession.shared` had learned (via the PostgREST path) that the host advertises HTTP/3 and tried QUIC for auth. #392's retry didn't rescue it because a **timed-out/cancelled** attempt doesn't mark HTTP/3 "broken", so retries keep re-stalling on QUIC.

Symptom timing (user-confirmed): no error during onboarding/program-gen; the retries pile up on the **first workout screen**, where the first Supabase owned-write (the session row) is enqueued under the placeholder.

## Fix

`SupabaseAuth` now runs on its **own ephemeral `URLSession`** (`AppDependencies`). A fresh session carries no cached Alt-Svc, so its first request negotiates **HTTP/2 over TCP** — the path the server serves fine. `waitsForConnectivity` rides out a brief drop. Sign-in completes at launch, so by the time the workout screen enqueues a row, `resolvedUserId` is the real `auth.uid()`.

Adds visible `[SupabaseAuth]` `print` diagnostics (restore vs fresh sign-in; per-attempt success/failure **with the error**; exhaustion; timeout branch) so any residual failure is unambiguous in the console.

## Verification

- Live endpoint test: 200 over HTTP/2 (proof the server is healthy).
- `SupabaseAuthTests` 7/7 pass; full app builds.

## Remaining follow-up (#391)

Onboarding/workout-start still proceed under the placeholder if sign-in ever fails outright — gate owned writes on a resolved session rather than silently dead-lettering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)