### PR TITLE
fix(#369) Slice 2: handle_new_user trigger + onboarding upsert (durable users-row)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,18 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-13 — Make sure every new login gets a profile row, automatically (2 of 6)
+
+**The problem, in plain words.** Lots of saves point back to a "profile" row keyed to your login. Today that row is only created during onboarding. So if a save ever fires before onboarding finishes — or if onboarding is skipped — there's no profile row and the database refuses the save. Belt with no suspenders.
+
+**What I changed.** Two things. (1) A tiny database rule (a "trigger") that **automatically creates a bare profile row the instant a new login is made**, server-side, before the app even asks. Onboarding then fills in the details on top. (2) Changed onboarding's profile write from "insert" to "upsert" (insert-or-update) so it cleanly lands on top of the row the trigger just made instead of colliding with it — and I made it only write the fields you actually provided, so re-doing onboarding can't blank out details you'd already set.
+
+**How it was checked.** New tests prove the upsert sends the right "merge, don't collide" instruction and that a plain insert still doesn't. An adversarial review agent did the most important check by hand: reading the real table definition to confirm the auto-create rule **cannot** accidentally block new sign-ins (the only required field is the id, which the rule always provides). It also caught that the auto-create rule's safety depends on it running as the database owner — so I made that explicit instead of relying on a default, matching how the app's other database rules are written.
+
+**Status:** code merged as PR #402 (Slice 2 of 6). One deliberate step remains: actually switching the database rule on in production — I'm gating that on a careful go-live check because a faulty rule there could block sign-ins, so it's not something to flip casually.
+
+---
+
 ## 2026-06-13 — Started the real fix for the gym-save failures: wait for login before starting a workout (1 of 6)
 
 **The problem, in plain words.** Even after login was fixed, saving a workout still failed. A team of review agents traced it to one habit the whole app shares: it stamps "who owns this data" at the moment a row is created and never re-checks it when the data is actually sent. So if a workout was started in the split-second before login finished, it got stamped with a stand-in "nobody" id — and the database later rejected every save tied to it.

--- a/ProjectApex/Features/Onboarding/OnboardingView.swift
+++ b/ProjectApex/Features/Onboarding/OnboardingView.swift
@@ -949,7 +949,9 @@ struct OnboardingView: View {
         // Mirror the auth uid into `.userId` (first-run signal + secondary read).
         try? keychain.store(userId.uuidString, for: .userId)
 
-        // Best-effort upsert into users table — failure is non-fatal for onboarding.
+        // Best-effort upsert into users table — ON CONFLICT (id) DO UPDATE so the
+        // row the handle_new_user trigger pre-provisioned (bare id) is overwritten
+        // with the full profile. Failure is non-fatal for onboarding.
         let nameStr = profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let userRow = UserInsertRow(
             id: userId,
@@ -959,7 +961,7 @@ struct OnboardingView: View {
             age: profile.age,
             trainingAge: profile.trainingAge.rawValue
         )
-        try? await deps.supabaseClient.insert(userRow, table: "users")
+        try? await deps.supabaseClient.upsert(userRow, table: "users")
 
         // #147: hydrate trainee_models.model_json.goal via the
         // update-trainee-goal Edge Function. Best-effort — failure leaves
@@ -1040,6 +1042,19 @@ private struct UserInsertRow: Codable, Sendable {
         case heightCm     = "height_cm"
         case age
         case trainingAge  = "training_age"
+    }
+
+    /// Omit nil fields rather than encoding them as JSON `null`. With the upsert
+    /// (`resolution=merge-duplicates`) a `null` would overwrite a previously-set
+    /// column on a re-onboard; omitting absent fields makes the merge additive.
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encodeIfPresent(displayName, forKey: .displayName)
+        try c.encodeIfPresent(bodyweightKg, forKey: .bodyweightKg)
+        try c.encodeIfPresent(heightCm, forKey: .heightCm)
+        try c.encodeIfPresent(age, forKey: .age)
+        try c.encodeIfPresent(trainingAge, forKey: .trainingAge)
     }
 }
 

--- a/ProjectApex/Services/SupabaseClient.swift
+++ b/ProjectApex/Services/SupabaseClient.swift
@@ -174,6 +174,26 @@ actor SupabaseClient {
         try await perform(request)
     }
 
+    /// Upserts `item` into `table`, merging on a primary-key conflict.
+    ///
+    /// Sends `Prefer: return=representation, resolution=merge-duplicates` so a row
+    /// that already exists (same PK) is updated in place rather than producing a
+    /// 409. Use instead of `insert` when the row may already exist — e.g. the
+    /// `users` table, where the `handle_new_user` trigger may have pre-provisioned
+    /// a bare `id` row before onboarding writes the full profile.
+    ///
+    /// - Parameters:
+    ///   - item: An `Encodable` value whose JSON representation matches the table columns.
+    ///   - table: The PostgREST table name.
+    /// - Throws: `SupabaseError` on HTTP or encoding failure.
+    func upsert<T: Encodable>(_ item: T, table: String) async throws {
+        let url = try tableURL(table: table)
+        var request = baseRequest(url: url, method: "POST")
+        request.setValue("return=representation, resolution=merge-duplicates", forHTTPHeaderField: "Prefer")
+        request.httpBody = try encoder.encode(item)
+        try await perform(request)
+    }
+
     /// Inserts `item` into `table` and returns the echoed-back row.
     ///
     /// - Parameters:

--- a/ProjectApexTests/SupabaseClientTests.swift
+++ b/ProjectApexTests/SupabaseClientTests.swift
@@ -160,6 +160,56 @@ final class SupabaseClientTests: XCTestCase {
         XCTAssertEqual(req.value(forHTTPHeaderField: "Prefer"), "return=representation")
     }
 
+    /// upsert() must send Prefer: return=representation, resolution=merge-duplicates
+    /// and POST to the table URL (used by onboarding's users write so the
+    /// trigger-provisioned bare row merges instead of 409-ing).
+    func test_upsert_sendsResolutionMergeDuplicatesHeader() async throws {
+        StubURLProtocol.stubbedStatusCode = 200
+        StubURLProtocol.stubbedData = "[]".data(using: .utf8)!
+
+        let client = makeClient()
+        try await client.upsert(TestRow(userId: UUID(), dayType: "push"), table: "users")
+
+        let req = try XCTUnwrap(StubURLProtocol.lastRequest)
+        XCTAssertEqual(req.httpMethod, "POST")
+        XCTAssertEqual(
+            req.value(forHTTPHeaderField: "Prefer"),
+            "return=representation, resolution=merge-duplicates"
+        )
+        XCTAssertTrue(req.url?.path.hasSuffix("/rest/v1/users") == true,
+                      "URL path must end with /rest/v1/users, got \(req.url?.path ?? "nil").")
+    }
+
+    /// upsert() succeeds against a 200 where insert() of the same row would 409.
+    func test_upsert_doesNotThrow_whenServerReturns200() async throws {
+        StubURLProtocol.stubbedStatusCode = 200
+        StubURLProtocol.stubbedData = "[]".data(using: .utf8)!
+
+        let client = makeClient()
+        do {
+            try await client.upsert(TestRow(userId: UUID(), dayType: "pull"), table: "users")
+        } catch {
+            XCTFail("upsert should not throw on 200, got \(error)")
+        }
+    }
+
+    /// Regression guard: insert() must NOT carry resolution=merge-duplicates, so the
+    /// two methods stay distinct (insert keeps plain return=representation).
+    func test_insert_doesNotSendResolutionHeader() async throws {
+        StubURLProtocol.stubbedStatusCode = 201
+        StubURLProtocol.stubbedData = "[]".data(using: .utf8)!
+
+        let client = makeClient()
+        try await client.insert(TestRow(userId: UUID(), dayType: "legs"), table: "users")
+
+        let req = try XCTUnwrap(StubURLProtocol.lastRequest)
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Prefer"), "return=representation")
+        XCTAssertFalse(
+            req.value(forHTTPHeaderField: "Prefer")?.contains("merge-duplicates") ?? false,
+            "insert() must not request merge-duplicates resolution"
+        )
+    }
+
     /// fetch() with filters must append PostgREST-syntax query params.
     func test_fetch_withFilters_appendsQueryParams() async throws {
         StubURLProtocol.stubbedStatusCode = 200

--- a/docs/migrations/down/20260613000000_handle_new_user_trigger.sql
+++ b/docs/migrations/down/20260613000000_handle_new_user_trigger.sql
@@ -1,0 +1,13 @@
+-- Reverse of 20260613000000_handle_new_user_trigger.sql
+--
+-- `supabase db push` is forward-only; this file is for manual operator use
+-- (psql -f) when rolling back the handle_new_user trigger (#369).
+-- Documentation only; not auto-applied.
+--
+-- Removes the trigger and its backing function. Any public.users rows that the
+-- trigger auto-provisioned before this rollback are left in place — they are
+-- harmless (onboarding's upsert would have created them anyway).
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+
+DROP FUNCTION IF EXISTS public.handle_new_user();

--- a/supabase/migrations/20260613000000_handle_new_user_trigger.sql
+++ b/supabase/migrations/20260613000000_handle_new_user_trigger.sql
@@ -1,0 +1,52 @@
+-- Reverse migration: docs/migrations/down/20260613000000_handle_new_user_trigger.sql
+-- (documentation only; not auto-applied by `supabase db push`)
+--
+-- Auth/RLS workstream (#369) — new-user bootstrap trigger.
+--
+-- Problem: every public table that FK-references users(id) fails an INSERT if the
+-- current auth.uid() has no public.users row. The iOS client creates that row
+-- during onboarding, but any owned write that lands BEFORE onboarding completes
+-- (e.g. a write-ahead-queue flush of a workout_session stamped with the real uid)
+-- produces a FK-violation 23503. And if GoTrue sign-in succeeds on a re-install
+-- but onboarding is skipped (developer reset, test account) the row is never
+-- created at all. This is the durable, server-side half of the owner-mismatch fix.
+--
+-- Fix: an AFTER INSERT trigger on auth.users that immediately provisions a minimal
+-- public.users row (id only; all profile columns are nullable per the schema).
+-- ON CONFLICT (id) DO NOTHING makes it idempotent — a concurrent onboarding upsert
+-- still wins and keeps its profile data.
+--
+-- SECURITY DEFINER (function explicitly OWNED BY the postgres superuser, below)
+-- is required because the trigger fires in GoTrue's auth-schema context as
+-- supabase_auth_admin, which does not have INSERT on public.users by default.
+-- `SET search_path = ''` (every object fully schema-qualified) matches the repo's
+-- existing SECURITY DEFINER pattern (deactivate_and_insert_program, #133) and is
+-- the stricter Supabase recommendation against search_path injection. Because the
+-- owner (postgres) is BYPASSRLS, the bare-id INSERT is not subject to the users
+-- RLS WITH CHECK (id = auth.uid()) — correct, since the trigger runs synchronously
+-- inside the auth.users INSERT before any client JWT exists. The explicit
+-- `ALTER FUNCTION ... OWNER TO postgres` makes that BYPASSRLS dependency
+-- non-implicit: the whole "this can't break sign-ups" guarantee rests on it.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  INSERT INTO public.users (id)
+  VALUES (NEW.id)
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.handle_new_user() OWNER TO postgres;
+
+-- Idempotent: drop before (re)create so repeated migration runs are safe.
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();


### PR DESCRIPTION
Slice 2 of the RLS owner-mismatch campaign — the durable, server-side half of #391.

## What
Guarantee a `public.users` row exists for every `auth.uid()`, so owned-write FKs can't `23503`-fail before onboarding runs (or if onboarding is skipped after a reset).

- **Migration** `20260613000000_handle_new_user_trigger.sql`: `AFTER INSERT` trigger on `auth.users` → `INSERT public.users(id) ON CONFLICT (id) DO NOTHING`. `SECURITY DEFINER`, explicit `OWNER TO postgres`, `SET search_path = ''` (matches the existing `deactivate_and_insert_program` pattern). Reverse doc under `docs/migrations/down/` with matching filename + pointer header.
- **`SupabaseClient.upsert`**: `Prefer: return=representation, resolution=merge-duplicates`. Onboarding `users` write `insert→upsert` so it merges over the trigger's bare-id row.
- **`UserInsertRow.encode`** → `encodeIfPresent` so nil fields are omitted (a re-onboard merge can't clobber set columns).

## Tests
`SupabaseClientTests` 18 pass — upsert sends the merge header, insert does not (regression guard), upsert no-throw on 200.

## Review
Adversarial Opus review: **no blocker.** It verified against the real `users` DDL that the trigger **cannot break sign-ups** (only NOT NULL column is `id`, which the trigger supplies; `ON CONFLICT (id)` hits the real PK). Applied both SHOULD-FIX items (explicit `OWNER TO postgres`; the `encodeIfPresent` clobber guard).

## ⚠️ Deploy gate
The migration is **not yet applied to prod**. `supabase db push` is a deliberate deploy step — a faulty `auth.users` trigger would roll back sign-ups — to be applied **with a fresh-anon-signup smoke test**, separately and with confirmation. Merging this PR lands the code/migration in the repo; it does not touch the live DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)