### PR TITLE
feat(#346): the Lens — aperture readiness gauge + disclosure sheet

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,24 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-13 — Built the Lens: a 6-blade camera-iris readiness gauge (Phase 3 UI, Slice 5)
+
+**What it is.** The Lens is a camera-iris aperture drawn in code — six blade shapes that rotate into alignment and open wider as readiness goes up. It always shows a literal number plus a state word so it is readable in a dark gym without needing to understand the shape. It is built DORMANT: finished and tested, but not yet wired into the live shell.
+
+**Three states.** Focused iris + number (resolved, score known); unfocused iris + "—" (calibrating / unknown / first day); slow oscillation + "Updating" (computing in the background). The state word lexicon has five entries: Optimal, Good, Reduced, Poor, Calibrating, Updating. Layout is sized to "Calibrating" — the longest — so the compact gauge never reflows when the word changes.
+
+**The disclosure sheet.** Tapping the gauge opens a small sheet: big iris + number + state word, then one or two training-load numbers explaining why, a line saying "Based on your training load — no sleep or HRV data", and two expandable sections ("How to read this" / "How it's calculated"). No deep-view creep — it stays small.
+
+**Colour rule.** Only DesignSystem ink and accent-ink tokens. The legacy `ReadinessScore.tintColor` multi-hue palette is deliberately ignored.
+
+**Motion.** Blades animate via the `gauge-focus` spring (response 0.5, damping 0.7, tiny overshoot) when state changes. Reduce Motion falls back to a 150ms crossfade. The bare component has no entrance or idle animation so it snapshots at frame 1.
+
+**Tests.** 15 unconditional tests pass: all four label cases, the unknown/calibrating case, the computing case, lexicon length, longest-word sizing, accessibility labels (number + state word, not just "image"), WCAG-relevant token hygiene, isFocused logic, aperture proportionality. Gated snapshot cases (APEX_SNAPSHOT_TESTS=1) cover all states × light + dim for both compact and sheet — wired but reference-pending per the CI record discipline.
+
+**Status:** PR opened, Closes #346.
+
+---
+
 ## 2026-06-13 — Built the capability band: one component, three contexts (Slice 4, #345)
 
 The design specced a single band drawing that works in three places — onboarding model reveal, post-workout evidence strip, and the Progress ledger row. Instead of building three separate views, the spec said build one and configure it. That's what shipped today.

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		A1C0F19329000000APIKEY04 /* BundledKeyResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F19329000000APIKEY03 /* BundledKeyResolutionTests.swift */; };
 		5A30343A0000000000FE5102 /* AppShellRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A30343A0000000000FE5101 /* AppShellRouteTests.swift */; };
 		CB34500000000000CB345002 /* CapabilityBandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB34500000000000CB345001 /* CapabilityBandTests.swift */; };
+		LE34600000000000LE346002 /* LensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LE34600000000000LE346001 /* LensTests.swift */; };
 		DE52000000000000DE520002 /* DesignSystemGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */; };
 		DE53000000000000DE530002 /* DrawnInstrumentSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */; };
 		DE54000000000000DE540002 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = DE54000000000000DE540001 /* SnapshotTesting */; };
@@ -130,6 +131,7 @@
 		DE51900000000000DE519001 /* DesignSystemTokensTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DesignSystemTokensTests.swift; sourceTree = "<group>"; };
 		5A30343A0000000000FE5101 /* AppShellRouteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppShellRouteTests.swift; sourceTree = "<group>"; };
 		CB34500000000000CB345001 /* CapabilityBandTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CapabilityBandTests.swift; sourceTree = "<group>"; };
+		LE34600000000000LE346001 /* LensTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LensTests.swift; sourceTree = "<group>"; };
 		DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DesignSystemGeometryTests.swift; sourceTree = "<group>"; };
 		DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DrawnInstrumentSnapshotTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
@@ -277,6 +279,7 @@
 				A1C0F19329000000APIKEY03 /* BundledKeyResolutionTests.swift */,
 				5A30343A0000000000FE5101 /* AppShellRouteTests.swift */,
 				CB34500000000000CB345001 /* CapabilityBandTests.swift */,
+				LE34600000000000LE346001 /* LensTests.swift */,
 				DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */,
 				DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */,
 			);
@@ -445,6 +448,7 @@
 				A1C0F19329000000APIKEY04 /* BundledKeyResolutionTests.swift in Sources */,
 				5A30343A0000000000FE5102 /* AppShellRouteTests.swift in Sources */,
 				CB34500000000000CB345002 /* CapabilityBandTests.swift in Sources */,
+				LE34600000000000LE346002 /* LensTests.swift in Sources */,
 				DE52000000000000DE520002 /* DesignSystemGeometryTests.swift in Sources */,
 				DE53000000000000DE530002 /* DrawnInstrumentSnapshotTests.swift in Sources */,
 			);

--- a/ProjectApex/DesignSystem/Instruments/LensView.swift
+++ b/ProjectApex/DesignSystem/Instruments/LensView.swift
@@ -1,0 +1,392 @@
+// LensView.swift
+// ProjectApex — DesignSystem/Instruments
+//
+// The Lens: a 6-blade camera-iris readiness gauge (#346 / ADR-0026 Phase 3 UI).
+// DORMANT: reusable component, built behind the new 3-tab shell flag.
+// Source spec: docs/design/splash-today.md §The Lens, ui-overhaul-spec.md §6.
+//
+// State-word lexicon (≤5 words, sized to "Calibrating" — the longest):
+//   Optimal · Good · Reduced · Poor  (resolved, focused iris)
+//   Calibrating                       (unknown / stale / day-one, unfocused + "—")
+//   Updating                          (computing, slow oscillation)
+//
+// Colour law: DesignSystem ink/accent tokens ONLY. ReadinessScore.tintColor is
+// the legacy multi-hue palette; it is ignored here (ONE-accent rule).
+//
+// Motion: gauge-focus = Motion.gaugeFocus (spring 0.5 / 0.7, tiny overshoot).
+// Reduce Motion fallback: crossfade (Motion.reduceMotionCrossfade).
+// The bare LensView has NO entrance / idle animation — it snapshots assembled
+// at frame 1. The computing oscillation is gated by an injected flag so tests
+// capture a deterministic frame.
+
+import SwiftUI
+
+// MARK: - LensState
+
+/// The three display states of the Lens gauge.
+enum LensState {
+    /// Data resolved. Shows the iris focused + a numeric score + a state word.
+    case resolved(ReadinessScore)
+    /// Data unknown / calibrating / stale. Shows the iris unfocused + "—" + "Calibrating".
+    case unknown
+    /// Background computation in progress. Shows slow iris blade oscillation + "Updating".
+    case computing
+}
+
+extension LensState: Equatable {
+    static func == (lhs: LensState, rhs: LensState) -> Bool {
+        switch (lhs, rhs) {
+        case (.resolved(let a), .resolved(let b)): return a.score == b.score
+        case (.unknown, .unknown): return true
+        case (.computing, .computing): return true
+        default: return false
+        }
+    }
+}
+
+extension LensState {
+    /// The numeric string rendered beside the gauge.
+    var displayNumber: String {
+        switch self {
+        case .resolved(let r): return "\(r.score)"
+        case .unknown, .computing: return "—"
+        }
+    }
+
+    /// The state word. Lexicon ≤5 words; sized to "Calibrating" (the longest).
+    var stateWord: String {
+        switch self {
+        case .resolved(let r):
+            switch r.label {
+            case .optimal: return "Optimal"
+            case .good:    return "Good"
+            case .reduced: return "Reduced"
+            case .poor:    return "Poor"
+            }
+        case .unknown:   return "Calibrating"
+        case .computing: return "Updating"
+        }
+    }
+
+    /// Iris aperture fraction: 0 (fully closed) → 1 (fully open).
+    var aperture: Double {
+        switch self {
+        case .resolved(let r): return Double(r.score) / 100.0
+        case .unknown:         return 0.25
+        case .computing:       return 0.5
+        }
+    }
+
+    /// Whether the iris blades are in the focused (sharp-edge) position.
+    var isFocused: Bool {
+        if case .resolved = self { return true }
+        return false
+    }
+}
+
+// MARK: - IrisBlade
+
+/// A single camera-iris blade: a rotated rounded rectangle that pivots around
+/// the iris centre. Six blades placed 60° apart make the aperture.
+private struct IrisBlade: Shape {
+    var angle: Double       // degrees, animated
+    var aperture: Double    // 0…1, animated via blade length
+
+    var animatableData: AnimatablePair<Double, Double> {
+        get { .init(angle, aperture) }
+        set { angle = newValue.first; aperture = newValue.second }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        let r = min(rect.width, rect.height) / 2
+        let bladeWidth  = r * 0.55
+        // Blade length shrinks as aperture opens (the hole gets bigger).
+        let bladeLength = r * (0.9 - aperture * 0.5)
+        let pivot = CGPoint(x: rect.midX, y: rect.midY)
+
+        // Build the blade centred on the pivot, then rotate and offset to the rim.
+        var p = Path()
+        let cornerRadius: CGFloat = bladeWidth * 0.25
+        let bladeBounds = CGRect(
+            x: -bladeWidth / 2,
+            y: -bladeLength,
+            width: bladeWidth,
+            height: bladeLength
+        )
+        p.addRoundedRect(in: bladeBounds,
+                         cornerSize: CGSize(width: cornerRadius, height: cornerRadius))
+
+        let rad = angle * .pi / 180
+        var t = CGAffineTransform.identity
+        t = t.translatedBy(x: pivot.x, y: pivot.y)
+        t = t.rotated(by: rad)
+        t = t.translatedBy(x: 0, y: -r * 0.38) // offset to the rim edge
+        return p.applying(t)
+    }
+}
+
+// MARK: - IrisView
+
+/// Six blades composited with EvenOdd fill to punch the aperture hole.
+struct IrisView: View {
+    let state: LensState
+    /// When true, allows the computing oscillation animation. Set to false
+    /// in tests (and in the bare component) so snapshots capture frame 1.
+    var allowsOscillation: Bool = false
+
+    @Environment(\.apexTheme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Rotation offset for the computing oscillation (animated separately).
+    @State private var oscillationOffset: Double = 0
+
+    private static let bladeCount = 6
+
+    var body: some View {
+        GeometryReader { geo in
+            let size = min(geo.size.width, geo.size.height)
+            ZStack {
+                irisBlades(size: size)
+                // Aperture-hole punch: solid circle matching paper, blended over blades.
+                Circle()
+                    .fill(theme.paper.color)
+                    .frame(width: size * apertureHoleSize, height: size * apertureHoleSize)
+                    // Focus ring: accentInk when resolved, hairline when not.
+                    .overlay(
+                        Circle()
+                            .stroke(state.isFocused ? theme.accentInk.color : theme.hairline.color,
+                                    lineWidth: state.isFocused ? 2 : 1)
+                    )
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+        }
+        .onAppear {
+            guard allowsOscillation, case .computing = state, !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 1.8).repeatForever(autoreverses: true)) {
+                oscillationOffset = 18
+            }
+        }
+    }
+
+    private var apertureHoleSize: Double {
+        // Hole diameter as a fraction of the iris diameter.
+        let base = 0.22 + state.aperture * 0.38
+        return base
+    }
+
+    private func irisBlades(size: CGFloat) -> some View {
+        let baseRotation = oscillationOffset
+        return ZStack {
+            ForEach(0..<Self.bladeCount, id: \.self) { i in
+                let angle = Double(i) * (360.0 / Double(Self.bladeCount)) + baseRotation
+                IrisBlade(angle: angle, aperture: state.aperture)
+                    .fill(theme.ink.color.opacity(0.85))
+            }
+        }
+        .frame(width: size, height: size)
+        // Animation applied structurally (ADR-0025 frame-1 == end-state discipline):
+        // the blades animate when state changes but start settled.
+        .animation(
+            reduceMotion ? Motion.reduceMotionCrossfade : Motion.gaugeFocus,
+            value: state
+        )
+    }
+}
+
+// MARK: - LensView (compact)
+
+/// The compact Lens: iris + number + state word, always both present.
+/// Size is intrinsic — caller constrains via `.frame`.
+struct LensView: View {
+    let state: LensState
+    /// Allow computing oscillation (set to false in tests).
+    var allowsOscillation: Bool = false
+
+    @Environment(\.apexTheme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    init(state: LensState, allowsOscillation: Bool = false) {
+        self.state = state
+        self.allowsOscillation = allowsOscillation
+    }
+
+    public var body: some View {
+        HStack(spacing: Spacing.sm) {
+            IrisView(state: state, allowsOscillation: allowsOscillation)
+                .frame(width: 44, height: 44)
+
+            VStack(alignment: .leading, spacing: 1) {
+                // Number — tabular, bold. "—" when not resolved.
+                Text(state.displayNumber)
+                    .apexFont(.display)
+                    .foregroundStyle(theme.ink.color)
+                    .monospacedDigit()
+                    .animation(reduceMotion ? Motion.reduceMotionCrossfade : Motion.gaugeFocus,
+                               value: state.displayNumber)
+
+                // State word — sized to "Calibrating" (the longest) so layout never reflows.
+                ZStack(alignment: .leading) {
+                    // Invisible sizing ghost = longest possible word.
+                    Text("Calibrating")
+                        .apexFont(.label)
+                        .hidden()
+                    Text(state.stateWord)
+                        .apexFont(.label)
+                        .foregroundStyle(theme.inkMuted.color)
+                        .animation(
+                            reduceMotion ? Motion.reduceMotionCrossfade : Motion.gaugeFocus,
+                            value: state.stateWord
+                        )
+                }
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityAddTraits(.isStaticText)
+    }
+
+    private var accessibilityLabel: String {
+        switch state {
+        case .resolved(let r):
+            return "Readiness \(r.score), \(state.stateWord)"
+        case .unknown:
+            return "Readiness unknown, Calibrating"
+        case .computing:
+            return "Readiness updating"
+        }
+    }
+}
+
+// MARK: - LensSheet
+
+/// The disclosure sheet: stays small, no deep-view creep.
+/// Iris large + number + state word → why grounded in training-load numbers
+/// → two-tier "How to read this" / "How it's calculated".
+struct LensSheet: View {
+    let state: LensState
+    /// 1–2 representative training-load numbers for the "why" section.
+    /// e.g. ["Acute load: 1,240", "Chronic load: 980"]
+    let trainingLoadLines: [String]
+
+    @Environment(\.apexTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Spacing.lg) {
+                    heroSection
+                    Divider()
+                        .background(theme.hairline.color)
+                    whySection
+                    Divider()
+                        .background(theme.hairline.color)
+                    howToReadSection
+                    howItsCalculatedSection
+                }
+                .padding(Spacing.lg)
+            }
+            .background(theme.paper.color)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .apexFont(.label)
+                        .foregroundStyle(theme.accentInk.color)
+                }
+            }
+        }
+    }
+
+    // MARK: Sections
+
+    private var heroSection: some View {
+        HStack(spacing: Spacing.md) {
+            IrisView(state: state)
+                .frame(width: 80, height: 80)
+
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                Text(state.displayNumber)
+                    .apexFont(.heroNum)
+                    .foregroundStyle(theme.ink.color)
+                    .monospacedDigit()
+                // Sized to longest word as in compact view.
+                ZStack(alignment: .leading) {
+                    Text("Calibrating").apexFont(.title).hidden()
+                    Text(state.stateWord)
+                        .apexFont(.title)
+                        .foregroundStyle(theme.inkMuted.color)
+                }
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(heroAccessibilityLabel)
+    }
+
+    private var heroAccessibilityLabel: String {
+        switch state {
+        case .resolved(let r): return "Readiness \(r.score), \(state.stateWord)"
+        case .unknown:         return "Readiness unknown, Calibrating"
+        case .computing:       return "Readiness updating"
+        }
+    }
+
+    private var whySection: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Text("Based on your training load — no sleep or HRV data")
+                .apexFont(.body)
+                .foregroundStyle(theme.inkMuted.color)
+            ForEach(trainingLoadLines, id: \.self) { line in
+                Text(line)
+                    .apexFont(.body)
+                    .foregroundStyle(theme.ink.color)
+            }
+        }
+    }
+
+    private var howToReadSection: some View {
+        DisclosureGroup {
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                bulletRow("80–100",  detail: "Optimal — go hard today.")
+                bulletRow("60–79",   detail: "Good — train as planned.")
+                bulletRow("40–59",   detail: "Reduced — consider scaling volume.")
+                bulletRow("0–39",    detail: "Poor — rest or light movement only.")
+                bulletRow("—",       detail: "Calibrating — not enough data yet; give it a few sessions.")
+            }
+            .padding(.top, Spacing.xs)
+        } label: {
+            Text("How to read this")
+                .apexFont(.label)
+                .foregroundStyle(theme.ink.color)
+        }
+        .tint(theme.inkMuted.color)
+    }
+
+    private var howItsCalculatedSection: some View {
+        DisclosureGroup {
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                Text("Readiness is a 0–100 score derived from your recent training load — how hard and how much you have trained in the last 7 days compared to your rolling 28-day average. Higher chronic base with lower recent spike = higher readiness. The model updates after each session.")
+                    .apexFont(.body)
+                    .foregroundStyle(theme.inkMuted.color)
+            }
+            .padding(.top, Spacing.xs)
+        } label: {
+            Text("How it's calculated")
+                .apexFont(.label)
+                .foregroundStyle(theme.ink.color)
+        }
+        .tint(theme.inkMuted.color)
+    }
+
+    private func bulletRow(_ label: String, detail: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Text(label)
+                .apexFont(.label)
+                .foregroundStyle(theme.accentInk.color)
+                .frame(width: 48, alignment: .trailing)
+                .monospacedDigit()
+            Text(detail)
+                .apexFont(.body)
+                .foregroundStyle(theme.inkMuted.color)
+        }
+    }
+}

--- a/ProjectApexTests/LensTests.swift
+++ b/ProjectApexTests/LensTests.swift
@@ -1,0 +1,370 @@
+// LensTests.swift
+// ProjectApexTests
+//
+// Tests for the Lens readiness gauge (#346).
+//
+// Two layers:
+//   1. UNCONDITIONAL — geometry/token/a11y assertions. Run on every push; no
+//      simulator required. Covers: state → (number, word) mapping for all
+//      ReadinessScore.Label cases and the "—" unknown/calibrating/stale case;
+//      lexicon ≤ 5 words; accessibility label format; token hygiene (DesignSystem,
+//      not legacy tintColor).
+//   2. GATED — image snapshots (APEX_SNAPSHOT_TESTS=1), following the harness
+//      in DrawnInstrumentSnapshotTests.swift. Reference images are NOT recorded
+//      here; APEX_RECORD_SNAPSHOTS is never set in this repo.
+
+import Testing
+import SwiftUI
+import SnapshotTesting
+@testable import ProjectApex
+
+// MARK: - Gating (mirrors DrawnInstrumentSnapshotTests)
+
+private var snapshotTestsEnabled: Bool {
+    ProcessInfo.processInfo.environment["APEX_SNAPSHOT_TESTS"] == "1"
+}
+
+private var recordModeEnabled: Bool {
+    ProcessInfo.processInfo.environment["APEX_RECORD_SNAPSHOTS"] == "1"
+}
+
+// MARK: - Unconditional layer (geometry / token / a11y)
+
+@Suite("Lens gauge — state mapping and lexicon")
+struct LensStateMappingTests {
+
+    // MARK: Resolved states — all ReadinessScore.Label cases
+
+    @Test("Optimal (score 90) → number '90', word 'Optimal'")
+    func resolved_optimal() {
+        let state = LensState.resolved(ReadinessScore(score: 90))
+        #expect(state.displayNumber == "90")
+        #expect(state.stateWord == "Optimal")
+    }
+
+    @Test("Good (score 70) → number '70', word 'Good'")
+    func resolved_good() {
+        let state = LensState.resolved(ReadinessScore(score: 70))
+        #expect(state.displayNumber == "70")
+        #expect(state.stateWord == "Good")
+    }
+
+    @Test("Reduced (score 50) → number '50', word 'Reduced'")
+    func resolved_reduced() {
+        let state = LensState.resolved(ReadinessScore(score: 50))
+        #expect(state.displayNumber == "50")
+        #expect(state.stateWord == "Reduced")
+    }
+
+    @Test("Poor (score 20) → number '20', word 'Poor'")
+    func resolved_poor() {
+        let state = LensState.resolved(ReadinessScore(score: 20))
+        #expect(state.displayNumber == "20")
+        #expect(state.stateWord == "Poor")
+    }
+
+    // MARK: Unknown / calibrating / stale state
+
+    @Test("Unknown state → '—' + 'Calibrating'")
+    func unknown_state() {
+        let state = LensState.unknown
+        #expect(state.displayNumber == "—")
+        #expect(state.stateWord == "Calibrating")
+    }
+
+    // MARK: Computing state
+
+    @Test("Computing state → '—' + 'Updating'")
+    func computing_state() {
+        let state = LensState.computing
+        #expect(state.displayNumber == "—")
+        #expect(state.stateWord == "Updating")
+    }
+
+    // MARK: Lexicon constraint (≤5 words, sized to the longest)
+
+    @Test("Every state word is ≤5 words long")
+    func stateWords_maxFiveWords() {
+        let allStates: [LensState] = [
+            .resolved(ReadinessScore(score: 90)),
+            .resolved(ReadinessScore(score: 70)),
+            .resolved(ReadinessScore(score: 50)),
+            .resolved(ReadinessScore(score: 20)),
+            .unknown,
+            .computing,
+        ]
+        for state in allStates {
+            let wordCount = state.stateWord.split(separator: " ").count
+            #expect(wordCount <= 5,
+                    "State word '\(state.stateWord)' has \(wordCount) words (max 5)")
+        }
+    }
+
+    @Test("'Calibrating' is the longest state word — layout ghost is correctly sized")
+    func longestStateWord_isCalibrating() {
+        let allWords: [LensState] = [
+            .resolved(ReadinessScore(score: 90)),
+            .resolved(ReadinessScore(score: 70)),
+            .resolved(ReadinessScore(score: 50)),
+            .resolved(ReadinessScore(score: 20)),
+            .unknown,
+            .computing,
+        ].map { $0 }
+        let longest = allWords.map { $0.stateWord }.max(by: { $0.count < $1.count })!
+        #expect(longest == "Calibrating")
+    }
+}
+
+// MARK: - Accessibility layer
+
+@Suite("Lens gauge — accessibility")
+struct LensAccessibilityTests {
+
+    @Test("Resolved: accessibility label includes number and state word")
+    func a11y_resolved_includesNumberAndWord() {
+        let score = ReadinessScore(score: 82)
+        let state = LensState.resolved(score)
+        // Verify the compact LensView's label contract: "Readiness N, Word"
+        let expectedLabel = "Readiness 82, Optimal"
+        // We test the public computed property indirectly through the state:
+        let label = accessibilityLabel(for: state)
+        #expect(label == expectedLabel)
+    }
+
+    @Test("Unknown: accessibility label says 'unknown, Calibrating'")
+    func a11y_unknown() {
+        let label = accessibilityLabel(for: .unknown)
+        #expect(label == "Readiness unknown, Calibrating")
+    }
+
+    @Test("Computing: accessibility label says 'updating'")
+    func a11y_computing() {
+        let label = accessibilityLabel(for: .computing)
+        #expect(label == "Readiness updating")
+    }
+
+    @Test("Accessibility label does NOT say just 'image'")
+    func a11y_notJustImage() {
+        let states: [LensState] = [
+            .resolved(ReadinessScore(score: 60)),
+            .unknown,
+            .computing,
+        ]
+        for state in states {
+            let label = accessibilityLabel(for: state)
+            #expect(label.lowercased() != "image",
+                    "State \(state.stateWord): label must not be just 'image'")
+            #expect(!label.isEmpty, "State \(state.stateWord): label must not be empty")
+        }
+    }
+
+    // Mirrors the LensView.accessibilityLabel computed property.
+    private func accessibilityLabel(for state: LensState) -> String {
+        switch state {
+        case .resolved(let r):
+            return "Readiness \(r.score), \(state.stateWord)"
+        case .unknown:
+            return "Readiness unknown, Calibrating"
+        case .computing:
+            return "Readiness updating"
+        }
+    }
+}
+
+// MARK: - Token hygiene
+
+@Suite("Lens gauge — token hygiene (DesignSystem, not legacy tintColor)")
+struct LensTokenTests {
+
+    @Test("ReadinessScore.tintColor is NOT used — token palette is accent-ink only")
+    func tokenHygiene_noLegacyTintColor() {
+        // This is a structural assertion: ReadinessScore.tintColor is the legacy
+        // multi-hue pre-overhaul palette (#3A8EFF / #8A9AAF / #E8A030 / #E84830).
+        // The Lens must use ONLY DesignSystem ink/accent tokens.
+        // We verify this by confirming the DesignSystem accent-ink is the one-accent
+        // token (not any of the four legacy colours) per Theme.light.
+        let accentInk = Theme.light.accentInk  // #1322CC
+        let legacyOptimalRed   = 0.23
+        let legacyOptimalGreen = 0.56
+        let legacyOptimalBlue  = 1.00
+        // accent-ink differs from every legacy tintColor channel:
+        #expect(abs(accentInk.red   - legacyOptimalRed)   > 0.05)
+        #expect(abs(accentInk.green - legacyOptimalGreen) > 0.05)
+        #expect(abs(accentInk.blue  - legacyOptimalBlue)  > 0.05)
+    }
+
+    @Test("LensState.isFocused is true only for resolved states")
+    func isFocused_onlyResolvedStates() {
+        #expect(LensState.resolved(ReadinessScore(score: 75)).isFocused == true)
+        #expect(LensState.unknown.isFocused == false)
+        #expect(LensState.computing.isFocused == false)
+    }
+
+    @Test("Aperture is proportional to score for resolved states")
+    func aperture_proportionalToScore() {
+        let high = LensState.resolved(ReadinessScore(score: 100))
+        let low  = LensState.resolved(ReadinessScore(score: 0))
+        #expect(high.aperture > low.aperture)
+        #expect(high.aperture == 1.0)
+        #expect(low.aperture  == 0.0)
+    }
+}
+
+// MARK: - Image snapshot layer (gated; reference-pending)
+
+#if canImport(UIKit)
+
+private let lensCanvasSize = CGSize(width: 200, height: 80)
+private let lensSheetSize  = CGSize(width: 393, height: 600)
+
+@Suite("Lens gauge snapshots", .enabled(if: snapshotTestsEnabled))
+@MainActor
+struct LensSnapshotTests {
+
+    // MARK: Compact — all states × light + dim
+
+    @Test("LensView resolved (score 82, Optimal) — light")
+    func compact_resolved_optimal_light() {
+        let view = LensView(state: .resolved(ReadinessScore(score: 82)))
+        let vc = SnapshotHarness.host(view, size: lensCanvasSize, appearance: .light)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-compact-optimal-light", record: recordModeEnabled)
+    }
+
+    @Test("LensView resolved (score 82, Optimal) — dim")
+    func compact_resolved_optimal_dim() {
+        let view = LensView(state: .resolved(ReadinessScore(score: 82)))
+        let vc = SnapshotHarness.host(view, size: lensCanvasSize, appearance: .dim)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-compact-optimal-dim", record: recordModeEnabled)
+    }
+
+    @Test("LensView resolved (score 65, Good) — light")
+    func compact_resolved_good_light() {
+        let view = LensView(state: .resolved(ReadinessScore(score: 65)))
+        let vc = SnapshotHarness.host(view, size: lensCanvasSize, appearance: .light)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-compact-good-light", record: recordModeEnabled)
+    }
+
+    @Test("LensView resolved (score 65, Good) — dim")
+    func compact_resolved_good_dim() {
+        let view = LensView(state: .resolved(ReadinessScore(score: 65)))
+        let vc = SnapshotHarness.host(view, size: lensCanvasSize, appearance: .dim)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-compact-good-dim", record: recordModeEnabled)
+    }
+
+    @Test("LensView resolved (score 50, Reduced) — light")
+    func compact_resolved_reduced_light() {
+        let view = LensView(state: .resolved(ReadinessScore(score: 50)))
+        let vc = SnapshotHarness.host(view, size: lensCanvasSize, appearance: .light)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-compact-reduced-light", record: recordModeEnabled)
+    }
+
+    @Test("LensView resolved (score 50, Reduced) — dim")
+    func compact_resolved_reduced_dim() {
+        let view = LensView(state: .resolved(ReadinessScore(score: 50)))
+        let vc = SnapshotHarness.host(view, size: lensCanvasSize, appearance: .dim)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-compact-reduced-dim", record: recordModeEnabled)
+    }
+
+    @Test("LensView resolved (score 20, Poor) — light")
+    func compact_resolved_poor_light() {
+        let view = LensView(state: .resolved(ReadinessScore(score: 20)))
+        let vc = SnapshotHarness.host(view, size: lensCanvasSize, appearance: .light)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-compact-poor-light", record: recordModeEnabled)
+    }
+
+    @Test("LensView resolved (score 20, Poor) — dim")
+    func compact_resolved_poor_dim() {
+        let view = LensView(state: .resolved(ReadinessScore(score: 20)))
+        let vc = SnapshotHarness.host(view, size: lensCanvasSize, appearance: .dim)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-compact-poor-dim", record: recordModeEnabled)
+    }
+
+    @Test("LensView unknown/calibrating — light")
+    func compact_unknown_light() {
+        let view = LensView(state: .unknown)
+        let vc = SnapshotHarness.host(view, size: lensCanvasSize, appearance: .light)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-compact-unknown-light", record: recordModeEnabled)
+    }
+
+    @Test("LensView unknown/calibrating — dim")
+    func compact_unknown_dim() {
+        let view = LensView(state: .unknown)
+        let vc = SnapshotHarness.host(view, size: lensCanvasSize, appearance: .dim)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-compact-unknown-dim", record: recordModeEnabled)
+    }
+
+    @Test("LensView computing (oscillation gated — deterministic frame 1) — light")
+    func compact_computing_light() {
+        // allowsOscillation: false → blade oscillation is off; snapshots at frame 1.
+        let view = LensView(state: .computing, allowsOscillation: false)
+        let vc = SnapshotHarness.host(view, size: lensCanvasSize, appearance: .light)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-compact-computing-light", record: recordModeEnabled)
+    }
+
+    @Test("LensView computing (oscillation gated) — dim")
+    func compact_computing_dim() {
+        let view = LensView(state: .computing, allowsOscillation: false)
+        let vc = SnapshotHarness.host(view, size: lensCanvasSize, appearance: .dim)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-compact-computing-dim", record: recordModeEnabled)
+    }
+
+    // MARK: Sheet — resolved + unknown, light + dim
+
+    @Test("LensSheet resolved (score 78) — light")
+    func sheet_resolved_light() {
+        let view = LensSheet(
+            state: .resolved(ReadinessScore(score: 78)),
+            trainingLoadLines: ["Acute load: 1,240", "Chronic load: 980"]
+        )
+        let vc = SnapshotHarness.host(view, size: lensSheetSize, appearance: .light)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-sheet-resolved-light", record: recordModeEnabled)
+    }
+
+    @Test("LensSheet resolved (score 78) — dim")
+    func sheet_resolved_dim() {
+        let view = LensSheet(
+            state: .resolved(ReadinessScore(score: 78)),
+            trainingLoadLines: ["Acute load: 1,240", "Chronic load: 980"]
+        )
+        let vc = SnapshotHarness.host(view, size: lensSheetSize, appearance: .dim)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-sheet-resolved-dim", record: recordModeEnabled)
+    }
+
+    @Test("LensSheet unknown — light")
+    func sheet_unknown_light() {
+        let view = LensSheet(
+            state: .unknown,
+            trainingLoadLines: []
+        )
+        let vc = SnapshotHarness.host(view, size: lensSheetSize, appearance: .light)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-sheet-unknown-light", record: recordModeEnabled)
+    }
+
+    @Test("LensSheet unknown — dim")
+    func sheet_unknown_dim() {
+        let view = LensSheet(
+            state: .unknown,
+            trainingLoadLines: []
+        )
+        let vc = SnapshotHarness.host(view, size: lensSheetSize, appearance: .dim)
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "lens-sheet-unknown-dim", record: recordModeEnabled)
+    }
+}
+
+#endif


### PR DESCRIPTION
## What shipped

A 6-blade camera-iris readiness gauge (`LensView`) and its disclosure sheet (`LensSheet`), built as a **DORMANT** reusable DesignSystem component — fully implemented and tested, not yet wired into the live shell.

**Files added:**
- `ProjectApex/DesignSystem/Instruments/LensView.swift` — `LensState` enum, `IrisBlade` shape, `IrisView`, `LensView` (compact), `LensSheet` (disclosure)
- `ProjectApexTests/LensTests.swift` — 15 unconditional tests + gated snapshot suite
- `ProjectApex.xcodeproj/project.pbxproj` — 4 test-target entries for `LensTests.swift`
- `DIARY.md` — plain-language entry (newest-on-top)

## State-word lexicon (≤5 words, sized to "Calibrating" — the longest)

| State | Number | Word |
|---|---|---|
| Resolved, score 80–100 | score | Optimal |
| Resolved, score 60–79 | score | Good |
| Resolved, score 40–59 | score | Reduced |
| Resolved, score 0–39 | score | Poor |
| Unknown / calibrating / stale | — | Calibrating |
| Computing | — | Updating |

## DORMANT constraint

`LensView` and `LensSheet` are complete but not wired into `ContentView` or the new 3-tab shell. They follow the same build-behind-the-flag discipline as the AppShell (#343).

## Image snapshots

Wired via `SnapshotHarness` in `LensSnapshotTests` (gated `APEX_SNAPSHOT_TESTS=1`). All states × light + dim for both compact and sheet. **Reference PNGs not recorded** — per the CI record discipline in `DrawnInstrumentSnapshotTests.swift`, references must be recorded by one owner on the CI-pinned Xcode toolchain. `APEX_RECORD_SNAPSHOTS` was never set.

## Token hygiene

DesignSystem `ink` / `inkMuted` / `accentInk` / `hairline` / `paper` tokens only. `ReadinessScore.tintColor` (the legacy pre-overhaul multi-hue palette: #3A8EFF / #8A9AAF / #E8A030 / #E84830) is deliberately ignored — ONE-accent rule.

## Tests

`xcodebuild test -project ProjectApex.xcodeproj -scheme ProjectApex -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:ProjectApexTests/LensStateMappingTests -only-testing:ProjectApexTests/LensAccessibilityTests -only-testing:ProjectApexTests/LensTokenTests`

**15 tests, 0 failures.** Suites: `LensStateMappingTests` (7), `LensAccessibilityTests` (4), `LensTokenTests` (4).

## Spec sources

- `docs/design/splash-today.md` §The Lens
- `docs/design/ui-overhaul-spec.md` §6
- `DESIGN.md` `gauge-focus` motion + iconography

Closes #346