### PR TITLE
fix(#369) Slice 3: Reset All drains the live write-ahead queue + paused session

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -23,6 +23,20 @@ Started 2026-06-07.
 
 **Status:** opened as a PR off `feat/350-live-loop-core`. Dormant build — new screen only; old views still live.
 
+---
+
+## 2026-06-13 — "Reset All" now truly empties the outbox, not just the on-disk copy (3 of 6)
+
+**The problem, in plain words.** The app keeps an "outbox" of saves waiting to reach the server. When you tap "Reset All," the app wiped the saved-to-disk copy of that outbox — but the *running* copy already loaded in memory survived, and would quietly re-save itself the moment anything new got added. So a reset could leave behind stale, mis-owned saves that fail again after you set the app up fresh.
+
+**What I changed.** Two small lines in the reset routine: actually tell the live outbox to empty itself (in memory and on disk), and clear any paused-workout snapshot. Now a reset is a true clean slate — provided you quit and reopen afterward, which the reset message already tells you to do.
+
+**How it was checked.** I added a test that fills the outbox's "failed pile," empties it via the reset call, and then re-opens it from scratch to prove nothing came back — the gap the old test missed (it only ever cleared an already-empty outbox). A review agent confirmed the ordering is safe and flagged one real edge — a workout that's *actively in progress* at the instant you reset isn't cleared from memory — which I filed as #403 (it's covered in practice by the quit-and-reopen step). I also made the test poll instead of sleeping a fixed time, so it can't flake.
+
+**Status:** merged as PR #404 (Slice 3 of 6). Next: when the app reopens an old paused workout, check it still belongs to you before replaying it.
+
+---
+
 ## 2026-06-13 — Make sure every new login gets a profile row, automatically (2 of 6)
 
 **The problem, in plain words.** Lots of saves point back to a "profile" row keyed to your login. Today that row is only created during onboarding. So if a save ever fires before onboarding finishes — or if onboarding is skipped — there's no profile row and the database refuses the save. Belt with no suspenders.

--- a/ProjectApex/Settings/DeveloperSettingsView.swift
+++ b/ProjectApex/Settings/DeveloperSettingsView.swift
@@ -600,6 +600,15 @@ struct DeveloperSettingsView: View {
         // 2. Clear GymFactStore weight corrections (belt-and-suspenders after UserDefaults wipe)
         await deps.gymFactStore.clearAll()
 
+        // 2b. Drain the LIVE write-ahead queue actor (queue + dead-letter) and clear
+        // any paused session. removePersistentDomain wiped their on-disk UserDefaults,
+        // but the in-memory WAQ actor would re-persist its stale items on the next
+        // enqueue — so a reset without this leaves old-owner/placeholder writes that
+        // replay RLS-403s after re-onboarding (#369 owner-mismatch campaign, slice 3).
+        // PausedSessionState.clear() also resets the in-memory repairPending flag.
+        await deps.writeAheadQueue.clearAll()
+        PausedSessionState.clear()
+
         // 3. Remove the persisted userId so onboarding creates a fresh identity
         try? keychain.delete(.userId)
 

--- a/ProjectApexTests/WriteAheadQueueTests.swift
+++ b/ProjectApexTests/WriteAheadQueueTests.swift
@@ -325,6 +325,47 @@ final class WriteAheadQueueTests: XCTestCase {
         XCTAssertEqual(pending, 0, "clearAll during in-flight flush must leave an empty queue without trapping")
     }
 
+    /// #369 slice 3 (Reset All): clearAll() must drain a POPULATED dead-letter and
+    /// remove its on-disk persistence — not just an empty queue. This is the exact
+    /// behaviour performResetAll relies on: the live WAQ actor holds dead-lettered
+    /// owner-mismatched writes in memory + UserDefaults, and a reset that doesn't
+    /// call clearAll() would let them replay RLS-403s after re-onboarding.
+    func testClearAll_drainsPopulatedDeadLetter_andItsPersistence() async throws {
+        let defaults = UserDefaults(suiteName: "waq.test.\(UUID().uuidString)")!
+        let queue = WriteAheadQueue(supabase: makeMockSupabase(), userDefaults: defaults, baseRetryDelay: 0.001)
+
+        // Drive an item into the dead-letter store via the permanent-failure path.
+        await queue.registerFlushHandler(forTable: "set_logs") { _ in
+            .permanentFailure("seed dead-letter")
+        }
+        try await queue.enqueue(TestSetLogPayload.mock(), table: "set_logs")
+
+        // Poll until the permanent-failure path dead-letters the item (avoids a
+        // fixed-sleep flake on a loaded runner — 1s ceiling).
+        var deadBefore = await queue.failedWrites()
+        for _ in 0..<100 where deadBefore.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            deadBefore = await queue.failedWrites()
+        }
+        XCTAssertEqual(deadBefore.count, 1, "precondition: one item dead-lettered")
+
+        await queue.clearAll()
+
+        let pendingAfter = await queue.pendingCount
+        XCTAssertEqual(pendingAfter, 0, "queue empty after clearAll")
+        let deadAfter = await queue.failedWrites()
+        XCTAssertTrue(deadAfter.isEmpty, "in-memory dead-letter drained by clearAll")
+
+        // Reload from the same UserDefaults — proves clearAll removed the persisted
+        // dead-letter, not just the in-memory copy (otherwise the reset's poison
+        // would survive a relaunch).
+        let reloaded = WriteAheadQueue(supabase: makeMockSupabase(), userDefaults: defaults)
+        let reloadedPending = await reloaded.pendingCount
+        XCTAssertEqual(reloadedPending, 0, "persisted queue empty after clearAll")
+        let reloadedDead = await reloaded.failedWrites()
+        XCTAssertTrue(reloadedDead.isEmpty, "persisted dead-letter empty after clearAll")
+    }
+
     // MARK: Test 8 (#184): retry-exhausted items are dead-lettered, not dropped
 
     /// Reproduces #184: an item that exhausts its retries was silently removed


### PR DESCRIPTION
Slice 3 of the RLS owner-mismatch campaign.

## What
`performResetAll()` wiped UserDefaults (`removePersistentDomain`) but never cleared the **live** `WriteAheadQueue` actor — so its in-memory queue + dead-letter survived and would re-persist on the next enqueue, leaving old-owner/placeholder writes that replay RLS-403s after re-onboarding. Two lines:
- `await deps.writeAheadQueue.clearAll()` — drains in-memory queue + dead-letter + their UserDefaults keys.
- `PausedSessionState.clear()` — clears the paused snapshot + resets `repairPending`.

(The Supabase-session clears already shipped in #389; this is the missing WAQ half.)

## Test
`testClearAll_drainsPopulatedDeadLetter_andItsPersistence` — seeds a dead-letter via the permanent-failure path, `clearAll()`, then **reloads from the same UserDefaults** to prove both the in-memory and persisted dead-letter are drained (the prior test only cleared an empty queue). WAQ suite 11 pass.

## Review
Sonnet review: **no blocker** — actor serialization makes the `await clearAll()` ordering safe regardless of concurrent flush. Applied the poll-loop test fix; filed **#403** for the active-in-memory-session-at-reset edge (mitigated by the mandatory quit+relaunch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)