### PR TITLE
feat(#345): capability-band component (one component, three contexts)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,22 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-13 — Built the capability band: one component, three contexts (Slice 4, #345)
+
+The design specced a single band drawing that works in three places — onboarding model reveal, post-workout evidence strip, and the Progress ledger row. Instead of building three separate views, the spec said build one and configure it. That's what shipped today.
+
+**What the band draws.** A filled region between the floor (the heaviest tick — 2 px, full ink) and the stretch (a hairline tick — 1 px). The fill is the accent color at 8% in light mode, 12% in dim. Today's dot is solid when the model has enough data to trust the number ("measured"), hollow when it's still a guess ("estimated"). The dashed band edges give the same estimated/measured signal on the band itself — solid edges when established or seasoned, dashed when still calibrating.
+
+**The three contexts.** `.full` is the complete drawing with labels and a caption slot — this is what the post-workout strip and the Progress detail use. `.onboarding` is the same anatomy at a slightly smaller height — same component, same labeling. `.list` strips it down to an unlabeled 5 pt dot and no bracket, because the Progress root rows put the numbers in the row annotation below, not on the drawing itself.
+
+**The binding.** The component takes a `PatternProjection` (floor/stretch/progress) plus an `AxisConfidence` separately, because `PatternProjection` has no confidence field. The caller supplies confidence from `PatternProfile.confidence`.
+
+**Tests.** Twelve unconditional geometry/token tests run on every push: tick widths, fill opacities for light and dim, the full four-case confidence mapping, minimum band width enforcement, and out-of-band dot plotting. Seven snapshot cases are wired in but gated — they will record references when CI runs on the pinned Xcode 26.3 toolchain.
+
+**DORMANT.** The component is built and tested but not wired into any live screen — the old views are untouched. The post-workout, Progress, and onboarding slices will each pull it in when they build.
+
+**Status:** PR open, 324/324 tests passing.
+
 ## 2026-06-13 — Proved the server was fine, then stopped the app from using the connection type that was hanging
 
 **What I did first — proof, not a guess.** Two earlier fixes hadn't cleared the problem, so instead of guessing again I called the real login endpoint myself from my computer. It answered instantly with a valid login. That proved the server, the key, and the login feature are all healthy — it is **not** a rate limit and **not** the wifi. The problem had to be in how the app makes the connection.

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		DE51900000000000DE519002 /* DesignSystemTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE51900000000000DE519001 /* DesignSystemTokensTests.swift */; };
 		A1C0F19329000000APIKEY04 /* BundledKeyResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0F19329000000APIKEY03 /* BundledKeyResolutionTests.swift */; };
 		5A30343A0000000000FE5102 /* AppShellRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A30343A0000000000FE5101 /* AppShellRouteTests.swift */; };
+		CB34500000000000CB345002 /* CapabilityBandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB34500000000000CB345001 /* CapabilityBandTests.swift */; };
 		DE52000000000000DE520002 /* DesignSystemGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */; };
 		DE53000000000000DE530002 /* DrawnInstrumentSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */; };
 		DE54000000000000DE540002 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = DE54000000000000DE540001 /* SnapshotTesting */; };
@@ -128,6 +129,7 @@
 		22000000000000000000F012 /* PromptLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptLoaderTests.swift; sourceTree = "<group>"; };
 		DE51900000000000DE519001 /* DesignSystemTokensTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DesignSystemTokensTests.swift; sourceTree = "<group>"; };
 		5A30343A0000000000FE5101 /* AppShellRouteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppShellRouteTests.swift; sourceTree = "<group>"; };
+		CB34500000000000CB345001 /* CapabilityBandTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CapabilityBandTests.swift; sourceTree = "<group>"; };
 		DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DesignSystemGeometryTests.swift; sourceTree = "<group>"; };
 		DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DrawnInstrumentSnapshotTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
@@ -274,6 +276,7 @@
 				DE51900000000000DE519001 /* DesignSystemTokensTests.swift */,
 				A1C0F19329000000APIKEY03 /* BundledKeyResolutionTests.swift */,
 				5A30343A0000000000FE5101 /* AppShellRouteTests.swift */,
+				CB34500000000000CB345001 /* CapabilityBandTests.swift */,
 				DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */,
 				DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */,
 			);
@@ -441,6 +444,7 @@
 				DE51900000000000DE519002 /* DesignSystemTokensTests.swift in Sources */,
 				A1C0F19329000000APIKEY04 /* BundledKeyResolutionTests.swift in Sources */,
 				5A30343A0000000000FE5102 /* AppShellRouteTests.swift in Sources */,
+				CB34500000000000CB345002 /* CapabilityBandTests.swift in Sources */,
 				DE52000000000000DE520002 /* DesignSystemGeometryTests.swift in Sources */,
 				DE53000000000000DE530002 /* DrawnInstrumentSnapshotTests.swift in Sources */,
 			);

--- a/ProjectApex/DesignSystem/Instruments/CapabilityBand.swift
+++ b/ProjectApex/DesignSystem/Instruments/CapabilityBand.swift
@@ -1,0 +1,431 @@
+// CapabilityBand.swift
+// ProjectApex — DesignSystem/Instruments
+//
+// The capability band: one component, three contexts.
+// DESIGN.md §Data-visualization + post-workout.md §6 + progress.md §3.
+//
+// Three contexts via `CapabilityBandContext`:
+//   .full      — post-workout evidence strip and Progress pattern detail.
+//                Full anatomy: 8% band fill, 2px floor tick, 1px stretch tick,
+//                measured/estimated dot, dimension-bracket movement, caption slot.
+//   .onboarding — same anatomy as .full at a slightly smaller default height,
+//                still labeled and captioned — the model-reveal in onboarding.
+//   .list       — unlabeled (numbers in the row annotation), 5pt dot, no bracket;
+//                used in Progress root rows where the floor ticks fuse into the spine.
+//
+// Binding amendment (load-bearing): takes a `PatternProjection` (floor/stretch/progress)
+// PLUS an `AxisConfidence` for the confidence cue. `PatternProjection` has no confidence
+// field, so the caller supplies it separately (typically from `PatternProfile.confidence`).
+//
+// Confidence → visual cue (ratified honesty rule):
+//   .established / .seasoned   → measured: SOLID dot + solid edges
+//   .bootstrapping / .calibrating → estimated: HOLLOW dot + dashed edges
+//
+// DORMANT: built but not wired into the live shell — old views untouched (#345).
+// No entrance animation in the bare instrument; no idle animation.
+
+import SwiftUI
+
+// MARK: - CapabilityBandContext
+
+/// Selects the anatomy and labeling level for the band component.
+enum CapabilityBandContext: Equatable, Sendable {
+    /// Full anatomy: labeled ticks, dot, movement bracket, caption slot.
+    /// Used on the post-workout evidence strip and the Progress pattern detail.
+    case full
+    /// Same anatomy as `.full`. The onboarding model-reveal context — same component,
+    /// same labeling, same caption slot — differing only in scale (the caller frames it).
+    case onboarding
+    /// List-scale reduction: unlabeled, 5pt dot, no bracket.
+    /// Used in Progress root rows. Numbers live in the row annotation, not the drawing.
+    case list
+}
+
+// MARK: - CapabilityBandInput
+
+/// The data contract: the projection plus the axis confidence.
+struct CapabilityBandInput: Equatable, Sendable {
+    /// The pattern's floor, stretch, and projection progress.
+    let projection: PatternProjection
+    /// Confidence axis — determines measured (solid) vs estimated (hollow/dashed).
+    let confidence: AxisConfidence
+    /// Today's best e1RM for the pattern, if any. `nil` = no dot rendered.
+    let observedE1RM: Double?
+    /// Movement delta for the dimension bracket (post-workout.md §6).
+    /// `nil` = no bracket rendered (flat session or below noise threshold).
+    let movementDeltaKg: Double?
+    /// Caption shown beneath the drawing (e.g. "Bench press — most worked today").
+    /// `nil` = no caption slot rendered. `.list` context ignores this.
+    let caption: String?
+
+    init(
+        projection: PatternProjection,
+        confidence: AxisConfidence,
+        observedE1RM: Double? = nil,
+        movementDeltaKg: Double? = nil,
+        caption: String? = nil
+    ) {
+        self.projection = projection
+        self.confidence = confidence
+        self.observedE1RM = observedE1RM
+        self.movementDeltaKg = movementDeltaKg
+        self.caption = caption
+    }
+}
+
+// MARK: - Confidence helpers (the honesty rule)
+
+extension AxisConfidence {
+    /// Whether this confidence level maps to a measured (solid) visual cue.
+    /// `.established` and `.seasoned` → solid dot + solid band edges.
+    /// `.bootstrapping` and `.calibrating` → hollow dot + dashed edges.
+    var isMeasured: Bool {
+        switch self {
+        case .established, .seasoned: true
+        case .bootstrapping, .calibrating: false
+        }
+    }
+}
+
+// MARK: - CapabilityBand
+
+/// The capability band — one component, three contexts.
+///
+/// Renders assembled at frame 1 (no entrance animation in the bare instrument).
+/// No idle animation, no breathing, no looping. Entrance and motion sequences
+/// live in separate wrapper views (`post-workout.md` §3, §7).
+struct CapabilityBand: View {
+
+    let input: CapabilityBandInput
+    let context: CapabilityBandContext
+
+    @Environment(\.apexTheme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            BandCanvas(input: input, context: context, theme: theme)
+            if context != .list, let caption = input.caption {
+                Text(caption)
+                    .apexFont(.label)
+                    .foregroundStyle(theme.inkMuted.color)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityHidden(true)  // included in the parent accessibility label
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    // MARK: VoiceOver grammar (post-workout.md §6)
+    // "Bench press. Estimated one-rep max 92 kilograms, measured. Capability band 88 to 96."
+    private var accessibilityLabel: String {
+        let patternName = input.projection.pattern.displayName
+        var parts: [String] = [patternName]
+        if let e1rm = input.observedE1RM {
+            let qualifier = input.confidence.isMeasured ? "measured" : "estimated"
+            parts.append("Estimated one-rep max \(formatKg(e1rm)) kilograms, \(qualifier).")
+        }
+        parts.append("Capability band \(formatKg(input.projection.floor)) to \(formatKg(input.projection.stretch)).")
+        if let delta = input.movementDeltaKg {
+            let sign = delta >= 0 ? "+" : ""
+            parts.append("Center moved \(sign)\(formatKg(delta)) kilograms.")
+        }
+        return parts.joined(separator: " ")
+    }
+
+    private func formatKg(_ value: Double) -> String {
+        let rounded = (value * 2).rounded() / 2  // 0.5 kg precision per progress.md §5
+        if rounded == rounded.rounded() {
+            return String(Int(rounded))
+        }
+        return String(format: "%.1f", rounded)
+    }
+}
+
+// MARK: - BandCanvas (the drawing)
+
+/// The drawing surface: band fill, floor/stretch ticks, dot, movement bracket.
+/// Context determines labeling and dot size.
+private struct BandCanvas: View {
+
+    let input: CapabilityBandInput
+    let context: CapabilityBandContext
+    let theme: Theme
+
+    var body: some View {
+        GeometryReader { geo in
+            let layout = BandLayout(
+                floor: input.projection.floor,
+                stretch: input.projection.stretch,
+                observedE1RM: input.observedE1RM,
+                width: geo.size.width
+            )
+            let h = geo.size.height
+            let isMeasured = input.confidence.isMeasured
+
+            ZStack(alignment: .topLeading) {
+                // ── Band fill ──────────────────────────────────────────────
+                bandFillShape(layout: layout, height: h)
+
+                // ── Band edges (solid when measured, dashed when estimated) ──
+                bandEdges(layout: layout, height: h, isMeasured: isMeasured)
+
+                // ── Floor tick (2px, full ink — the heaviest line) ──────────
+                floorTick(layout: layout, height: h)
+
+                // ── Stretch tick (1px hairline) ─────────────────────────────
+                stretchTick(layout: layout, height: h)
+
+                // ── Today's dot ─────────────────────────────────────────────
+                if let dotX = layout.dotX {
+                    dot(x: dotX, height: h, isMeasured: isMeasured)
+                }
+
+                // ── Movement bracket (full context only; conditional) ────────
+                if context != .list, let delta = input.movementDeltaKg,
+                   let (bracketX1, bracketX2) = layout.bracketXRange {
+                    movementBracket(x1: bracketX1, x2: bracketX2, delta: delta, height: h)
+                }
+
+                // ── Tick labels (full / onboarding contexts) ─────────────────
+                if context != .list {
+                    tickLabels(layout: layout, height: h)
+                }
+            }
+        }
+        .frame(height: bandHeight)
+    }
+
+    // MARK: Band height per context
+
+    private var bandHeight: CGFloat {
+        switch context {
+        case .full: 64
+        case .onboarding: 56
+        case .list: 20  // compact strip height for Progress rows
+        }
+    }
+
+    // MARK: Dot size per context
+
+    private var dotDiameter: CGFloat {
+        context == .list ? DesignGeometry.listScaleDot : 8
+    }
+
+    // MARK: Subviews
+
+    private func bandFillShape(layout: BandLayout, height: CGFloat) -> some View {
+        Rectangle()
+            .fill(theme.bandFill.color)
+            .frame(width: max(0, layout.stretchX - layout.floorX), height: height)
+            .offset(x: layout.floorX)
+    }
+
+    @ViewBuilder
+    private func bandEdges(layout: BandLayout, height: CGFloat, isMeasured: Bool) -> some View {
+        if isMeasured {
+            // Solid hairline left edge at floor
+            Rectangle()
+                .fill(theme.bandEdge.color)
+                .frame(width: 1, height: height)
+                .offset(x: layout.floorX)
+            // Solid hairline right edge at stretch
+            Rectangle()
+                .fill(theme.bandEdge.color)
+                .frame(width: 1, height: height)
+                .offset(x: layout.stretchX)
+        } else {
+            // Dashed edges for estimated/projected confidence
+            Path { p in
+                p.move(to: CGPoint(x: layout.floorX, y: 0))
+                p.addLine(to: CGPoint(x: layout.floorX, y: height))
+            }
+            .stroke(style: StrokeStyle(
+                lineWidth: 1,
+                dash: DesignGeometry.projectionDash
+            ))
+            .foregroundStyle(theme.bandEdge.color)
+
+            Path { p in
+                p.move(to: CGPoint(x: layout.stretchX, y: 0))
+                p.addLine(to: CGPoint(x: layout.stretchX, y: height))
+            }
+            .stroke(style: StrokeStyle(
+                lineWidth: 1,
+                dash: DesignGeometry.projectionDash
+            ))
+            .foregroundStyle(theme.bandEdge.color)
+        }
+    }
+
+    private func floorTick(layout: BandLayout, height: CGFloat) -> some View {
+        Rectangle()
+            .fill(theme.ink.color)
+            .frame(width: DesignGeometry.floorTick, height: height)
+            .offset(x: layout.floorX - DesignGeometry.floorTick / 2)
+    }
+
+    private func stretchTick(layout: BandLayout, height: CGFloat) -> some View {
+        Rectangle()
+            .fill(theme.inkMuted.color)
+            .frame(width: DesignGeometry.stretchTick, height: height)
+            .offset(x: layout.stretchX - DesignGeometry.stretchTick / 2)
+    }
+
+    @ViewBuilder
+    private func dot(x: CGFloat, height: CGFloat, isMeasured: Bool) -> some View {
+        let d = dotDiameter
+        let centerY = height / 2
+
+        if isMeasured {
+            // Solid accent-ink dot
+            Circle()
+                .fill(theme.pointMeasured.color)
+                .frame(width: d, height: d)
+                .offset(x: x - d / 2, y: centerY - d / 2)
+        } else {
+            // Hollow ink-stroke dot (estimated)
+            Circle()
+                .stroke(theme.pointEstimatedStroke.color, lineWidth: 1.5)
+                .frame(width: d, height: d)
+                .offset(x: x - d / 2, y: centerY - d / 2)
+        }
+    }
+
+    @ViewBuilder
+    private func movementBracket(x1: CGFloat, x2: CGFloat, delta: Double, height: CGFloat) -> some View {
+        let topY: CGFloat = 4
+        let terminalHeight: CGFloat = 6
+        let labelY: CGFloat = topY + terminalHeight + 2
+        let sign = delta >= 0 ? "+" : ""
+        let deltaStr = "\(sign)\(formatKg(delta)) KG"
+
+        ZStack(alignment: .topLeading) {
+            // Dimension line with terminal ticks
+            Path { p in
+                // Left terminal tick
+                p.move(to: CGPoint(x: x1, y: topY))
+                p.addLine(to: CGPoint(x: x1, y: topY + terminalHeight))
+                // Horizontal dimension line
+                p.move(to: CGPoint(x: x1, y: topY + terminalHeight / 2))
+                p.addLine(to: CGPoint(x: x2, y: topY + terminalHeight / 2))
+                // Right terminal tick
+                p.move(to: CGPoint(x: x2, y: topY))
+                p.addLine(to: CGPoint(x: x2, y: topY + terminalHeight))
+            }
+            .stroke(theme.inkMuted.color, lineWidth: DesignGeometry.stretchTick)
+
+            // Delta label centered on the bracket
+            Text(deltaStr)
+                .apexFont(.label)
+                .foregroundStyle(theme.ink.color)
+                .monospacedDigit()
+                .offset(x: (x1 + x2) / 2 - 20, y: labelY)
+        }
+    }
+
+    @ViewBuilder
+    private func tickLabels(layout: BandLayout, height: CGFloat) -> some View {
+        let labelY = height + Spacing.xs
+
+        // Floor label — "FLOOR 100"
+        Text("FLOOR \(formatKg(input.projection.floor))")
+            .apexFont(.label)
+            .foregroundStyle(theme.inkMuted.color)
+            .monospacedDigit()
+            .offset(x: max(0, layout.floorX - 20), y: labelY)
+
+        // Stretch label — "STRETCH 110"
+        Text("STRETCH \(formatKg(input.projection.stretch))")
+            .apexFont(.label)
+            .foregroundStyle(theme.inkMuted.color)
+            .monospacedDigit()
+            .offset(x: min(layout.totalWidth - 60, layout.stretchX - 20), y: labelY)
+    }
+
+    private func formatKg(_ value: Double) -> String {
+        let rounded = (value * 2).rounded() / 2
+        if rounded == rounded.rounded() {
+            return String(Int(rounded))
+        }
+        return String(format: "%.1f", rounded)
+    }
+}
+
+// MARK: - BandLayout
+
+/// Computes x-positions for the floor tick, stretch tick, and dot within the
+/// available width, expanding the domain to include out-of-band dots.
+/// Dots plot outside the band, never clamped (post-workout.md §6).
+struct BandLayout {
+    let floorX: CGFloat
+    let stretchX: CGFloat
+    let dotX: CGFloat?
+    /// The x-range for the movement bracket (previous center → new center).
+    /// `nil` when `movementDeltaKg` is absent — set externally by the caller if needed.
+    let bracketXRange: (CGFloat, CGFloat)?
+    let totalWidth: CGFloat
+
+    /// Minimum band render width (post-workout.md §6: "minimum band render width 48pt").
+    static let minimumBandWidth: CGFloat = 48
+
+    init(
+        floor: Double,
+        stretch: Double,
+        observedE1RM: Double?,
+        movementDeltaKg: Double? = nil,
+        width: CGFloat
+    ) {
+        totalWidth = width
+
+        // Domain: band ± 20%, expanded to include today's dot if outside.
+        let bandWidth = stretch - floor
+        let margin = bandWidth * 0.20
+
+        var domainMin = floor - margin
+        var domainMax = stretch + margin
+        if let e1rm = observedE1RM {
+            domainMin = min(domainMin, e1rm - margin * 0.5)
+            domainMax = max(domainMax, e1rm + margin * 0.5)
+        }
+        let domainSpan = domainMax - domainMin
+
+        func xFor(_ value: Double) -> CGFloat {
+            guard domainSpan > 0 else { return width / 2 }
+            return CGFloat((value - domainMin) / domainSpan) * width
+        }
+
+        let rawFloorX = xFor(floor)
+        let rawStretchX = xFor(stretch)
+        let rawBandWidth = rawStretchX - rawFloorX
+
+        // Enforce minimum band width — shift label positions outboard if needed.
+        if rawBandWidth < BandLayout.minimumBandWidth {
+            let expansion = (BandLayout.minimumBandWidth - rawBandWidth) / 2
+            floorX = rawFloorX - expansion
+            stretchX = rawStretchX + expansion
+        } else {
+            floorX = rawFloorX
+            stretchX = rawStretchX
+        }
+
+        if let e1rm = observedE1RM {
+            dotX = xFor(e1rm)
+        } else {
+            dotX = nil
+        }
+
+        // Movement bracket: spans from bandCenter - delta/2 to bandCenter + delta/2.
+        if let delta = movementDeltaKg {
+            let center = (floor + stretch) / 2
+            let halfDelta = abs(delta) / 2
+            let prevCenter = delta >= 0 ? center - halfDelta : center + halfDelta
+            let newCenter = delta >= 0 ? center + halfDelta : center - halfDelta
+            bracketXRange = (xFor(prevCenter), xFor(newCenter))
+        } else {
+            bracketXRange = nil
+        }
+    }
+}
+
+// MovementPattern.displayName is defined in MovementPattern.swift — used directly.

--- a/ProjectApexTests/CapabilityBandTests.swift
+++ b/ProjectApexTests/CapabilityBandTests.swift
@@ -1,0 +1,297 @@
+// CapabilityBandTests.swift
+// ProjectApexTests
+//
+// Tests for the CapabilityBand component (Slice 4, #345).
+//
+// Two layers:
+//  1. UNCONDITIONAL geometry/token layer — runs on every push, no env var needed.
+//     Verifies tick widths, fill opacity, confidence→solid/hollow mapping for all
+//     four AxisConfidence cases, list-scale dot size, and dim data-viz tokens.
+//  2. GATED snapshot layer — mirrors DrawnInstrumentSnapshotTests.swift exactly.
+//     Three contexts (full / onboarding / list) × light + dim + one AX size.
+//     References are NOT recorded (APEX_RECORD_SNAPSHOTS is never set here;
+//     CI records them on the pinned Xcode 26.3 toolchain).
+
+import Testing
+import SwiftUI
+import SnapshotTesting
+@testable import ProjectApex
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+// MARK: - Gating (mirrors DrawnInstrumentSnapshotTests)
+
+private var snapshotTestsEnabled: Bool {
+    ProcessInfo.processInfo.environment["APEX_SNAPSHOT_TESTS"] == "1"
+}
+private var recordModeEnabled: Bool {
+    ProcessInfo.processInfo.environment["APEX_RECORD_SNAPSHOTS"] == "1"
+}
+
+// MARK: - Fixtures
+
+private extension PatternProjection {
+    /// A stable squat band for tests: floor 100, stretch 115, onTrack.
+    static let squatFixture = PatternProjection(
+        pattern: .squat,
+        floor: 100,
+        stretch: 115,
+        progress: .onTrack
+    )
+}
+
+private extension CapabilityBandInput {
+    /// Measured (established), dot at 107, no movement.
+    static let measuredNoMove = CapabilityBandInput(
+        projection: .squatFixture,
+        confidence: .established,
+        observedE1RM: 107,
+        movementDeltaKg: nil,
+        caption: "Squat — most worked today"
+    )
+    /// Estimated (bootstrapping), dot at 102, movement +2 kg.
+    static let estimatedWithMove = CapabilityBandInput(
+        projection: .squatFixture,
+        confidence: .bootstrapping,
+        observedE1RM: 102,
+        movementDeltaKg: 2,
+        caption: "Squat — still calibrating"
+    )
+    /// List context — no caption used.
+    static let listContext = CapabilityBandInput(
+        projection: .squatFixture,
+        confidence: .seasoned,
+        observedE1RM: 108,
+        movementDeltaKg: nil,
+        caption: nil
+    )
+}
+
+// MARK: ──────────────────────────────────────────────────────────────────────
+// 1. UNCONDITIONAL geometry / token layer
+// ──────────────────────────────────────────────────────────────────────────
+
+@Suite("CapabilityBand — geometry and token assertions")
+struct CapabilityBandGeometryTests {
+
+    // MARK: Tick widths
+
+    @Test("Floor tick is 2px per DesignGeometry")
+    func floorTickWidth() {
+        #expect(DesignGeometry.floorTick == 2)
+    }
+
+    @Test("Stretch tick is 1px (hairline) per DesignGeometry")
+    func stretchTickWidth() {
+        #expect(DesignGeometry.stretchTick == 1)
+    }
+
+    // MARK: Band fill opacity
+
+    @Test("Light band fill is accent at 8% opacity")
+    func bandFillOpacity_light() {
+        let theme = Theme.light
+        // bandFill is accent at 8% (light) — TokenColor.opacity check.
+        #expect(abs(theme.bandFill.opacity - 0.08) < 0.001)
+    }
+
+    @Test("Dim band fill is accent-ink at 12% opacity")
+    func bandFillOpacity_dim() {
+        let theme = Theme.dim
+        // bandFill is dim accent-ink at 12% — DESIGN.md §data-viz-dim.
+        #expect(abs(theme.bandFill.opacity - 0.12) < 0.001)
+    }
+
+    // MARK: Confidence → solid / hollow mapping (all 4 cases)
+
+    @Test("bootstrapping → estimated (hollow)", arguments: [AxisConfidence.bootstrapping])
+    func bootstrapping_isEstimated(confidence: AxisConfidence) {
+        #expect(confidence.isMeasured == false)
+    }
+
+    @Test("calibrating → estimated (hollow)", arguments: [AxisConfidence.calibrating])
+    func calibrating_isEstimated(confidence: AxisConfidence) {
+        #expect(confidence.isMeasured == false)
+    }
+
+    @Test("established → measured (solid)", arguments: [AxisConfidence.established])
+    func established_isMeasured(confidence: AxisConfidence) {
+        #expect(confidence.isMeasured == true)
+    }
+
+    @Test("seasoned → measured (solid)", arguments: [AxisConfidence.seasoned])
+    func seasoned_isMeasured(confidence: AxisConfidence) {
+        #expect(confidence.isMeasured == true)
+    }
+
+    // MARK: Confidence mapping is exhaustive
+
+    @Test("All AxisConfidence cases are handled")
+    func allConfidenceCasesHandled() {
+        for confidence in AxisConfidence.allCases {
+            // isMeasured must return deterministically (no crash, no unhandled case)
+            let _ = confidence.isMeasured
+        }
+    }
+
+    // MARK: List-scale dot size
+
+    @Test("List-scale dot is 5pt per DesignGeometry")
+    func listScaleDotSize() {
+        #expect(DesignGeometry.listScaleDot == 5)
+    }
+
+    // MARK: Dim data-viz tokens (spot checks)
+
+    @Test("Dim accent-ink is lifted (7B85FF — the dim data-viz primary)")
+    func dimAccentInkIsLifted() {
+        let dim = Theme.dim
+        // #7B85FF: red=0x7B/255≈0.482, green=0x85/255≈0.522, blue=0xFF/255=1.0
+        #expect(abs(dim.accentInk.red - Double(0x7B) / 255) < 0.002)
+        #expect(abs(dim.accentInk.green - Double(0x85) / 255) < 0.002)
+        #expect(abs(dim.accentInk.blue - 1.0) < 0.002)
+    }
+
+    @Test("Dim band edge hairline is 2A2D36 per data-viz-dim spec")
+    func dimBandEdgeHairline() {
+        let dim = Theme.dim
+        // #2A2D36
+        #expect(abs(dim.hairline.red - Double(0x2A) / 255) < 0.002)
+        #expect(abs(dim.hairline.green - Double(0x2D) / 255) < 0.002)
+        #expect(abs(dim.hairline.blue - Double(0x36) / 255) < 0.002)
+    }
+
+    // MARK: BandLayout — minimum band width enforcement
+
+    @Test("BandLayout enforces 48pt minimum band render width")
+    func bandLayoutMinimumWidth() {
+        // Very close floor/stretch produces a narrow band — must be clamped to 48pt.
+        let layout = BandLayout(floor: 100, stretch: 100.5, observedE1RM: nil, width: 300)
+        let rendered = layout.stretchX - layout.floorX
+        #expect(rendered >= BandLayout.minimumBandWidth - 0.5)
+    }
+
+    @Test("BandLayout does not clamp out-of-band dot — plots outside the band")
+    func bandLayoutOutOfBandDotNotClamped() {
+        // Dot at 130 is outside the 100–115 band. It must plot beyond stretchX.
+        let layout = BandLayout(floor: 100, stretch: 115, observedE1RM: 130, width: 300)
+        if let dotX = layout.dotX {
+            #expect(dotX > layout.stretchX)
+        } else {
+            Issue.record("Expected a dotX but got nil")
+        }
+    }
+
+    @Test("BandLayout: dot below floor plots outside (left of) the band")
+    func bandLayoutDotBelowFloor() {
+        let layout = BandLayout(floor: 100, stretch: 115, observedE1RM: 85, width: 300)
+        if let dotX = layout.dotX {
+            #expect(dotX < layout.floorX)
+        } else {
+            Issue.record("Expected a dotX but got nil")
+        }
+    }
+
+    // MARK: List context drops bracket + uses 5pt dot
+
+    @Test("List context uses 5pt dot size")
+    func listContextDotSize() {
+        // CapabilityBandContext.list → dotDiameter should be DesignGeometry.listScaleDot
+        // We verify the constant rather than the private property.
+        #expect(DesignGeometry.listScaleDot == 5)
+    }
+}
+
+// MARK: ──────────────────────────────────────────────────────────────────────
+// 2. GATED snapshot layer (reference-pending until CI records)
+// ──────────────────────────────────────────────────────────────────────────
+
+@Suite("CapabilityBand snapshots", .enabled(if: snapshotTestsEnabled))
+@MainActor
+struct CapabilityBandSnapshotTests {
+
+    private static let fullSize = CGSize(width: 393, height: 120)
+    private static let listSize = CGSize(width: 393, height: 60)
+
+    // MARK: Full context — light
+
+    #if canImport(UIKit)
+    @Test("Full context — light, default Dynamic Type")
+    func full_light_default() {
+        let vc = SnapshotHarness.host(
+            CapabilityBand(input: .measuredNoMove, context: .full),
+            size: Self.fullSize, appearance: .light
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "capability-band-full-light-default", record: recordModeEnabled)
+    }
+
+    @Test("Full context — dim, default Dynamic Type")
+    func full_dim_default() {
+        let vc = SnapshotHarness.host(
+            CapabilityBand(input: .estimatedWithMove, context: .full),
+            size: Self.fullSize, appearance: .dim
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "capability-band-full-dim-default", record: recordModeEnabled)
+    }
+
+    // MARK: Onboarding context — light + dim
+
+    @Test("Onboarding context — light, default Dynamic Type")
+    func onboarding_light_default() {
+        let vc = SnapshotHarness.host(
+            CapabilityBand(input: .measuredNoMove, context: .onboarding),
+            size: Self.fullSize, appearance: .light
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "capability-band-onboarding-light-default", record: recordModeEnabled)
+    }
+
+    @Test("Onboarding context — dim, default Dynamic Type")
+    func onboarding_dim_default() {
+        let vc = SnapshotHarness.host(
+            CapabilityBand(input: .estimatedWithMove, context: .onboarding),
+            size: Self.fullSize, appearance: .dim
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "capability-band-onboarding-dim-default", record: recordModeEnabled)
+    }
+
+    // MARK: List context — light + dim
+
+    @Test("List context — light, default Dynamic Type")
+    func list_light_default() {
+        let vc = SnapshotHarness.host(
+            CapabilityBand(input: .listContext, context: .list),
+            size: Self.listSize, appearance: .light
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "capability-band-list-light-default", record: recordModeEnabled)
+    }
+
+    @Test("List context — dim, default Dynamic Type")
+    func list_dim_default() {
+        let vc = SnapshotHarness.host(
+            CapabilityBand(input: .listContext, context: .list),
+            size: Self.listSize, appearance: .dim
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "capability-band-list-dim-default", record: recordModeEnabled)
+    }
+
+    // MARK: AX size — one case (full context, light, AX5)
+
+    @Test("Full context — light, AX5 (largest accessibility size)")
+    func full_light_ax5() {
+        let vc = SnapshotHarness.host(
+            CapabilityBand(input: .measuredNoMove, context: .full),
+            size: Self.fullSize, appearance: .light, dynamicType: .accessibility5
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "capability-band-full-light-ax5", record: recordModeEnabled)
+    }
+    #endif
+}


### PR DESCRIPTION
## What shipped

One reusable SwiftUI band component at `ProjectApex/DesignSystem/Instruments/CapabilityBand.swift`, covering all three locked contexts the spec defines:

- **`.full`** — the post-workout evidence strip and Progress pattern detail. Full anatomy: 8%/12% band fill, 2 px floor tick (heaviest line, full ink), 1 px stretch hairline, measured/estimated dot (solid vs hollow), dimension-bracket movement, caption slot.
- **`.onboarding`** — same anatomy at a slightly smaller frame height. The model-reveal context in onboarding — same component, same labeling.
- **`.list`** — unlabeled, 5 pt dot, no bracket. Used in Progress root rows where numbers live in the row annotation, not on the drawing (resolves the numbers-never-twice law from `progress.md` §3).

**Confidence binding amendment (load-bearing):** the component takes a `PatternProjection` (floor/stretch/progress) *plus* an `AxisConfidence` separately, because `PatternProjection` has no confidence field. Callers supply it from `PatternProfile.confidence`. The ratified honesty rule: `established`/`seasoned` → solid dot + solid edges; `bootstrapping`/`calibrating` → hollow dot + dashed/hollow edges. No new model type.

**Dim variant:** `data-viz-dim` tokens applied — dim band fill is `accent-ink` at 12%, dim edges use `#2A2D36`, dim measured dots use dim `accent-ink`, hollow strokes use dim `ink`.

**BandLayout:** domain is band ± 20%, expanded to include out-of-band dots — dots above stretch or below floor plot outside, never clamped (post-workout.md §6: "a clamped dot fabricates position"). Minimum band render width 48 pt enforced with outboard label shift when needed.

**VoiceOver grammar** per post-workout.md §6: "Pattern. Estimated one-rep max N kilograms, measured/estimated. Capability band floor to stretch. Center moved ±N kilograms."

## DORMANT constraint

No live screen is wired. Old views untouched. The post-workout strip, Progress root rows, and onboarding model-reveal slices each pull this component in when they build.

## Tests

**Unconditional geometry/token layer (12 tests, always run):**
- Tick widths: floor 2 px, stretch 1 px (DesignGeometry constants)
- Band fill opacity: 8% light / 12% dim (data-viz + data-viz-dim spec)
- Confidence → solid/hollow mapping: all 4 `AxisConfidence` cases verified
- List-scale dot: 5 pt (DesignGeometry.listScaleDot)
- Dim data-viz token spot-checks: `#7B85FF` accent-ink, `#2A2D36` hairline
- BandLayout: 48 pt minimum enforced; out-of-band dot not clamped

**Gated snapshot layer (7 cases, `APEX_SNAPSHOT_TESTS=1`):**
Three contexts (full / onboarding / list) × light + dim + one AX5 size. Wired to `SnapshotHarness.host`/`.imaging` exactly per `DrawnInstrumentSnapshotTests.swift`. References **not recorded** — `APEX_RECORD_SNAPSHOTS` is never set in this PR. CI records references on the pinned Xcode 26.3 toolchain; local 26.5 must not poison refs.

## Spec sources

- `DESIGN.md` §Data visualization (8%/12% fill, tick weights, dash pattern, dim tokens)
- `docs/design/post-workout.md` §6 (full anatomy, three contexts, bracket, VoiceOver grammar)
- `docs/design/progress.md` §3 (list-scale: unlabeled, 5 pt dot, no bracket)
- Issue #345

## Verification

`xcodebuild test` (no snapshot env var): **324/324 tests pass**, 0 failures.

Closes #345