### PR TITLE
fix(#369) Slice 4: discard stale-owner paused session on resume

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,18 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-13 — When the app reopens an old paused workout, it now checks it's really yours first (4 of 6)
+
+**The problem, in plain words.** If you paused a workout and came back later, the app would pick it back up and try to save to it. But if that paused workout was created under an old/temporary login (which is exactly what was happening), the database rejects every save against it — and worse, the app would try to *re-create* that workout under the old owner, which also fails. This was the exact thing in your gym log: the app resumed an old session and the saves piled up red.
+
+**What I changed.** Before resuming a paused workout, the app now asks "does this workout belong to the login I'm signed in as right now?" If yes, it resumes exactly as before. If it belongs to a different (old) login, it doesn't try to replay it — it clears it out and shows a short note: "couldn't confirm your previous workout for this account — it was cleared. Start a new one." So instead of an endless wall of failed saves, you get a clean start.
+
+**How it was checked.** Two tests: one proves the "clear it out" routine empties the outbox and the paused snapshot; the other drives the real flow — a paused workout stamped with login A, the app signed in as login B — and proves the app stays idle, clears the old workout, and shows the note (it would fail if the ownership check were removed). A review agent confirmed the check runs *before* any save attempt, that clearing the whole outbox here is correct (everything in it belongs to the old login at that moment), and that the two tests are now load-bearing — I tightened one of them after it pointed out the original didn't really prove anything.
+
+**Status:** merged as PR #406 (Slice 4 of 6). Next: as a safety net, have the outbox itself refuse to retry a save whose owner doesn't match the current login.
+
+---
+
 ## 2026-06-13 — Built the new "do the set" screen (numbers big, one tap to log, then it becomes the rest timer)
 
 **What this is.** The first piece of the redesigned workout screen. It shows one set at a time: the exercise name, then the target weight and reps as big numbers you can read from across the gym. A full-width ink bar sits at the bottom that just says **Done**. Tap it once and the set is logged exactly as prescribed — no pop-up form, no fiddling with fields. The screen then smoothly turns into the rest timer in place, and when rest is over it shows the next set.

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -793,6 +793,17 @@ actor WorkoutSessionManager {
         print("[WorkoutSessionManager] Session \(sessionId) marked abandoned via recovery dismiss")
     }
 
+    /// Discards a stale paused session whose owner does not match the current
+    /// authenticated uid. Clears the write-ahead queue (live + dead-letter) and the
+    /// paused snapshot, but issues NO Supabase write — the frozen session_id and
+    /// set_logs belong to a different owner, so every write against them is rejected
+    /// by RLS (42501). (#369 owner-mismatch campaign, slice 4.)
+    func discardStalePausedSession() async {
+        await writeAheadQueue.clearAll()
+        PausedSessionState.clear()
+        print("[WorkoutSessionManager] stale-owner paused session discarded — WAQ cleared")
+    }
+
     /// Returns a hint string showing the available weight options near `weight` for the given
     /// equipment type, based on confirmed GymFactStore corrections for this user's gym.
     ///

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -524,7 +524,8 @@ struct WorkoutView: View {
         vm.resumeSession(
             pausedState: state,
             trainingDay: trainingDay,
-            supabase: deps.supabaseClient
+            supabase: deps.supabaseClient,
+            supabaseAuth: deps.supabaseAuth
         )
     }
 

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -372,9 +372,28 @@ final class WorkoutViewModel {
 
     /// Resumes a paused session. Flushes the write-ahead queue first so all
     /// set_log writes from the prior session are in Supabase before fetching.
-    func resumeSession(pausedState: PausedSessionState, trainingDay: TrainingDay, supabase: SupabaseClient) {
+    func resumeSession(pausedState: PausedSessionState, trainingDay: TrainingDay, supabase: SupabaseClient, supabaseAuth: SupabaseAuth) {
         isStartingSession = true
         Task {
+            // 0. Ownership gate (#369 slice 4): the paused session carries the owner
+            //    frozen at start time. If it doesn't match the current real auth uid
+            //    (identity changed across launches, or it was the placeholder),
+            //    replaying it — and re-inserting the workout_sessions row under the old
+            //    owner at step 2 — is rejected by RLS (42501). Discard instead of
+            //    replaying. awaitFirstResolution() is bounded; nil (sign-in unresolved)
+            //    is treated as a mismatch — an unverifiable session can't be resumed safely.
+            let resolvedUid = await supabaseAuth.awaitFirstResolution()?.userId
+            if resolvedUid != pausedState.userId {
+                await manager.discardStalePausedSession()
+                resumeRepairNotice = "Couldn't confirm your previous workout for this account — it was cleared. Start a new one when you're ready."
+                Task { [weak self] in
+                    try? await Task.sleep(nanoseconds: 5_000_000_000)
+                    self?.resumeRepairNotice = nil
+                }
+                isStartingSession = false
+                return
+            }
+
             // 1. Attempt to flush WAQ so pending set_logs land in Supabase before the fetch.
             //    If offline, flush is best-effort — unflushed items stay in the WAQ.
             await manager.flushWriteAheadQueue()

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -289,6 +289,35 @@ private func makeManager(
     )
 }
 
+/// Minimal Encodable payload for seeding the write-ahead queue in tests. File-scope
+/// (not a local type) so its Encodable conformance is non-isolated and satisfies
+/// `enqueue`'s `Sendable` requirement. #369 slice 4.
+nonisolated private struct DummyWAQItem: Encodable, Sendable { let id = UUID().uuidString }
+
+/// Like `makeManager` but also returns the injected `WriteAheadQueue` so tests can
+/// assert on it directly (the manager's `writeAheadQueue` is private). #369 slice 4.
+private func makeManagerWithWAQ(
+    provider: any LLMProvider = MockLLMProvider(response: prescriptionJSON()),
+    gymProfile: GymProfile? = nil
+) -> (WorkoutSessionManager, WriteAheadQueue) {
+    let inferenceService = AIInferenceService(provider: provider, gymProfile: gymProfile, maxRetries: 0)
+    let supabase = makeTestSupabase()
+    let memoryService = MemoryService(supabase: supabase, embeddingAPIKey: "")
+    let suiteName = "com.test.wsm.\(UUID().uuidString)"
+    let testDefaults = UserDefaults(suiteName: suiteName)!
+    let gymFactStore = GymFactStore(userDefaults: testDefaults)
+    let waq = WriteAheadQueue(supabase: supabase, userDefaults: testDefaults)
+    let manager = WorkoutSessionManager(
+        aiInference: inferenceService,
+        healthKit: HealthKitService(),
+        memoryService: memoryService,
+        supabase: supabase,
+        gymFactStore: gymFactStore,
+        writeAheadQueue: waq
+    )
+    return (manager, waq)
+}
+
 // MARK: - WorkoutSessionManagerTests
 
 final class WorkoutSessionManagerTests: XCTestCase {
@@ -305,6 +334,96 @@ final class WorkoutSessionManagerTests: XCTestCase {
     override func tearDown() {
         PausedSessionState.clear()
         super.tearDown()
+    }
+
+    // MARK: #369 slice 4 — discard stale-owner paused session on resume
+
+    /// discardStalePausedSession() clears the write-ahead queue (+ dead-letter) and
+    /// the paused snapshot, leaving a clean slate with no Supabase write.
+    func testDiscardStalePausedSession_clearsQueueDeadLetterAndPausedState() async throws {
+        let (manager, waq) = makeManagerWithWAQ()
+        // Seed a dead-letter that SURVIVES until discard (permanent-failure path).
+        // A success-stub would auto-flush the item away, making the WAQ-clear
+        // assertion vacuous; this keeps it load-bearing.
+        await waq.registerFlushHandler(forTable: "set_logs") { _ in .permanentFailure("seed") }
+        try? await waq.enqueue(DummyWAQItem(), table: "set_logs")
+        var deadBefore = await waq.failedWrites()
+        for _ in 0..<100 where deadBefore.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            deadBefore = await waq.failedWrites()
+        }
+        XCTAssertEqual(deadBefore.count, 1, "precondition: one item dead-lettered and pending")
+
+        let paused = PausedSessionState(
+            sessionId: UUID(), trainingDayId: UUID(), weekId: UUID(),
+            weekNumber: 1, exerciseIndex: 0, currentSetNumber: 1,
+            dayType: "Push_A", programId: UUID(), userId: UUID(), pausedAt: Date()
+        )
+        paused.save()
+        XCTAssertNotNil(PausedSessionState.load(), "precondition: paused session saved")
+
+        await manager.discardStalePausedSession()
+
+        let dl = await waq.failedWrites()
+        XCTAssertTrue(dl.isEmpty, "dead-letter drained by discard (clearAll)")
+        XCTAssertNil(PausedSessionState.load(), "paused state cleared after discard")
+    }
+
+    /// When the paused session's owner != the current auth uid, resumeSession must
+    /// discard it (not replay/re-insert under the old owner → RLS 403), leave the
+    /// manager idle, clear the paused snapshot, and surface a repair notice.
+    func testResumeSession_staleOwner_discardsAndStaysIdle() async throws {
+        let realUid = UUID()    // current real auth uid (B)
+        let frozenUid = UUID()  // uid frozen in the paused session (A) — different
+
+        // Scoped keychain with a restorable (future-expiry) session for the real uid,
+        // so awaitFirstResolution() returns it offline (no network).
+        let kc = KeychainService(serviceName: "com.projectapex.tests.stale.\(UUID().uuidString)")
+        try? kc.store("access-token", for: .supabaseAccessToken)
+        try? kc.store("refresh-token", for: .supabaseRefreshToken)
+        try? kc.store(String(Int(Date().addingTimeInterval(3600).timeIntervalSince1970)), for: .supabaseSessionExpiry)
+        try? kc.store(realUid.uuidString, for: .supabaseAuthUserId)
+        let auth = SupabaseAuth(supabaseURL: URL(string: "https://test.supabase.co")!, anonKey: "k", keychain: kc)
+
+        let manager = makeManager()
+        let vm = await WorkoutViewModel(manager: manager)
+
+        let paused = PausedSessionState(
+            sessionId: UUID(), trainingDayId: UUID(), weekId: UUID(),
+            weekNumber: 1, exerciseIndex: 0, currentSetNumber: 1,
+            dayType: "Push_A", programId: UUID(), userId: frozenUid, pausedAt: Date()
+        )
+        paused.save()
+
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+        await vm.resumeSession(pausedState: paused, trainingDay: day,
+                               supabase: makeTestSupabase(), supabaseAuth: auth)
+
+        // resumeSession spawns a Task; poll on the LAST state the gate sets
+        // (resumeRepairNotice, assigned after the discard) so we never observe a
+        // half-applied gate. 1s ceiling.
+        var settled = false
+        for _ in 0..<100 where !settled {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            settled = await MainActor.run { vm.resumeRepairNotice != nil }
+        }
+
+        let state = await manager.sessionState
+        XCTAssertEqual(state, .idle, "manager stays idle when a stale-owner session is discarded")
+        XCTAssertNil(PausedSessionState.load(), "paused state cleared")
+        await MainActor.run {
+            XCTAssertNotNil(vm.resumeRepairNotice, "resumeRepairNotice surfaced")
+            XCTAssertFalse(vm.isStartingSession, "isStartingSession reset")
+        }
+
+        clearAuthKeysForStaleTest(kc)
+    }
+
+    private func clearAuthKeysForStaleTest(_ kc: KeychainService) {
+        try? kc.delete(.supabaseAccessToken)
+        try? kc.delete(.supabaseRefreshToken)
+        try? kc.delete(.supabaseSessionExpiry)
+        try? kc.delete(.supabaseAuthUserId)
     }
 
     // MARK: Test 1: startSession → .active state transition


### PR DESCRIPTION
Slice 4 of the RLS owner-mismatch campaign — closes the **exact live failure** from the gym log (resume of `AC9F701C` → `patchNoMatch` + `set_logs` 403 pile-up).

## What
`WorkoutViewModel.resumeSession` flushed the WAQ and **re-inserted** the `workout_sessions` row under `pausedState.userId` (the owner frozen at start). When the restored auth uid differs, RLS rejects that (42501) and set_logs cascade.

- `WorkoutSessionManager.discardStalePausedSession()` — `clearAll()` + `PausedSessionState.clear()`, no Supabase write (the frozen rows belong to a different owner).
- `resumeSession` now takes `supabaseAuth` and runs a **step-0 ownership gate** before the flush/re-insert: `awaitFirstResolution()?.userId != pausedState.userId` → discard + repair notice + stay idle. `nil` (unresolved) is treated as a mismatch. `WorkoutView.performResume` updated (only caller).

## Tests
- `testDiscardStalePausedSession_…` — seeds a **surviving** dead-letter (permanent-failure path) so the WAQ-clear assertion is load-bearing.
- `testResumeSession_staleOwner_discardsAndStaysIdle` — paused uid A, auth resolves uid B → manager idle, paused state cleared, repair notice set. Fails if the gate is removed.

## Review
Opus review: **no blocker.** Verified the gate precedes the re-insert (stale write unreachable), `clearAll`-on-discard is correct (every WAQ item belongs to the stale owner at resume time), and nil-as-mismatch is safe (offline restore is network-free). Applied both fixes it raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)