### PR TITLE
fix(#369) Slice 6: gate calibration/goal/manual-log writes on a resolved owner

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,20 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-14 — Last piece: the goal/calibration/manual-log screens now wait for login before saving (6 of 6)
+
+**The problem, in plain words.** A handful of less-common save points — editing your goal, reviewing a calibration, logging a past workout by hand — still grabbed "who am I" the old, instant way, which during the first second after opening the app can be the temporary stand-in id. A save stamped that way gets rejected. The main workout flow was already fixed in the earlier pieces; this is the long tail.
+
+**What I changed.** Those three screens now wait for the real login the same way the workout screen does. For the two "best-effort" syncs (goal and calibration), only the part that talks to the server waits for login — the bit that updates your screen still happens instantly, so nothing feels slower. For logging a past workout by hand (which actually creates records), it now waits for login and, if it genuinely can't confirm one, shows "sign-in isn't confirmed yet, please try again" instead of silently doing nothing.
+
+**What I deliberately left for later (and why).** A few remaining save points live inside the app's main container screen, which a *separate* redesign is actively rebuilding right now. Editing it today would collide with that work and likely get thrown away when the redesign swaps it out. So I wrote those up as a tracked task (#409) to do once the redesign lands. I also confirmed the workout-note and AI-memory saves are already safe, because they're tied to the workout — and the workout itself can no longer start under the wrong login (earlier pieces).
+
+**How it was checked.** The whole app builds; a review agent confirmed each screen still updates locally regardless, that the "wait for login" step doesn't slow anything (the login is already settled by the time you reach these screens), and that no nearby save in the same files was missed.
+
+**Status:** merged as PR #412 (Slice 6 of 6 — the owner-mismatch campaign is complete bar the one tracked follow-up #409 and switching the database auto-create rule on in production).
+
+---
+
 ## 2026-06-13 — Built the Progress root: the capability ledger (Phase 3 UI, Slice 12 #354)
 
 **What it is.** The new Progress root screen — the "capability ledger." Instead of the old progress tab, the rebuilt shell now routes to a scrollable list of capability bands, one row per movement pattern, all aligned on a shared vertical spine. The spine is the key visual: every row's floor tick sits at the same x-position, so when you look at the screen you see one continuous 2px vertical line running from top to bottom. That line is the app saying "here is every pattern's floor, side by side."

--- a/ProjectApex/Features/Workout/CalibrationReviewView.swift
+++ b/ProjectApex/Features/Workout/CalibrationReviewView.swift
@@ -270,20 +270,24 @@ struct CalibrationReviewView: View {
             updatedAt: isoFormatter.string(from: goalState.updatedAt)
         )
 
-        let payload = Self.makeCalibrationStretchPayload(
-            userId: deps.resolvedUserId,
-            goal: goalBody,
-            editedStretch: editedStretch,
-            original: projections,
-            now: Date()
-        )
-
-        // Best-effort server write, mirroring GoalReviewView.save().
-        if let encoded = try? JSONEncoder().encode(payload) {
-            _ = try? await deps.supabaseClient.invokeFunction(
-                "update-trainee-goal",
-                body: encoded
+        // #369 slice 6: send the owned server write only under a resolved real
+        // owner; the placeholder would be rejected by the EF's ownership check.
+        // The local cache update + ack below still run regardless.
+        if let userId = await deps.resolvedOwnerUserId() {
+            let payload = Self.makeCalibrationStretchPayload(
+                userId: userId,
+                goal: goalBody,
+                editedStretch: editedStretch,
+                original: projections,
+                now: Date()
             )
+            // Best-effort server write, mirroring GoalReviewView.save().
+            if let encoded = try? JSONEncoder().encode(payload) {
+                _ = try? await deps.supabaseClient.invokeFunction(
+                    "update-trainee-goal",
+                    body: encoded
+                )
+            }
         }
 
         // Local cache update + ack so the banner hides immediately. Apply only

--- a/ProjectApex/Features/Workout/GoalReviewView.swift
+++ b/ProjectApex/Features/Workout/GoalReviewView.swift
@@ -256,18 +256,23 @@ struct GoalReviewView: View {
         defer { isSaving = false }
 
         // Both writes are best-effort, mirroring onboarding's goal hydration.
-        let payload = Self.makeGoalPayload(
-            userId: deps.resolvedUserId,
-            statement: statement,
-            focusAreas: selectedFocusAreas,
-            triggeringSessionCount: triggeringSessionCount,
-            now: Date()
-        )
-        if let encoded = try? JSONEncoder().encode(payload) {
-            _ = try? await deps.supabaseClient.invokeFunction(
-                "update-trainee-goal",
-                body: encoded
+        // #369 slice 6: send the owned server write only under a resolved real
+        // owner (a placeholder would be rejected by the EF). The local banner-hide
+        // below still runs regardless.
+        if let userId = await deps.resolvedOwnerUserId() {
+            let payload = Self.makeGoalPayload(
+                userId: userId,
+                statement: statement,
+                focusAreas: selectedFocusAreas,
+                triggeringSessionCount: triggeringSessionCount,
+                now: Date()
             )
+            if let encoded = try? JSONEncoder().encode(payload) {
+                _ = try? await deps.supabaseClient.invokeFunction(
+                    "update-trainee-goal",
+                    body: encoded
+                )
+            }
         }
 
         // Local banner-hide (Slice F1): only when a banner triggered this

--- a/ProjectApex/Features/Workout/ManualSessionLogView.swift
+++ b/ProjectApex/Features/Workout/ManualSessionLogView.swift
@@ -318,7 +318,14 @@ struct ManualSessionLogView: View {
         isSubmitting = true
         defer { isSubmitting = false }
 
-        let userId = deps.resolvedUserId
+        // #369 slice 6: a manual session creates owned workout_sessions/set_logs
+        // rows, so resolve the real owner first and abort rather than stamping the
+        // placeholder (which RLS would reject). isSubmitting resets via the defer;
+        // surface the reason via the existing Log-Failed alert rather than silently.
+        guard let userId = await deps.resolvedOwnerUserId() else {
+            errorMessage = "Sign-in isn't confirmed yet. Please wait a moment and try again."
+            return
+        }
 
         // DATE column (session_date): use local calendar date string to avoid UTC-offset rollover.
         let dateFormatter = DateFormatter()


### PR DESCRIPTION
Final slice of the RLS owner-mismatch campaign — the secondary-write tail.

## What
Applies the shared `resolvedOwnerUserId()` gate to the owned writes that still read sync `deps.resolvedUserId`:
- **CalibrationReviewView.save / GoalReviewView.save** — wrap only the `update-trainee-goal` EF write in `if let userId = await deps.resolvedOwnerUserId()`; the local cache update / banner-hide acks still run regardless.
- **ManualSessionLogView.submitSession** — `guard let … else { errorMessage = …; return }` (the guard precedes both inserts + the memory embed). Surfaces the reason via the existing Log-Failed alert rather than aborting silently.

## Deferred (tracked)
- **#409** — ContentView-coupled sites (`ProgramViewModel.userId` at init, gym_profiles equipment writes) + ProgramDayDetailView. `ContentView` is mid-strangler (#376), so editing now would collide/strand.
- **Already covered (no change):** memory embeds capturing `session.userId` + `TraineeModelService` — protected by slices 1+4 and the slice-5 WAQ flush guard.

## Verification
Full app compiles; SupabaseAuthTests 7 pass. Sonnet review: **no blocker** — local acks run regardless, `defer` resets `isSubmitting` on the guard return, no actor/double-resolution concern, no sibling write missed. Applied its NIT (manual-log error surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)