### PR TITLE
feat(#376) commit 2/2: flip useNewShell=true — AppShell go-live  ⚠️ DO NOT MERGE until on-device drill passes

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,14 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-15 — Turned on the new app: the 3-tab shell is now the live screen (#376 go-live)
+
+For months the whole redesign was built behind an off switch — the old screens stayed live while the new ones were assembled in the dark. This is the one-line flip that turns the new 3-tab app (Today / Train / Progress) on for real. Everything it needs to run safely — onboarding, crash-recovery, resuming a paused workout — was moved over in the previous step and double-checked line-by-line against the old code. The old screen becomes unused and gets deleted later in the close-out.
+
+Checked: full app suite green; and a real-device drill (force-quit mid-set, reopen, make sure the workout comes back) before this goes in. One-line revert if anything's off.
+
+---
+
 ## 2026-06-15 — Made the "needs setup" check actually test the real code (#376 follow-up)
 
 When the app is missing its keys it shows a "needs setup" screen instead of a doomed onboarding. The new shell's review pointed out the test for this was checking a hand-copied version of the rule, not the real one — so if someone broke the real check, the test would still pass. Pulled the rule into one tiny shared function that both the app and the test call, so the test now guards the actual production code. No behaviour change; the new shell still stays off.

--- a/ProjectApex/ProjectApexApp.swift
+++ b/ProjectApex/ProjectApexApp.swift
@@ -14,11 +14,12 @@ struct ProjectApexApp: App {
     @Environment(\.scenePhase) private var scenePhase
 
     /// Strangler entry seam (ADR-0026): the new 3-tab `AppShell` is selected by a
-    /// single compile-time constant. #343 lands it `false` — the shell is built,
-    /// wired, and unit-tested but not yet the live root, so the frozen `ContentView`
-    /// keeps owning onboarding, crash-recovery, and the paused-session resume
-    /// (machinery-last). Flip to `true` once that machinery is lifted (close-out #363).
-    private let useNewShell = false
+    /// single compile-time constant. #343 landed it `false`; #376 commit 1 lifted the
+    /// machinery (onboarding, crash-recovery, paused-resume, ProgramViewModel, the
+    /// launch gate) into `AppShell`, and this commit (#376 commit 2) flips it `true` —
+    /// `AppShell` is now the live root. The frozen `ContentView` becomes dead code,
+    /// removed at close-out (#363). Revert this one line to roll back go-live.
+    private let useNewShell = true
 
     init() {
         // Register the embedded design-system fonts at launch (ADR-0024 — runtime


### PR DESCRIPTION
## ⚠️ Human-gated: do NOT merge until the on-device drill passes.

The one-line strangler flip (ADR-0026) — `useNewShell = false → true`. After this, the live root is the new 3-tab `AppShell` (Today / Train / Progress); the frozen `ContentView` becomes dead code (removed at close-out #363).

### Why it's safe to flip
- Commit 1 (#419) lifted all 6 machineries into AppShell and was **double-reviewed line-by-line vs ContentView** — all 3 resume branches, the #318 alert ordering, and the 14-arg WorkoutView call are faithful; ContentView untouched; **single-`git revert` reversible**.
- The launch-gate test now pins the production predicate (#421).
- **Clean full-suite re-verify: 575 XCTest + 506 Swift Testing, 0 failures.**
- Go-live ships the OLD loop chrome (ActiveSetView/RestTimerView) — behaviour-identical; #350's new loop core activates later at #351.

### Your go-live checklist (before merging)
1. **Build this branch and run the on-device force-quit-mid-set drill** — start a session, force-quit mid-set, relaunch → confirm the crash alert appears and Resume restores the in-progress session (all three branches if you can). Process death can't be unit-tested.
2. *(Recommended)* run the **reference-PNG CI record on Xcode 26.3** (owed across ~9 slices) so the now-live surfaces have image snapshots.
3. Note the conscious change: the live/paused **Workout-tab badge is gone** (no Workout tab in the 3-tab shell; the paused banner partially replaces it).

On your OK I merge this (`Closes #376`). If the drill surfaces anything, it's one `git revert`.

Co-Authored-By: Claude Opus 4.8 (1M context)