### PR TITLE
fix(#369) Slice 1: gate workout-start on a resolved login (keystone)

### DIFF
--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -76,6 +76,27 @@ final class AppDependencies {
         UserIdentityResolver.resolve(keychain: keychainService, placeholder: Self.placeholderUserId)
     }
 
+    /// Awaits the first GoTrue session resolution, then returns the real auth uid
+    /// IFF it is not the placeholder. Returns `nil` when auth never resolved
+    /// (sign-in failed/timed out) or resolved only to the placeholder — callers
+    /// MUST treat nil as "abort this owner-stamped write" and never fall back to
+    /// the placeholder, mirroring the guard in `OnboardingView.persistUserIfNeeded`
+    /// (`UserIdentityResolver.onboardingUserId`). This is the resolve-before-stamp
+    /// surface owned writes adopt — workout-start as of this slice; later slices
+    /// migrate the remaining sync `resolvedUserId` sites onto it. Do not define a
+    /// second copy.
+    ///
+    /// Safe from any async context: `awaitFirstResolution` is internally bounded
+    /// (signInTimeout ceiling) and never hangs. On a restored session it returns in
+    /// microseconds; only a true fresh launch pays the sign-in latency.
+    func resolvedOwnerUserId() async -> UUID? {
+        _ = await supabaseAuth.awaitFirstResolution()
+        return UserIdentityResolver.onboardingUserId(
+            keychain: keychainService,
+            placeholder: Self.placeholderUserId
+        )
+    }
+
     // MARK: Private: Stored Anthropic key for re-init
 
     private let anthropicKey: String

--- a/ProjectApex/Features/Workout/PreWorkoutView.swift
+++ b/ProjectApex/Features/Workout/PreWorkoutView.swift
@@ -669,7 +669,7 @@ struct PreWorkoutView: View {
 
     private var startWorkoutButton: some View {
         Button {
-            viewModel.startSession(trainingDay: trainingDay, programId: programId, userId: deps.resolvedUserId, weekNumber: weekNumber, startingExerciseIndex: startingExerciseIndex)
+            viewModel.startSession(trainingDay: trainingDay, programId: programId, deps: deps, weekNumber: weekNumber, startingExerciseIndex: startingExerciseIndex)
         } label: {
             HStack(spacing: 10) {
                 if viewModel.isStartingSession {

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -105,10 +105,24 @@ final class WorkoutViewModel {
 
     // MARK: - Public Actions
 
-    /// Starts a new session for the given day. Manages isStartingSession flag.
-    func startSession(trainingDay: TrainingDay, programId: UUID, userId: UUID, weekNumber: Int = 1, startingExerciseIndex: Int = 0) {
+    /// Starts a new session for the given day. Awaits auth resolution so the
+    /// session is stamped with the real `auth.uid()`; aborts silently (resetting
+    /// `isStartingSession`) when auth has not resolved, so no placeholder-keyed
+    /// row is ever written (the RLS-403 owner-mismatch root cause). The
+    /// `isStartingSession` flag keeps the Start button disabled / spinner visible
+    /// during the brief await.
+    func startSession(trainingDay: TrainingDay, programId: UUID, deps: AppDependencies, weekNumber: Int = 1, startingExerciseIndex: Int = 0) {
+        // Re-entrancy guard (mirrors onSetComplete/onSkipSet): the auth await below
+        // widens the window between tap and session creation, so a second invocation
+        // before SwiftUI re-renders the disabled state could start two sessions.
+        guard !isStartingSession else { return }
         isStartingSession = true
         Task {
+            guard let userId = await deps.resolvedOwnerUserId() else {
+                // Auth did not resolve — do NOT stamp a placeholder-keyed row.
+                isStartingSession = false
+                return
+            }
             await manager.startSession(trainingDay: trainingDay, programId: programId, userId: userId, weekNumber: weekNumber, startingExerciseIndex: startingExerciseIndex)
             await pullState()
             isStartingSession = false

--- a/ProjectApexTests/SupabaseAuthTests.swift
+++ b/ProjectApexTests/SupabaseAuthTests.swift
@@ -468,4 +468,49 @@ final class UserIdentityResolverTests: XCTestCase {
             "no auth session yet → onboarding must NOT write a placeholder-keyed users row")
         clearIdentityKeys(keychain)
     }
+
+    // MARK: Keystone (Slice 1) — resolve-before-stamp ordering
+
+    /// The shared `AppDependencies.resolvedOwnerUserId()` gate awaits the first
+    /// session resolution BEFORE reading the identity. This proves the ordering
+    /// that makes that safe: on a fresh launch (empty Keychain) the guard is nil
+    /// (so a caller aborts rather than stamping the placeholder), and once
+    /// `awaitFirstResolution()` has signed in and persisted `.supabaseAuthUserId`,
+    /// the very next read is the REAL auth uid — never the placeholder. Regression
+    /// guard against reading the Keychain before sign-in lands.
+    func test_resolveBeforeStamp_awaitFirstResolutionThenRead_isRealUid_notPlaceholder() async throws {
+        let keychain = makeScopedKeychain()
+        clearAuthKeys(keychain)
+        clearIdentityKeys(keychain)
+        let uid = UUID()
+        GoTrueMockURLProtocol.reset()
+        GoTrueMockURLProtocol.stubs = [
+            ("/auth/v1/signup", .init(
+                statusCode: 200,
+                data: tokenJSON(access: "a", refresh: "r",
+                                expiresAt: Int(Date().timeIntervalSince1970) + 3600,
+                                userId: uid)
+            ))
+        ]
+        let auth = SupabaseAuth(
+            supabaseURL: testURL, anonKey: "anon",
+            keychain: keychain, urlSession: makeMockSession()
+        )
+
+        // Before resolution: no identity yet → guard is nil (caller must abort).
+        XCTAssertNil(
+            UserIdentityResolver.onboardingUserId(keychain: keychain, placeholder: placeholder),
+            "fresh launch, pre-resolution: the gate must be nil so no placeholder row is stamped"
+        )
+
+        // The gate awaits resolution first — this signs in and persists .supabaseAuthUserId.
+        _ = await auth.awaitFirstResolution()
+
+        // ...so the subsequent read is the real uid, never the placeholder.
+        let owner = UserIdentityResolver.onboardingUserId(keychain: keychain, placeholder: placeholder)
+        XCTAssertEqual(owner, uid, "after awaitFirstResolution the gate returns the real auth uid")
+        XCTAssertNotEqual(owner, placeholder)
+        clearAuthKeys(keychain)
+        clearIdentityKeys(keychain)
+    }
 }


### PR DESCRIPTION
First slice of the RLS owner-mismatch fix campaign (audit: owned writes 403 because they're stamped with the placeholder uid or a stale owner and replayed under the real `auth.uid()`).

## What
The keystone: introduce the **single resolve-before-stamp surface** and convert workout-start onto it.

- `AppDependencies.resolvedOwnerUserId() async -> UUID?` — awaits `awaitFirstResolution()` (bounded, never hangs) then reads the identity; returns `nil` when unresolved/placeholder so callers **abort** rather than stamp a placeholder-keyed row.
- `WorkoutViewModel.startSession(…, deps:)` awaits the gate, aborts on nil, and has a re-entrancy guard (the await widens the double-tap window). Only call site `PreWorkoutView:672` updated.

## Tests
`test_resolveBeforeStamp_awaitFirstResolutionThenRead_isRealUid_notPlaceholder` locks the await-then-read ordering. SupabaseAuthTests + UserIdentityResolverTests green (14). Full target compiles (signature change has one caller; manager tests unaffected).

## Review
Adversarial Opus review: **no blockers.** Verified the persist-before-return invariant in `SupabaseAuth.signInAnonymously` (persist precedes return), keychain instance match (`KeychainService.shared` both sides), and single call site. Applied the re-entrancy guard it flagged; filed #399 for the silent-abort UX hint.

## Scope
Workout-start only. Later slices migrate the remaining sync `resolvedUserId` write sites (memory/program/calibration/gym-profile) and add the resume-time + flush-time + DB-trigger defenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)