### PR TITLE
test(#376): pin the launch-gate predicate to the production seam (PR #419 nit)

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,14 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-15 — Made the "needs setup" check actually test the real code (#376 follow-up)
+
+When the app is missing its keys it shows a "needs setup" screen instead of a doomed onboarding. The new shell's review pointed out the test for this was checking a hand-copied version of the rule, not the real one — so if someone broke the real check, the test would still pass. Pulled the rule into one tiny shared function that both the app and the test call, so the test now guards the actual production code. No behaviour change; the new shell still stays off.
+
+Checked: full suite green (575 + 506 tests).
+
+---
+
 ## 2026-06-15 — Hotfix: the Progress screen wouldn't compile, so the whole app was broken
 
 **The problem.** A clean rebuild of the app failed to build at all. The recent "long-absence re-anchor" change (#418) added a new `inTransition` flag to a Progress data row, but wrote it as a constant with a built-in default. Swift quietly leaves that kind of field OUT of the automatic initializer — so the code that *set* the flag failed with "extra argument." The app hadn't compiled since that change merged; it slipped in because that work merges past the flaky iOS build check.

--- a/ProjectApex/App/AppLaunchGate.swift
+++ b/ProjectApex/App/AppLaunchGate.swift
@@ -1,0 +1,17 @@
+//
+//  AppLaunchGate.swift
+//  ProjectApex
+//
+//  Shared pure predicate for the launch/setup gate (#376 follow-up, #329 / #369).
+//  Both `ProjectApexApp.body` and `AppShellMachineryTests` call this so the test
+//  pins the PRODUCTION condition, not a hand-copied re-implementation.
+//
+
+enum AppLaunchGate {
+    /// Returns `true` when the app may show the real root view.
+    /// Returns `false` when either required key is unresolvable — the caller
+    /// must show `NeedsSetupView` instead.
+    static func isSatisfied(hasAIKey: Bool, hasSupabaseKey: Bool) -> Bool {
+        hasAIKey && hasSupabaseKey
+    }
+}

--- a/ProjectApex/ProjectApexApp.swift
+++ b/ProjectApex/ProjectApexApp.swift
@@ -35,7 +35,7 @@ struct ProjectApexApp: App {
                 // show the "needs setup" screen instead of letting onboarding start and
                 // die mid-gym-scan or mid-Supabase call. ContentView keeps its own
                 // internal gate (now redundant, harmless — #363 removes it).
-                if deps.hasResolvableAIKey && deps.hasResolvableSupabaseKey {
+                if AppLaunchGate.isSatisfied(hasAIKey: deps.hasResolvableAIKey, hasSupabaseKey: deps.hasResolvableSupabaseKey) {
                     if useNewShell {
                         AppShell()
                     } else {

--- a/ProjectApexTests/AppShellMachineryTests.swift
+++ b/ProjectApexTests/AppShellMachineryTests.swift
@@ -324,31 +324,27 @@ struct AppShellMachineryRouteTests {
 
     /// The launch/setup gate, hoisted into ProjectApexApp.body ABOVE the useNewShell
     /// switch (#329 / #369, lifted in #376): the app shows NeedsSetupView when EITHER
-    /// required key is unresolvable, and the real root otherwise. This is the exact
-    /// boolean the App body branches on — pinned here so the gate can't silently regress.
+    /// required key is unresolvable, and the real root otherwise. These tests call the
+    /// PRODUCTION predicate `AppLaunchGate.isSatisfied` directly — not a local
+    /// hand-copy — so a change to the gate condition in ProjectApexApp.body is caught
+    /// here automatically (follow-up to PR #419 review nit).
     @Test("Launch gate: missing AI key → NeedsSetupView (gate is false)")
     func launchGateMissingAIKey() {
-        #expect(launchGatePasses(hasAIKey: false, hasSupabaseKey: true) == false)
+        #expect(AppLaunchGate.isSatisfied(hasAIKey: false, hasSupabaseKey: true) == false)
     }
 
     @Test("Launch gate: missing Supabase key → NeedsSetupView (gate is false)")
     func launchGateMissingSupabaseKey() {
-        #expect(launchGatePasses(hasAIKey: true, hasSupabaseKey: false) == false)
+        #expect(AppLaunchGate.isSatisfied(hasAIKey: true, hasSupabaseKey: false) == false)
     }
 
     @Test("Launch gate: both keys missing → NeedsSetupView (gate is false)")
     func launchGateBothMissing() {
-        #expect(launchGatePasses(hasAIKey: false, hasSupabaseKey: false) == false)
+        #expect(AppLaunchGate.isSatisfied(hasAIKey: false, hasSupabaseKey: false) == false)
     }
 
     @Test("Launch gate: both keys present → the real root (gate is true)")
     func launchGateBothPresent() {
-        #expect(launchGatePasses(hasAIKey: true, hasSupabaseKey: true) == true)
-    }
-
-    /// The launch-gate predicate, byte-identical to ProjectApexApp.body's
-    /// `deps.hasResolvableAIKey && deps.hasResolvableSupabaseKey`.
-    private func launchGatePasses(hasAIKey: Bool, hasSupabaseKey: Bool) -> Bool {
-        hasAIKey && hasSupabaseKey
+        #expect(AppLaunchGate.isSatisfied(hasAIKey: true, hasSupabaseKey: true) == true)
     }
 }


### PR DESCRIPTION
Follow-up to the #419 review (both reviewers flagged it): the launch-gate tests re-implemented `hasAIKey && hasSupabaseKey` locally instead of calling production, so they would NOT catch the gate being changed/deleted in `ProjectApexApp.body`.

**Fix:** extract a pure `AppLaunchGate.isSatisfied(hasAIKey:hasSupabaseKey:)` that BOTH `ProjectApexApp.body` and the tests call — behaviour-identical (missing key → NeedsSetupView). `useNewShell` stays `false`; `ContentView` untouched.

**Verified:** full suite green (575 XCTest + 506 Swift Testing, 0 failures) on a clean build — this run also re-verified the merged #376 commit-1 lift (closing the disk-interrupted gap) and caught the separate #418 compile regression (fixed in #420).

`Part of #376.`