### PR TITLE
fix(#369) Slice 5: dead-letter owner-mismatched WAQ items at flush

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -21,6 +21,19 @@ Started 2026-06-07.
 
 **Status:** PR open from `feat/354-progress-root`. 393 tests (12 new + 381 existing), all green.
 
+---
+
+## 2026-06-14 — The outbox now drops a save it knows will be rejected, instead of hammering it 5 times (5 of 6)
+
+**The problem, in plain words.** The "outbox" of pending saves retries anything that fails — five times, with growing waits — assuming the failure is temporary (bad signal, server hiccup). But a save stamped with the wrong owner is *never* going to succeed; the database will reject it every single time. So the app would waste five rounds of guaranteed-to-fail tries on each one, filling the log with red and slowing real saves.
+
+**What I changed.** The outbox now does a quick check just before sending: "does this save's owner match who I'm signed in as right now?" If it clearly doesn't, it sets the save aside immediately (into the "couldn't send" pile) instead of retrying five times. If there's no owner to check, or the login isn't settled yet, it skips the check and behaves exactly as before — so it can never wrongly drop a good save.
+
+**How it was checked.** Four tests cover the whole grid: wrong owner is set aside on the first try (no retries — proven precisely); right owner sends normally; no-login-yet skips the check; and saves that don't carry an owner (like individual sets, which are tied to the workout instead) are never touched. A review agent did the careful part by hand — it traced that the "who's signed in" value and the "who owns this save" value always come from the same source, so they can't drift apart and cause a good save to be dropped, and it checked every kind of save the app sends to confirm the check targets the right ones and skips the rest.
+
+**Status:** merged as PR #407 (Slice 5 of 6). One slice left: apply the same "confirm the login first" rule to the remaining writes (notes/memory, program edits, profile).
+
+---
 
 ## 2026-06-13 — When the app reopens an old paused workout, it now checks it's really yours first (4 of 6)
 

--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -231,7 +231,13 @@ final class AppDependencies {
         // 9. WriteAheadQueue — reliable Supabase write queue (P3-T06)
         // Hoisted above SessionPlanService so the trainee-model stack below
         // can be injected into SessionPlanService (B1 / #86).
-        let waq = WriteAheadQueue(supabase: supabaseClient)
+        let waq = WriteAheadQueue(
+            supabase: supabaseClient,
+            // #369 slice 5: dead-letter owner-mismatched items at flush instead of
+            // burning 5 RLS-403 retries. Reads the already-resolved session (no await
+            // on resolution) — nil during the resolution window safely skips the check.
+            currentAuthUid: { [auth] in await auth.currentSession?.userId }
+        )
         self.writeAheadQueue = waq
 
         // 10. TraineeModelLocalStore + TraineeModelUpdateJob (Phase 1 / Slices 8 + 11)

--- a/ProjectApex/Services/WriteAheadQueue.swift
+++ b/ProjectApex/Services/WriteAheadQueue.swift
@@ -132,16 +132,24 @@ actor WriteAheadQueue {
     private let userDefaults: UserDefaults
     private let baseRetryDelay: TimeInterval
 
+    /// Returns the current authenticated user ID, or nil when no session has
+    /// resolved yet. Injected so the actor can check payload ownership at flush
+    /// time without coupling to SupabaseAuth directly (#369 slice 5). Defaults to
+    /// `{ nil }`, which disables the owner check (existing call-sites unchanged).
+    private let currentAuthUid: @Sendable () async -> UUID?
+
     // MARK: - Init
 
     init(
         supabase: SupabaseClient,
         userDefaults: UserDefaults = .standard,
-        baseRetryDelay: TimeInterval = WriteAheadQueue.defaultBaseRetryDelay
+        baseRetryDelay: TimeInterval = WriteAheadQueue.defaultBaseRetryDelay,
+        currentAuthUid: @escaping @Sendable () async -> UUID? = { nil }
     ) {
         self.supabase = supabase
         self.userDefaults = userDefaults
         self.baseRetryDelay = baseRetryDelay
+        self.currentAuthUid = currentAuthUid
         // Restore any persisted queue + dead-letter items from a previous session
         self.queue = Self.loadPersistedQueue(userDefaults: userDefaults)
         self.deadLetter = Self.loadPersistedDeadLetter(userDefaults: userDefaults)
@@ -275,6 +283,21 @@ actor WriteAheadQueue {
     /// Routes a queue item to its registered handler, or falls back to the
     /// default Supabase REST insert path for items without a custom handler.
     private func dispatch(_ item: QueuedWrite) async -> WAQFlushOutcome {
+        // Owner-mismatch guard (#369 slice 5): if the payload carries a top-level
+        // "user_id" that doesn't match the current auth.uid(), dead-letter it
+        // immediately — no retry. This fires when a frozen-owner item (stamped in a
+        // placeholder/prior-uid window) reaches flush after a real session resolved;
+        // retrying 5× would always produce RLS 403. When no session has resolved
+        // (currentAuthUid → nil) or the payload has no user_id (e.g. set_logs), the
+        // check is skipped and the flush proceeds normally.
+        if let uid = await currentAuthUid(),
+           let payloadOwnerId = Self.extractUserId(from: item.payload),
+           payloadOwnerId != uid {
+            let reason = "owner mismatch: payload user_id \(payloadOwnerId) != auth.uid() \(uid)"
+            Self.logger.error("[WriteAheadQueue] \(reason, privacy: .public) — item \(item.id, privacy: .public), table: \(item.table, privacy: .public)")
+            return .permanentFailure(reason)
+        }
+
         if let handler = flushHandlers[item.table] {
             return await handler(item)
         }
@@ -403,6 +426,19 @@ actor WriteAheadQueue {
               let items = try? JSONDecoder().decode([QueuedWrite].self, from: data)
         else { return [] }
         return items
+    }
+
+    // MARK: - Private: Owner extraction
+
+    /// Decodes the top-level `"user_id"` string from a JSON payload, if present.
+    /// Returns nil when the key is absent (e.g. set_logs, session_notes) or the
+    /// value is not a valid UUID — both treated as "no direct owner to check", so
+    /// the flush proceeds normally. (#369 slice 5.)
+    private static func extractUserId(from payload: Data) -> UUID? {
+        guard let json = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
+              let raw = json["user_id"] as? String
+        else { return nil }
+        return UUID(uuidString: raw)
     }
 }
 

--- a/ProjectApexTests/WriteAheadQueueTests.swift
+++ b/ProjectApexTests/WriteAheadQueueTests.swift
@@ -48,6 +48,15 @@ nonisolated private struct TestSetLogPayload: Encodable, Sendable {
     }
 }
 
+/// Payload that DOES carry a top-level `user_id` (e.g. workout_sessions), used to
+/// exercise the #369 slice-5 owner-mismatch guard. File-scope so its Encodable
+/// conformance is non-isolated.
+nonisolated private struct OwnedWAQPayload: Encodable, Sendable {
+    let userId: String
+    enum CodingKeys: String, CodingKey { case userId = "user_id" }
+    init(userId: UUID) { self.userId = userId.uuidString }
+}
+
 // MARK: - Mock URLProtocol for controlling HTTP responses
 
 private final class WAQMockURLProtocol: URLProtocol, @unchecked Sendable {
@@ -364,6 +373,92 @@ final class WriteAheadQueueTests: XCTestCase {
         XCTAssertEqual(reloadedPending, 0, "persisted queue empty after clearAll")
         let reloadedDead = await reloaded.failedWrites()
         XCTAssertTrue(reloadedDead.isEmpty, "persisted dead-letter empty after clearAll")
+    }
+
+    // MARK: #369 slice 5 — owner-mismatch flush guard
+
+    /// An item whose payload user_id != current auth.uid() is dead-lettered on the
+    /// first dispatch (permanent failure), with no retries — retrying would always
+    /// produce RLS 403.
+    func testFlush_ownerMismatch_deadLettersWithoutRetry() async throws {
+        let defaults = UserDefaults(suiteName: "waq.test.\(UUID().uuidString)")!
+        let authUid = UUID()
+        let queue = WriteAheadQueue(
+            supabase: makeMockSupabase(), userDefaults: defaults, baseRetryDelay: 0.001,
+            currentAuthUid: { authUid }
+        )
+        try await queue.enqueue(OwnedWAQPayload(userId: UUID()), table: "workout_sessions")
+
+        var dead = await queue.failedWrites()
+        for _ in 0..<100 where dead.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            dead = await queue.failedWrites()
+        }
+        XCTAssertEqual(dead.count, 1, "owner-mismatched item must be dead-lettered")
+        XCTAssertEqual(dead.first?.retryCount, 0, "permanent failure → dead-lettered with no retries")
+        let pending = await queue.pendingCount
+        XCTAssertEqual(pending, 0, "queue drained")
+    }
+
+    /// An item whose payload user_id matches the current auth.uid() flushes normally.
+    func testFlush_ownerMatch_proceedsNormally() async throws {
+        let defaults = UserDefaults(suiteName: "waq.test.\(UUID().uuidString)")!
+        let authUid = UUID()
+        let queue = WriteAheadQueue(
+            supabase: makeMockSupabase(), userDefaults: defaults,
+            currentAuthUid: { authUid }
+        )
+        await queue.registerFlushHandler(forTable: "workout_sessions") { _ in .success }
+        try await queue.enqueue(OwnedWAQPayload(userId: authUid), table: "workout_sessions")
+
+        var pending = await queue.pendingCount
+        for _ in 0..<100 where pending != 0 {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            pending = await queue.pendingCount
+        }
+        XCTAssertEqual(pending, 0, "matching-owner item flushes")
+        let dead = await queue.failedWrites()
+        XCTAssertTrue(dead.isEmpty, "matching-owner item must not dead-letter")
+    }
+
+    /// With the default `currentAuthUid = { nil }` (no resolved session), the owner
+    /// check is skipped and the item flushes normally.
+    func testFlush_noUidProvider_skipsOwnerCheck() async throws {
+        let defaults = UserDefaults(suiteName: "waq.test.\(UUID().uuidString)")!
+        let queue = WriteAheadQueue(supabase: makeMockSupabase(), userDefaults: defaults)
+        await queue.registerFlushHandler(forTable: "workout_sessions") { _ in .success }
+        try await queue.enqueue(OwnedWAQPayload(userId: UUID()), table: "workout_sessions")
+
+        var pending = await queue.pendingCount
+        for _ in 0..<100 where pending != 0 {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            pending = await queue.pendingCount
+        }
+        XCTAssertEqual(pending, 0, "nil uid provider disables the owner check; item flushes")
+        let dead = await queue.failedWrites()
+        XCTAssertTrue(dead.isEmpty)
+    }
+
+    /// A payload with NO top-level user_id (e.g. set_logs) is never owner-checked,
+    /// even when a real auth.uid() is present — ownership is indirect via the session.
+    func testFlush_payloadWithoutUserIdKey_skipsOwnerCheck() async throws {
+        let defaults = UserDefaults(suiteName: "waq.test.\(UUID().uuidString)")!
+        let authUid = UUID()
+        let queue = WriteAheadQueue(
+            supabase: makeMockSupabase(), userDefaults: defaults,
+            currentAuthUid: { authUid }
+        )
+        await queue.registerFlushHandler(forTable: "set_logs") { _ in .success }
+        try await queue.enqueue(TestSetLogPayload.mock(), table: "set_logs")
+
+        var pending = await queue.pendingCount
+        for _ in 0..<100 where pending != 0 {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            pending = await queue.pendingCount
+        }
+        XCTAssertEqual(pending, 0, "set_logs (no user_id) flushes — owner check skipped")
+        let dead = await queue.failedWrites()
+        XCTAssertTrue(dead.isEmpty)
     }
 
     // MARK: Test 8 (#184): retry-exhausted items are dead-lettered, not dropped


### PR DESCRIPTION
Slice 5 of the RLS owner-mismatch campaign — defense-in-depth at the write-ahead queue.

## What
The WAQ retried every failure up to 5× assuming transience; an owner-mismatched write RLS-403s every time, wasting 5 guaranteed-failing retries.

- `WriteAheadQueue` gains an injected `currentAuthUid: @Sendable () async -> UUID?` (default `{ nil }` → check disabled; existing call-sites unchanged).
- `dispatch()` guards first: non-nil `currentAuthUid()` **and** a differing top-level payload `user_id` → `.permanentFailure` (dead-letter immediately, no retry). nil uid / no `user_id` key → **skip** (flush proceeds) so a good write is never wrongly dropped.
- `AppDependencies` wires it to `auth.currentSession?.userId`.

`set_logs` (ownership indirect via `session_id`) are intentionally not covered — separate follow-up.

## Tests
mismatch → dead-lettered with `retryCount == 0`; match → flushes; nil-provider → skip; no-`user_id` (set_logs) → skip. WAQ suite 15 pass.

## Review
Opus review: **CLEAN, no blockers.** Verified **no false-positive path** (stamp uid and guard uid share one keychain/in-memory source; token refresh preserves the uid; every nil branch is a safe skip), and matched `extractUserId`'s key against **every** real WAQ payload (workout_sessions + trainee_model carry top-level `user_id`; set_logs/notes/patches correctly skip). 3 NITs, all non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)