### PR TITLE
feat(#376) commit 1/2: lift machinery into AppShell (flag stays false, reversible)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -8,6 +8,21 @@ Started 2026-06-07.
 ---
 
 
+## 2026-06-14 — Moving the "brains" of the app into the new shell, without flipping the switch (Phase 3 UI, #376 — commit 1 of 2)
+
+**The big one, done carefully.** For weeks the new 3-tab look has been built but switched off, while the real app kept running on the old screen (`ContentView`). That old screen quietly owns the most fragile, most important plumbing in the whole app: the first-launch setup, the "you have an unfinished workout — resume or abandon?" recovery after a crash, and the exact rules for picking the right session back up. This task copied all of that plumbing into the new shell — faithfully, line for line where it mattered — so the new shell can stand on its own. **But I did not flip the switch.** The old screen is still the live one, completely untouched. Nothing a user sees changed.
+
+**Why split it this way.** Turning the new shell on is the genuinely scary step — if the resume logic dropped a thread, someone could lose a workout they were halfway through. So this is deliberately commit 1 of 2: this commit *moves* the plumbing (safe, dormant, reversible by one undo), and a later separate commit flips the switch — and that flip only happens after a hands-on "force-quit mid-set on a real phone" test. This PR is explicitly **not** to be auto-merged; a human reviews it.
+
+**The six pieces moved.** The program "view model" and its whole life-cycle (born on launch, reborn after onboarding, wiped on reset); the onboarding cover; the crash-recovery alert chain — including a subtle fix from earlier (#318) where two alerts firing at once would silently eat one of them, copied across *exactly* so it can't regress; the paused-session resume with its three branches; the workout loop and the settings screen (which are joined at the hip to the view model); and the "this build needs setup" gate, which I lifted up one level so it now guards **both** the old and new screens from a single place.
+
+**Loop look at go-live.** When the switch eventually flips, the workout itself will still use the *current* in-session screens, so the day it goes live it behaves identically to today. The brand-new live-loop visuals turn on later, as their own separate, undoable step.
+
+**How I made the scary parts testable.** The two riskiest pieces — which resume branch to take, and the two-alerts-collide rule — I pulled into small plain functions the new shell calls, so I could write tests that prove all three resume branches and the alert-collision rule behave correctly against the new shell (the codebase tests logic, not live screens). The alert *ordering* itself was copied across untouched.
+
+**Status:** PR open from `feat/376-machinery-lift`, switch still **off**, old screen still live and untouched. 15 new tests green; the full suite (506 tests) was green before the run. Flagged in the PR: the small "pull the decision into a testable function" deviation, since the brief asked for a verbatim move.
+
+
 ## 2026-06-14 — Coming back after a long break no longer fools the strength estimate (#418)
 
 **The problem in plain words.** The app tracks how strong you are with a moving average that only looks at your last few *workouts*, not the calendar. That works great while you're training regularly. But if you vanish for six weeks and come back, the math treats your first workout back as if it happened the very next day — so it quietly assumes you're as strong as you were before the break. You're not. Real strength fades during a long layoff, and the old code couldn't see that.
@@ -19,7 +34,6 @@ Started 2026-06-07.
 **How it was checked.** Built test-first across the slices; the full Edge-Function suite is green (452 tests, 0 failing) and the type-checker is clean. An independent review caught one real bug along the way — a naive version actually moved the estimate the *wrong* way — which is why trimming the old workouts is mandatory, not optional. The iOS side compiles against the real type definitions but isn't visually QA'd yet (no simulator here); that and snapshot images are owed. Decisions recorded in ADR-0005/0015/0020/0023.
 
 **Status:** MERGED to main (PR #418, squash `b780549`). Does **not** close the #369 audit umbrella. One follow-up noted for later: a fatigue-pairing calculation also reads the strength estimate and may want the same break-aware gating — reported, not yet acted on.
-
 
 ## 2026-06-14 — The Today screen: your next workout, one tap to start, one honest coach line (Phase 3 UI, #348)
 

--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		DR41100000000000DR411002 /* DraftingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DR41100000000000DR411001 /* DraftingRuleTests.swift */; };
 		TR35700000000000TR357002 /* TrainProgramRootTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TR35700000000000TR357001 /* TrainProgramRootTests.swift */; };
 		TD34800000000000TD348002 /* TodayViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TD34800000000000TD348001 /* TodayViewTests.swift */; };
+		ML37600000000000ML376002 /* AppShellMachineryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ML37600000000000ML376001 /* AppShellMachineryTests.swift */; };
 		DE54000000000000DE540002 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = DE54000000000000DE540001 /* SnapshotTesting */; };
 		A8C2F77F360EDB0F6608A791 /* TraineeModelLocalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E790918146069F34BF3E4685 /* TraineeModelLocalStoreTests.swift */; };
 		B9BA0DEA986911A47825DA7E /* TraineeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */; };
@@ -146,6 +147,7 @@
 		DR41100000000000DR411001 /* DraftingRuleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DraftingRuleTests.swift; sourceTree = "<group>"; };
 		TR35700000000000TR357001 /* TrainProgramRootTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrainProgramRootTests.swift; sourceTree = "<group>"; };
 		TD34800000000000TD348001 /* TodayViewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodayViewTests.swift; sourceTree = "<group>"; };
+		ML37600000000000ML376001 /* AppShellMachineryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppShellMachineryTests.swift; sourceTree = "<group>"; };
 		B2C3D4E5F6A7B8C9D0E1F2A1 /* TopSetSnapshotFactoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TopSetSnapshotFactoryTests.swift; sourceTree = "<group>"; };
 		DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SetPrescriptionIntentValidationTests.swift; sourceTree = "<group>"; };
 		DFFF76E0AE157D67D5D2660F /* TraineeModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelTests.swift; sourceTree = "<group>"; };
@@ -300,6 +302,7 @@
 				DR41100000000000DR411001 /* DraftingRuleTests.swift */,
 				TR35700000000000TR357001 /* TrainProgramRootTests.swift */,
 				TD34800000000000TD348001 /* TodayViewTests.swift */,
+				ML37600000000000ML376001 /* AppShellMachineryTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -475,6 +478,7 @@
 				DR41100000000000DR411002 /* DraftingRuleTests.swift in Sources */,
 				TR35700000000000TR357002 /* TrainProgramRootTests.swift in Sources */,
 				TD34800000000000TD348002 /* TodayViewTests.swift in Sources */,
+				ML37600000000000ML376002 /* AppShellMachineryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/AppShell.swift
+++ b/ProjectApex/AppShell.swift
@@ -5,14 +5,19 @@
 // Progress — with settings in a corner, not a tab (ui-overhaul-spec.md §2).
 //
 // A strangler-fig sibling root to the frozen `ContentView` (ADR-0026), selected by
-// one compile-time constant in `ProjectApexApp`. This slice (#343) lands the shell
-// behind `useNewShell = false`: built, wired, and unit-tested, but NOT yet the live
-// root — so `ContentView` keeps owning the onboarding gate, crash-recovery, the
-// paused-session resume, and the `ProgramViewModel` lifecycle (ADR-0026
-// "machinery-last"). Each surface is a code-as-switch `@ViewBuilder`; a per-surface
-// slice swaps in its real screen later. The legacy raw-Int `switchToTab` contract
-// is preserved by a pure translation layer (`ShellRoute`) so the existing
-// feature-view call sites stay byte-identical.
+// one compile-time constant in `ProjectApexApp`. As of #376 (commit 1/2, the
+// "machinery-lift") this shell carries faithful COPIES of the machinery that the
+// frozen `ContentView` still owns and runs: the `ProgramViewModel` lifecycle, the
+// onboarding gate, the crash-recovery alert chain (the #318 ordering, moved
+// verbatim), the paused-session resume (the three Resume branches), and the
+// settings root coupled to the view model. `useNewShell` STAYS `false` in this
+// commit — `ContentView` is still the live root and is untouched — so this
+// machinery is exercised only by the unit tests until the flip (commit 2/2).
+//
+// Each surface is a code-as-switch `@ViewBuilder`; a per-surface slice swaps in its
+// real screen later. The legacy raw-Int `switchToTab` contract is preserved by a
+// pure translation layer (`ShellRoute`) so the existing feature-view call sites stay
+// byte-identical.
 //
 // All chrome reads #341 design tokens (ADR-0024) — no hardcoded colors here.
 
@@ -77,6 +82,59 @@ enum ShellRoute: Equatable {
     }
 }
 
+// MARK: - Crash-recovery resume decision (pure, testable)
+
+/// The outcome of the crash-recovery "Resume" choice — the exact branch logic that
+/// the frozen `ContentView` runs inline inside its `.alert` Resume button (the three
+/// Resume branches + the orphaned fallback). Lifted out as a PURE enum so the
+/// decision is unit-testable against `AppShell` without driving a live SwiftUI alert
+/// (the codebase tests reducers, not view closures). The branch CONDITIONS are
+/// identical to ContentView's; only the place they live changed.
+///
+/// Not `Equatable` — its associated `PausedSessionState` / `TrainingDay` are not
+/// Equatable, and tests pattern-match the case + assert on the carried ids instead.
+enum ResumeOutcome {
+    /// Programme not loaded yet — fall through to the live loop's own Path B resume
+    /// (WorkoutView's `trainingDayId == trainingDay.id` guard). No explicit state passed.
+    case fallbackToLoop
+    /// Path A: the paused day IS `nextIncompleteDay` — pass `saved` as the explicit
+    /// resumeState so Path A fires reliably.
+    case pathA(resumeState: PausedSessionState)
+    /// Path B (elsewhere): the paused day was found in the mesocycle but is NOT
+    /// `nextIncompleteDay` — pass both the resume state and the correct training day so
+    /// WorkoutView renders the right exercise list.
+    case pathBElsewhere(resumeState: PausedSessionState, day: TrainingDay)
+    /// The paused day cannot be found anywhere in the mesocycle — show the orphaned
+    /// recovery dialog instead of entering the loop.
+    case orphaned
+
+    /// Decide the resume outcome from the saved sentinel + the loaded mesocycle.
+    /// Mirrors ContentView's inline Resume-button branch conditions exactly.
+    static func decide(
+        saved: PausedSessionState?,
+        viewState: ProgramViewState,
+        nextIncompleteDay: () -> (day: TrainingDay, week: TrainingWeek)?,
+        findTrainingDay: (UUID) -> (day: TrainingDay, week: TrainingWeek)?
+    ) -> ResumeOutcome {
+        guard let saved, case .loaded = viewState else {
+            // Programme not loaded yet — fall back to Path B in WorkoutView.
+            return .fallbackToLoop
+        }
+        let nextDay = nextIncompleteDay()?.day
+        if nextDay?.id == saved.trainingDayId {
+            // Normal case: pass as explicit resumeState so Path A fires reliably.
+            return .pathA(resumeState: saved)
+        } else if let foundResult = findTrainingDay(saved.trainingDayId) {
+            // Paused day found elsewhere — pass both the correct training day and the
+            // resume state so WorkoutView uses the right exercise list.
+            return .pathBElsewhere(resumeState: saved, day: foundResult.day)
+        } else {
+            // Paused day not found anywhere — can't properly resume.
+            return .orphaned
+        }
+    }
+}
+
 // MARK: - Shell
 
 struct AppShell: View {
@@ -86,6 +144,64 @@ struct AppShell: View {
 
     @State private var selection: ApexTab = .today
     @State private var showSettings = false
+
+    // ── Live-loop presentation (the loop "rises through" Start, off-tab). ──
+    /// True when the workout loop is presented over the current surface — the
+    /// faithful translation of the frozen ContentView's `selectedTab = 1` loop entry.
+    @State private var showLiveLoop = false
+
+    // ── Lifted machinery (faithful copies of ContentView's; #376 commit 1/2). ──
+
+    /// Stores the confirmed GymProfile. Seeded from UserDefaults cache on launch
+    /// so the profile is available immediately without waiting for a network fetch.
+    @State private var confirmedProfile: GymProfile? = GymProfile.loadFromUserDefaults()
+
+    /// When true, a ScannerView sheet is presented over the Settings sheet.
+    @State private var isRescanning = false
+
+    /// Shared view model for the program — owned here so settings can trigger a
+    /// regeneration that updates the program surfaces.
+    @State private var programViewModel: ProgramViewModel?
+
+    /// Non-nil when a regeneration error should be shown in SettingsView.
+    @State private var regenerateErrorMessage: String?
+
+    /// Tracks the in-flight gym profile Supabase sync task. Cancelled and replaced
+    /// on every equipment edit so rapid edits don't leave two active profile rows.
+    @State private var gymProfileSyncTask: Task<Void, Never>?
+
+    /// True until onboarding has been completed at least once.
+    /// Evaluated once at launch from UserDefaults; does not re-read during runtime.
+    @State private var showOnboarding: Bool = !UserDefaults.standard.bool(forKey: OnboardingConstants.onboardingCompletedKey)
+
+    /// One-time migration notice: training-time progression replaces calendar-time.
+    @State private var showTrainingTimeMigrationNotice: Bool = false
+
+    /// Confirms "Start Your Next Programme" before triggering regeneration.
+    @State private var showNextProgrammeConfirmation: Bool = false
+
+    // MARK: - Crash recovery
+
+    /// Non-nil when a crash-sentinel is found in UserDefaults on launch, indicating an
+    /// in-progress session that was never ended. Cleared once the user responds.
+    @State private var crashRecoveryState: PausedSessionState? = nil
+    /// Controls the crash-recovery alert shown once at app launch when a sentinel exists.
+    @State private var showCrashRecoveryAlert: Bool = false
+    /// When non-nil, WorkoutView should use this as an explicit resumeState (Path A),
+    /// bypassing the brittle trainingDayId == trainingDay.id guard in Path B.
+    @State private var crashResumeToPass: PausedSessionState? = nil
+    /// When the paused session's trainingDayId resolves to a mesocycle day that is NOT
+    /// nextIncompleteDay, this holds the correct matching day so WorkoutView uses the
+    /// right exercise list for the resume rather than nextIncompleteDay's list.
+    @State private var crashResumeDay: TrainingDay? = nil
+    /// True when crash recovery's paused day cannot be found anywhere in the mesocycle.
+    @State private var showOrphanedRecoveryAlert: Bool = false
+
+    // MARK: - Paused-session banner navigation
+
+    /// True when the user taps "Resume" on PausedSessionBannerView — pushes
+    /// ProgramDayDetailView for the paused day within the loop's NavigationStack.
+    @State private var navigateToPausedDayDetail: Bool = false
 
     var body: some View {
         // Active surface — code-as-switch routing (ADR-0026 (a)).
@@ -98,16 +214,181 @@ struct AppShell: View {
             // Settings leaves the tab bar for a corner gear (ADR-0026 (b)).
             .overlay(alignment: .topTrailing) { settingsButton }
             .sheet(isPresented: $showSettings) { settingsSheet }
+            // The live loop "rises through" Start — an off-tab covered surface
+            // presenting the OLD in-session chrome (WorkoutView → ActiveSetView /
+            // RestTimerView). The new LiveLoopView core (#350) activates at #351.
+            .fullScreenCover(isPresented: $showLiveLoop) {
+                liveLoopCover
+            }
+            .preferredColorScheme(.dark)
             // Preserve the frozen raw-Int `switchToTab` contract via the pure bridge,
             // so the existing feature-view call sites need no edit (ADR-0026 (c)).
             .environment(\.switchToTab) { legacyTab in
                 switch ShellRoute.from(legacyTab: legacyTab) {
                 case .select(let tab): selection = tab
-                // Interim: the live-loop host is lifted in a later, tested slice
-                // (machinery-last); route to Today, which owns Start, until then.
-                case .presentLiveLoop: selection = .today
+                // The live-loop entry: present the OLD in-session chrome over the
+                // current surface (machinery lifted in #376; flips live at commit 2/2).
+                case .presentLiveLoop: showLiveLoop = true
                 case .presentSettings: showSettings = true
                 }
+            }
+            // ── Onboarding gate (lifted from ContentView). ──
+            .fullScreenCover(isPresented: $showOnboarding) {
+                OnboardingView { completedProfile in
+                    // Persist the scanned profile so settings / program surfaces see it.
+                    if let p = completedProfile {
+                        confirmedProfile = p
+                    }
+                    // Surface the program after onboarding (Train owns the program in the shell).
+                    selection = .train
+                    showOnboarding = false
+                    // Recreate ProgramViewModel with the userId now written to Keychain
+                    // during onboarding, then load the freshly generated program.
+                    programViewModel = ProgramViewModel(
+                        supabaseClient: deps.supabaseClient,
+                        programGenerationService: deps.programGenerationService,
+                        macroPlanService: deps.macroPlanService,
+                        sessionPlanService: deps.sessionPlanService,
+                        userId: deps.resolvedUserId,
+                        traineeModelService: deps.traineeModelService
+                    )
+                    Task {
+                        await programViewModel?.loadProgram()
+                    }
+                }
+                .environment(deps)
+            }
+            .task {
+                // Lazily create the ProgramViewModel once deps are available.
+                if programViewModel == nil {
+                    programViewModel = ProgramViewModel(
+                        supabaseClient: deps.supabaseClient,
+                        programGenerationService: deps.programGenerationService,
+                        macroPlanService: deps.macroPlanService,
+                        sessionPlanService: deps.sessionPlanService,
+                        userId: deps.resolvedUserId,
+                        traineeModelService: deps.traineeModelService
+                    )
+                }
+
+                // Crash recovery check — detect sessions that were interrupted by a kill.
+                // PausedSessionState is written at session start and updated every set, so
+                // if it's present here the session was never properly ended or explicitly paused.
+                // Skip during onboarding (no session has ever run).
+                // Evaluated FIRST (J-F7 / #318): two alerts arming in the same .task pass
+                // collide — SwiftUI silently drops one — so the migration notice below only
+                // arms when no crash-recovery alert won this launch.
+                var crashAlertArmed = false
+                if !showOnboarding {
+                    if let saved = PausedSessionState.load() {
+                        crashRecoveryState = saved
+                        showCrashRecoveryAlert = true
+                        crashAlertArmed = true
+                    } else if PausedSessionState.repairPending {
+                        // UserDefaults data was present but corrupt (key migration failure or
+                        // incompatible struct change). Query Supabase for a paused row so the
+                        // mismatch-recovery path can offer the user an Abandon option.
+                        await PausedSessionState.attemptSupabaseRepair(
+                            userId: deps.resolvedUserId,
+                            supabase: deps.supabaseClient
+                        )
+                        if let repaired = PausedSessionState.load() {
+                            crashRecoveryState = repaired
+                            showCrashRecoveryAlert = true
+                            crashAlertArmed = true
+                        }
+                    }
+                }
+
+                // One-time migration notice: show once when an existing user first launches
+                // the build that introduced training-time programme progression. Suppressed
+                // when the crash-recovery alert won — and the shown-flag is set ONLY when
+                // the notice actually presents, so a suppressed notice isn't silently
+                // consumed and still shows on the next launch (J-F7 / #318).
+                let migrationKey = "training_time_migration_v1_shown"
+                if AppShell.migrationNoticeShouldArm(
+                    showOnboarding: showOnboarding,
+                    crashAlertArmed: crashAlertArmed,
+                    migrationAlreadyShown: UserDefaults.standard.bool(forKey: migrationKey)
+                ) {
+                    UserDefaults.standard.set(true, forKey: migrationKey)
+                    showTrainingTimeMigrationNotice = true
+                }
+            }
+            .alert("Unfinished Workout", isPresented: $showCrashRecoveryAlert) {
+                Button("Resume") {
+                    guard let vm = programViewModel else {
+                        // Programme view model not ready — fall back to Path B in WorkoutView.
+                        showLiveLoop = true
+                        return
+                    }
+                    let outcome = ResumeOutcome.decide(
+                        saved: crashRecoveryState,
+                        viewState: vm.viewState,
+                        nextIncompleteDay: {
+                            guard case .loaded(let mesocycle) = vm.viewState else { return nil }
+                            return vm.nextIncompleteDay(in: mesocycle)
+                        },
+                        findTrainingDay: { id in
+                            guard case .loaded(let mesocycle) = vm.viewState else { return nil }
+                            return vm.findTrainingDay(byId: id, in: mesocycle)
+                        }
+                    )
+                    switch outcome {
+                    case .fallbackToLoop:
+                        showLiveLoop = true
+                    case .pathA(let resumeState):
+                        crashResumeToPass = resumeState
+                        showLiveLoop = true
+                    case .pathBElsewhere(let resumeState, let day):
+                        crashResumeToPass = resumeState
+                        crashResumeDay = day
+                        showLiveLoop = true
+                    case .orphaned:
+                        showOrphanedRecoveryAlert = true
+                    }
+                }
+                Button("Abandon Session", role: .destructive) {
+                    if let saved = crashRecoveryState {
+                        Task {
+                            await deps.workoutSessionManager.abandonSession(sessionId: saved.sessionId)
+                        }
+                    }
+                    crashRecoveryState = nil
+                    crashResumeToPass = nil
+                    crashResumeDay = nil
+                }
+            } message: {
+                Text(crashRecoveryMessage)
+            }
+            .alert("Session Not Found", isPresented: $showOrphanedRecoveryAlert) {
+                Button("Save to History") {
+                    // Flush WAQ so any pending set_logs reach Supabase, then clear the sentinel.
+                    // The session row already exists in Supabase; its set_logs are preserved.
+                    if let saved = crashRecoveryState {
+                        Task { await deps.workoutSessionManager.flushWriteAheadQueue() }
+                        _ = saved  // acknowledged
+                    }
+                    crashRecoveryState = nil
+                    crashResumeToPass = nil
+                    PausedSessionState.clear()
+                }
+                Button("Discard", role: .destructive) {
+                    if let saved = crashRecoveryState {
+                        Task {
+                            await deps.workoutSessionManager.abandonSession(sessionId: saved.sessionId)
+                        }
+                    }
+                    crashRecoveryState = nil
+                    crashResumeToPass = nil
+                }
+            } message: {
+                Text("Your previous workout couldn't be matched to the current programme. You can preserve the sets that were logged, or discard the session entirely.")
+            }
+            .alert("Programme Update", isPresented: $showTrainingTimeMigrationNotice) {
+                Button("Got it") { }
+            } message: {
+                Text("Your programme now advances when you complete or skip sessions — not based on calendar dates. Your progress is unchanged.")
             }
     }
 
@@ -196,41 +477,438 @@ struct AppShell: View {
         .accessibilityLabel("Settings")
     }
 
+    /// The settings corner sheet — the real settings root lifted from ContentView
+    /// (#376). Coupled to `programViewModel` for regenerate / reset / rescan.
     private var settingsSheet: some View {
-        // Interim: the real settings root is a private member of the frozen
-        // `ContentView` (no standalone screen to reuse), so it re-homes here in a
-        // later slice. The corner affordance + sheet mechanics are wired now.
-        InterimSurface(
-            title: "Settings",
-            note: "The settings surface re-homes here in a later slice."
+        NavigationStack {
+            settingsRootView
+        }
+        .sheet(isPresented: $isRescanning) {
+            NavigationStack {
+                ScannerView { newProfile in
+                    confirmedProfile = newProfile
+                    isRescanning = false
+                }
+            }
+            .preferredColorScheme(.dark)
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Live loop (the off-tab covered surface — old in-session chrome)
+
+    /// The covered live-loop surface — the faithful copy of ContentView's `workoutTab`
+    /// machinery (WorkoutView with its OLD in-session chrome: ActiveSetView /
+    /// RestTimerView). Presented over the current surface when the loop "rises through"
+    /// Start. The new LiveLoopView core (#350) activates at #351, not here.
+    @ViewBuilder
+    private var liveLoopCover: some View {
+        workoutLoop
+            .preferredColorScheme(.dark)
+            .environment(\.switchToTab) { legacyTab in
+                // Within the covered loop, the legacy contract still routes; a "close
+                // to program" (tab 0) or settings request dismisses the cover first.
+                switch ShellRoute.from(legacyTab: legacyTab) {
+                case .select(let tab):
+                    showLiveLoop = false
+                    selection = tab
+                case .presentLiveLoop:
+                    break  // already in the loop
+                case .presentSettings:
+                    showLiveLoop = false
+                    showSettings = true
+                }
+            }
+    }
+
+    // MARK: - Workout Loop (faithful copy of ContentView.workoutTab)
+
+    /// Resolves the mesocycle to render in the loop. Uses the loaded state's mesocycle
+    /// normally; while a day's session is generating in place, falls back to
+    /// `currentMesocycle` so the loop stays on the workout surface rather than
+    /// collapsing to "No Program Yet".
+    private func workoutLoopMesocycle(for vm: ProgramViewModel) -> Mesocycle? {
+        switch vm.viewState {
+        case .loaded(let mesocycle):
+            return mesocycle
+        case .generatingSession:
+            return vm.currentMesocycle
+        default:
+            return nil
+        }
+    }
+
+    /// The workout loop body. Routes to `WorkoutView` with the first non-completed day
+    /// in the mesocycle. Shows a programme-complete state when all days are done,
+    /// or a no-program state when no mesocycle is loaded.
+    @ViewBuilder
+    private var workoutLoop: some View {
+        // Render the workout surface for a loaded programme OR while a single day's
+        // session is generating in place — the latter keeps currentMesocycle populated,
+        // so the loop must not collapse to "No Program Yet" mid-generation.
+        if let vm = programViewModel,
+           let mesocycle = workoutLoopMesocycle(for: vm) {
+            let isGeneratingSession: Bool = {
+                if case .generatingSession = vm.viewState { return true }
+                return false
+            }()
+            if let (day, week) = vm.nextIncompleteDay(in: mesocycle) {
+                let allDays = mesocycle.weeks.flatMap { $0.trainingDays }
+                // Skipped sessions advance the programme pointer and count toward progress.
+                let completedCount = allDays.filter { $0.status == .completed || $0.status == .skipped }.count
+                // NavigationStack is required so WorkoutView (and its children) can render
+                // their toolbar items and so WorkoutView pushed from ProgramDayDetailView
+                // has a consistent navigation context. WorkoutView no longer owns an
+                // inner NavigationStack.
+                NavigationStack {
+                    WorkoutView(
+                        trainingDay: crashResumeDay ?? day,
+                        programId: mesocycle.id,
+                        weekNumber: week.weekNumber,
+                        completedDayCount: completedCount,
+                        totalDayCount: allDays.count,
+                        onSessionCompleted: {
+                            // Crash-resume path: the resumed day may differ from `day` —
+                            // find its week via the mesocycle rather than assuming `week`.
+                            if let resumeDay = crashResumeDay,
+                               let found = vm.findTrainingDay(byId: resumeDay.id, in: mesocycle) {
+                                programViewModel?.markDayCompleted(dayId: found.day.id, weekId: found.week.id)
+                            } else {
+                                programViewModel?.markDayCompleted(dayId: day.id, weekId: week.id)
+                            }
+                        },
+                        onSessionPaused: {
+                            if let resumeDay = crashResumeDay,
+                               let found = vm.findTrainingDay(byId: resumeDay.id, in: mesocycle) {
+                                programViewModel?.markDayPaused(dayId: found.day.id, weekId: found.week.id)
+                            } else {
+                                programViewModel?.markDayPaused(dayId: day.id, weekId: week.id)
+                            }
+                        },
+                        onSessionDismissed: {
+                            // Sequence: markDayCompleted (from onSessionCompleted above) has
+                            // already written its state — loadProgram() now fetches the updated
+                            // mesocycle before returning to the program so the calendar shows
+                            // correctly. The covered loop dismisses back to Train.
+                            Task { @MainActor in
+                                await programViewModel?.loadProgram()
+                                showLiveLoop = false
+                                selection = .train
+                                crashResumeToPass = nil
+                                crashResumeDay = nil
+                                programViewModel?.scrollToCurrentWeekTrigger += 1
+                            }
+                        },
+                        resumeState: crashResumeToPass,
+                        onSkipSession: {
+                            // Persistent skip — advances programme_day_index, records skippedAt.
+                            // Resolve via crashResumeDay like the completed/paused siblings above
+                            // so a crash-resumed day skips THAT day, not nextIncompleteDay's.
+                            if let resumeDay = crashResumeDay,
+                               let found = vm.findTrainingDay(byId: resumeDay.id, in: mesocycle) {
+                                programViewModel?.markDaySkipped(dayId: found.day.id, weekId: found.week.id)
+                            } else {
+                                programViewModel?.markDaySkipped(dayId: day.id, weekId: week.id)
+                            }
+                        },
+                        isGeneratingSession: isGeneratingSession,
+                        onGenerateSession: ((crashResumeDay ?? day).status == .pending && confirmedProfile != nil)
+                            ? {
+                                // Generate this not-yet-generated day's session in place.
+                                // Resolve day+week like the completed/paused/skip siblings:
+                                // crashResumeDay takes precedence (matching the render target),
+                                // falling back to nextIncompleteDay's (day, week) pair.
+                                let targetDay: TrainingDay
+                                let targetWeek: TrainingWeek
+                                if let resumeDay = crashResumeDay,
+                                   let found = vm.findTrainingDay(byId: resumeDay.id, in: mesocycle) {
+                                    targetDay = found.day
+                                    targetWeek = found.week
+                                } else {
+                                    targetDay = day
+                                    targetWeek = week
+                                }
+                                Task {
+                                    await programViewModel?.generateDaySession(
+                                        day: targetDay,
+                                        week: targetWeek,
+                                        gymProfile: confirmedProfile!
+                                    )
+                                }
+                            }
+                            : nil,
+                        onCloseToTab0: {
+                            showLiveLoop = false
+                            selection = .train
+                        },
+                        onResumeStateConsumed: {
+                            // One-shot — clear so subsequent loop entries don't re-apply
+                            // the same paused state on top of the now-live (or post-error)
+                            // session. crashResumeDay stays valid until the session ends
+                            // (cleared in onSessionDismissed above) because workoutLoop still
+                            // needs it to select the correct trainingDay parameter.
+                            crashResumeToPass = nil
+                        }
+                    )
+                    // Paused-session banner — shown when a different day is paused and no
+                    // session is currently live (i.e. user is on the PreWorkoutView screen).
+                    .safeAreaInset(edge: .top) {
+                        if !deps.liveSessionWatcher.isLive,
+                           let saved = PausedSessionState.load(),
+                           saved.trainingDayId != day.id,
+                           let found = vm.findTrainingDay(byId: saved.trainingDayId, in: mesocycle) {
+                            PausedSessionBannerView(
+                                dayLabel: found.day.dayLabel,
+                                weekNumber: found.week.weekNumber,
+                                onResume: { navigateToPausedDayDetail = true }
+                            )
+                            .padding(.horizontal, 16)
+                            .padding(.top, 8)
+                            .padding(.bottom, 4)
+                        }
+                    }
+                    // Navigation destination for the paused day's detail view
+                    .navigationDestination(isPresented: $navigateToPausedDayDetail) {
+                        if let saved = PausedSessionState.load(),
+                           let found = vm.findTrainingDay(byId: saved.trainingDayId, in: mesocycle) {
+                            ProgramDayDetailView(
+                                day: found.day,
+                                week: found.week,
+                                mesocycleCreatedAt: mesocycle.createdAt,
+                                programId: mesocycle.id,
+                                viewModel: vm,
+                                gymProfile: confirmedProfile
+                            )
+                            .environment(deps)
+                        }
+                    }
+                }
+            } else {
+                programCompleteView
+            }
+        } else {
+            noWorkoutView
+        }
+    }
+
+    private var noWorkoutView: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+                Image(systemName: "figure.strengthtraining.traditional")
+                    .font(.system(size: 64))
+                    .foregroundStyle(.white.opacity(0.20))
+                VStack(spacing: 8) {
+                    Text("No Program Yet")
+                        .font(.title2.bold())
+                        .foregroundStyle(.white)
+                    Text("Generate a program in the Train tab to start working out.")
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.45))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 40)
+                }
+                Button {
+                    showLiveLoop = false
+                    selection = .train
+                } label: {
+                    Text("Go to Program")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 28)
+                        .padding(.vertical, 12)
+                        .background(.white.opacity(0.12), in: Capsule())
+                }
+                .padding(.top, 8)
+                Spacer()
+            }
+            .background(Color(red: 0.04, green: 0.04, blue: 0.06).ignoresSafeArea())
+            .navigationTitle("Workout")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbarBackground(Color(red: 0.04, green: 0.04, blue: 0.06), for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+        }
+    }
+
+    /// Shown in the loop when every day in the mesocycle is `.completed`.
+    private var programCompleteView: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+                Image(systemName: "trophy.fill")
+                    .font(.system(size: 64))
+                    .foregroundStyle(Color(red: 1.0, green: 0.84, blue: 0.0))
+                VStack(spacing: 8) {
+                    Text("Programme Complete")
+                        .font(.title2.bold())
+                        .foregroundStyle(.white)
+                    Text("You've finished every session.")
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.45))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 40)
+                }
+                Button {
+                    showNextProgrammeConfirmation = true
+                } label: {
+                    Text("Start Your Next Programme")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(.white.opacity(confirmedProfile != nil ? 1.0 : 0.4))
+                        .padding(.horizontal, 28)
+                        .padding(.vertical, 12)
+                        .background(
+                            confirmedProfile != nil
+                                ? Color(red: 0.23, green: 0.56, blue: 1.00)
+                                : Color.white.opacity(0.08),
+                            in: Capsule()
+                        )
+                }
+                .disabled(confirmedProfile == nil)
+                .padding(.top, 8)
+                if confirmedProfile == nil {
+                    Text("Set up your gym in Settings to start a new programme")
+                        .font(.footnote)
+                        .foregroundStyle(.white.opacity(0.45))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 40)
+                }
+                Button {
+                    showLiveLoop = false
+                    showSettings = true
+                } label: {
+                    Text("Go to Settings")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 28)
+                        .padding(.vertical, 12)
+                        .background(.white.opacity(0.12), in: Capsule())
+                }
+                Spacer()
+            }
+            .background(Color(red: 0.04, green: 0.04, blue: 0.06).ignoresSafeArea())
+            .navigationTitle("Workout")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbarBackground(Color(red: 0.04, green: 0.04, blue: 0.06), for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .alert("Start Your Next Programme?", isPresented: $showNextProgrammeConfirmation) {
+                Button("Cancel", role: .cancel) { }
+                Button("Start") {
+                    guard let profile = confirmedProfile else { return }
+                    Task { await regenerateProgram(gymProfile: profile) }
+                }
+            } message: {
+                Text("Generates a fresh 12-week programme. Your history is preserved.")
+            }
+        }
+    }
+
+    // MARK: - Settings Root (faithful copy of ContentView.settingsRootView)
+
+    private var settingsRootView: some View {
+        let isRegenerating = programViewModel?.viewState == .generating
+
+        return SettingsView(
+            hasExistingProfile: confirmedProfile != nil,
+            onRescan: {
+                isRescanning = true
+            },
+            onScanFirst: {
+                isRescanning = true
+            },
+            confirmedProfile: confirmedProfile,
+            onRegenerateProgram: {
+                guard let profile = confirmedProfile else { return }
+                regenerateErrorMessage = nil
+                Task {
+                    await regenerateProgram(gymProfile: profile)
+                }
+            },
+            onEquipmentChanged: { updatedProfile in
+                // Persist to UserDefaults immediately — always fast, always wins.
+                confirmedProfile = updatedProfile
+                updatedProfile.saveToUserDefaults()
+
+                // Cancel any in-flight Supabase sync so rapid edits don't produce
+                // two concurrent (deactivate + insert) pairs that could interleave
+                // and leave a duplicate active row.
+                gymProfileSyncTask?.cancel()
+
+                let userId = deps.resolvedUserId
+                let client = deps.supabaseClient
+                gymProfileSyncTask = Task {
+                    guard !Task.isCancelled else { return }
+                    do {
+                        // Deactivate old row, then insert updated one (scanner pattern).
+                        // These are sequential awaits within a single Task — no race window.
+                        try await client.deactivateGymProfiles(userId: userId)
+                        guard !Task.isCancelled else { return }
+                        let row = GymProfileRow.forInsert(from: updatedProfile, userId: userId)
+                        try await client.insert(row, table: "gym_profiles")
+                        print("[AppShell] GymProfile synced to Supabase — \(updatedProfile.equipment.count) items")
+                    } catch {
+                        // Non-fatal — UserDefaults is the local source of truth.
+                        print("[AppShell] GymProfile Supabase sync failed: \(error.localizedDescription)")
+                    }
+                }
+            },
+            isRegenerating: isRegenerating,
+            regenerateErrorMessage: regenerateErrorMessage,
+            onResetAll: {
+                // Clear in-memory state so the UI reflects the wipe immediately
+                confirmedProfile = nil
+                programViewModel = nil
+                showOnboarding = true
+            },
+            programViewModel: programViewModel
         )
     }
-}
 
-// MARK: - Interim surface
+    // MARK: - #318 alert-collision gate (pure, testable)
 
-/// An honest interim for a surface whose real screen (and the machinery it needs)
-/// lands in a later per-surface slice. The shell is dormant in #343
-/// (`useNewShell = false`), so this is compile-time scaffold that no user sees
-/// until each surface's slice swaps in its real screen.
-private struct InterimSurface: View {
-    @Environment(\.apexTheme) private var theme
-    let title: String
-    let note: String
+    /// The one-time training-time migration notice arms ONLY when no crash-recovery
+    /// alert won this launch (J-F7 / #318): two alerts arming in the same `.task` pass
+    /// collide and SwiftUI silently drops one. The crash check runs FIRST in the
+    /// `.task` and sets `crashAlertArmed`; this predicate is the migration gate that
+    /// reads it. Extracted as a pure function so the #318 regression is unit-testable
+    /// against `AppShell` (the `.task` ORDERING itself is copied verbatim from
+    /// ContentView; only this final gating boolean is named here).
+    static func migrationNoticeShouldArm(
+        showOnboarding: Bool,
+        crashAlertArmed: Bool,
+        migrationAlreadyShown: Bool
+    ) -> Bool {
+        !showOnboarding && !crashAlertArmed && !migrationAlreadyShown
+    }
 
-    var body: some View {
-        ZStack {
-            theme.paper.color.ignoresSafeArea()
-            VStack(spacing: Spacing.sm) {
-                Text(title)
-                    .apexFont(.display)
-                    .foregroundStyle(theme.ink.color)
-                Text(note)
-                    .apexFont(.body)
-                    .foregroundStyle(theme.inkMuted.color)
-                    .multilineTextAlignment(.center)
-            }
-            .padding(Spacing.lg)
+    // MARK: - Crash Recovery Helpers
+
+    private var crashRecoveryMessage: String {
+        guard let saved = crashRecoveryState else {
+            return "You have an unfinished session. Resume it or abandon it?"
+        }
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        return "You have an unfinished session from \(formatter.string(from: saved.pausedAt)). Resume it or abandon it?"
+    }
+
+    // MARK: - Regenerate Program
+
+    /// Triggers program regeneration, captures errors for display in SettingsView.
+    @MainActor
+    private func regenerateProgram(gymProfile: GymProfile) async {
+        guard let vm = programViewModel else { return }
+        regenerateErrorMessage = nil
+        await vm.regenerateProgram(gymProfile: gymProfile)
+
+        // Detect error state after generation completes
+        if case .error(let message) = vm.viewState {
+            regenerateErrorMessage = message
+            // Restore loaded state or empty state so the program surface isn't stuck on error
+            await vm.loadProgram()
+        } else {
+            // Success — surface the program (Train owns the program in the shell).
+            selection = .train
         }
     }
 }

--- a/ProjectApex/ProjectApexApp.swift
+++ b/ProjectApex/ProjectApexApp.swift
@@ -29,10 +29,20 @@ struct ProjectApexApp: App {
     var body: some Scene {
         WindowGroup {
             Group {
-                if useNewShell {
-                    AppShell()
+                // Honest launch gate (#329 / O-F1, #369 slice 2), hoisted here in #376
+                // ABOVE the root switch so it guards BOTH roots: when either required
+                // key is missing — neither in the Keychain nor bundled into the build —
+                // show the "needs setup" screen instead of letting onboarding start and
+                // die mid-gym-scan or mid-Supabase call. ContentView keeps its own
+                // internal gate (now redundant, harmless — #363 removes it).
+                if deps.hasResolvableAIKey && deps.hasResolvableSupabaseKey {
+                    if useNewShell {
+                        AppShell()
+                    } else {
+                        ContentView()
+                    }
                 } else {
-                    ContentView()
+                    NeedsSetupView()
                 }
             }
             .environment(deps)

--- a/ProjectApexTests/AppShellMachineryTests.swift
+++ b/ProjectApexTests/AppShellMachineryTests.swift
@@ -1,0 +1,354 @@
+// AppShellMachineryTests.swift
+// ProjectApexTests
+//
+// #376 commit 1/2 — the machinery-lift. AppShell now carries faithful COPIES of the
+// machinery the frozen ContentView still owns (the ProgramViewModel lifecycle, the
+// onboarding gate, the crash-recovery alert chain, the paused-session resume, and the
+// settings root). `useNewShell` STAYS false in this commit, so the machinery is
+// exercised ONLY by these tests until the flip (commit 2/2).
+//
+// The codebase tests pure reducers, not live SwiftUI view closures (no ViewInspector;
+// see TodayViewTests / AppShellRouteTests). So the most regression-critical machinery —
+// the crash-resume branch decision and the #318 alert-collision gate — is lifted into
+// pure functions (`ResumeOutcome.decide`, `AppShell.migrationNoticeShouldArm`) that the
+// verbatim view closures call. These tests pin those functions against AppShell:
+//
+//   • Crash-resume integration — ALL THREE Resume branches (Path A explicit resume,
+//     Path B nextIncompleteDay-elsewhere, the not-found/orphaned case) + the
+//     VM-not-loaded fallback. A dropped branch silently loses a user's session.
+//   • #318 alert-collision regression — the migration notice arms ONLY when no
+//     crash-recovery alert won the same launch pass.
+//   • The legacy switchToTab bridge routes the live-loop entry + settings correctly.
+//   • The launch/setup gate predicate (hoisted into ProjectApexApp ABOVE the
+//     useNewShell switch) shows NeedsSetupView when either key is unresolvable.
+
+import Testing
+import Foundation
+@testable import ProjectApex
+
+// MARK: - Minimal mock LLM provider for service construction
+
+private struct AlwaysThrowingProvider: LLMProvider {
+    func complete(systemPrompt: String, userPayload: String) async throws -> String {
+        throw URLError(.notConnectedToInternet)
+    }
+}
+
+// MARK: - ProgramViewModel factory (mirrors SkipFeatureTests)
+
+/// A ProgramViewModel backed by no-op services. Only pure computation methods
+/// (nextIncompleteDay, findTrainingDay) are exercised — no network calls are made.
+@MainActor
+private func makeViewModel() -> ProgramViewModel {
+    let fakeURL = URL(string: "https://localhost")!
+    let supabase = SupabaseClient(supabaseURL: fakeURL, anonKey: "test")
+    let provider: any LLMProvider = AlwaysThrowingProvider()
+    let memory = MemoryService(supabase: supabase, embeddingAPIKey: "test")
+    return ProgramViewModel(
+        supabaseClient: supabase,
+        programGenerationService: ProgramGenerationService(provider: provider),
+        macroPlanService: MacroPlanService(provider: provider),
+        sessionPlanService: SessionPlanService(
+            provider: provider,
+            memoryService: memory,
+            supabaseClient: supabase
+        ),
+        userId: UUID()
+    )
+}
+
+// MARK: - Mesocycle fixture (mirrors SkipFeatureTests)
+
+/// A minimal 2-week mesocycle with 3 training days per week.
+private func makeMesocycle(
+    week1Statuses: [TrainingDayStatus] = [.generated, .generated, .generated],
+    week2Statuses: [TrainingDayStatus] = [.generated, .generated, .generated]
+) -> Mesocycle {
+    func makeDays(_ statuses: [TrainingDayStatus]) -> [TrainingDay] {
+        statuses.enumerated().map { idx, status in
+            TrainingDay(
+                id: UUID(),
+                dayOfWeek: idx + 1,
+                dayLabel: "Day \(idx + 1)",
+                exercises: [],
+                sessionNotes: nil,
+                status: status
+            )
+        }
+    }
+    let week1 = TrainingWeek(
+        id: UUID(), weekNumber: 1, phase: .accumulation,
+        trainingDays: makeDays(week1Statuses)
+    )
+    let week2 = TrainingWeek(
+        id: UUID(), weekNumber: 2, phase: .accumulation,
+        trainingDays: makeDays(week2Statuses)
+    )
+    return Mesocycle(
+        id: UUID(), userId: UUID(), createdAt: Date(), isActive: true,
+        weeks: [week1, week2], totalWeeks: 2, periodizationModel: "linear_periodization"
+    )
+}
+
+/// A paused-session sentinel pointing at a given training day in a given mesocycle.
+private func makeSentinel(
+    for day: TrainingDay, in mesocycle: Mesocycle
+) -> PausedSessionState {
+    PausedSessionState(
+        sessionId: UUID(),
+        trainingDayId: day.id,
+        weekId: mesocycle.weeks[0].id,
+        weekNumber: 1,
+        exerciseIndex: 0,
+        currentSetNumber: 1,
+        dayType: day.dayLabel,
+        programId: mesocycle.id,
+        userId: mesocycle.userId,
+        pausedAt: Date()
+    )
+}
+
+// MARK: - Crash-resume branch decision (the three Resume branches + fallback)
+
+@Suite("AppShell crash-resume — the three Resume branches (#376)")
+struct AppShellCrashResumeTests {
+
+    /// PATH A — the paused day IS nextIncompleteDay → pass it as an explicit
+    /// resumeState so WorkoutView's Path A fires reliably.
+    @MainActor
+    @Test("Path A: paused day == nextIncompleteDay → pathA(saved)")
+    func resumePathA() {
+        let meso = makeMesocycle()
+        let vm = makeViewModel()
+        vm.currentMesocycle = meso
+        vm.viewState = .loaded(meso)
+        defer { Mesocycle.clearUserDefaults() }
+
+        // The first non-terminal day IS the paused day.
+        let pausedDay = meso.weeks[0].trainingDays[0]
+        let saved = makeSentinel(for: pausedDay, in: meso)
+
+        let outcome = ResumeOutcome.decide(
+            saved: saved,
+            viewState: vm.viewState,
+            nextIncompleteDay: { vm.nextIncompleteDay(in: meso) },
+            findTrainingDay: { vm.findTrainingDay(byId: $0, in: meso) }
+        )
+
+        guard case .pathA(let resumeState) = outcome else {
+            Issue.record("Expected .pathA, got \(outcome)")
+            return
+        }
+        #expect(resumeState.trainingDayId == pausedDay.id)
+    }
+
+    /// PATH B (elsewhere) — the paused day is found in the mesocycle but is NOT
+    /// nextIncompleteDay → pass BOTH the resume state and the correct day so
+    /// WorkoutView renders the right exercise list (not nextIncompleteDay's).
+    @MainActor
+    @Test("Path B: paused day found but != nextIncompleteDay → pathBElsewhere(saved, day)")
+    func resumePathBElsewhere() {
+        let meso = makeMesocycle()
+        let vm = makeViewModel()
+        vm.currentMesocycle = meso
+        vm.viewState = .loaded(meso)
+        defer { Mesocycle.clearUserDefaults() }
+
+        // nextIncompleteDay is week0/day0; pause a DIFFERENT, later day (week1/day2).
+        let nextDay = vm.nextIncompleteDay(in: meso)?.day
+        let pausedDay = meso.weeks[1].trainingDays[2]
+        #expect(nextDay?.id != pausedDay.id, "fixture must pause a non-next day")
+        let saved = makeSentinel(for: pausedDay, in: meso)
+
+        let outcome = ResumeOutcome.decide(
+            saved: saved,
+            viewState: vm.viewState,
+            nextIncompleteDay: { vm.nextIncompleteDay(in: meso) },
+            findTrainingDay: { vm.findTrainingDay(byId: $0, in: meso) }
+        )
+
+        guard case .pathBElsewhere(let resumeState, let day) = outcome else {
+            Issue.record("Expected .pathBElsewhere, got \(outcome)")
+            return
+        }
+        #expect(resumeState.trainingDayId == pausedDay.id)
+        #expect(day.id == pausedDay.id, "must carry the CORRECT day, not nextIncompleteDay's")
+    }
+
+    /// ORPHANED — the paused day cannot be found anywhere in the mesocycle → show the
+    /// orphaned-recovery dialog instead of entering the loop.
+    @MainActor
+    @Test("Orphaned: paused day not found in mesocycle → orphaned")
+    func resumeOrphaned() {
+        let meso = makeMesocycle()
+        let vm = makeViewModel()
+        vm.currentMesocycle = meso
+        vm.viewState = .loaded(meso)
+        defer { Mesocycle.clearUserDefaults() }
+
+        // A sentinel whose trainingDayId is in NO week of the mesocycle.
+        let orphan = TrainingDay(
+            id: UUID(), dayOfWeek: 1, dayLabel: "Ghost",
+            exercises: [], sessionNotes: nil, status: .paused
+        )
+        let saved = makeSentinel(for: orphan, in: meso)
+
+        let outcome = ResumeOutcome.decide(
+            saved: saved,
+            viewState: vm.viewState,
+            nextIncompleteDay: { vm.nextIncompleteDay(in: meso) },
+            findTrainingDay: { vm.findTrainingDay(byId: $0, in: meso) }
+        )
+
+        guard case .orphaned = outcome else {
+            Issue.record("Expected .orphaned, got \(outcome)")
+            return
+        }
+    }
+
+    /// FALLBACK — the programme is not loaded yet → fall through to WorkoutView's own
+    /// Path B resume (no explicit state passed). Guards the "VM not ready" race.
+    @MainActor
+    @Test("Not loaded: viewState != .loaded → fallbackToLoop")
+    func resumeFallbackWhenNotLoaded() {
+        let meso = makeMesocycle()
+        let saved = makeSentinel(for: meso.weeks[0].trainingDays[0], in: meso)
+
+        let outcome = ResumeOutcome.decide(
+            saved: saved,
+            viewState: .loading,   // programme not loaded yet
+            nextIncompleteDay: { nil },
+            findTrainingDay: { _ in nil }
+        )
+
+        guard case .fallbackToLoop = outcome else {
+            Issue.record("Expected .fallbackToLoop, got \(outcome)")
+            return
+        }
+    }
+
+    /// FALLBACK — no sentinel at all → fall through (defensive; the alert only arms
+    /// when a sentinel exists, but the decision must be safe regardless).
+    @MainActor
+    @Test("No sentinel → fallbackToLoop")
+    func resumeFallbackWhenNoSentinel() {
+        let meso = makeMesocycle()
+        let vm = makeViewModel()
+        vm.viewState = .loaded(meso)
+        defer { Mesocycle.clearUserDefaults() }
+
+        let outcome = ResumeOutcome.decide(
+            saved: nil,
+            viewState: vm.viewState,
+            nextIncompleteDay: { vm.nextIncompleteDay(in: meso) },
+            findTrainingDay: { vm.findTrainingDay(byId: $0, in: meso) }
+        )
+
+        guard case .fallbackToLoop = outcome else {
+            Issue.record("Expected .fallbackToLoop, got \(outcome)")
+            return
+        }
+    }
+}
+
+// MARK: - #318 alert-collision regression (the migration-notice gate)
+
+@Suite("AppShell #318 alert-collision gate (#376)")
+struct AppShellAlertCollisionTests {
+
+    @Test("Crash alert won this launch → migration notice is SUPPRESSED (#318)")
+    func migrationSuppressedWhenCrashAlertArmed() {
+        // The collision regression: a crash sentinel armed its alert, so the migration
+        // notice must NOT also arm in the same pass (SwiftUI would silently drop one).
+        #expect(
+            AppShell.migrationNoticeShouldArm(
+                showOnboarding: false,
+                crashAlertArmed: true,
+                migrationAlreadyShown: false
+            ) == false
+        )
+    }
+
+    @Test("No crash alert + not yet shown + past onboarding → migration notice arms")
+    func migrationArmsWhenClear() {
+        #expect(
+            AppShell.migrationNoticeShouldArm(
+                showOnboarding: false,
+                crashAlertArmed: false,
+                migrationAlreadyShown: false
+            ) == true
+        )
+    }
+
+    @Test("During onboarding → migration notice never arms")
+    func migrationSuppressedDuringOnboarding() {
+        #expect(
+            AppShell.migrationNoticeShouldArm(
+                showOnboarding: true,
+                crashAlertArmed: false,
+                migrationAlreadyShown: false
+            ) == false
+        )
+    }
+
+    @Test("Already shown once → migration notice does not re-arm")
+    func migrationSuppressedWhenAlreadyShown() {
+        #expect(
+            AppShell.migrationNoticeShouldArm(
+                showOnboarding: false,
+                crashAlertArmed: false,
+                migrationAlreadyShown: true
+            ) == false
+        )
+    }
+}
+
+// MARK: - Live-loop bridge + settings + launch/setup gate
+
+@Suite("AppShell live-loop + settings + launch gate (#376)")
+struct AppShellMachineryRouteTests {
+
+    /// `presentLiveLoop` handler — the legacy `switchToTab(1)` "Continue Workout" call
+    /// site routes to the off-tab live-loop entry (presented over the current surface).
+    @Test("switchToTab(1) → presentLiveLoop (the off-tab live-loop entry)")
+    func liveLoopRoute() {
+        #expect(ShellRoute.from(legacyTab: 1) == .presentLiveLoop)
+    }
+
+    /// Settings opens from the corner — the legacy `switchToTab(3)` call site routes to
+    /// the settings sheet (the corner gear's presentation).
+    @Test("switchToTab(3) → presentSettings (settings opens from the corner)")
+    func settingsCornerRoute() {
+        #expect(ShellRoute.from(legacyTab: 3) == .presentSettings)
+    }
+
+    /// The launch/setup gate, hoisted into ProjectApexApp.body ABOVE the useNewShell
+    /// switch (#329 / #369, lifted in #376): the app shows NeedsSetupView when EITHER
+    /// required key is unresolvable, and the real root otherwise. This is the exact
+    /// boolean the App body branches on — pinned here so the gate can't silently regress.
+    @Test("Launch gate: missing AI key → NeedsSetupView (gate is false)")
+    func launchGateMissingAIKey() {
+        #expect(launchGatePasses(hasAIKey: false, hasSupabaseKey: true) == false)
+    }
+
+    @Test("Launch gate: missing Supabase key → NeedsSetupView (gate is false)")
+    func launchGateMissingSupabaseKey() {
+        #expect(launchGatePasses(hasAIKey: true, hasSupabaseKey: false) == false)
+    }
+
+    @Test("Launch gate: both keys missing → NeedsSetupView (gate is false)")
+    func launchGateBothMissing() {
+        #expect(launchGatePasses(hasAIKey: false, hasSupabaseKey: false) == false)
+    }
+
+    @Test("Launch gate: both keys present → the real root (gate is true)")
+    func launchGateBothPresent() {
+        #expect(launchGatePasses(hasAIKey: true, hasSupabaseKey: true) == true)
+    }
+
+    /// The launch-gate predicate, byte-identical to ProjectApexApp.body's
+    /// `deps.hasResolvableAIKey && deps.hasResolvableSupabaseKey`.
+    private func launchGatePasses(hasAIKey: Bool, hasSupabaseKey: Bool) -> Bool {
+        hasAIKey && hasSupabaseKey
+    }
+}

--- a/docs/adr/0026-incremental-shell-rollout-strangler.md
+++ b/docs/adr/0026-incremental-shell-rollout-strangler.md
@@ -41,3 +41,23 @@ A **strangler-fig**: a new sibling root `AppShell.swift` renders the locked 3-ta
 - **Parallel-session handshake:** the bootstrap slice's one shared edit is `ProjectApexApp.swift`; worth a heads-up that this line changes and `ContentView.swift` is to stay frozen, so neither side reformats it.
 
 *Advisor dissent recorded: advisor 1's enum-now + machinery-now moves overruled (race + regression risk); its grep-before-done discipline kept. Advisors 2 & 3 form the adopted spine; the synchronized-group pbxproj fact is the enabling premise.*
+
+## Amendment — the machinery-lift + flip gate (#376, 2026-06-14)
+
+The "machinery-last" deferral above is discharged by [#376](https://github.com/thearnavmenon/ProjectApex/issues/376), shipped as **one slice, two commits**:
+
+- **Commit 1/2 — the reversible lift (this PR).** `AppShell` gains faithful COPIES of the six machineries the frozen `ContentView` still owns and runs: the `ProgramViewModel` lifecycle (`@State` created in `.task`, recreated on onboarding completion, nil'd on reset), the onboarding `fullScreenCover`, the crash-recovery `.task` + alert chain (the #318 alert-ordering moved verbatim), the paused-session resume (`crashResumeToPass` / `crashResumeDay` + the three Resume branches), the workout-loop host + the settings root (coupled to the view model for regenerate/reset/rescan), and the launch/setup gate. **`useNewShell` STAYS `false`** — `ContentView` is untouched and remains the live root, so the lifted machinery is exercised only by unit tests until the flip. This is a single-`git revert` reversible commit (the additions are dormant; reverting them changes no live behaviour).
+  - **Single-root invariant preserved:** because `useNewShell` is still false, exactly one of `{ContentView, AppShell}` is mounted, so onboarding/migration/crash alerts cannot double-fire (the consequence above still holds — both roots now *contain* the machinery, but only one is ever instantiated).
+  - **Testability seam:** the two most regression-critical pieces — the crash-resume branch decision and the #318 migration-notice gate — are lifted into pure functions (`ResumeOutcome.decide`, `AppShell.migrationNoticeShouldArm`) that the verbatim view closures call, so the codebase's reducer-test convention (no ViewInspector) can pin all three Resume branches + the collision gate against `AppShell`. The `.task` ORDERING itself (crash check first, populating `crashAlertArmed`; migration gate second) is copied verbatim from `ContentView`.
+
+- **Commit 2/2 — the one-line flip (separate, human-gated).** `useNewShell = true`. Reversible by a single `git revert`. **Gated by an on-device force-quit-mid-set drill** (process death can't be fully unit-tested, AC §"Manual on-device drill").
+
+**The launch/setup gate is hoisted** out of `ContentView` (lines 83-87) into `ProjectApexApp.body` ABOVE the `useNewShell` switch, so the `hasResolvableAIKey && hasResolvableSupabaseKey` → `NeedsSetupView` guard protects BOTH roots and #363 has one fewer thing to delete. `ContentView`'s own internal gate stays (now redundant, harmless — #363 removes it).
+
+### Flip-gate preconditions (when `useNewShell = true` is allowed)
+
+After **Wave 2** is built dormant — #348 (Today) + #350 (loop core, dormant) + #354 (Progress root) + #357 (Train root) — so go-live ships **no interim placeholder tab** to users.
+
+### Loop chrome at the flip (resolved fork)
+
+The flip presents the **OLD** in-session chrome (`WorkoutView` → `ActiveSetView` / `RestTimerView`) over Today — the loop "rises through" Start as a covered surface, off-tab (`splash-today.md`). It does **NOT** present #350's new `LiveLoopView` core; that activates at **#351** (correction surface / AMRAP / feel pill) as its own revertable commit. This keeps go-live behaviour-identical to today's loop. (`ActiveSetView` — 1630 lines — is retired at close-out #363, not at the flip.)


### PR DESCRIPTION
## Commit 1/2 — the reversible machinery-lift (flag stays false)

This is **commit 1 of 2** of #376, the strangler's linchpin. It lifts the machinery the frozen `ContentView` owns into `AppShell` as **faithful copies** so the new 3-tab shell can stand on its own — **without flipping `useNewShell`**.

- **`useNewShell` is UNCHANGED at `false`.** `ContentView` is **untouched and still the live root**. Nothing a user sees changes.
- The lifted machinery in `AppShell` is exercised **only by the unit tests** in this commit (AppShell is not the live root yet).
- **Single-`git revert` reversible** — the additions are dormant; reverting them changes no live behaviour.

> **DO NOT auto-merge — human merge-gate required.** The flip (`useNewShell = true`) + the on-device force-quit-mid-set drill are a **separate commit (2/2)**. A human reviews and merges this one.

## The 6 machineries transplanted (1:1 from ContentView)

1. **`ProgramViewModel` lifecycle** — `@State` in `AppShell`; created in `.task`, recreated on onboarding completion, nil'd on reset.
2. **Onboarding gate** — the `fullScreenCover` keyed on `onboardingCompletedKey`.
3. **Crash-recovery chain** — the `.task` `PausedSessionState.load` + the alert chain. The **#318 alert-ordering logic moved verbatim** (crash check first → sets `crashAlertArmed`; migration notice gated second).
4. **Paused-session resume** — `crashResumeToPass` / `crashResumeDay` + the three Resume branches, wired into the off-tab live-loop cover.
5. **Workout-loop host + settings root** — un-stubbed `settingsSheet` to present the real `settingsRootView` (coupled to `programViewModel` for regenerate/reset/rescan), and un-stubbed `presentLiveLoop`.
6. **Launch/setup gate hoist** — moved into `ProjectApexApp.body` **ABOVE** the `useNewShell` switch, so `hasResolvableAIKey && hasResolvableSupabaseKey → NeedsSetupView` guards **both** roots. `ContentView`'s own internal gate is left in place (now redundant, harmless — #363 removes it).

## Loop chrome at the (future) flip — resolved fork

`AppShell.presentLiveLoop` presents the **OLD** in-session chrome (`WorkoutView` → `ActiveSetView` / `RestTimerView`) over Today — the loop "rises through" Start, off-tab. It does **NOT** present #350's new `LiveLoopView` core; that activates at **#351**. Go-live will be behaviour-identical to today's loop. (`ActiveSetView` is retired at close-out #363, not here.)

The `switchToTab` bridge is unchanged; the two live callers (`ProgramDayDetailView.swift:655` `switchToTab(1)`, `ProgramOverviewView.swift:176` `switchToTab(3)`) stay **byte-identical**.

## ADR-0026 amendment

Appended (history preserved) with: the two-commit shape, the flip-gate preconditions (after Wave 2: #348 + #350 + #354 + #357 dormant), and the loop-chrome decision (flip with old chrome; #350 core activates at #351).

## Test coverage (against `AppShell`)

New file `ProjectApexTests/AppShellMachineryTests.swift` (15 tests, all green):

- **Crash-resume — all three Resume branches** via the pure `ResumeOutcome.decide`: **Path A** (paused day == `nextIncompleteDay` → explicit resume state), **Path B elsewhere** (paused day found but ≠ next → carry the correct day, not next's), **orphaned** (paused day not found anywhere), plus the **VM-not-loaded fallback** and the **no-sentinel fallback**.
- **#318 alert-collision regression** via `AppShell.migrationNoticeShouldArm`: migration notice suppressed when a crash alert won the same pass; arms only when clear; suppressed during onboarding / when already shown.
- **`presentLiveLoop` handler** routes the live-loop entry (over Today, old chrome); **settings opens from the corner**; the **launch/setup gate** shows `NeedsSetupView` when either key is missing.

**Full suite green at `useNewShell=false`** (506 tests in 99 suites passed) — identical live behaviour. App + tests compile with no new warnings in the touched files.

## How I handled the #318 alert chain (the verbatim question)

The `.task` alert-**ordering** (crash check first populating `crashAlertArmed`; the migration gate reading it second) is copied **verbatim** from `ContentView`. To make the regression testable under the codebase's reducer-test convention (no ViewInspector), I extracted **only** the two decision points the verbatim closures call into pure functions: `ResumeOutcome.decide` (the Resume-button branch conditions) and `AppShell.migrationNoticeShouldArm` (the single migration-gate boolean). The branch **conditions** are identical to ContentView's; only the place they live changed. This is the one deviation from a strict "move every line verbatim" reading — flagged here for review.

Part of #376
