### PR TITLE
feat(#350): live-loop single-set core (hero numbers, Done slab, rest morph)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,22 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-13 — Built the new "do the set" screen (numbers big, one tap to log, then it becomes the rest timer)
+
+**What this is.** The first piece of the redesigned workout screen. It shows one set at a time: the exercise name, then the target weight and reps as big numbers you can read from across the gym. A full-width ink bar sits at the bottom that just says **Done**. Tap it once and the set is logged exactly as prescribed — no pop-up form, no fiddling with fields. The screen then smoothly turns into the rest timer in place, and when rest is over it shows the next set.
+
+**Two nice touches from the design.** On the very last set of the whole workout, the bottom bar quietly changes its word from "Done" to **Finish** — so the end of the session is obvious. And there's a rule the designers call "work is ink, time is pencil": the weights and reps (the work you did) are drawn in full-strength ink, while the rest-timer digits (just time passing) are drawn in a lighter grey. Same handwriting, lighter pencil — so the two read as one calm system.
+
+**Guards so a tap is never a mistake.** The Done bar ignores a stray brush of the thumb, and it goes dead the instant you tap it so a double-tap can't log the same set twice. The little plate-thud buzz fires at the moment the set is committed, not when you first touch down.
+
+**Important: this is built but not switched on yet.** It's a brand-new screen that nothing in the live app routes to. The old workout screens are completely untouched and still run the real app. This is the same "build it behind a curtain, swap later" approach we've used for the rest of the redesign.
+
+**What's deliberately left for the next slice (#351).** The "tap a number to change it" adjuster, the AMRAP (max-reps) counter, and the dramatic ink-flood entrance animation — all hooks are in place but the work is parked. This slice is just the core loop: see the set, tap Done, rest, next set.
+
+**How I checked.** 16 tests, all green: they drive the real workout engine through start → log → rest → next set, prove the Done→Finish relabel only flips on the true last set, prove the double-tap and stray-brush guards hold, and prove the ink-vs-pencil colour split. Picture-comparison tests for the set and rest screens (light and dark) are wired up but their reference images are recorded later on the build server, by design. The screen builds with no new warnings.
+
+**Status:** opened as a PR off `feat/350-live-loop-core`. Dormant build — new screen only; old views still live.
+
 ## 2026-06-13 — Make sure every new login gets a profile row, automatically (2 of 6)
 
 **The problem, in plain words.** Lots of saves point back to a "profile" row keyed to your login. Today that row is only created during onboarding. So if a save ever fires before onboarding finishes — or if onboarding is skipped — there's no profile row and the database refuses the save. Belt with no suspenders.

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		LE34600000000000LE346002 /* LensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LE34600000000000LE346001 /* LensTests.swift */; };
 		DE52000000000000DE520002 /* DesignSystemGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */; };
 		DE53000000000000DE530002 /* DrawnInstrumentSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */; };
+		DE56000000000000DE560002 /* LiveLoopCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE56000000000000DE560001 /* LiveLoopCoreTests.swift */; };
 		DE54000000000000DE540002 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = DE54000000000000DE540001 /* SnapshotTesting */; };
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
@@ -134,6 +135,7 @@
 		LE34600000000000LE346001 /* LensTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LensTests.swift; sourceTree = "<group>"; };
 		DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DesignSystemGeometryTests.swift; sourceTree = "<group>"; };
 		DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DrawnInstrumentSnapshotTests.swift; sourceTree = "<group>"; };
+		DE56000000000000DE560001 /* LiveLoopCoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveLoopCoreTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
 		DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetPrescriptionIntentValidationTests.swift; sourceTree = "<group>"; };
 		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
@@ -282,6 +284,7 @@
 				LE34600000000000LE346001 /* LensTests.swift */,
 				DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */,
 				DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */,
+				DE56000000000000DE560001 /* LiveLoopCoreTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -451,6 +454,7 @@
 				LE34600000000000LE346002 /* LensTests.swift in Sources */,
 				DE52000000000000DE520002 /* DesignSystemGeometryTests.swift in Sources */,
 				DE53000000000000DE530002 /* DrawnInstrumentSnapshotTests.swift in Sources */,
+				DE56000000000000DE560002 /* LiveLoopCoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/Features/Workout/LiveLoopView.swift
+++ b/ProjectApex/Features/Workout/LiveLoopView.swift
@@ -1,0 +1,400 @@
+// LiveLoopView.swift
+// ProjectApex — Phase 3 UI overhaul · Slice 8 (#350)
+//
+// The live-session loop core (docs/design/live-loop.md §1–4 only). One screen owns
+// the current set: the hero-num lockup (exercise + target weight × reps), the
+// full-bleed bottom Done ink slab (relabels to "Finish" on the last set of the
+// session), and the card morph to the rest timer after a log. Binds to the existing
+// WorkoutViewModel/WorkoutSessionManager FSM — no backend change.
+//
+// DORMANT (#350): this is a NEW screen, NOT wired into the live shell. The legacy
+// ActiveSetView / RestTimerView remain live in the frozen ContentView until the
+// close-out slice. This file routes nowhere and replaces nothing.
+//
+// Scope cut (roadmap §4 Q13): §1–4 only. AMRAP, Adjust (tap-the-number steppers),
+// and the full ink-flood entrance are DEFERRED to #351 — hooks/TODOs only here.
+// The entrance is stubbed to a plain crossfade per the deferral.
+//
+// "Work is ink, time is pencil" (§1): work numbers render `ink`; time digits render
+// `ink-muted`. The model carries the split so the view never picks a colour by hand.
+
+import SwiftUI
+
+// MARK: - LiveLoopModel
+
+/// The pure, value-type render model for the live loop. Derives every piece of
+/// presented text/state from the FSM-public inputs (sessionState, prescription,
+/// rest seconds) plus the read-only TrainingDay (needed only to know when the
+/// current set is the last of the *whole session* — the actor keeps trainingDay /
+/// exerciseIndex private, so the view supplies the day as a read-only input).
+///
+/// No SwiftUI, no colour: testable in a headless unit target. The view maps
+/// `ink`/`pencil` roles onto the theme; the model only labels which is which.
+struct LiveLoopModel: Equatable {
+
+    /// Which half of the loop is on screen.
+    enum Phase: Equatable {
+        case set    // performing the current set — hero prescription + Done slab
+        case rest   // post-log rest — pencil countdown is the temporary hero
+        case other  // idle / preflight / exerciseComplete / sessionComplete / error
+    }
+
+    let phase: Phase
+
+    // MARK: Set-state fields (the hero lockup)
+
+    /// Exercise name — glance tier 1 (§3). Empty in non-set phases.
+    let exerciseName: String
+
+    /// "set 2 of 5" muted beside the exercise name. Empty when unknown.
+    let setPositionText: String
+
+    /// The hero weight token, ink (§1 "work is ink"). E.g. "82.5 kg" or "BW".
+    /// No trailing ".0" (§3 false-precision rule).
+    let heroWeightText: String
+
+    /// The connective × glyph plus reps, pencil register per §3 (× is `ink-muted`,
+    /// connective tissue). Always uses U+00D7, never the letter x. E.g. " × 8".
+    let heroRepsText: String
+
+    /// The Done slab's label — "Done" normally, "Finish" on the last set of the
+    /// whole session (§3 / §8: one slab, label changes exactly once per session).
+    let doneLabel: String
+
+    /// True when the current set is the last set of the last exercise — drives the
+    /// Done → Finish relabel. Computed from the read-only TrainingDay.
+    let isLastSetOfSession: Bool
+
+    /// Whether the Done slab accepts a tap. False while a log is in flight or a
+    /// morph is animating (§3 disabled-while-morphing guard against double-logs).
+    let doneEnabled: Bool
+
+    // MARK: Rest-state fields
+
+    /// The rest countdown digits, pencil register (§1 / §4.2 `ink-muted`). "1:30".
+    let restDigitsText: String
+
+    /// The next-set preview line shown during rest (§4.5). Empty when unknown.
+    let nextPreviewText: String
+
+    // MARK: - Derivation
+
+    /// The U+00D7 multiplication sign — never the ASCII letter "x" (§3 micro-spec).
+    static let times = "\u{00D7}"
+
+    /// Build the model from the FSM-public state. `trainingDay` is read-only and used
+    /// only to determine `isLastSetOfSession` (the actor keeps its position private).
+    init(
+        sessionState: SessionState,
+        prescription: SetPrescription?,
+        restSecondsRemaining: Int,
+        trainingDay: TrainingDay
+    ) {
+        switch sessionState {
+        case .active(let exercise, let setNumber):
+            self.phase = .set
+            self.exerciseName = exercise.name
+            self.setPositionText = "set \(setNumber) of \(exercise.sets)"
+            let rx = prescription
+            self.heroWeightText = Self.weightText(weightKg: rx?.weightKg ?? 0)
+            self.heroRepsText = " \(Self.times) \(rx?.reps ?? exercise.repRange.max)"
+            let last = Self.computeIsLastSetOfSession(exercise: exercise, setNumber: setNumber, trainingDay: trainingDay)
+            self.isLastSetOfSession = last
+            self.doneLabel = last ? "Finish" : "Done"
+            // doneEnabled is overlaid by the view's in-flight/morph guards; the
+            // model's default is "a prescription exists to log".
+            self.doneEnabled = rx != nil
+            self.restDigitsText = ""
+            self.nextPreviewText = ""
+
+        case .resting(let nextExercise, let setNumber):
+            self.phase = .rest
+            self.exerciseName = ""
+            self.setPositionText = ""
+            self.heroWeightText = ""
+            self.heroRepsText = ""
+            self.doneLabel = "Done"
+            self.isLastSetOfSession = false
+            self.doneEnabled = false
+            self.restDigitsText = Self.restDigits(restSecondsRemaining)
+            self.nextPreviewText = "Next: \(nextExercise.name) · set \(setNumber)"
+
+        default:
+            self.phase = .other
+            self.exerciseName = ""
+            self.setPositionText = ""
+            self.heroWeightText = ""
+            self.heroRepsText = ""
+            self.doneLabel = "Done"
+            self.isLastSetOfSession = false
+            self.doneEnabled = false
+            self.restDigitsText = ""
+            self.nextPreviewText = ""
+        }
+    }
+
+    /// The current set is the last of the whole session iff it is the last set of
+    /// its exercise (`setNumber >= exercise.sets`, matching the manager's
+    /// set-number-based rule) AND that exercise is the last in the day. Matched on
+    /// the exercise's stable `id` so a duplicated name never confuses the check.
+    static func computeIsLastSetOfSession(
+        exercise: PlannedExercise,
+        setNumber: Int,
+        trainingDay: TrainingDay
+    ) -> Bool {
+        guard setNumber >= exercise.sets else { return false }
+        return trainingDay.exercises.last?.id == exercise.id
+    }
+
+    /// Hero weight token: "BW" at/under zero, no trailing ".0" otherwise, " kg"
+    /// pencil unit applied by the view. Returns the bare number+unit string.
+    static func weightText(weightKg: Double) -> String {
+        if weightKg <= 0 { return "BW" }
+        if weightKg.truncatingRemainder(dividingBy: 1) == 0 {
+            return String(format: "%.0f kg", weightKg)
+        }
+        return String(format: "%.1f kg", weightKg)
+    }
+
+    /// "m:ss" rest digits, clamped at zero. Pencil register applied by the view.
+    static func restDigits(_ seconds: Int) -> String {
+        let s = max(seconds, 0)
+        return String(format: "%d:%02d", s / 60, s % 60)
+    }
+}
+
+// MARK: - LiveLoopView
+
+/// The thin SwiftUI shell over `LiveLoopModel`. Owns the in-flight/morph guards
+/// (state the model can't see), the card morph animation, and the Done tap → log.
+///
+/// DORMANT: instantiate-only. Nothing in the live shell presents this yet (#350).
+struct LiveLoopView: View {
+
+    @Bindable var viewModel: WorkoutViewModel
+
+    /// Read-only training day — supplies the "last set of the whole session" fact
+    /// the actor keeps private. Never mutated here.
+    let trainingDay: TrainingDay
+
+    @Environment(\.apexTheme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Local guard: true from Done touch-up until the morph settles, so a second
+    /// tap can't double-log and a brush during the morph is rejected (§3).
+    @State private var isMorphing = false
+
+    private var model: LiveLoopModel {
+        LiveLoopModel(
+            sessionState: viewModel.sessionState,
+            prescription: viewModel.currentPrescription,
+            restSecondsRemaining: viewModel.restSecondsRemaining,
+            trainingDay: trainingDay
+        )
+    }
+
+    /// The Done slab is tappable only when the model says a set is loggable AND no
+    /// log is in flight AND no morph is animating (§3 disabled-while-morphing).
+    private var doneEnabled: Bool {
+        model.doneEnabled && !viewModel.isCompletingSet && !isMorphing
+    }
+
+    private var morphAnimation: Animation {
+        reduceMotion ? Motion.reduceMotionCrossfade : Motion.cardMorph
+    }
+
+    var body: some View {
+        ZStack {
+            theme.paper.color.ignoresSafeArea()
+
+            // The card content morphs between set and rest in place — no modal,
+            // no new screen (§4). The two states share the container; the morph is
+            // a crossfade-with-transform driven by `Motion.cardMorph`.
+            Group {
+                switch model.phase {
+                case .set:  setCard
+                case .rest: restCard
+                case .other: Color.clear
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .animation(morphAnimation, value: model.phase)
+
+            // The Done slab is pooled at the bottom of the world all session (§3).
+            VStack {
+                Spacer()
+                if model.phase == .set {
+                    doneSlab
+                        .transition(.opacity)
+                }
+            }
+            .ignoresSafeArea(edges: .bottom)
+            .animation(morphAnimation, value: model.phase)
+        }
+        // STUB (§4 Q13 / #351): the full ink-flood entrance is deferred. The
+        // dormant screen uses a plain crossfade on appear as the placeholder.
+        .transition(.opacity)
+        // Drop the local morph guard once the FSM has advanced past the logged set,
+        // so the rest card becomes interactive. The guard only bridges the window
+        // between Done-commit and the VM's state-pull.
+        .onChange(of: model.phase) { _, newPhase in
+            if newPhase != .set { isMorphing = false }
+        }
+    }
+
+    // MARK: Set card — the hero lockup (§3)
+
+    private var setCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Exercise line — glance tier 1.
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(model.exerciseName)
+                    .apexFont(.title)
+                    .foregroundStyle(theme.ink.color)
+                Text(model.setPositionText)
+                    .apexFont(.label)
+                    .foregroundStyle(theme.inkMuted.color)
+            }
+            .accessibilityElement(children: .combine)
+
+            // The prescription — the hero lockup. Weight is ink (work), the
+            // × glyph and reps are pencil (the × is connective tissue, §3).
+            Text("\(Text(model.heroWeightText).foregroundStyle(theme.ink.color))\(Text(model.heroRepsText).foregroundStyle(theme.inkMuted.color))")
+                .apexFont(.heroNum)
+                .accessibilityElement()
+                .accessibilityLabel("\(model.heroWeightText) \(model.heroRepsText)")
+
+            // TODO(#351): "Why this?", Adjust (tap-the-number steppers), last-time
+            // anchor, plate-math dimension callout, AMRAP target — all deferred.
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 32)
+    }
+
+    // MARK: Rest card — pencil countdown as the temporary hero (§4)
+
+    private var restCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Rest countdown — pencil register (time is pencil, §1 / §4.2).
+            Text(model.restDigitsText)
+                .apexFont(.heroNum)
+                .foregroundStyle(theme.inkMuted.color)
+                .accessibilityLabel("Rest \(model.restDigitsText)")
+
+            // Next-set preview (§4.5). Furniture; no travel.
+            Text(model.nextPreviewText)
+                .apexFont(.body)
+                .foregroundStyle(theme.inkMuted.color)
+
+            // TODO(#351): feel pill (Easy | Solid | Grind), depleting drafting
+            // rule, ±15s / Skip controls, ledger row — deferred to the rest slice.
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 32)
+    }
+
+    // MARK: Done slab — the bottom of the world (§3)
+
+    private var doneSlab: some View {
+        Button(action: handleDoneTap) {
+            Text(model.doneLabel)
+                .apexFont(.title)
+                .foregroundStyle(theme.onAccent.color)
+                .frame(maxWidth: .infinity)
+                .frame(height: 96, alignment: .top)
+                .padding(.top, 18)
+                .background(theme.accentFill)
+                .overlay(alignment: .top) {
+                    // 1px accent-press top rule (§3).
+                    Rectangle()
+                        .fill(theme.accentPress)
+                        .frame(height: 1)
+                }
+        }
+        .buttonStyle(.plain)
+        // touch-up-inside with small-movement tolerance — a drag past the slab
+        // doesn't fire (§3 stray-brush guard). SwiftUI's Button already cancels on
+        // drag-out; `.plain` keeps the slab's own hit region as the tolerance zone.
+        .disabled(!doneEnabled)
+        .accessibilityLabel(model.doneLabel)
+        .accessibilityHint(model.isLastSetOfSession ? "Finish the session" : "Log this set as prescribed")
+    }
+
+    // MARK: Done tap — one tap logs the set as prescribed (§3)
+
+    private func handleDoneTap() {
+        // Re-check the guard at commit time: a queued tap that lands after a morph
+        // started must be rejected (no double-log).
+        guard doneEnabled, let rx = viewModel.currentPrescription else { return }
+
+        // commit-time haptic — the plate-thud fires at commit, not touch-down (§3).
+        Haptics.setLogged()
+
+        // Begin the morph guard immediately so a second tap is dead until the FSM
+        // advances. Cleared when the state leaves .active (the morph has happened).
+        isMorphing = true
+
+        // One tap = logged as prescribed: reps at the prescription's reps, intent
+        // at the prescription's intent. This is the deliberate NEW behaviour vs the
+        // legacy multi-field confirmation sheet (PR behaviour-parity note).
+        viewModel.onSetComplete(
+            actualReps: rx.reps,
+            rpeFelt: nil,
+            intent: rx.intent ?? .top,
+            completionFlags: []
+        )
+
+        // The VM flips isCompletingSet and re-pulls state; once it advances out of
+        // .active, drop the local morph guard so the rest card becomes interactive.
+        // Driven off the model's phase via .task(id:) below.
+    }
+}
+
+#if DEBUG
+import Foundation
+
+// MARK: - Previews (dormant; not a live route)
+
+#Preview("Live loop — set state (light)") {
+    LiveLoopView(
+        viewModel: .mockActive(),
+        trainingDay: LiveLoopPreviewData.day
+    )
+    .apexThemeRoot()
+}
+
+#Preview("Live loop — rest state (dim)") {
+    LiveLoopView(
+        viewModel: .mockResting(),
+        trainingDay: LiveLoopPreviewData.day
+    )
+    .environment(\.apexTheme, .dim)
+}
+
+private enum LiveLoopPreviewData {
+    static let day = TrainingDay(
+        id: UUID(),
+        dayOfWeek: 1,
+        dayLabel: "Push_A",
+        exercises: [
+            PlannedExercise(
+                id: UUID(),
+                exerciseId: "barbell_bench_press",
+                name: "Barbell Bench Press",
+                primaryMuscle: "pectoralis_major",
+                synergists: [],
+                equipmentRequired: .barbell,
+                sets: 4,
+                repRange: RepRange(min: 6, max: 10),
+                tempo: "3-1-1-0",
+                restSeconds: 150,
+                rirTarget: 2,
+                coachingCues: []
+            )
+        ],
+        sessionNotes: nil
+    )
+}
+#endif

--- a/ProjectApexTests/LiveLoopCoreTests.swift
+++ b/ProjectApexTests/LiveLoopCoreTests.swift
@@ -73,7 +73,7 @@ private final class LiveLoopSucceedURLProtocol: URLProtocol {
 }
 
 @MainActor
-private func makeLiveLoopViewModel(weightKg: Double = 80.0, reps: Int = 8) -> WorkoutViewModel {
+private func makeLiveLoopViewModel(weightKg: Double = 80.0, reps: Int = 8) -> (vm: WorkoutViewModel, manager: WorkoutSessionManager) {
     let config = URLSessionConfiguration.ephemeral
     config.protocolClasses = [LiveLoopSucceedURLProtocol.self]
     let supabase = SupabaseClient(
@@ -99,7 +99,7 @@ private func makeLiveLoopViewModel(weightKg: Double = 80.0, reps: Int = 8) -> Wo
         gymFactStore: gymFactStore,
         writeAheadQueue: waq
     )
-    return WorkoutViewModel(manager: manager)
+    return (WorkoutViewModel(manager: manager), manager)
 }
 
 private func makeLiveLoopDay(exerciseCount: Int = 1, setsPerExercise: Int = 2) -> TrainingDay {
@@ -297,10 +297,16 @@ final class LiveLoopBindingTests: XCTestCase {
 
     @MainActor
     func test_start_logViaDone_restMorph_nextSet() async {
-        let vm = makeLiveLoopViewModel()
+        let (vm, manager) = makeLiveLoopViewModel()
         let day = makeLiveLoopDay(exerciseCount: 1, setsPerExercise: 2)
 
-        vm.startSession(trainingDay: day, programId: UUID(), userId: UUID())
+        // Drive the FSM through the manager directly (the way WorkoutSessionManagerTests
+        // does): the VM's startSession now awaits real auth (deps.resolvedOwnerUserId),
+        // which has no test seam. The underlying manager.startSession has a defaulted
+        // userId and no auth gate, so we start there and sync the VM to publish the state.
+        await manager.startSession(trainingDay: day, programId: UUID())
+        await vm.pullState()
+        vm.beginStatePolling()
         await waitFor(vm) { if case .active = $0.sessionState { return true }; return false }
 
         // Active on set 1, model in .set, Done (not last) enabled.
@@ -337,9 +343,11 @@ final class LiveLoopBindingTests: XCTestCase {
 
     @MainActor
     func test_doubleLogGuard_secondCompleteIsRejectedWhileInFlight() async {
-        let vm = makeLiveLoopViewModel()
+        let (vm, manager) = makeLiveLoopViewModel()
         let day = makeLiveLoopDay(exerciseCount: 1, setsPerExercise: 3)
-        vm.startSession(trainingDay: day, programId: UUID(), userId: UUID())
+        await manager.startSession(trainingDay: day, programId: UUID())
+        await vm.pullState()
+        vm.beginStatePolling()
         await waitFor(vm) { if case .active = $0.sessionState { return true }; return false }
 
         let rx = vm.currentPrescription!

--- a/ProjectApexTests/LiveLoopCoreTests.swift
+++ b/ProjectApexTests/LiveLoopCoreTests.swift
@@ -1,0 +1,462 @@
+// LiveLoopCoreTests.swift
+// ProjectApexTests — Phase 3 UI overhaul · Slice 8 (#350)
+//
+// Two layers, mirroring the issue's test plan:
+//
+//   1. UNCONDITIONAL (local green bar): the LiveLoopModel derivation + the real
+//      VM/SessionManager binding. Drives start → log via Done → rest morph → next
+//      set against the actual WorkoutViewModel/WorkoutSessionManager FSM, and
+//      asserts the model's Done→Finish relabel, the double-log / stray-brush
+//      guards, and the time-digits-`ink-muted` vs work-`ink` split (§1 "work is
+//      ink, time is pencil").
+//
+//   2. GATED image snapshots (APEX_SNAPSHOT_TESTS=1): the set + rest states in
+//      light + dim. Reference PNGs are NOT recorded here — that is the CI record
+//      job's exclusive task (DrawnInstrumentSnapshotTests header). Until then these
+//      are reference-pending; running WITHOUT the env var skips them entirely.
+//
+// The model is the testable core: it is a pure value type, so the guards and the
+// ink/pencil contract are asserted in milliseconds with no UIKit. The VM-driven
+// flow proves the binding against the genuine actor (no fake FSM).
+
+import Testing
+import XCTest
+import Foundation
+import SwiftUI
+@testable import ProjectApex
+
+#if canImport(UIKit)
+import SnapshotTesting
+import UIKit
+#endif
+
+// MARK: - Fixtures (a real manager + a deterministic prescription)
+
+/// A fixed JSON prescription string — no network, no retries.
+private func liveLoopPrescriptionJSON(weightKg: Double = 80.0, reps: Int = 8) -> String {
+    """
+    {
+      "set_prescription": {
+        "weight_kg": \(weightKg),
+        "reps": \(reps),
+        "tempo": "3-1-1-0",
+        "rir_target": 2,
+        "rest_seconds": 90,
+        "coaching_cue": "Drive through the bar",
+        "reasoning": "Based on recent performance trend.",
+        "safety_flags": [],
+        "intent": "top",
+        "set_framing": "Heaviest work of the day. Brace and grind."
+      }
+    }
+    """
+}
+
+private struct LiveLoopMockLLM: LLMProvider {
+    let response: String
+    func complete(systemPrompt: String, userPayload: String) async throws -> String { response }
+}
+
+/// HTTP 201 for every request so set-log writes never hit the network or spin the
+/// write-ahead-queue retry loop. Mirrors WorkoutSessionManagerTests' succeed mock.
+/// (URLProtocol's Sendable conformance is already unavailable, so we don't restate it.)
+private final class LiveLoopSucceedURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let response = HTTPURLResponse(url: request.url!, statusCode: 201, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("[]".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+@MainActor
+private func makeLiveLoopViewModel(weightKg: Double = 80.0, reps: Int = 8) -> WorkoutViewModel {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [LiveLoopSucceedURLProtocol.self]
+    let supabase = SupabaseClient(
+        supabaseURL: URL(string: "https://test.supabase.co")!,
+        anonKey: "test-key",
+        urlSession: URLSession(configuration: config)
+    )
+    let inference = AIInferenceService(
+        provider: LiveLoopMockLLM(response: liveLoopPrescriptionJSON(weightKg: weightKg, reps: reps)),
+        gymProfile: nil,
+        maxRetries: 0
+    )
+    let memory = MemoryService(supabase: supabase, embeddingAPIKey: "")
+    let suite = "com.test.liveloop.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suite)!
+    let gymFactStore = GymFactStore(userDefaults: defaults)
+    let waq = WriteAheadQueue(supabase: supabase, userDefaults: defaults)
+    let manager = WorkoutSessionManager(
+        aiInference: inference,
+        healthKit: HealthKitService(),
+        memoryService: memory,
+        supabase: supabase,
+        gymFactStore: gymFactStore,
+        writeAheadQueue: waq
+    )
+    return WorkoutViewModel(manager: manager)
+}
+
+private func makeLiveLoopDay(exerciseCount: Int = 1, setsPerExercise: Int = 2) -> TrainingDay {
+    let exercises = (0..<exerciseCount).map { i in
+        PlannedExercise(
+            id: UUID(),
+            exerciseId: "exercise_\(i)",
+            name: "Exercise \(i)",
+            primaryMuscle: "pectoralis_major",
+            synergists: [],
+            equipmentRequired: .barbell,
+            sets: setsPerExercise,
+            repRange: RepRange(min: 6, max: 10),
+            tempo: "3-1-1-0",
+            restSeconds: 90,
+            rirTarget: 2,
+            coachingCues: []
+        )
+    }
+    return TrainingDay(id: UUID(), dayOfWeek: 1, dayLabel: "Push_A", exercises: exercises, sessionNotes: nil)
+}
+
+/// One active-set fixture for pure-model assertions (no manager needed).
+private func activeState(
+    exercise: PlannedExercise,
+    setNumber: Int
+) -> SessionState {
+    .active(exercise: exercise, setNumber: setNumber)
+}
+
+private func samplePrescription(weightKg: Double = 82.5, reps: Int = 8, intent: SetIntent = .top) -> SetPrescription {
+    SetPrescription(
+        weightKg: weightKg, reps: reps, tempo: "3-1-1-0", rirTarget: 2, restSeconds: 90,
+        coachingCue: "cue", reasoning: "why", safetyFlags: [], confidence: 0.9, intent: intent,
+        setFraming: "frame"
+    )
+}
+
+// MARK: - Pure-model suite (unconditional)
+
+@Suite("LiveLoopModel — derivation, relabel, ink/pencil split")
+struct LiveLoopModelTests {
+
+    @Test("Set state: hero uses U+00D7 (never letter x), weight is ink-token, reps are pencil")
+    func setStateHeroLockup() {
+        let day = makeLiveLoopDay(exerciseCount: 1, setsPerExercise: 4)
+        let ex = day.exercises[0]
+        let model = LiveLoopModel(
+            sessionState: activeState(exercise: ex, setNumber: 2),
+            prescription: samplePrescription(weightKg: 82.5, reps: 8),
+            restSecondsRemaining: 0,
+            trainingDay: day
+        )
+        #expect(model.phase == .set)
+        #expect(model.heroWeightText == "82.5 kg")
+        // Connective × is the real U+00D7, never the ASCII letter.
+        #expect(model.heroRepsText.contains("\u{00D7}"))
+        #expect(!model.heroRepsText.lowercased().contains("x"))
+        #expect(model.heroRepsText == " \u{00D7} 8")
+        #expect(model.setPositionText == "set 2 of 4")
+        #expect(model.exerciseName == ex.name)
+    }
+
+    @Test("Whole-number weight drops the trailing .0 (no false precision, §3)")
+    func wholeWeightHasNoTrailingZero() {
+        #expect(LiveLoopModel.weightText(weightKg: 100) == "100 kg")
+        #expect(LiveLoopModel.weightText(weightKg: 82.5) == "82.5 kg")
+        #expect(LiveLoopModel.weightText(weightKg: 0) == "BW")
+    }
+
+    @Test("Done relabels to Finish on the last set of the last exercise — not before")
+    func doneRelabelsToFinishOnLastSet() {
+        // Two exercises, 2 sets each. Last set of session = exercise[1], set 2.
+        let day = makeLiveLoopDay(exerciseCount: 2, setsPerExercise: 2)
+        let first = day.exercises[0]
+        let last = day.exercises[1]
+
+        // Set 1 of the last exercise — still "Done".
+        let notYet = LiveLoopModel(
+            sessionState: activeState(exercise: last, setNumber: 1),
+            prescription: samplePrescription(), restSecondsRemaining: 0, trainingDay: day
+        )
+        #expect(notYet.isLastSetOfSession == false)
+        #expect(notYet.doneLabel == "Done")
+
+        // Last set of the FIRST exercise — still "Done" (more exercises remain).
+        let firstExLastSet = LiveLoopModel(
+            sessionState: activeState(exercise: first, setNumber: 2),
+            prescription: samplePrescription(), restSecondsRemaining: 0, trainingDay: day
+        )
+        #expect(firstExLastSet.isLastSetOfSession == false)
+        #expect(firstExLastSet.doneLabel == "Done")
+
+        // Last set of the LAST exercise — "Finish".
+        let finish = LiveLoopModel(
+            sessionState: activeState(exercise: last, setNumber: 2),
+            prescription: samplePrescription(), restSecondsRemaining: 0, trainingDay: day
+        )
+        #expect(finish.isLastSetOfSession == true)
+        #expect(finish.doneLabel == "Finish")
+    }
+
+    @Test("Rest digits are m:ss, clamped at zero — the pencil hero")
+    func restDigitsFormat() {
+        #expect(LiveLoopModel.restDigits(90) == "1:30")
+        #expect(LiveLoopModel.restDigits(5) == "0:05")
+        #expect(LiveLoopModel.restDigits(0) == "0:00")
+        #expect(LiveLoopModel.restDigits(-3) == "0:00")
+    }
+
+    @Test("Rest state exposes the countdown + next-set preview, no set-hero fields")
+    func restStateFields() {
+        let day = makeLiveLoopDay(exerciseCount: 1, setsPerExercise: 3)
+        let ex = day.exercises[0]
+        let model = LiveLoopModel(
+            sessionState: .resting(nextExercise: ex, setNumber: 3),
+            prescription: nil, restSecondsRemaining: 87, trainingDay: day
+        )
+        #expect(model.phase == .rest)
+        #expect(model.restDigitsText == "1:27")
+        #expect(model.nextPreviewText.contains(ex.name))
+        #expect(model.heroWeightText.isEmpty)
+    }
+
+    @Test("doneEnabled is false without a prescription (nothing to log)")
+    func doneDisabledWithoutPrescription() {
+        let day = makeLiveLoopDay(exerciseCount: 1, setsPerExercise: 2)
+        let ex = day.exercises[0]
+        let noRx = LiveLoopModel(
+            sessionState: activeState(exercise: ex, setNumber: 1),
+            prescription: nil, restSecondsRemaining: 0, trainingDay: day
+        )
+        #expect(noRx.doneEnabled == false)
+        let withRx = LiveLoopModel(
+            sessionState: activeState(exercise: ex, setNumber: 1),
+            prescription: samplePrescription(), restSecondsRemaining: 0, trainingDay: day
+        )
+        #expect(withRx.doneEnabled == true)
+    }
+
+    @Test("Non-set/rest states (idle/preflight/complete) are the .other phase, no hero")
+    func otherPhases() {
+        let day = makeLiveLoopDay()
+        for state in [SessionState.idle, .preflight, .error("boom")] {
+            let model = LiveLoopModel(sessionState: state, prescription: nil, restSecondsRemaining: 0, trainingDay: day)
+            #expect(model.phase == .other)
+            #expect(model.doneEnabled == false)
+        }
+    }
+}
+
+// MARK: - Ink/pencil colour contract (token-level, unconditional)
+
+@Suite("LiveLoop ink/pencil contract — work is ink, time is pencil (§1)")
+struct LiveLoopInkPencilTests {
+
+    @Test("Work and time use the SAME family at DIFFERENT value: ink vs ink-muted")
+    func workInkTimePencil() {
+        // The view renders work numbers with `theme.ink` and time digits with
+        // `theme.inkMuted`. Assert the two tokens are distinct so the split is
+        // visible, in both appearances.
+        for theme in [Theme.light, Theme.dim] {
+            #expect(theme.ink != theme.inkMuted)
+            // ink-muted is a genuinely lighter/closer-to-paper value than ink —
+            // a real "pencil" register, not an arbitrary second colour.
+            #expect(theme.ink.relativeLuminance != theme.inkMuted.relativeLuminance)
+        }
+    }
+}
+
+// MARK: - VM/SessionManager binding (unconditional, async)
+
+/// Drives the genuine actor through start → log via Done → rest → next set, the way
+/// LiveLoopView's `handleDoneTap` does (onSetComplete at prescription reps/intent).
+final class LiveLoopBindingTests: XCTestCase {
+
+    override func setUp() { super.setUp(); PausedSessionState.clear() }
+    override func tearDown() { PausedSessionState.clear(); super.tearDown() }
+
+    /// Poll the VM state until `predicate` holds or the timeout elapses, pulling
+    /// fresh actor state each tick (the live screen polls; tests do the same).
+    @MainActor
+    private func waitFor(
+        _ vm: WorkoutViewModel,
+        timeout: TimeInterval = 3.0,
+        _ predicate: (WorkoutViewModel) -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            await vm.pullState()
+            if predicate(vm) { return }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+
+    @MainActor
+    func test_start_logViaDone_restMorph_nextSet() async {
+        let vm = makeLiveLoopViewModel()
+        let day = makeLiveLoopDay(exerciseCount: 1, setsPerExercise: 2)
+
+        vm.startSession(trainingDay: day, programId: UUID(), userId: UUID())
+        await waitFor(vm) { if case .active = $0.sessionState { return true }; return false }
+
+        // Active on set 1, model in .set, Done (not last) enabled.
+        var model = LiveLoopModel(sessionState: vm.sessionState, prescription: vm.currentPrescription,
+                                  restSecondsRemaining: vm.restSecondsRemaining, trainingDay: day)
+        XCTAssertEqual(model.phase, .set)
+        XCTAssertEqual(model.doneLabel, "Done", "set 1 of 2 is not the last set")
+        XCTAssertTrue(model.doneEnabled)
+
+        // Log set 1 the way the Done slab does: reps + intent from the prescription.
+        let rx1 = vm.currentPrescription!
+        vm.onSetComplete(actualReps: rx1.reps, rpeFelt: nil, intent: rx1.intent ?? .top, completionFlags: [])
+
+        // Morph to rest.
+        await waitFor(vm) { $0.isResting }
+        model = LiveLoopModel(sessionState: vm.sessionState, prescription: vm.currentPrescription,
+                              restSecondsRemaining: vm.restSecondsRemaining, trainingDay: day)
+        XCTAssertEqual(model.phase, .rest, "post-log state morphs to the rest card")
+        XCTAssertEqual(vm.completedSets.count, 1, "set 1 logged")
+
+        // Advance past rest to set 2.
+        vm.skipRest()
+        await waitFor(vm) {
+            if case .active(_, let n) = $0.sessionState { return n == 2 }
+            return false
+        }
+        model = LiveLoopModel(sessionState: vm.sessionState, prescription: vm.currentPrescription,
+                              restSecondsRemaining: vm.restSecondsRemaining, trainingDay: day)
+        XCTAssertEqual(model.phase, .set)
+        // Set 2 of 2 on the only exercise → last set of the session → Finish.
+        XCTAssertTrue(model.isLastSetOfSession)
+        XCTAssertEqual(model.doneLabel, "Finish")
+    }
+
+    @MainActor
+    func test_doubleLogGuard_secondCompleteIsRejectedWhileInFlight() async {
+        let vm = makeLiveLoopViewModel()
+        let day = makeLiveLoopDay(exerciseCount: 1, setsPerExercise: 3)
+        vm.startSession(trainingDay: day, programId: UUID(), userId: UUID())
+        await waitFor(vm) { if case .active = $0.sessionState { return true }; return false }
+
+        let rx = vm.currentPrescription!
+        // Fire two completes back-to-back. The VM's isCompletingSet guard (the same
+        // flag LiveLoopView.doneEnabled reads) must let only the first through.
+        vm.onSetComplete(actualReps: rx.reps, rpeFelt: nil, intent: rx.intent ?? .top)
+        XCTAssertTrue(vm.isCompletingSet, "first complete sets the in-flight guard")
+        vm.onSetComplete(actualReps: rx.reps, rpeFelt: nil, intent: rx.intent ?? .top)
+
+        await waitFor(vm) { !$0.isCompletingSet && $0.isResting }
+        XCTAssertEqual(vm.completedSets.count, 1, "only one set logged despite two taps")
+    }
+
+    @MainActor
+    func test_strayBrushGuard_doneDisabledWhenNoPrescriptionOrInFlight() async {
+        // The view's doneEnabled = model.doneEnabled && !isCompletingSet && !isMorphing.
+        // Prove the model half: no prescription → not loggable (a brush on a card with
+        // nothing to log is rejected at the source).
+        let day = makeLiveLoopDay(exerciseCount: 1, setsPerExercise: 2)
+        let ex = day.exercises[0]
+        let noRx = LiveLoopModel(sessionState: .active(exercise: ex, setNumber: 1),
+                                 prescription: nil, restSecondsRemaining: 0, trainingDay: day)
+        XCTAssertFalse(noRx.doneEnabled)
+    }
+}
+
+// MARK: - VoiceOver + geometry (host-rendered, unconditional where UIKit exists)
+
+#if canImport(UIKit)
+@MainActor
+@Suite("LiveLoop accessibility — VoiceOver reads hero numbers + Done")
+struct LiveLoopAccessibilityTests {
+
+    /// The hero lockup and the Done slab carry explicit accessibility labels so
+    /// VoiceOver reads "82.5 kg × 8" and "Done"/"Finish". We assert the label
+    /// strings the view builds from the model (the view threads these verbatim).
+    @Test("Hero label reads weight × reps; Done label tracks the relabel")
+    func voiceOverLabels() {
+        let day = makeLiveLoopDay(exerciseCount: 1, setsPerExercise: 2)
+        let ex = day.exercises[0]
+
+        let setModel = LiveLoopModel(sessionState: .active(exercise: ex, setNumber: 1),
+                                     prescription: samplePrescription(weightKg: 82.5, reps: 8),
+                                     restSecondsRemaining: 0, trainingDay: day)
+        // The view's accessibilityLabel for the hero is "\(weight) \(reps)".
+        let heroLabel = "\(setModel.heroWeightText) \(setModel.heroRepsText)"
+        #expect(heroLabel.contains("82.5 kg"))
+        #expect(heroLabel.contains("\u{00D7} 8"))
+        #expect(setModel.doneLabel == "Done")
+
+        let finishModel = LiveLoopModel(sessionState: .active(exercise: ex, setNumber: 2),
+                                        prescription: samplePrescription(),
+                                        restSecondsRemaining: 0, trainingDay: day)
+        #expect(finishModel.doneLabel == "Finish")
+    }
+}
+#endif
+
+// MARK: - Gated image snapshots (reference-pending; NEVER record here)
+
+#if canImport(UIKit)
+// `nonisolated` so the `.enabled(if:)` macro can reference these from the suite's
+// nonisolated context (under the project's `-default-isolation=MainActor`).
+nonisolated private var liveLoopSnapshotEnabled: Bool {
+    ProcessInfo.processInfo.environment["APEX_SNAPSHOT_TESTS"] == "1"
+}
+nonisolated private var liveLoopRecordMode: Bool {
+    ProcessInfo.processInfo.environment["APEX_RECORD_SNAPSHOTS"] == "1"
+}
+
+@Suite("LiveLoop snapshots — set + rest, light + dim", .enabled(if: liveLoopSnapshotEnabled))
+@MainActor
+struct LiveLoopSnapshotTests {
+
+    private static let canvas = CGSize(width: 393, height: 852)
+
+    private static func host(_ view: some View, appearance: Appearance) -> UIViewController {
+        let rooted = view
+            .environment(\.apexTheme, Theme.current(appearance))
+            .frame(width: canvas.width, height: canvas.height)
+        let vc = UIHostingController(rootView: rooted)
+        vc.view.frame = CGRect(origin: .zero, size: canvas)
+        vc.view.backgroundColor = UIColor(
+            red: Theme.current(appearance).paper.red,
+            green: Theme.current(appearance).paper.green,
+            blue: Theme.current(appearance).paper.blue,
+            alpha: 1
+        )
+        vc.view.setNeedsLayout()
+        vc.view.layoutIfNeeded()
+        return vc
+    }
+
+    private static let imaging: Snapshotting<UIViewController, UIImage> = .image(precision: 0.99, perceptualPrecision: 0.98)
+
+    @Test("Set state — light")
+    func setState_light() {
+        let vc = Self.host(LiveLoopView(viewModel: .mockActive(), trainingDay: makeLiveLoopDay()), appearance: .light)
+        assertSnapshot(of: vc, as: Self.imaging, named: "liveloop-set-light", record: liveLoopRecordMode)
+    }
+
+    @Test("Set state — dim")
+    func setState_dim() {
+        let vc = Self.host(LiveLoopView(viewModel: .mockActive(), trainingDay: makeLiveLoopDay()), appearance: .dim)
+        assertSnapshot(of: vc, as: Self.imaging, named: "liveloop-set-dim", record: liveLoopRecordMode)
+    }
+
+    @Test("Rest state — light")
+    func restState_light() {
+        let vc = Self.host(LiveLoopView(viewModel: .mockResting(), trainingDay: makeLiveLoopDay()), appearance: .light)
+        assertSnapshot(of: vc, as: Self.imaging, named: "liveloop-rest-light", record: liveLoopRecordMode)
+    }
+
+    @Test("Rest state — dim")
+    func restState_dim() {
+        let vc = Self.host(LiveLoopView(viewModel: .mockResting(), trainingDay: makeLiveLoopDay()), appearance: .dim)
+        assertSnapshot(of: vc, as: Self.imaging, named: "liveloop-rest-dim", record: liveLoopRecordMode)
+    }
+}
+#endif


### PR DESCRIPTION
## What shipped

Slice 8 of the Phase 3 UI overhaul: a NEW screen, `LiveLoopView`, that owns the live-session set loop per [`docs/design/live-loop.md`](docs/design/live-loop.md) **§1–4**.

- **Hero-num lockup (§3):** exercise name + target weight × reps as hero numbers. The × is U+00D7 (never the letter x). Weight renders `ink` (work); the × glyph and reps render `ink-muted` (pencil).
- **Full-bleed bottom Done ink slab (§3):** edge-to-edge, flat top with a 1px `accent-press` top rule, ~96pt with the home-indicator zone inside. **Relabels to "Finish" on the last set of the whole session** — computed from the read-only `TrainingDay` the view takes as input (the `WorkoutSessionManager` actor keeps `trainingDay`/`exerciseIndex` private, so the day is passed in; no backend change). One tap = the set logged as prescribed.
- **Guards (§3):** disabled-while-morphing (no double-logs), stray-brush rejection (the slab's own hit region + Button's drag-out cancel), and `Haptics.setLogged()` fired at **commit**, not touch-down.
- **Rest morph (§4):** the card morphs set ↔ rest in place — no modal — on `Motion.cardMorph` (~350ms); Reduce-Motion uses `Motion.reduceMotionCrossfade`. Rest digits are the pencil hero (`ink-muted`); no idle animation; overshoot banned.
- **"Work is ink, time is pencil" (§1):** work numbers `ink`, time digits `ink-muted` — asserted at the token level.

## DORMANT constraint

This is a **new view only**. It is **not routed** into the live shell. **`ActiveSetView`, `RestTimerView`, `AppShell`, `useNewShell`, and `ProjectApexApp` are untouched.** The legacy `ActiveSetView`/`RestTimerView` remain live in the frozen `ContentView` until the close-out slice.

## Cut line — §1–4 only (roadmap §4 Q13)

Deferred to **#351** (hooks/TODOs only, not built here):
- **AMRAP** target + keypad-first rep counter.
- **Adjust** (tap-the-number morphing steppers).
- The full **ink-flood entrance** — stubbed here to a plain crossfade.

## Behaviour-parity gaps vs `ActiveSetView`

- **Headline — one tap vs a confirmation sheet.** Legacy `ActiveSetView` (~1630 lines) opens a multi-field rep/RPE/intent **confirmation sheet** on Done. The new live-loop Done is **one tap = logged as prescribed**: it logs `prescription.reps` at `prescription.intent` directly, with no sheet. This is a deliberate NEW behaviour (the per-set edit/correction surface that makes it safe is §6, owned by a later slice).
- **No Done→Finish relabel in legacy.** Legacy "Finish" lives in an overflow "End Workout Early" menu; there is no Done→Finish relabel. The live loop makes the slab's label flip to "Finish" on the last set of the session.
- **RPE / completion-flags / intent picker not surfaced.** The one-tap path logs `rpeFelt: nil` and no completion flags; the legacy sheet collects these. (Per spec these move to the §6 set-edit correction surface — out of this slice.)
- **Annotations not yet rendered.** "Why this?", last-time anchor, plate-math callout, set-type tags, the feel pill, and rest ±15s/Skip controls are present in legacy and are TODO(#351)/later-slice here.

## Tests

`ProjectApexTests/LiveLoopCoreTests.swift` — **16 tests, all green**, run **without** `APEX_SNAPSHOT_TESTS`:

```
xcodebuild test -project ProjectApex.xcodeproj -scheme ProjectApex \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -only-testing:ProjectApexTests/LiveLoopModelTests \
  -only-testing:ProjectApexTests/LiveLoopInkPencilTests \
  -only-testing:ProjectApexTests/LiveLoopBindingTests \
  -only-testing:ProjectApexTests/LiveLoopAccessibilityTests \
  -only-testing:ProjectApexTests/LiveLoopSnapshotTests
```

- **`LiveLoopBindingTests`** (XCTest, drives the real `WorkoutViewModel`/`WorkoutSessionManager`): **start → log via Done → rest morph → next set**; the double-log guard (two completes back-to-back → one set logged); the stray-brush guard (no prescription → not loggable).
- **`LiveLoopModelTests` / `LiveLoopInkPencilTests` / `LiveLoopAccessibilityTests`** (Swift Testing): Done→Finish relabel only on the true last set, hero/×/weight derivation (U+00D7, no trailing `.0`), the `ink` vs `ink-muted` token split, VoiceOver labels for the hero numbers + Done/Finish.
- **`LiveLoopSnapshotTests`** (gated on `APEX_SNAPSHOT_TESTS=1`): set + rest states in light + dim. **Image-snapshots are wired but reference PNGs are intentionally NOT recorded** — the CI record job owns that (mirrors `DrawnInstrumentSnapshotTests`). `APEX_RECORD_SNAPSHOTS` was never set.

## Closing keyword — `Part of #350`

Using **`Part of #350`**, not `Closes`. The core loop is proven via VM-driven tests and both states are snapshot-wired, but AC item 1 ("**Start a session** → log via Done → rest morph → next set") at the running-app level needs the live-shell **routing** that this slice deliberately excludes (the DORMANT constraint forbids touching `AppShell`/`useNewShell`). That wiring — and the §6 set-edit correction surface that makes one-tap-Done safe — is owned by **#351** / the close-out slice.

**Remaining for #350 to fully close:**
- Route `LiveLoopView` into the new 3-tab shell (replace the dormant flag) — owner: close-out / #351.
- Record the snapshot reference PNGs on the CI-pinned toolchain — owner: CI record job.

Spec: [`docs/design/live-loop.md`](docs/design/live-loop.md) §1–4.

Part of #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)