### PR TITLE
fix: ProgressRootLedger compile regression from #418 (un-break main)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,16 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-15 — Hotfix: the Progress screen wouldn't compile, so the whole app was broken
+
+**The problem.** A clean rebuild of the app failed to build at all. The recent "long-absence re-anchor" change (#418) added a new `inTransition` flag to a Progress data row, but wrote it as a constant with a built-in default. Swift quietly leaves that kind of field OUT of the automatic initializer — so the code that *set* the flag failed with "extra argument." The app hadn't compiled since that change merged; it slipped in because that work merges past the flaky iOS build check.
+
+**The fix.** One character: changed the field from a constant to a variable, which puts it back into the initializer (still defaulting to off, so nothing else changes). Caught by the clean full-suite re-verify done as part of the shell go-live prep.
+
+**Checked.** Full suite green again (575 + 506 tests, 0 failures). Fixed in PR — main compiles.
+
+---
+
 
 ## 2026-06-14 — Moving the "brains" of the app into the new shell, without flipping the switch (Phase 3 UI, #376 — commit 1 of 2)
 

--- a/ProjectApex/Features/Progress/ProgressRootLedger.swift
+++ b/ProjectApex/Features/Progress/ProgressRootLedger.swift
@@ -59,7 +59,7 @@ struct ProgressRootLedger: View {
         /// (PatternProfile.inTransitionMode). When true the row carries a small
         /// transition marker so the band's floor/stretch isn't read as settled.
         /// Defaulted so existing fixtures stay valid.
-        let inTransition: Bool = false
+        var inTransition: Bool = false
     }
 
     // MARK: Inputs


### PR DESCRIPTION
## main does not compile (since #418)

`ProgressRootLedger.swift:368: error: extra argument 'inTransition' in call` — caught by the **clean full-suite re-verify** during #376 go-live prep.

**Cause:** #418 ("long-absence re-anchor") added `PatternRow.inTransition` as `let inTransition: Bool = false`. A Swift `let` *with a default value* is **excluded from the synthesized memberwise initializer**, so the call passing `inTransition:` (and the rendering that reads it) couldn't compile. It merged past the `--admin`'d flaky iOS CI, so main has been red.

**Fix:** `let` → `var` (one char). A `var` with a default **is** in the memberwise init, defaulted — so existing fixtures that omit it stay valid, and the call now type-checks. Verified the only instance of the trap (GoalReviewView's `inTransition` is a local constant, not a struct field).

**Verified:** the identical change ran the full suite GREEN — **575 XCTest + 506 Swift Testing, 0 failures** — on a clean build (this also re-verified the merged #376 commit-1 lift). Merging `--admin` past the flaky CI per the standing rule.

Flagging to the parallel #418/#369 stream: main was non-compiling; please pull this before stacking further.