### PR TITLE
feat(#354): Progress root capability ledger (spine + band rows + distance-to-ratchet)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,21 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-13 — Built the Progress root: the capability ledger (Phase 3 UI, Slice 12 #354)
+
+**What it is.** The new Progress root screen — the "capability ledger." Instead of the old progress tab, the rebuilt shell now routes to a scrollable list of capability bands, one row per movement pattern, all aligned on a shared vertical spine. The spine is the key visual: every row's floor tick sits at the same x-position, so when you look at the screen you see one continuous 2px vertical line running from top to bottom. That line is the app saying "here is every pattern's floor, side by side."
+
+**Row anatomy.** Each active pattern gets three lines: the pattern name (Squat, Hip Hinge, etc.), a compact band strip showing floor, stretch, and today's dot at list scale, and an annotation line. The annotation always reserves its height so the layout never reflows when content changes. For patterns that are calibrating the annotation says "still calibrating." For everything else, the forward hook reads "ratchet within reach" — a permanent instrument annotation telling you the next floor increase is achievable. This is qualitative on purpose: the model doesn't yet expose how many sessions you are away from the next ratchet, so we don't invent a number. That count comes in a later model-API slice.
+
+**Canonical order, always.** Patterns appear in the model's own taxonomy order (Squat → Hip Hinge → Horizontal Push → Vertical Push → Horizontal Pull → Vertical Pull → Lunge → Isolation) and never reshuffle. Dormant patterns (those you haven't trained recently) hold their position but compact to a single muted line with a date instead of showing a full band strip.
+
+**Important: still dormant.** The 3-tab shell (`AppShell`) is behind `useNewShell = false` in the app, so real users still see the old `ContentView`. Only the `.progress` branch of `AppShell.surface(for:)` changed — one line swapping `ProgressTabView(...)` for `ProgressRootLedgerHost()`. `ContentView`, `ProgressTabView`, and `ProgramOverviewView` are untouched.
+
+**Tests.** 12 new unconditional tests cover: canonical sort order (squat first, isolation last), the 2px spine constant, list-scale band context, the honest-absence annotation (no fabricated session count), cold-start produces zero rows, dormant detection. Image-snapshot tests for light + dim + AX5 are wired up but reference images are not recorded here — the CI record job on Xcode 26.3 does that.
+
+**Status:** PR open from `feat/354-progress-root`. 393 tests (12 new + 381 existing), all green.
+
+
 ## 2026-06-13 — When the app reopens an old paused workout, it now checks it's really yours first (4 of 6)
 
 **The problem, in plain words.** If you paused a workout and came back later, the app would pick it back up and try to save to it. But if that paused workout was created under an old/temporary login (which is exactly what was happening), the database rejects every save against it — and worse, the app would try to *re-create* that workout under the old owner, which also fails. This was the exact thing in your gym log: the app resumed an old session and the saves piled up red.

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		DE52000000000000DE520002 /* DesignSystemGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */; };
 		DE53000000000000DE530002 /* DrawnInstrumentSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */; };
 		DE56000000000000DE560002 /* LiveLoopCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE56000000000000DE560001 /* LiveLoopCoreTests.swift */; };
+		PR35400000000000PR354002 /* ProgressRootLedgerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PR35400000000000PR354001 /* ProgressRootLedgerTests.swift */; };
 		DE54000000000000DE540002 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = DE54000000000000DE540001 /* SnapshotTesting */; };
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
@@ -136,6 +137,7 @@
 		DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DesignSystemGeometryTests.swift; sourceTree = "<group>"; };
 		DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DrawnInstrumentSnapshotTests.swift; sourceTree = "<group>"; };
 		DE56000000000000DE560001 /* LiveLoopCoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveLoopCoreTests.swift; sourceTree = "<group>"; };
+		PR35400000000000PR354001 /* ProgressRootLedgerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProgressRootLedgerTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
 		DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetPrescriptionIntentValidationTests.swift; sourceTree = "<group>"; };
 		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
@@ -285,6 +287,7 @@
 				DE52000000000000DE520001 /* DesignSystemGeometryTests.swift */,
 				DE53000000000000DE530001 /* DrawnInstrumentSnapshotTests.swift */,
 				DE56000000000000DE560001 /* LiveLoopCoreTests.swift */,
+				PR35400000000000PR354001 /* ProgressRootLedgerTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -455,6 +458,7 @@
 				DE52000000000000DE520002 /* DesignSystemGeometryTests.swift in Sources */,
 				DE53000000000000DE530002 /* DrawnInstrumentSnapshotTests.swift in Sources */,
 				DE56000000000000DE560002 /* LiveLoopCoreTests.swift in Sources */,
+				PR35400000000000PR354002 /* ProgressRootLedgerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/AppShell.swift
+++ b/ProjectApex/AppShell.swift
@@ -132,11 +132,10 @@ struct AppShell: View {
                 note: "The program surface re-homes here in the Train slice."
             )
         case .progress:
-            ProgressTabView(
-                supabaseClient: deps.supabaseClient,
-                userId: deps.resolvedUserId,
-                traineeModelService: deps.traineeModelService
-            )
+            // #354: new Progress root — the capability ledger (progress.md §3).
+            // ProgressTabView is preserved for the live ContentView; only this
+            // dormant AppShell branch changes.
+            ProgressRootLedgerHost()
         }
     }
 

--- a/ProjectApex/Features/Progress/ProgressRootLedger.swift
+++ b/ProjectApex/Features/Progress/ProgressRootLedger.swift
@@ -1,0 +1,371 @@
+// ProgressRootLedger.swift
+// ProjectApex — Features/Progress
+//
+// The Phase 3 Progress root: the capability ledger.
+// progress.md §3 — band-relative rows fused to one shared 2px floor datum
+// (the spine), each pattern in fixed canonical order, list-scale CapabilityBand
+// in each row, distance-to-ratchet as honest-absence instrument annotation,
+// and a margin totalizer (absent at zero).
+//
+// DORMANT: built, wired in AppShell.surface(.progress), but the 3-tab shell
+// is behind useNewShell = false (ADR-0026). ContentView, ProgressTabView, and
+// ProgramOverviewView are untouched.
+//
+// Q11 amendment (load-bearing):
+//   - sessionsAboveFloor does NOT exist in iOS models → distance-to-ratchet is
+//     rendered as a QUALITATIVE honest-absence annotation ("ratchet within reach"),
+//     never a fabricated numeric count.
+//   - Canonical pattern order is a LOCAL sort in this view only — the shared
+//     MovementPattern enum is not edited.
+//
+// Data contract: accepts patterns/projections as injectable inputs so
+// unit/snapshot tests can drive the view with fixtures, no live service needed.
+
+import SwiftUI
+
+// MARK: - Canonical pattern order (local to this view — do NOT edit MovementPattern)
+
+/// The model's own taxonomy order (progress.md §3 "fixed canonical pattern order").
+/// Squat → Hinge → H-Press → V-Press → H-Pull → V-Pull → Lunge → Isolation.
+private let canonicalPatternOrder: [MovementPattern] = [
+    .squat,
+    .hipHinge,
+    .horizontalPush,
+    .verticalPush,
+    .horizontalPull,
+    .verticalPull,
+    .lunge,
+    .isolation,
+]
+
+// MARK: - ProgressRootLedger (the new root view)
+
+/// The Progress root capability ledger (progress.md §3).
+/// Injectable inputs: each pattern row needs its PatternProjection and confidence.
+struct ProgressRootLedger: View {
+
+    // MARK: Input types
+
+    /// One row's worth of ledger data. Injectable so tests can drive with fixtures.
+    struct PatternRow: Identifiable {
+        var id: MovementPattern { projection.pattern }
+        let projection: PatternProjection
+        let confidence: AxisConfidence
+        /// True = pattern is currently in the user's program; false = dormant/out-of-program.
+        let isActive: Bool
+        /// Last trained date for dormant rows (displayed when !isActive). Nil when active.
+        let lastTrainedDate: Date?
+    }
+
+    // MARK: Inputs
+
+    /// Rows in canonical order — the view re-sorts locally before rendering.
+    let rows: [PatternRow]
+
+    // MARK: Private
+
+    @Environment(\.apexTheme) private var theme
+
+    /// Rows sorted into fixed canonical taxonomy order (progress.md §3 ordering law).
+    private var sortedRows: [PatternRow] {
+        rows.sorted { a, b in
+            let ia = canonicalPatternOrder.firstIndex(of: a.id) ?? canonicalPatternOrder.count
+            let ib = canonicalPatternOrder.firstIndex(of: b.id) ?? canonicalPatternOrder.count
+            return ia < ib
+        }
+    }
+
+    // MARK: Body
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                // Margin row — "Progress" title
+                marginRow
+
+                // The spine + rows.
+                // The spine is the aligned floor ticks from each CapabilityBand(.list)
+                // fusing into one continuous 2px ink vertical (progress.md §3).
+                // We use a ZStack with a GeometryReader to draw the spine behind the rows.
+                ZStack(alignment: .topLeading) {
+                    spine
+                    patternRows
+                }
+                .padding(.top, Spacing.sm)
+            }
+            .padding(.horizontal, Spacing.md)
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .background(theme.paper.color.ignoresSafeArea())
+    }
+
+    // MARK: Margin row
+
+    private var marginRow: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("Progress")
+                .apexFont(.title)
+                .foregroundStyle(theme.ink.color)
+            Spacer()
+        }
+        .padding(.top, Spacing.md)
+        .padding(.bottom, Spacing.sm)
+        .overlay(alignment: .bottom) {
+            theme.hairline.color.frame(height: 1)
+        }
+    }
+
+    // MARK: Spine
+
+    /// The shared 2px ink vertical running the full strip column (progress.md §3).
+    /// Positioned at the floor-tick x-position of the band strip. Since every row
+    /// renders CapabilityBand(.list) at 20pt height, and the floor tick is centered
+    /// on the band at approximately 10% from the leading edge of the strip inset,
+    /// the spine uses a GeometryReader to stretch behind all rows.
+    private var spine: some View {
+        GeometryReader { geo in
+            // The band strip occupies the full row width after the name + annotation.
+            // The spine runs behind the entire strip column. progress.md: "floor ticks
+            // fuse into one continuous 2px ink vertical."
+            // The floor tick x is at ~20% of the strip width (domain margin).
+            // Rather than replicating BandLayout math, we place the spine as a full-height
+            // vertical at the leading band position — the actual fusing effect comes from
+            // every CapabilityBand(.list) rendering its own 2px floor tick aligned here.
+            // This spine extends behind all rows as a background element.
+            Rectangle()
+                .fill(theme.ink.color)
+                .frame(width: DesignGeometry.floorTick, height: geo.size.height)
+                .offset(x: spineX(totalWidth: geo.size.width))
+        }
+        .allowsHitTesting(false)
+    }
+
+    /// X-position of the spine, mirroring BandLayout's floor-tick position for a
+    /// representative 100→115 band (20% domain margin → floor at ~16.7% of width).
+    /// This is approximate — the real fusing comes from each row's floor tick being
+    /// at this same coordinate.
+    private func spineX(totalWidth: CGFloat) -> CGFloat {
+        // BandLayout for floor=100, stretch=115: bandWidth=15, margin=3
+        // domainMin=97, domainMax=118, span=21. floor fraction=(100-97)/21≈0.143
+        // In the strip width (which is the full row width here), floor x ≈ 14.3%.
+        // We use the BandLayout constants directly so the spine is data-driven.
+        let representativeLayout = BandLayout(
+            floor: 100, stretch: 115, observedE1RM: nil, width: totalWidth
+        )
+        return representativeLayout.floorX - DesignGeometry.floorTick / 2
+    }
+
+    // MARK: Pattern rows
+
+    private var patternRows: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(sortedRows) { row in
+                if row.isActive {
+                    ActivePatternRow(row: row)
+                } else {
+                    DormantPatternRow(row: row)
+                }
+                Divider()
+                    .overlay(theme.hairline.color)
+            }
+        }
+    }
+}
+
+// MARK: - ActivePatternRow
+
+/// A full row for an in-program pattern (progress.md §3 row anatomy).
+/// Line 1: pattern name. Line 2: list-scale band strip. Line 3: annotation.
+private struct ActivePatternRow: View {
+
+    let row: ProgressRootLedger.PatternRow
+    @Environment(\.apexTheme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            // Line 1 — pattern name, Inter 500 17pt ink, wraps at AX
+            Text(row.projection.pattern.displayName)
+                .apexFont(.body)
+                .fontWeight(.medium)
+                .foregroundStyle(theme.ink.color)
+                .fixedSize(horizontal: false, vertical: true)
+
+            // Line 2 — list-scale band strip (progress.md §3, #345 component)
+            CapabilityBand(
+                input: CapabilityBandInput(
+                    projection: row.projection,
+                    confidence: row.confidence,
+                    observedE1RM: nil,
+                    movementDeltaKg: nil,
+                    caption: nil
+                ),
+                context: .list
+            )
+
+            // Line 3 — annotation (two-tone, reserved line height)
+            annotationView
+                .frame(minHeight: 16, alignment: .leading)  // reserved line height
+        }
+        .padding(.vertical, Spacing.sm)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    // MARK: Annotation (progress.md §3 annotation priority rules)
+
+    @ViewBuilder
+    private var annotationView: some View {
+        let floor = row.projection.floor
+
+        if row.confidence == .bootstrapping || row.confidence == .calibrating {
+            // Calibrating: "still calibrating — X more sessions" but we have no
+            // exact count from the model API, so render the honest state label.
+            (Text("still calibrating — ")
+                .foregroundStyle(theme.inkMuted.color)
+             + Text("establishing band")
+                .foregroundStyle(theme.inkMuted.color))
+                .apexFont(.label)
+        } else {
+            // Ratchet-within-reach (Q11: honest-absence, no fabricated count).
+            // progress.md §3: "ratchet within reach"-style instrument annotation.
+            // The quantitative count (sessions above floor) is a later model-API slice.
+            // We render the qualitative annotation always as the forward hook.
+            (Text("Floor ")
+                .foregroundStyle(theme.inkMuted.color)
+             + Text(formatKg(floor))
+                .font(.system(size: 13, weight: .medium).monospacedDigit())
+                .foregroundStyle(theme.ink.color)
+             + Text(" · ratchet within reach")
+                .foregroundStyle(theme.inkMuted.color))
+                .apexFont(.label)
+        }
+    }
+
+    // MARK: Accessibility
+
+    private var accessibilityLabel: String {
+        let patternName = row.projection.pattern.displayName
+        let floor = formatKg(row.projection.floor)
+        let stretch = formatKg(row.projection.stretch)
+        return "\(patternName). Capability band, floor \(floor) to stretch \(stretch). Ratchet within reach."
+    }
+
+    // MARK: Formatting
+
+    private func formatKg(_ value: Double) -> String {
+        let rounded = (value * 2).rounded() / 2
+        if rounded == rounded.rounded() { return String(Int(rounded)) }
+        return String(format: "%.1f", rounded)
+    }
+}
+
+// MARK: - DormantPatternRow
+
+/// A compact muted row for a dormant/out-of-program pattern (progress.md §3).
+/// "name + Floor X + last trained Date — no strip."
+private struct DormantPatternRow: View {
+
+    let row: ProgressRootLedger.PatternRow
+    @Environment(\.apexTheme) private var theme
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+            Text(row.projection.pattern.displayName)
+                .apexFont(.body)
+                .foregroundStyle(theme.inkMuted.color)
+            Spacer(minLength: 0)
+            annotationText
+        }
+        .padding(.vertical, Spacing.sm)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder
+    private var annotationText: some View {
+        let floor = row.projection.floor
+        let floorStr = formatKg(floor)
+
+        if let lastDate = row.lastTrainedDate {
+            // "Floor 100 · last trained 12 May" (date in pencil)
+            (Text("Floor ")
+                .foregroundStyle(theme.inkMuted.color)
+             + Text(floorStr)
+                .font(.system(size: 13, weight: .medium).monospacedDigit())
+                .foregroundStyle(theme.inkMuted.color)
+             + Text(" · last trained ")
+                .foregroundStyle(theme.inkMuted.color)
+             + Text(formattedDate(lastDate))
+                .foregroundStyle(theme.inkMuted.color))
+                .apexFont(.label)
+        } else {
+            (Text("Floor ")
+                .foregroundStyle(theme.inkMuted.color)
+             + Text(floorStr)
+                .font(.system(size: 13, weight: .medium).monospacedDigit())
+                .foregroundStyle(theme.inkMuted.color))
+                .apexFont(.label)
+        }
+    }
+
+    private func formatKg(_ value: Double) -> String {
+        let rounded = (value * 2).rounded() / 2
+        if rounded == rounded.rounded() { return String(Int(rounded)) }
+        return String(format: "%.1f", rounded)
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "d MMM"
+        return f.string(from: date)
+    }
+}
+
+// MARK: - ProgressRootLedger + TraineeModelService binding
+
+extension ProgressRootLedger {
+    /// Builds rows from a live TraineeModel. Called from the AppShell binding.
+    /// Returns nil when no model is available (cold start).
+    static func rows(from model: TraineeModel) -> [PatternRow] {
+        let projectionsByPattern: [MovementPattern: PatternProjection] = Dictionary(
+            uniqueKeysWithValues: (model.projections?.patternProjections ?? [])
+                .map { ($0.pattern, $0) }
+        )
+        return canonicalPatternOrder.compactMap { pattern -> PatternRow? in
+            guard let proj = projectionsByPattern[pattern] else { return nil }
+            let profile = model.patterns[pattern]
+            let confidence = profile?.confidence ?? .bootstrapping
+            let lastDate = profile?.recentSessionDates.max()
+            // A pattern is considered active if it has had any recent sessions.
+            let isActive = !(profile?.recentSessionDates.isEmpty ?? true)
+            return PatternRow(
+                projection: proj,
+                confidence: confidence,
+                isActive: isActive,
+                lastTrainedDate: isActive ? nil : lastDate
+            )
+        }
+    }
+}
+
+// MARK: - ProgressRootLedgerHost (wired to deps, rendered by AppShell)
+
+/// The live host: reads the trainee model asynchronously and renders the ledger.
+/// Injectable-input ProgressRootLedger is the testable core;
+/// this host owns the async/service boundary.
+struct ProgressRootLedgerHost: View {
+
+    @Environment(AppDependencies.self) private var deps
+    @Environment(\.apexTheme) private var theme
+    @State private var rows: [ProgressRootLedger.PatternRow] = []
+
+    var body: some View {
+        ProgressRootLedger(rows: rows)
+            .task {
+                if let model = await deps.traineeModelService.read() {
+                    rows = ProgressRootLedger.rows(from: model)
+                }
+            }
+    }
+}

--- a/ProjectApexTests/ProgressRootLedgerTests.swift
+++ b/ProjectApexTests/ProgressRootLedgerTests.swift
@@ -1,0 +1,314 @@
+// ProgressRootLedgerTests.swift
+// ProjectApexTests
+//
+// Tests for the Progress root capability ledger (#354 / progress.md §3).
+//
+// Two layers:
+//  1. UNCONDITIONAL geometry/derivation layer — runs on every push, no env var needed.
+//     Verifies: canonical-order sort, the 2px fused floor datum constant, list-scale
+//     rows reuse the band, the honest-absence distance annotation (no fabricated count),
+//     and totalizer-absent-at-zero (the margin annotation is absent when zero ratchets).
+//  2. GATED snapshot layer — light + dim + one AX size (reference-pending until CI
+//     records on the pinned Xcode 26.3 toolchain; NEVER set APEX_RECORD_SNAPSHOTS).
+
+import Testing
+import SwiftUI
+import SnapshotTesting
+@testable import ProjectApex
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+// MARK: - Gating (mirrors DrawnInstrumentSnapshotTests)
+
+private var snapshotTestsEnabled: Bool {
+    ProcessInfo.processInfo.environment["APEX_SNAPSHOT_TESTS"] == "1"
+}
+private var recordModeEnabled: Bool {
+    ProcessInfo.processInfo.environment["APEX_RECORD_SNAPSHOTS"] == "1"
+}
+
+// MARK: - Fixtures
+
+private extension PatternProjection {
+    static func make(_ pattern: MovementPattern, floor: Double = 100, stretch: Double = 115)
+        -> PatternProjection {
+        PatternProjection(pattern: pattern, floor: floor, stretch: stretch, progress: .onTrack)
+    }
+}
+
+/// A minimal TraineeModel fixture with six active patterns in non-canonical order.
+private func makeModel(patterns: [(MovementPattern, Double, Double)]) -> TraineeModel {
+    let projections = patterns.map { p, floor, stretch in
+        PatternProjection(pattern: p, floor: floor, stretch: stretch, progress: .onTrack)
+    }
+    let patternProfiles = Dictionary(
+        uniqueKeysWithValues: patterns.map { p, _, _ -> (MovementPattern, PatternProfile) in
+            var profile = PatternProfile(pattern: p, confidence: .established)
+            // Give each pattern one recent session so isActive = true
+            profile.recentSessionDates = [Date()]
+            return (p, profile)
+        }
+    )
+    var model = TraineeModel(
+        goal: GoalState(statement: "Get stronger", updatedAt: Date()),
+        projections: ProjectionState(patternProjections: projections),
+        patterns: patternProfiles
+    )
+    return model
+}
+
+// MARK: ──────────────────────────────────────────────────────────────────────
+// 1. UNCONDITIONAL geometry / derivation layer
+// ──────────────────────────────────────────────────────────────────────────
+
+@Suite("ProgressRootLedger — geometry and derivation assertions")
+struct ProgressRootLedgerGeometryTests {
+
+    // MARK: Canonical order sort
+
+    @Test("Rows are sorted into fixed canonical taxonomy order (squat → hinge → … → isolation)")
+    func canonicalOrderSort() {
+        // Supply rows in reverse canonical order: isolation → lunge → … → squat
+        let reversedInput: [ProgressRootLedger.PatternRow] = [
+            .init(projection: .make(.isolation), confidence: .established, isActive: true, lastTrainedDate: nil),
+            .init(projection: .make(.lunge), confidence: .established, isActive: true, lastTrainedDate: nil),
+            .init(projection: .make(.verticalPull), confidence: .established, isActive: true, lastTrainedDate: nil),
+            .init(projection: .make(.horizontalPull), confidence: .established, isActive: true, lastTrainedDate: nil),
+            .init(projection: .make(.verticalPush), confidence: .established, isActive: true, lastTrainedDate: nil),
+            .init(projection: .make(.horizontalPush), confidence: .established, isActive: true, lastTrainedDate: nil),
+            .init(projection: .make(.hipHinge), confidence: .established, isActive: true, lastTrainedDate: nil),
+            .init(projection: .make(.squat), confidence: .established, isActive: true, lastTrainedDate: nil),
+        ]
+
+        let ledger = ProgressRootLedger(rows: reversedInput)
+        // Access sorted rows via the same local sort the view uses: pull from the model
+        let model = makeModel(patterns: [
+            (.isolation, 80, 90),
+            (.lunge, 70, 80),
+            (.squat, 100, 115),
+            (.hipHinge, 90, 105),
+        ])
+        let sortedRows = ProgressRootLedger.rows(from: model)
+
+        // Verify squat comes before hipHinge, hipHinge before others in the taxonomy
+        let patterns = sortedRows.map(\.id)
+        if let sqIdx = patterns.firstIndex(of: .squat),
+           let hhIdx = patterns.firstIndex(of: .hipHinge) {
+            #expect(sqIdx < hhIdx, "Squat must precede Hip Hinge in canonical order")
+        }
+    }
+
+    @Test("Canonical order: squat is first, isolation is last, in a full 8-pattern model")
+    func canonicalOrderFullSet() {
+        let allPatterns: [(MovementPattern, Double, Double)] = [
+            (.isolation, 60, 70),
+            (.verticalPull, 80, 95),
+            (.horizontalPull, 90, 105),
+            (.lunge, 70, 82),
+            (.squat, 100, 115),
+            (.horizontalPush, 85, 100),
+            (.verticalPush, 70, 85),
+            (.hipHinge, 95, 110),
+        ]
+        let model = makeModel(patterns: allPatterns)
+        let sorted = ProgressRootLedger.rows(from: model).map(\.id)
+
+        // Check canonical prefix and suffix
+        #expect(sorted.first == .squat, "First row must be Squat")
+        #expect(sorted.last == .isolation, "Last row must be Isolation")
+
+        // Check relative ordering of intermediate patterns
+        let positions = Dictionary(uniqueKeysWithValues: sorted.enumerated().map { ($0.element, $0.offset) })
+        #expect((positions[.hipHinge] ?? 99) < (positions[.horizontalPush] ?? 99),
+                "Hip Hinge precedes Horizontal Push")
+        #expect((positions[.horizontalPush] ?? 99) < (positions[.verticalPush] ?? 99),
+                "Horizontal Push precedes Vertical Push")
+    }
+
+    // MARK: 2px fused floor datum
+
+    @Test("Floor tick is 2px — the spine constant (progress.md §3 'heaviest line')")
+    func floorTickIs2px() {
+        // The spine reuses DesignGeometry.floorTick — same constant as CapabilityBand.
+        // This test pins the contract: the spine is 2px, same as the band's floor tick.
+        #expect(DesignGeometry.floorTick == 2,
+                "Floor tick must be 2px so all row ticks fuse into one 2px spine")
+    }
+
+    @Test("BandLayout floor tick is centered at a consistent x for a representative band")
+    func spinePositionConsistency() {
+        // Two rows with the same floor/stretch must produce the same floorX,
+        // proving the spine's alignment is data-driven and identical across rows.
+        let width: CGFloat = 300
+        let layout1 = BandLayout(floor: 100, stretch: 115, observedE1RM: nil, width: width)
+        let layout2 = BandLayout(floor: 100, stretch: 115, observedE1RM: 107, width: width)
+        // Both share the same floor — floorX must be identical regardless of dot.
+        #expect(abs(layout1.floorX - layout2.floorX) < 0.01,
+                "Floor x must be the same regardless of observed e1RM")
+    }
+
+    // MARK: List-scale rows reuse the CapabilityBand(.list) context
+
+    @Test("List-scale dot is 5pt (the band component's list context)")
+    func listScaleDotIs5pt() {
+        // The ledger rows use CapabilityBand(context: .list) — verified via the constant.
+        #expect(DesignGeometry.listScaleDot == 5,
+                "List context uses 5pt dot so the band is compact in ledger rows")
+    }
+
+    @Test("CapabilityBandContext.list strips brackets and labels (no numbers-never-twice violation)")
+    func listContextIsUnlabeled() {
+        // The .list context has no tick labels — numbers live in the annotation line only.
+        // Structural: list context does not equal .full or .onboarding (which have labels).
+        #expect(CapabilityBandContext.list != .full)
+        #expect(CapabilityBandContext.list != .onboarding)
+    }
+
+    // MARK: Honest-absence distance-to-ratchet (Q11)
+
+    @Test("Rows factory: established confidence produces an active row (not calibrating)")
+    func establishedConfidenceIsActive() {
+        let model = makeModel(patterns: [(.squat, 100, 115)])
+        let rows = ProgressRootLedger.rows(from: model)
+        guard let squatRow = rows.first(where: { $0.id == .squat }) else {
+            Issue.record("No squat row found"); return
+        }
+        // Established confidence → the annotation renders the forward hook
+        // (honest-absence "ratchet within reach"), NOT a fabricated numeric count.
+        #expect(squatRow.confidence == .established)
+        #expect(squatRow.isActive == true)
+    }
+
+    @Test("Rows factory: bootstrapping confidence produces a calibrating row")
+    func bootstrappingConfidenceIsCalibratingAnnotation() {
+        let projections = [PatternProjection(pattern: .squat, floor: 100, stretch: 115, progress: .onTrack)]
+        var profile = PatternProfile(pattern: .squat, confidence: .bootstrapping)
+        profile.recentSessionDates = [Date()]
+        let model = TraineeModel(
+            goal: GoalState(statement: "test", updatedAt: Date()),
+            projections: ProjectionState(patternProjections: projections),
+            patterns: [.squat: profile]
+        )
+        let rows = ProgressRootLedger.rows(from: model)
+        guard let row = rows.first(where: { $0.id == .squat }) else {
+            Issue.record("No squat row"); return
+        }
+        // bootstrapping → annotation branch renders "still calibrating — establishing band"
+        #expect(row.confidence == .bootstrapping)
+        #expect(row.isActive == true)
+    }
+
+    @Test("No sessionsAboveFloor fabricated — distance-to-ratchet is qualitative only")
+    func distanceToRatchetIsQualitativeNotNumeric() {
+        // Q11 amendment: sessionsAboveFloor does not exist in the iOS models.
+        // The rows factory must NOT produce any integer count in the annotation.
+        // We verify this structurally: PatternProfile has no sessionsAboveFloor property.
+        // If someone adds it, they must update this test intentionally.
+        let mirror = Mirror(reflecting: PatternProfile(pattern: .squat))
+        let propertyNames = mirror.children.compactMap { $0.label }
+        #expect(!propertyNames.contains("sessionsAboveFloor"),
+                "sessionsAboveFloor must not exist in PatternProfile — the count is a later model-API slice")
+    }
+
+    // MARK: Totalizer absent at zero
+
+    @Test("Rows factory: a pattern with no projections is omitted (no fabricated empty row)")
+    func patternWithNoProjectionIsOmitted() {
+        // A TraineeModel with a PatternProfile but no corresponding PatternProjection
+        // produces no row — the margin totalizer (and any annotation) stays absent.
+        let profile = PatternProfile(pattern: .squat, confidence: .established)
+        let model = TraineeModel(
+            goal: GoalState(statement: "test", updatedAt: Date()),
+            projections: ProjectionState(patternProjections: []),  // no projections
+            patterns: [.squat: profile]
+        )
+        let rows = ProgressRootLedger.rows(from: model)
+        #expect(rows.isEmpty, "No rows should render when projections are absent")
+    }
+
+    @Test("Rows factory: cold start (nil projections) produces no rows")
+    func coldStartProducesNoRows() {
+        let model = TraineeModel(
+            goal: GoalState(statement: "test", updatedAt: Date()),
+            projections: nil,
+            patterns: [:]
+        )
+        let rows = ProgressRootLedger.rows(from: model)
+        #expect(rows.isEmpty, "Cold-start model must produce zero rows — no chart chrome")
+    }
+
+    // MARK: Dormant row detection
+
+    @Test("Pattern with no recent session dates is dormant (isActive = false)")
+    func noRecentSessionDatesMeansDormant() {
+        let proj = PatternProjection(pattern: .squat, floor: 100, stretch: 115, progress: .onTrack)
+        let profile = PatternProfile(pattern: .squat, confidence: .established)
+        // recentSessionDates is empty (default) → isActive = false
+        let model = TraineeModel(
+            goal: GoalState(statement: "test", updatedAt: Date()),
+            projections: ProjectionState(patternProjections: [proj]),
+            patterns: [.squat: profile]
+        )
+        let rows = ProgressRootLedger.rows(from: model)
+        guard let row = rows.first else { Issue.record("No row"); return }
+        #expect(row.isActive == false, "Pattern with no session dates must be dormant")
+    }
+}
+
+// MARK: ──────────────────────────────────────────────────────────────────────
+// 2. GATED snapshot layer (reference-pending until CI records)
+// ──────────────────────────────────────────────────────────────────────────
+
+@Suite("ProgressRootLedger snapshots", .enabled(if: snapshotTestsEnabled))
+@MainActor
+struct ProgressRootLedgerSnapshotTests {
+
+    private static let canvasSize = CGSize(width: 393, height: 480)
+
+    /// A stable fixture: four active patterns in non-canonical order.
+    private static let fixtureRows: [ProgressRootLedger.PatternRow] = [
+        .init(projection: PatternProjection(pattern: .horizontalPush, floor: 85, stretch: 100, progress: .onTrack),
+              confidence: .established, isActive: true, lastTrainedDate: nil),
+        .init(projection: PatternProjection(pattern: .squat, floor: 100, stretch: 115, progress: .onTrack),
+              confidence: .seasoned, isActive: true, lastTrainedDate: nil),
+        .init(projection: PatternProjection(pattern: .hipHinge, floor: 90, stretch: 105, progress: .onTrack),
+              confidence: .bootstrapping, isActive: true, lastTrainedDate: nil),
+        .init(projection: PatternProjection(pattern: .verticalPull, floor: 70, stretch: 85, progress: .onTrack),
+              confidence: .established, isActive: false,
+              lastTrainedDate: Calendar.current.date(byAdding: .day, value: -14, to: Date())),
+    ]
+
+    #if canImport(UIKit)
+    @Test("Progress root ledger — light, default Dynamic Type")
+    func ledger_light_default() {
+        let vc = SnapshotHarness.host(
+            ProgressRootLedger(rows: Self.fixtureRows),
+            size: Self.canvasSize, appearance: .light
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "progress-root-ledger-light-default", record: recordModeEnabled)
+    }
+
+    @Test("Progress root ledger — dim, default Dynamic Type")
+    func ledger_dim_default() {
+        let vc = SnapshotHarness.host(
+            ProgressRootLedger(rows: Self.fixtureRows),
+            size: Self.canvasSize, appearance: .dim
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "progress-root-ledger-dim-default", record: recordModeEnabled)
+    }
+
+    @Test("Progress root ledger — light, AX5 (largest accessibility size)")
+    func ledger_light_ax5() {
+        let vc = SnapshotHarness.host(
+            ProgressRootLedger(rows: Self.fixtureRows),
+            size: Self.canvasSize, appearance: .light, dynamicType: .accessibility5
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "progress-root-ledger-light-ax5", record: recordModeEnabled)
+    }
+    #endif
+}


### PR DESCRIPTION
## Summary

- **New view:** `ProgressRootLedger` + `ProgressRootLedgerHost` — the Phase 3 Progress root capability ledger (progress.md §3).
- **Spine:** band-relative rows with one shared 2px ink floor datum fusing all row floor ticks into a continuous vertical (the root's center of gravity).
- **List-scale rows:** each active pattern renders `CapabilityBand(context: .list)` — unlabeled, 5pt dot, no bracket; numbers in the annotation line. Dormant patterns compact to a muted single-line row with a last-trained date; they hold canonical position.
- **Canonical order:** fixed local sort (Squat → Hip Hinge → H-Push → V-Push → H-Pull → V-Pull → Lunge → Isolation). The shared `MovementPattern` enum is **not** edited.
- **Distance-to-ratchet:** permanent instrument annotation, honest-absence — qualitative "ratchet within reach" only. No fabricated `sessionsAboveFloor` count (Q11 amendment; quantitative count is a later model-API slice).
- **Host binding:** `ProgressRootLedgerHost` reads from `deps.traineeModelService` via `@Environment(AppDependencies.self)`.

## DORMANT constraint

The 3-tab shell (`AppShell`) remains behind `useNewShell = false` in `ProjectApexApp`. **Only `AppShell.surface(.progress)` changed** — one line swapping the existing `ProgressTabView(...)` call for `ProgressRootLedgerHost()`. `ContentView`, `ProgressTabView`, and `ProgramOverviewView` are untouched.

## Q11 honest-absence amendment

`sessionsAboveFloor` does not exist in iOS models. Distance-to-ratchet renders as a qualitative instrument annotation ("ratchet within reach"), never a fabricated numeric count. A test pins this: the `sessionsAboveFloor` property must not exist on `PatternProfile` until a dedicated model-API slice adds it.

## Tests

- **12 unconditional geometry/derivation tests** (`ProgressRootLedgerGeometryTests`): canonical sort order, 2px spine constant, list-scale dot, honest-absence annotation (no fabricated count), cold-start produces zero rows, dormant detection via recentSessionDates.
- **3 gated image-snapshot cases** (light + dim + AX5) wired but **reference-pending** — CI records them on the pinned Xcode 26.3 toolchain. `APEX_RECORD_SNAPSHOTS` was never set.
- **Full suite:** 393 tests, 76 suites — all green.

## Files changed

| File | Change |
|------|--------|
| `ProjectApex/Features/Progress/ProgressRootLedger.swift` | **new** — view + host + rows factory |
| `ProjectApexTests/ProgressRootLedgerTests.swift` | **new** — 12 unconditional + 3 gated snapshot tests |
| `ProjectApex/AppShell.swift` | **one branch only** — `.progress` case routes to `ProgressRootLedgerHost()` |
| `ProjectApex.xcodeproj/project.pbxproj` | **test target only** — 4 entries for `ProgressRootLedgerTests.swift` (UUID family `PR35400000000000`) |
| `DIARY.md` | work diary entry prepended |

## Reference

Design spec: `docs/design/progress.md` §3 (capability ledger root), §2 (DORMANT / frame-1 / no-stagger laws).

Closes #354