### PR TITLE
feat(#357): Train program root (day-spine + generation horizon + tick status + rest-as-node)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,23 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-14 — The Train program root: your plan drawn as a vertical day-spine (Phase 3 UI, Slice 15 #357)
+
+**What it is.** The new Train tab's main screen, drawn as a single vertical spine running down the page — the left edge is the timeline, and each training day hangs off it. This week shows in full: each day a row with a small status mark (a filled dot = done, a hollow dot = scheduled-but-not-done) and a short list of that day's exercises. Days you don't train are first-class "rest" nodes on the spine, not blank gaps. Below this week, the rest of the plan shows compressed and faint — pattern/focus only, no fake numbers — because the coach hasn't worked those days out yet.
+
+**The honest part.** The whole point is the line between *what the coach has placed* and *what it's still going to figure out closer to the day*. Placed days are drawn in ink with real exercises; not-yet-placed days are drawn in pencil as a shape only, inside a faint diagonal hatch zone, with a drawn "PLACED ABOVE · SHAPE BELOW" line between the two. The further out a week is, the more it compresses — but in three clear steps, never a smooth fade. And there are deliberately no streaks, no rings, no "3 of 5 done" counters, no shame mark on a missed day — the calendar is a plan, not a report card. A skipped day just stays a hollow dot, like any other day the plan moved past.
+
+**Derived, not stored (no data changes).** Rest days and skeleton days aren't new saved states — they're worked out from what's already there. A weekday with no training day = a rest node. A day with no generated exercises yet = a skeleton (pencil) day. I added zero new cases to the saved data and changed no model, so nothing about how programs are stored changed. The mapping from a day's status to its dot, and these rest/skeleton rules, all live in the new screen (the dot drawing itself is a dumb shared piece).
+
+**How it gets its data (the seam).** The new shell doesn't yet own the program's live "view model," so this screen takes its data as a plain input that tests can hand it directly, and the live version reads the same saved-program cache the old screen reads first. When no program is cached it shows an honest empty state. The real live wiring (current-week tracking, days re-resolving on screen) is a clearly-marked TODO for a later slice (#376).
+
+**Still dormant.** This is a brand-new screen wired only into the off-by-default new 3-tab shell. The live app still runs the old program screen untouched — nothing users see changed.
+
+**Tests.** New unconditional tests cover the dot mapping for every day status above and below the horizon, rest-and-skeleton-from-gaps, the three discrete compression steps, "Week X of N," and a guard proving the screen carries no streak/counter/adherence field. Image snapshots for light + dim + an accessibility size are wired up but their reference images aren't recorded here — the CI record job on Xcode 26.3 does that.
+
+**Status:** PR open from `feat/357-train-root`. New suites all green (23 tests in the scoped run); whole app + tests compile with no new warnings.
+
+
 ## 2026-06-14 — The drafting-rule system: drawing what the model knows vs. is still guessing (Phase 3 UI, #411)
 
 **What it is.** A shared set of drawing pieces for one idea that shows up on three screens: the line between *what the coach has placed* and *what it hasn't worked out yet*. The rule is simple — if the model has committed to something, draw it in ink with real numbers; if it's still provisional, draw it in pencil as a shape only; and always draw the boundary between the two as an actual line, never leave it to ink-vs-pencil alone (because the muted pencil colour already means "time/metadata," so on its own it reads as "minor detail," not "not figured out yet").

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		PR35400000000000PR354002 /* ProgressRootLedgerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PR35400000000000PR354001 /* ProgressRootLedgerTests.swift */; };
 		ST41000000000000ST410002 /* StatusTickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ST41000000000000ST410001 /* StatusTickTests.swift */; };
 		DR41100000000000DR411002 /* DraftingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DR41100000000000DR411001 /* DraftingRuleTests.swift */; };
+		TR35700000000000TR357002 /* TrainProgramRootTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TR35700000000000TR357001 /* TrainProgramRootTests.swift */; };
 		DE54000000000000DE540002 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = DE54000000000000DE540001 /* SnapshotTesting */; };
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
@@ -142,6 +143,7 @@
 		PR35400000000000PR354001 /* ProgressRootLedgerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProgressRootLedgerTests.swift; sourceTree = "<group>"; };
 		ST41000000000000ST410001 /* StatusTickTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StatusTickTests.swift; sourceTree = "<group>"; };
 		DR41100000000000DR411001 /* DraftingRuleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DraftingRuleTests.swift; sourceTree = "<group>"; };
+		TR35700000000000TR357001 /* TrainProgramRootTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrainProgramRootTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
 		DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetPrescriptionIntentValidationTests.swift; sourceTree = "<group>"; };
 		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 				PR35400000000000PR354001 /* ProgressRootLedgerTests.swift */,
 				ST41000000000000ST410001 /* StatusTickTests.swift */,
 				DR41100000000000DR411001 /* DraftingRuleTests.swift */,
+				TR35700000000000TR357001 /* TrainProgramRootTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -467,6 +470,7 @@
 				PR35400000000000PR354002 /* ProgressRootLedgerTests.swift in Sources */,
 				ST41000000000000ST410002 /* StatusTickTests.swift in Sources */,
 				DR41100000000000DR411002 /* DraftingRuleTests.swift in Sources */,
+				TR35700000000000TR357002 /* TrainProgramRootTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/AppShell.swift
+++ b/ProjectApex/AppShell.swift
@@ -114,10 +114,11 @@ struct AppShell: View {
     // MARK: Routing — code-as-switch
 
     /// "Is this surface built?" is the literal presence of its real view's
-    /// constructor here (ADR-0026 (a)). Progress re-homes its real screen now
-    /// (it needs only `deps`). Today and Train depend on the `ProgramViewModel`
-    /// lifecycle that machinery-last keeps in `ContentView`, so they show an
-    /// honest interim until their per-surface slice lifts that machinery.
+    /// constructor here (ADR-0026 (a)). Progress (#354) and Train (#357) re-home
+    /// their real roots now — each reads its data through `deps`, with the
+    /// `ProgramViewModel` lifecycle still lifted later (#376, machinery-last).
+    /// Today depends on that lifecycle, so it shows an honest interim until the
+    /// Today slice lands.
     @ViewBuilder
     private func surface(for tab: ApexTab) -> some View {
         switch tab {
@@ -127,10 +128,11 @@ struct AppShell: View {
                 note: "The coach/home surface lands in the Today slice."
             )
         case .train:
-            InterimSurface(
-                title: "Train",
-                note: "The program surface re-homes here in the Train slice."
-            )
+            // #357: new Train root — the program day-spine (train.md §3).
+            // ProgramOverviewView is preserved for the live ContentView; only this
+            // dormant AppShell branch changes. The host owns the data boundary; the
+            // ProgramViewModel lifecycle is lifted here in #376 (machinery-last).
+            TrainProgramRootHost()
         case .progress:
             // #354: new Progress root — the capability ledger (progress.md §3).
             // ProgressTabView is preserved for the live ContentView; only this

--- a/ProjectApex/Features/Program/TrainProgramRoot.swift
+++ b/ProjectApex/Features/Program/TrainProgramRoot.swift
@@ -1,0 +1,564 @@
+// TrainProgramRoot.swift
+// ProjectApex — Features/Program
+//
+// The Phase 3 Train program root: the plan, drawn as a measured vertical day-spine
+// (train.md §3, ADR-0028). The left edge is the time datum; days hang off it down
+// the page; the generation horizon is a marked position on the spine.
+//
+//   • Above the horizon — generated days render INK with numbers (real prescriptions).
+//   • Below the horizon — skeleton days render PENCIL shape-only (pattern/focus, no
+//     number) inside the to-be-placed sparse-diagonal hatch zone.
+//   • A drawn GenerationHorizonBreak datum separates the two (material alone is
+//     insufficient — ink-muted already means time/metadata everywhere else).
+//   • The commitment gradient is DISCRETE tiers (CommitmentTier), not a fade.
+//   • Position lockup "Week X of N" via DraftingRegister.
+//   • This-week days are spine rows, each with a StatusTick; rest days are
+//     first-class recessed RestWellNode nodes.
+//   • No streaks / rings / counters / adherence (honesty — a plan, not a report card).
+//
+// DORMANT: a NEW screen routed only by the dormant 3-tab shell (AppShell.surface(.train),
+// behind useNewShell = false, ADR-0026). The live ProgramOverviewView + ContentView are
+// untouched and keep running until the #376 flip.
+//
+// THE TICK MAPPING + THE INVERSION LIVE HERE (StatusTick is a dumb primitive,
+// train.md §3 / ADR-0028 two-axis model):
+//   - (TrainingDayStatus + horizon position) → StatusTickValue is mapped in this file.
+//   - Rest day  = a day-of-week with NO TrainingDay  → RestWellNode.
+//   - Skeleton day = a day in a MesocycleSkeleton/WeekIntent with no generated
+//     PlannedExercises (below the horizon) → pencil shape only.
+//   No enum case is added to the persisted Codable TrainingDayStatus; no model changes.
+//
+// MOTION: every row renders assembled at frame 1; a day re-resolving on screen
+// hard-swaps assembled (≤150ms crossfade in the host's #376 lifecycle), never a
+// tween/cascade/flourish; no idle animation (train.md §2).
+//
+// THE PROGRAMVIEWMODEL SEAM (reported in the PR): AppShell does NOT host
+// ProgramViewModel yet (lifted in #376, machinery-last). So this view takes its data
+// as an injectable `ViewState` (a Mesocycle + skeleton + the current-week index,
+// reduced to spine rows) so snapshot/unit tests drive it with fixtures. The host
+// reads the SAME UserDefaults fast-path ProgramViewModel.loadProgram() uses first
+// (Mesocycle.loadFromUserDefaults, a @MainActor sync source needing no service), and
+// renders an honest empty state when no program is cached. See `// #376:` below.
+
+import SwiftUI
+
+// MARK: - TrainProgramRoot (the new root view)
+
+/// The Train program root, drawn as a vertical day-spine (train.md §3).
+/// Injectable input: a `ViewState` reduced from a Mesocycle (+ skeleton). The
+/// view does no service work — the host owns the data boundary.
+struct TrainProgramRoot: View {
+
+    // MARK: Input types
+
+    /// One row on the day-spine: a placed (ink) training day, a skeleton (pencil)
+    /// shape, or a first-class rest node. Derived in `ViewState.rows(...)`; the
+    /// view only draws what it is handed.
+    struct DayRow: Identifiable {
+        enum Kind: Equatable {
+            /// A placed training day above the horizon — ink with its exercise brief.
+            case placed(tick: StatusTickValue, exerciseBrief: String)
+            /// A skeleton day below the horizon — pencil shape only (focus, no number).
+            case skeleton(focus: String)
+            /// A rest day — derived from a day-of-week gap; a recessed well node.
+            case rest(recoveryLine: String)
+        }
+
+        let id: String
+        /// 1 = Monday … 7 = Sunday (ISO-8601). The spine orders rows by this.
+        let dayOfWeek: Int
+        /// Short pattern / focus label, e.g. "Push A", "Lower — squat focus".
+        let title: String
+        /// The discrete commitment tier (this-week / compressed / glyph-per-day).
+        let tier: CommitmentTier
+        /// True for today's row — the one quiet static "today" marker (no pulse).
+        let isToday: Bool
+        let kind: Kind
+    }
+
+    /// The whole reduced screen state. Injectable so tests drive it with fixtures.
+    struct ViewState {
+        /// 1-based current week number (the work number, ink).
+        let weekNumber: Int
+        /// Total weeks in the cycle (the "of N", pencil).
+        let totalWeeks: Int
+        /// The cycle's name / intent if it has one ("Strength block"); else nil.
+        let cycleName: String?
+        /// The this-week spine rows (placed days + rest nodes), in day order.
+        let thisWeekRows: [DayRow]
+        /// The compressed horizon rows below the datum (skeleton shape only).
+        let horizonRows: [DayRow]
+
+        /// True when there is nothing to draw — the honest empty state.
+        var isEmpty: Bool { thisWeekRows.isEmpty && horizonRows.isEmpty }
+    }
+
+    // MARK: Input
+
+    let state: ViewState
+
+    @Environment(\.apexTheme) private var theme
+
+    // MARK: Body
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                positionLockup
+
+                if state.isEmpty {
+                    emptyState
+                } else {
+                    thisWeekSpine
+                    horizonZone
+                }
+            }
+            .padding(.horizontal, Spacing.md)
+        }
+        .scrollBounceBehavior(.basedOnSize)
+        .background(theme.paper.color.ignoresSafeArea())
+    }
+
+    // MARK: Position lockup — "Week X of N" (DraftingRegister grammar)
+
+    /// "Week 2 of 6" + the cycle name/intent if present (splash-today.md evidence
+    /// lockup: work numbers ink, "of N" pencil). No "weeks completed" bar — that is
+    /// the banned adherence totalizer (train.md §3, §11.4).
+    private var positionLockup: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            DraftingRule(style: .solid, showsMarginTick: true)
+
+            // "Week 2" ink + " of 6" pencil.
+            (InkPencil.run(
+                ink: "Week \(state.weekNumber)",
+                pencil: " of \(state.totalWeeks)",
+                theme: theme
+            ))
+            .apexFont(.title)
+            .monospacedDigit()
+
+            if let name = state.cycleName, !name.isEmpty {
+                Text(name)
+                    .apexFont(.label)
+                    .foregroundStyle(theme.inkMuted.color)
+            }
+        }
+        .padding(.top, Spacing.md)
+        .padding(.bottom, Spacing.sm)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "Week \(state.weekNumber) of \(state.totalWeeks)"
+            + (state.cycleName.map { ". \($0)" } ?? "")
+        )
+    }
+
+    // MARK: This week — the spine, in full
+
+    private var thisWeekSpine: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(state.thisWeekRows) { row in
+                spineRow(row)
+                Divider().overlay(theme.hairline.color)
+            }
+        }
+        .padding(.top, Spacing.sm)
+    }
+
+    /// One this-week row: a status tick (or a rest well node) + the day's brief.
+    @ViewBuilder
+    private func spineRow(_ row: DayRow) -> some View {
+        switch row.kind {
+        case .rest(let recoveryLine):
+            // Rest is first-class — a recessed well node, never a gap or grayed cell.
+            RestWellNode(recoveryLine: recoveryLine)
+                .padding(.vertical, Spacing.xs)
+
+        case .placed(let tick, let brief):
+            HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                StatusTick(
+                    value: tick,
+                    isToday: row.isToday,
+                    accessibilityLabel: tickLabel(for: tick, title: row.title)
+                )
+                VStack(alignment: .leading, spacing: Spacing.xs) {
+                    Text(row.title)               // pattern / focus — ink
+                        .apexFont(.body)
+                        .foregroundStyle(theme.ink.color)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if !brief.isEmpty {
+                        Text(brief)               // the session's exercises in brief — ink
+                            .apexFont(.label)
+                            .foregroundStyle(theme.ink.color)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, Spacing.sm)
+            .contentShape(Rectangle())
+            .accessibilityElement(children: .combine)
+
+        case .skeleton(let focus):
+            // A this-week day can fall below the horizon (per-day granularity): render
+            // it as a pencil shape-only row even within the week. No tick (undrawn).
+            skeletonRow(title: row.title, focus: focus)
+        }
+    }
+
+    // MARK: The horizon, compressed — skeleton shape only, on the gradient
+
+    /// The remaining weeks below the datum: the drawn horizon break, then the
+    /// to-be-placed hatch zone carrying the pencil skeleton rows.
+    @ViewBuilder
+    private var horizonZone: some View {
+        if !state.horizonRows.isEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                // The drawn datum — "PLACED ABOVE · SHAPE BELOW".
+                GenerationHorizonBreak()
+                    .padding(.vertical, Spacing.sm)
+
+                // The skeleton zone: the sparse-diagonal hatch behind the pencil rows.
+                ZStack(alignment: .topLeading) {
+                    ToBePlacedHatch()
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(state.horizonRows) { row in
+                            horizonRow(row)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// A skeleton row below the datum, rendered at its commitment tier:
+    ///   - .compressed   → a brief pencil shape (focus line).
+    ///   - .glyphPerDay  → one pencil glyph (the title only).
+    @ViewBuilder
+    private func horizonRow(_ row: DayRow) -> some View {
+        switch row.kind {
+        case .skeleton(let focus):
+            switch row.tier {
+            case .glyphPerDay:
+                skeletonRow(title: row.title, focus: "")    // one pencil glyph per day
+            case .compressed, .thisWeek:
+                skeletonRow(title: row.title, focus: focus)  // compressed brief shape
+            }
+        case .rest(let recoveryLine):
+            RestWellNode(recoveryLine: recoveryLine)
+                .padding(.vertical, Spacing.xs)
+        case .placed(let tick, let brief):
+            // Defensive: a placed day in the horizon set still draws as a placed row.
+            HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                StatusTick(value: tick, accessibilityLabel: tickLabel(for: tick, title: row.title))
+                Text(brief.isEmpty ? row.title : "\(row.title) · \(brief)")
+                    .apexFont(.label)
+                    .foregroundStyle(theme.ink.color)
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, Spacing.xs)
+        }
+    }
+
+    /// A pencil shape-only row (no tick, no number) — the skeleton render.
+    private func skeletonRow(title: String, focus: String) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text(title)
+                .apexFont(.body)
+                .foregroundStyle(theme.inkMuted.color)     // pencil — model hasn't placed it
+                .fixedSize(horizontal: false, vertical: true)
+            if !focus.isEmpty {
+                Text(focus)
+                    .apexFont(.label)
+                    .foregroundStyle(theme.inkMuted.color)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.vertical, Spacing.sm)
+        .padding(.leading, Spacing.lg)                     // inset so the hatch reads behind it
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title). Shape only — placed closer to the day.")
+    }
+
+    // MARK: Empty state (honest — never a fabricated frame)
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Text("No program yet")
+                .apexFont(.body)
+                .foregroundStyle(theme.ink.color)
+            Text("Your plan appears here once it's generated.")
+                .apexFont(.label)
+                .foregroundStyle(theme.inkMuted.color)
+        }
+        .padding(.vertical, Spacing.lg)
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: VoiceOver copy for a tick (the instrument has no fallback copy)
+
+    private func tickLabel(for value: StatusTickValue, title: String) -> String {
+        switch value {
+        case .filled:  return "\(title) — done."
+        case .hollow:  return "\(title) — scheduled."
+        case .undrawn: return "\(title) — shape only."
+        }
+    }
+}
+
+// MARK: - Derivation (the tick mapping + the inversion — PURE, testable, no model change)
+
+extension TrainProgramRoot {
+
+    /// The day-status tick mapping (train.md §3, ADR-0028 two-axis model). StatusTick
+    /// is a dumb primitive, so THIS is where (TrainingDayStatus + horizon position)
+    /// resolves to a StatusTickValue:
+    ///   - completed                          → .filled  (a logged fact — no count/ring)
+    ///   - generated / paused                 → .hollow  (committed, not done)
+    ///   - pending ABOVE the horizon          → .hollow  (placed-and-waiting)
+    ///   - skeleton / BELOW the horizon       → .undrawn (the hatch zone carries it)
+    ///   - skipped                            → .hollow  (stayed-hollow — NO shame mark;
+    ///                                          "missed = a day the plan moved past")
+    ///
+    /// `isAboveHorizon` is the generation-horizon position: a day is above the
+    /// horizon when its session has been generated (has placed prescriptions). A
+    /// `pending` day below the horizon is skeleton → `.undrawn`.
+    static func tickValue(for status: TrainingDayStatus, isAboveHorizon: Bool) -> StatusTickValue {
+        switch status {
+        case .completed:
+            return .filled
+        case .generated, .paused:
+            return .hollow
+        case .skipped:
+            // Stayed-hollow: a missed day is just a day the plan moved past — no shame mark.
+            return .hollow
+        case .pending:
+            // Placed-but-waiting reads hollow above the horizon; skeleton below it.
+            return isAboveHorizon ? .hollow : .undrawn
+        }
+    }
+
+    /// THE INVERSION (train.md §3 #357 amendment): a placed day has generated
+    /// `PlannedExercise`s; a skeleton day does not. A day is "above the horizon"
+    /// iff it carries real prescriptions — derived from EXISTING state, no model
+    /// change. A `.completed`/`.generated`/`.paused` day is always above the
+    /// horizon (it has been resolved) even if its exercise array wasn't persisted.
+    static func isAboveHorizon(_ day: TrainingDay) -> Bool {
+        if !day.exercises.isEmpty { return true }
+        switch day.status {
+        case .completed, .generated, .paused, .skipped: return true
+        case .pending: return false
+        }
+    }
+}
+
+// MARK: - ViewState construction from a Mesocycle (+ optional skeleton)
+
+extension TrainProgramRoot.ViewState {
+
+    /// The canonical rest-day line (train.md §3: state what recovery buys, never a gap).
+    static let restLine = "Rest — recovery builds the adaptation."
+
+    /// Builds the screen state from a live `Mesocycle`. The current week is the
+    /// week index supplied (ProgramViewModel.currentWeekIndex in the host); rows are
+    /// derived for this week (full spine, rest-from-gaps) and the remaining weeks
+    /// (compressed skeleton shapes on the discrete commitment gradient).
+    ///
+    /// `trainingDaysPerWeek` drives rest-day derivation: any of the 7 weekdays with
+    /// no `TrainingDay` in the week becomes a `RestWellNode` (the gap → rest inversion).
+    /// `todayWeekday` (1…7, default = the live weekday) marks the one static today row.
+    static func from(
+        mesocycle: Mesocycle,
+        currentWeekIndex: Int,
+        todayWeekday: Int = Calendar.current.component(.weekday, from: Date())
+    ) -> TrainProgramRoot.ViewState {
+        let weeks = mesocycle.weeks
+        guard !weeks.isEmpty else {
+            return TrainProgramRoot.ViewState(
+                weekNumber: 1, totalWeeks: mesocycle.totalWeeks,
+                cycleName: nil, thisWeekRows: [], horizonRows: []
+            )
+        }
+        let weekIdx = min(max(0, currentWeekIndex), weeks.count - 1)
+        let thisWeek = weeks[weekIdx]
+
+        // ── This week: placed/skeleton day rows + rest-from-gaps, in weekday order. ──
+        let thisWeekRows = spineRows(
+            for: thisWeek,
+            todayWeekday: convertToISOWeekday(todayWeekday),
+            tier: .thisWeek
+        )
+
+        // ── The horizon: remaining weeks, compressed skeleton shapes on the gradient. ──
+        var horizonRows: [TrainProgramRoot.DayRow] = []
+        for (offset, week) in weeks.enumerated() where offset > weekIdx {
+            // Distance-from-now in days, bucketed into the discrete tier.
+            let weeksOut = offset - weekIdx
+            let tier = CommitmentTier.forDistance(days: weeksOut * 7)
+            for day in week.trainingDays.sorted(by: { $0.dayOfWeek < $1.dayOfWeek }) {
+                let focus = day.dayLabel.replacingOccurrences(of: "_", with: " ")
+                horizonRows.append(
+                    TrainProgramRoot.DayRow(
+                        id: day.id.uuidString,
+                        dayOfWeek: day.dayOfWeek,
+                        title: focus,
+                        tier: tier,
+                        isToday: false,
+                        kind: .skeleton(focus: weekFocusLine(week))
+                    )
+                )
+            }
+        }
+
+        // Cycle name from the periodization model, humanized (e.g. "Linear Periodization").
+        let cycleName = mesocycle.periodizationModel
+            .replacingOccurrences(of: "_", with: " ")
+            .capitalized
+
+        return TrainProgramRoot.ViewState(
+            weekNumber: thisWeek.weekNumber,
+            totalWeeks: mesocycle.totalWeeks,
+            cycleName: cycleName.isEmpty ? nil : cycleName,
+            thisWeekRows: thisWeekRows,
+            horizonRows: horizonRows
+        )
+    }
+
+    /// The this-week spine: every weekday 1…7. A weekday with a `TrainingDay`
+    /// renders a placed/skeleton row (per the horizon); a weekday with NO
+    /// `TrainingDay` renders a `RestWellNode` (the gap → rest inversion).
+    static func spineRows(
+        for week: TrainingWeek,
+        todayWeekday: Int,
+        tier: CommitmentTier
+    ) -> [TrainProgramRoot.DayRow] {
+        let daysByWeekday = Dictionary(
+            week.trainingDays.map { ($0.dayOfWeek, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        var rows: [TrainProgramRoot.DayRow] = []
+        for weekday in 1...7 {
+            if let day = daysByWeekday[weekday] {
+                let title = day.dayLabel.replacingOccurrences(of: "_", with: " ")
+                let above = TrainProgramRoot.isAboveHorizon(day)
+                if above {
+                    rows.append(
+                        TrainProgramRoot.DayRow(
+                            id: day.id.uuidString,
+                            dayOfWeek: weekday,
+                            title: title,
+                            tier: tier,
+                            isToday: weekday == todayWeekday,
+                            kind: .placed(
+                                tick: TrainProgramRoot.tickValue(for: day.status, isAboveHorizon: true),
+                                exerciseBrief: exerciseBrief(day)
+                            )
+                        )
+                    )
+                } else {
+                    // A this-week day below the horizon — skeleton shape only.
+                    rows.append(
+                        TrainProgramRoot.DayRow(
+                            id: day.id.uuidString,
+                            dayOfWeek: weekday,
+                            title: title,
+                            tier: tier,
+                            isToday: weekday == todayWeekday,
+                            kind: .skeleton(focus: "numbers placed closer to the day")
+                        )
+                    )
+                }
+            } else {
+                // No TrainingDay this weekday → a first-class rest node (the gap inversion).
+                rows.append(
+                    TrainProgramRoot.DayRow(
+                        id: "rest-\(week.id.uuidString)-\(weekday)",
+                        dayOfWeek: weekday,
+                        title: "Rest",
+                        tier: tier,
+                        isToday: weekday == todayWeekday,
+                        kind: .rest(recoveryLine: restLine)
+                    )
+                )
+            }
+        }
+        return rows
+    }
+
+    /// A terse exercise brief for a placed day, e.g. "Bench · Overhead Press · Cable Fly".
+    /// Names only — no loads (the day-preview, §4, carries the full prescription).
+    private static func exerciseBrief(_ day: TrainingDay) -> String {
+        day.exercises.map(\.name).joined(separator: " · ")
+    }
+
+    /// The week's focus line for a skeleton row — humanized from the week label, or
+    /// the phase if there is no label. Pattern/focus only, never a number.
+    private static func weekFocusLine(_ week: TrainingWeek) -> String {
+        if let label = week.weekLabel, !label.isEmpty { return label }
+        return week.phase.rawValue.capitalized
+    }
+
+    /// `Calendar.weekday` is 1 = Sunday … 7 = Saturday; the model's `dayOfWeek` is
+    /// 1 = Monday … 7 = Sunday (ISO-8601). Convert so "today" lands on the right row.
+    private static func convertToISOWeekday(_ calendarWeekday: Int) -> Int {
+        // calendar: 1=Sun,2=Mon,…,7=Sat  →  ISO: 1=Mon,…,6=Sat,7=Sun
+        let iso = ((calendarWeekday + 5) % 7) + 1
+        return iso
+    }
+}
+
+// MARK: - TrainProgramRootHost (wired to deps, rendered by AppShell)
+
+/// The live host: the data boundary for the dormant Train surface.
+///
+/// THE #376 SEAM — reported in the PR. AppShell does NOT host `ProgramViewModel`
+/// yet (its lifecycle is lifted in #376, machinery-last). Rather than reach for a
+/// ProgramViewModel that does not exist on `deps`, this host reads the SAME
+/// UserDefaults fast-path `ProgramViewModel.loadProgram()` consults first
+/// (`Mesocycle.loadFromUserDefaults()` — a `@MainActor` sync source needing no
+/// service). When no program is cached, it renders the honest empty state.
+///
+/// What #376 must lift here when ProgramViewModel becomes available to the shell:
+///   - the live current-week index (`ProgramViewModel.currentWeekIndex(in:)`) instead
+///     of the cache's first incomplete week derived locally;
+///   - the generation-in-flight states (`.generating` / `.generatingSession`) so a
+///     day re-resolving on screen hard-swaps assembled (≤150ms crossfade);
+///   - observation of `currentMesocycle` so an in-place day mutation re-renders.
+struct TrainProgramRootHost: View {
+
+    @Environment(AppDependencies.self) private var deps
+    @Environment(\.apexTheme) private var theme
+    @State private var state: TrainProgramRoot.ViewState?
+
+    var body: some View {
+        Group {
+            if let state {
+                TrainProgramRoot(state: state)
+            } else {
+                // Loading-or-empty: render the bare root with an empty state, frame-1.
+                TrainProgramRoot(state: .init(
+                    weekNumber: 1, totalWeeks: 12,
+                    cycleName: nil, thisWeekRows: [], horizonRows: []
+                ))
+            }
+        }
+        .task {
+            // #376: replace this UserDefaults read with the hosted ProgramViewModel
+            // (live week index + generation-in-flight states + in-place observation).
+            guard let mesocycle = Mesocycle.loadFromUserDefaults() else { return }
+            let weekIdx = Self.firstIncompleteWeekIndex(in: mesocycle)
+            state = .from(mesocycle: mesocycle, currentWeekIndex: weekIdx)
+        }
+    }
+
+    /// The current-week index, derived locally from the cache (mirrors
+    /// `ProgramViewModel.currentWeekIndex(in:)`): the first week containing a
+    /// non-terminal day. #376 swaps this for the hosted ProgramViewModel's own.
+    static func firstIncompleteWeekIndex(in mesocycle: Mesocycle) -> Int {
+        for (wIdx, week) in mesocycle.weeks.enumerated() {
+            for day in week.trainingDays where day.status != .completed && day.status != .skipped {
+                return wIdx
+            }
+        }
+        return max(0, mesocycle.weeks.count - 1)
+    }
+}

--- a/ProjectApexTests/TrainProgramRootTests.swift
+++ b/ProjectApexTests/TrainProgramRootTests.swift
@@ -1,0 +1,389 @@
+// TrainProgramRootTests.swift
+// ProjectApexTests
+//
+// Tests for the Train program root (#357 / train.md §3 / ADR-0028).
+//
+// Two layers (mirroring ProgressRootLedgerTests):
+//  1. UNCONDITIONAL derivation layer — runs on every push, no env var needed.
+//     Verifies the tick mapping for every TrainingDayStatus × horizon position,
+//     rest-from-day-gaps, skeleton-from-gaps (the inversion — no model change),
+//     the discrete-tier bucketing, Week-X-of-N, and the no-streak/no-counter
+//     honesty guard.
+//  2. GATED snapshot layer — light + dim + one AX size (reference-pending until CI
+//     records on the pinned Xcode 26.3 toolchain; NEVER set APEX_RECORD_SNAPSHOTS).
+
+import Testing
+import SwiftUI
+import SnapshotTesting
+import Foundation
+@testable import ProjectApex
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+// MARK: - Gating (mirrors DrawnInstrumentSnapshotTests)
+
+private var snapshotTestsEnabled: Bool {
+    ProcessInfo.processInfo.environment["APEX_SNAPSHOT_TESTS"] == "1"
+}
+private var recordModeEnabled: Bool {
+    ProcessInfo.processInfo.environment["APEX_RECORD_SNAPSHOTS"] == "1"
+}
+
+// MARK: - Fixtures
+
+private func makeExercise(_ name: String) -> PlannedExercise {
+    PlannedExercise(
+        id: UUID(),
+        exerciseId: name.lowercased().replacingOccurrences(of: " ", with: "_"),
+        name: name,
+        primaryMuscle: "pectoralis_major",
+        synergists: [],
+        equipmentRequired: .barbell,
+        sets: 4,
+        repRange: RepRange(min: 6, max: 10),
+        tempo: "3-1-1-0",
+        restSeconds: 150,
+        rirTarget: 2,
+        coachingCues: []
+    )
+}
+
+private func makeDay(
+    weekday: Int,
+    label: String,
+    status: TrainingDayStatus,
+    exercises: [PlannedExercise] = []
+) -> TrainingDay {
+    TrainingDay(
+        id: UUID(),
+        dayOfWeek: weekday,
+        dayLabel: label,
+        exercises: exercises,
+        sessionNotes: nil,
+        status: status
+    )
+}
+
+private func makeWeek(
+    number: Int,
+    phase: MesocyclePhase = .accumulation,
+    label: String? = nil,
+    days: [TrainingDay]
+) -> TrainingWeek {
+    TrainingWeek(id: UUID(), weekNumber: number, phase: phase, trainingDays: days, weekLabel: label)
+}
+
+private func makeMesocycle(weeks: [TrainingWeek], totalWeeks: Int = 12) -> Mesocycle {
+    Mesocycle(
+        id: UUID(),
+        userId: UUID(),
+        createdAt: Date(),
+        isActive: true,
+        weeks: weeks,
+        totalWeeks: totalWeeks,
+        periodizationModel: "linear_periodization"
+    )
+}
+
+// MARK: ──────────────────────────────────────────────────────────────────────
+// 1. UNCONDITIONAL derivation layer
+// ──────────────────────────────────────────────────────────────────────────
+
+@Suite("TrainProgramRoot — tick mapping (TrainingDayStatus × horizon position)")
+struct TrainProgramRootTickMappingTests {
+
+    @Test("completed → filled (a logged fact)")
+    func completedIsFilled() {
+        #expect(TrainProgramRoot.tickValue(for: .completed, isAboveHorizon: true) == .filled)
+        // Completed is always a fact regardless of horizon position.
+        #expect(TrainProgramRoot.tickValue(for: .completed, isAboveHorizon: false) == .filled)
+    }
+
+    @Test("generated → hollow (committed, not done)")
+    func generatedIsHollow() {
+        #expect(TrainProgramRoot.tickValue(for: .generated, isAboveHorizon: true) == .hollow)
+    }
+
+    @Test("paused → hollow (committed, not done)")
+    func pausedIsHollow() {
+        #expect(TrainProgramRoot.tickValue(for: .paused, isAboveHorizon: true) == .hollow)
+    }
+
+    @Test("pending ABOVE the horizon → hollow (placed-and-waiting)")
+    func pendingAboveHorizonIsHollow() {
+        #expect(TrainProgramRoot.tickValue(for: .pending, isAboveHorizon: true) == .hollow)
+    }
+
+    @Test("pending BELOW the horizon → undrawn (skeleton; the hatch zone carries it)")
+    func pendingBelowHorizonIsUndrawn() {
+        #expect(TrainProgramRoot.tickValue(for: .pending, isAboveHorizon: false) == .undrawn)
+    }
+
+    @Test("skipped → hollow, NOT a shame mark (missed = a day the plan moved past)")
+    func skippedStaysHollowNoShameMark() {
+        // The load-bearing honesty rule: a skipped day must never render a distinct
+        // "missed"/shame mark. It stays in the hollow vocabulary like any other
+        // committed-not-done day.
+        #expect(TrainProgramRoot.tickValue(for: .skipped, isAboveHorizon: true) == .hollow)
+        #expect(TrainProgramRoot.tickValue(for: .skipped, isAboveHorizon: false) == .hollow)
+    }
+
+    @Test("StatusTickValue has no fourth 'missed' case — the vocabulary is filled/hollow/undrawn only")
+    func vocabularyIsThreeValuesOnly() {
+        // Map every status × both horizon positions; the result set is a subset of
+        // {filled, hollow, undrawn} — there is no shame/missed value to reach for.
+        let statuses: [TrainingDayStatus] = [.pending, .generated, .completed, .paused, .skipped]
+        let produced = Set(statuses.flatMap { s in
+            [TrainProgramRoot.tickValue(for: s, isAboveHorizon: true),
+             TrainProgramRoot.tickValue(for: s, isAboveHorizon: false)]
+        })
+        #expect(produced.isSubset(of: [.filled, .hollow, .undrawn]))
+    }
+}
+
+@Suite("TrainProgramRoot — the inversion (rest/skeleton from gaps, no model change)")
+struct TrainProgramRootInversionTests {
+
+    @Test("isAboveHorizon: a day with placed exercises is above the horizon (ink)")
+    func dayWithExercisesIsAboveHorizon() {
+        let day = makeDay(weekday: 1, label: "Push_A", status: .generated, exercises: [makeExercise("Bench")])
+        #expect(TrainProgramRoot.isAboveHorizon(day) == true)
+    }
+
+    @Test("isAboveHorizon: a pending day with no exercises is BELOW the horizon (skeleton)")
+    func pendingEmptyDayIsBelowHorizon() {
+        let day = makeDay(weekday: 1, label: "Push_A", status: .pending, exercises: [])
+        #expect(TrainProgramRoot.isAboveHorizon(day) == false)
+    }
+
+    @Test("isAboveHorizon: a completed day with no persisted exercises is still above the horizon")
+    func completedEmptyDayIsAboveHorizon() {
+        // A resolved day (completed/generated/paused/skipped) is above the horizon
+        // even if its exercise array wasn't persisted locally.
+        let day = makeDay(weekday: 1, label: "Push_A", status: .completed, exercises: [])
+        #expect(TrainProgramRoot.isAboveHorizon(day) == true)
+    }
+
+    @Test("Rest-from-gaps: a weekday with no TrainingDay becomes a RestWellNode row")
+    func restDerivedFromWeekdayGap() {
+        // Week trains Mon(1) and Wed(3) only → the other 5 weekdays are rest nodes.
+        let week = makeWeek(number: 1, days: [
+            makeDay(weekday: 1, label: "Push_A", status: .generated, exercises: [makeExercise("Bench")]),
+            makeDay(weekday: 3, label: "Pull_A", status: .generated, exercises: [makeExercise("Row")]),
+        ])
+        let rows = TrainProgramRoot.ViewState.spineRows(for: week, todayWeekday: 1, tier: .thisWeek)
+        // 7 weekday rows total.
+        #expect(rows.count == 7)
+        let restCount = rows.filter { if case .rest = $0.kind { return true } else { return false } }.count
+        #expect(restCount == 5, "Five untrained weekdays must each become a rest node")
+        // Mon and Wed are placed.
+        let placedWeekdays = rows.compactMap { row -> Int? in
+            if case .placed = row.kind { return row.dayOfWeek } else { return nil }
+        }
+        #expect(placedWeekdays == [1, 3])
+    }
+
+    @Test("Skeleton-from-gaps: a this-week day with no generated exercises renders pencil shape-only")
+    func skeletonDerivedFromMissingExercises() {
+        // A pending day with no exercises in this week is below the horizon → skeleton.
+        let week = makeWeek(number: 1, days: [
+            makeDay(weekday: 1, label: "Push_A", status: .generated, exercises: [makeExercise("Bench")]),
+            makeDay(weekday: 3, label: "Lower_B", status: .pending, exercises: []),
+        ])
+        let rows = TrainProgramRoot.ViewState.spineRows(for: week, todayWeekday: 99, tier: .thisWeek)
+        let wed = rows.first { $0.dayOfWeek == 3 }
+        #expect(wed != nil)
+        if case .skeleton = wed?.kind {
+            // expected — pencil shape only
+        } else {
+            Issue.record("A pending, exercise-less this-week day must render as a skeleton row")
+        }
+    }
+
+    @Test("No model change: TrainingDayStatus has exactly the five persisted cases")
+    func noEnumCasesAdded() {
+        // The #357 inversion must NOT add cases to the persisted Codable enum. This
+        // guard fails loudly if a future change widens the enum (rest/skeleton must
+        // stay derived, not stored).
+        let cases: [TrainingDayStatus] = [.pending, .generated, .completed, .paused, .skipped]
+        #expect(Set(cases).count == 5)
+        // Round-trip each through its rawValue to prove the persisted shape is unchanged.
+        for c in cases {
+            #expect(TrainingDayStatus(rawValue: c.rawValue) == c)
+        }
+    }
+}
+
+@Suite("TrainProgramRoot — discrete commitment-tier bucketing")
+struct TrainProgramRootTierTests {
+
+    @Test("Days ≤ 7 out bucket into .thisWeek")
+    func thisWeekTier() {
+        #expect(CommitmentTier.forDistance(days: 0) == .thisWeek)
+        #expect(CommitmentTier.forDistance(days: 7) == .thisWeek)
+    }
+
+    @Test("Days 8…14 out bucket into .compressed")
+    func compressedTier() {
+        #expect(CommitmentTier.forDistance(days: 8) == .compressed)
+        #expect(CommitmentTier.forDistance(days: 14) == .compressed)
+    }
+
+    @Test("Days > 14 out bucket into .glyphPerDay")
+    func glyphPerDayTier() {
+        #expect(CommitmentTier.forDistance(days: 15) == .glyphPerDay)
+        #expect(CommitmentTier.forDistance(days: 70) == .glyphPerDay)
+    }
+
+    @Test("The gradient is DISCRETE — exactly three tiers, no continuous fade")
+    func tierIsDiscrete() {
+        // ADR-0028 no-slope carve-out: the commitment gradient must be discrete tiers,
+        // never a continuous opacity fade. There are exactly three.
+        #expect(CommitmentTier.allCases.count == 3)
+    }
+
+    @Test("Horizon weeks bucket onto the gradient by distance-from-now")
+    func horizonWeeksUseTier() {
+        // Build a 4-week cycle; current week 0 → week 1 is ~7 days (thisWeek),
+        // week 2 is ~14 (compressed), week 3 is ~21 (glyphPerDay).
+        let weeks = (1...4).map { n in
+            makeWeek(number: n, label: "Week \(n)", days: [
+                makeDay(weekday: 1, label: "Push", status: .pending, exercises: []),
+            ])
+        }
+        let meso = makeMesocycle(weeks: weeks)
+        let state = TrainProgramRoot.ViewState.from(mesocycle: meso, currentWeekIndex: 0, todayWeekday: 1)
+        // Horizon rows come from weeks 2,3,4 (offsets 1,2,3).
+        let tiers = Set(state.horizonRows.map(\.tier))
+        #expect(tiers.contains(.thisWeek) || tiers.contains(.compressed) || tiers.contains(.glyphPerDay))
+        // The farthest week (offset 3 → 21 days) must be glyphPerDay.
+        #expect(state.horizonRows.last?.tier == .glyphPerDay)
+    }
+}
+
+@Suite("TrainProgramRoot — position lockup and honesty guards")
+struct TrainProgramRootStateTests {
+
+    @Test("Week-X-of-N: the position lockup reads the current week and total weeks")
+    func weekXofN() {
+        let weeks = [
+            makeWeek(number: 1, days: [makeDay(weekday: 1, label: "A", status: .completed)]),
+            makeWeek(number: 2, days: [makeDay(weekday: 1, label: "B", status: .pending, exercises: [makeExercise("X")])]),
+        ]
+        let meso = makeMesocycle(weeks: weeks, totalWeeks: 6)
+        // Current week index 1 → "Week 2 of 6".
+        let state = TrainProgramRoot.ViewState.from(mesocycle: meso, currentWeekIndex: 1, todayWeekday: 99)
+        #expect(state.weekNumber == 2)
+        #expect(state.totalWeeks == 6)
+    }
+
+    @Test("Empty mesocycle → empty state, no fabricated rows")
+    func emptyMesocycleIsEmpty() {
+        let meso = makeMesocycle(weeks: [])
+        let state = TrainProgramRoot.ViewState.from(mesocycle: meso, currentWeekIndex: 0)
+        #expect(state.isEmpty)
+        #expect(state.thisWeekRows.isEmpty)
+        #expect(state.horizonRows.isEmpty)
+    }
+
+    @Test("Honesty guard: no streak/counter/adherence field exists on the view state")
+    func noStreakOrCounterField() {
+        // train.md §3 / §11.4: the calendar is a plan, not a report card. The view
+        // state must carry no streak, completion-count, or adherence totalizer.
+        // Structural guard via Mirror — if someone adds one, this fails intentionally.
+        let weeks = [makeWeek(number: 1, days: [makeDay(weekday: 1, label: "A", status: .completed)])]
+        let state = TrainProgramRoot.ViewState.from(mesocycle: makeMesocycle(weeks: weeks), currentWeekIndex: 0)
+        let names = Mirror(reflecting: state).children.compactMap { $0.label?.lowercased() }
+        for banned in ["streak", "adherence", "completedcount", "completioncount", "sessionscomplete", "ringprogress"] {
+            #expect(!names.contains(banned), "View state must not carry a '\(banned)' field — the calendar is a plan, not a report card")
+        }
+    }
+
+    @Test("currentWeekIndex clamps out-of-range input to a valid week")
+    func weekIndexClamps() {
+        let weeks = [makeWeek(number: 1, days: [makeDay(weekday: 1, label: "A", status: .pending, exercises: [makeExercise("X")])])]
+        let meso = makeMesocycle(weeks: weeks)
+        // Index 99 is out of range → clamps to the last (only) week.
+        let state = TrainProgramRoot.ViewState.from(mesocycle: meso, currentWeekIndex: 99, todayWeekday: 99)
+        #expect(state.weekNumber == 1)
+    }
+
+    @Test("Host's firstIncompleteWeekIndex finds the first non-terminal week")
+    func hostFindsFirstIncompleteWeek() {
+        let weeks = [
+            makeWeek(number: 1, days: [makeDay(weekday: 1, label: "A", status: .completed)]),
+            makeWeek(number: 2, days: [makeDay(weekday: 1, label: "B", status: .completed),
+                                       makeDay(weekday: 3, label: "C", status: .pending)]),
+        ]
+        let meso = makeMesocycle(weeks: weeks)
+        #expect(TrainProgramRootHost.firstIncompleteWeekIndex(in: meso) == 1)
+    }
+}
+
+// MARK: ──────────────────────────────────────────────────────────────────────
+// 2. GATED snapshot layer (reference-pending until CI records)
+// ──────────────────────────────────────────────────────────────────────────
+
+@Suite("TrainProgramRoot snapshots", .enabled(if: snapshotTestsEnabled))
+@MainActor
+struct TrainProgramRootSnapshotTests {
+
+    private static let canvasSize = CGSize(width: 393, height: 720)
+
+    /// A stable fixture: a this-week spine with generated-ink days + rest gaps,
+    /// plus a horizon of skeleton-pencil weeks below the datum — exercising the
+    /// generated-ink-above / skeleton-hatch-below / horizon-datum / rest-well-node
+    /// composition in one frame.
+    private static var fixtureState: TrainProgramRoot.ViewState {
+        let week1 = makeWeek(number: 2, phase: .accumulation, label: "Strength Block", days: [
+            makeDay(weekday: 1, label: "Push_A", status: .completed,
+                    exercises: [makeExercise("Bench Press"), makeExercise("Overhead Press")]),
+            makeDay(weekday: 3, label: "Pull_A", status: .generated,
+                    exercises: [makeExercise("Barbell Row"), makeExercise("Lat Pulldown")]),
+            makeDay(weekday: 5, label: "Lower_A", status: .pending, exercises: []),  // this-week skeleton
+        ])
+        let week2 = makeWeek(number: 3, label: "Intensification", days: [
+            makeDay(weekday: 1, label: "Push_B", status: .pending, exercises: []),
+            makeDay(weekday: 3, label: "Pull_B", status: .pending, exercises: []),
+        ])
+        let week3 = makeWeek(number: 4, label: "Peak", days: [
+            makeDay(weekday: 1, label: "Push_C", status: .pending, exercises: []),
+        ])
+        let meso = makeMesocycle(weeks: [week1, week2, week3])
+        return TrainProgramRoot.ViewState.from(mesocycle: meso, currentWeekIndex: 0, todayWeekday: 3)
+    }
+
+    #if canImport(UIKit)
+    @Test("Train program root — light, default Dynamic Type")
+    func trainRoot_light_default() {
+        let vc = SnapshotHarness.host(
+            TrainProgramRoot(state: Self.fixtureState),
+            size: Self.canvasSize, appearance: .light
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "train-program-root-light-default", record: recordModeEnabled)
+    }
+
+    @Test("Train program root — dim, default Dynamic Type")
+    func trainRoot_dim_default() {
+        let vc = SnapshotHarness.host(
+            TrainProgramRoot(state: Self.fixtureState),
+            size: Self.canvasSize, appearance: .dim
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "train-program-root-dim-default", record: recordModeEnabled)
+    }
+
+    @Test("Train program root — light, AX5 (largest accessibility size)")
+    func trainRoot_light_ax5() {
+        let vc = SnapshotHarness.host(
+            TrainProgramRoot(state: Self.fixtureState),
+            size: Self.canvasSize, appearance: .light, dynamicType: .accessibility5
+        )
+        assertSnapshot(of: vc, as: SnapshotHarness.imaging,
+                       named: "train-program-root-light-ax5", record: recordModeEnabled)
+    }
+    #endif
+}


### PR DESCRIPTION
## What shipped

The Phase 3 **Train program root** — a NEW screen drawn as a measured **vertical day-spine** (`docs/design/train.md` §3, [ADR-0028](../blob/main/docs/adr/0028-drafting-rule-and-status-tick-instruments.md)). The left edge is the time datum; days hang off it down the page.

- **Generation-horizon datum.** Generated days render **ink with numbers** (real exercise briefs) above a drawn `GenerationHorizonBreak`; skeleton days render **pencil shape-only** (focus, no number) below it, inside the `ToBePlacedHatch` sparse-diagonal skeleton zone.
- **Discrete commitment gradient** via `CommitmentTier` (this-week full detail → compressed → one glyph per day) — NOT a continuous fade (the ADR-0028 no-slope carve-out).
- **Position lockup** "Week X of N" via `DraftingRegister` (work numbers ink, "of N" pencil).
- **This-week days = spine rows**, each with a `StatusTick`; **rest days = first-class recessed `RestWellNode`** nodes.
- **No streaks / rings / counters / adherence** — the calendar is a plan, not a report card (guarded by test).

## The tick mapping + the inversion live in the view (no model change)

`StatusTick` is a dumb primitive, so `(TrainingDayStatus + horizon position) → StatusTickValue` is mapped here: `completed`→filled; `generated`/`paused`/above-horizon-`pending`→hollow; skeleton/below-horizon-`pending`→undrawn; **`skipped`→stayed-hollow (NO shame mark — "missed = a day the plan moved past")**.

The **#357 inversion** is derived from EXISTING state: a **rest day** = a weekday with no `TrainingDay` → `RestWellNode`; a **skeleton day** = a day with no generated `PlannedExercise`s (below the horizon). **No enum case added to the persisted Codable `TrainingDayStatus`, no model changed.**

## DORMANT

A new view routed **only** via `AppShell.surface(.train)` (the dormant 3-tab shell, `useNewShell = false`), exactly how #354 wired `.progress → ProgressRootLedgerHost`. **`ProgramOverviewView`, `ContentView`, and `useNewShell` are untouched** — the live program screen keeps running until the #376 flip. The only `AppShell` change is the `.train` branch (+ its routing doc comment).

## The ProgramViewModel seam (+ #376 TODO)

AppShell does **not** host `ProgramViewModel` yet (its lifecycle is lifted in #376, machinery-last). So:

- `TrainProgramRoot` takes its data as an **injectable `ViewState`** (a Mesocycle + current-week index reduced to spine rows) so snapshot/unit tests drive it with fixtures.
- `TrainProgramRootHost` reads the **same `Mesocycle.loadFromUserDefaults()` fast-path** `ProgramViewModel.loadProgram()` consults first (a `@MainActor` sync source needing no service), with an honest empty state when no program is cached.
- A clear `// #376:` TODO marks what the real ProgramViewModel lifecycle must lift: the live current-week index, the generation-in-flight states (so a day re-resolving on screen hard-swaps assembled), and in-place `currentMesocycle` observation.

## Motion

Every row renders **assembled at frame 1**; no idle animation; no tween/cascade/flourish (`train.md` §2). The under-the-eye regeneration *trigger* is the host's #376 lifecycle, but the no-animation render contract holds now.

## Tests

`ProjectApexTests/TrainProgramRootTests.swift`:
- **Unconditional derivation suites (green bar, 23 tests):** the tick mapping for every `TrainingDayStatus` × horizon position; rest-from-gaps; skeleton-from-gaps; the discrete-tier bucketing; Week-X-of-N; the no-streak/no-counter honesty guard; a guard that the persisted enum keeps exactly its five cases.
- **Gated image-snapshot suite** (the spine: generated-ink above + skeleton-hatch below + horizon datum + a rest well node, × light + dim + one AX), mirroring `DrawnInstrumentSnapshotTests` / `ProgressRootLedgerTests`. **Wired but reference-pending** — recorded by the CI Xcode-26.3 job, **never locally; `APEX_RECORD_SNAPSHOTS` never set, no PNGs recorded.**

Run (no snapshot env var):
```
xcodebuild test -project ProjectApex.xcodeproj -scheme ProjectApex \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -only-testing:ProjectApexTests/TrainProgramRootTickMappingTests \
  -only-testing:ProjectApexTests/TrainProgramRootInversionTests \
  -only-testing:ProjectApexTests/TrainProgramRootTierTests \
  -only-testing:ProjectApexTests/TrainProgramRootStateTests
```
→ **23 tests, all green.** Whole app + tests compile; no new warnings.

## pbxproj

New app `.swift` (`TrainProgramRoot.swift`) = **0** pbxproj entries (auto-discovered, like `ProgressRootLedger.swift`). New test file = **4** entries (mirroring `AppShellRouteTests.swift` / `DraftingRuleTests.swift`), unique `TR357` UUID family.

## References

`docs/design/train.md` §3 · [ADR-0028](../blob/main/docs/adr/0028-drafting-rule-and-status-tick-instruments.md) (the committed-vs-provisional two-axis model).

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)