### PR TITLE
fix(#403): Reset All clears an active in-memory workout session

### DIFF
--- a/ProjectApex/Settings/DeveloperSettingsView.swift
+++ b/ProjectApex/Settings/DeveloperSettingsView.swift
@@ -576,14 +576,19 @@ struct DeveloperSettingsView: View {
         // 2. Clear GymFactStore weight corrections (belt-and-suspenders after UserDefaults wipe)
         await deps.gymFactStore.clearAll()
 
-        // 2b. Drain the LIVE write-ahead queue actor (queue + dead-letter) and clear
-        // any paused session. removePersistentDomain wiped their on-disk UserDefaults,
-        // but the in-memory WAQ actor would re-persist its stale items on the next
-        // enqueue — so a reset without this leaves old-owner/placeholder writes that
-        // replay RLS-403s after re-onboarding (#369 owner-mismatch campaign, slice 3).
-        // PausedSessionState.clear() also resets the in-memory repairPending flag.
-        await deps.writeAheadQueue.clearAll()
-        PausedSessionState.clear()
+        // 2b. Reset the LIVE in-memory state that survives the UserDefaults wipe:
+        // the write-ahead queue actor (queue + dead-letter), any paused session, and
+        // an ACTIVE (non-paused) WorkoutSessionManager session. removePersistentDomain
+        // wiped their on-disk UserDefaults, but the in-memory WAQ actor would re-persist
+        // its stale items on the next enqueue, and an active manager session still holds
+        // the OLD auth.uid() and could enqueue owner-mismatched writes within this
+        // process lifetime — both replay RLS-403s after re-onboarding (#369 owner-mismatch
+        // campaign, slices 3 & #403). PausedSessionState.clear() also resets the in-memory
+        // repairPending flag. resetToIdle() nils the active session.
+        await performLocalStateReset(
+            writeAheadQueue: deps.writeAheadQueue,
+            workoutSessionManager: deps.workoutSessionManager
+        )
 
         // 3. Remove the persisted userId so onboarding creates a fresh identity
         try? keychain.delete(.userId)
@@ -645,6 +650,22 @@ struct DeveloperSettingsView: View {
         await vm.loadProgram()
         showBanner("Programme reloaded from Supabase.", isError: false)
     }
+}
+
+// MARK: - Local in-memory reset (#403)
+
+/// Resets the in-memory state that survives a `UserDefaults` wipe during Reset All.
+/// `removePersistentDomain` clears the on-disk copies, but these live actors hold
+/// their own in-memory state that would otherwise re-persist (WAQ) or keep enqueuing
+/// writes under the old `auth.uid()` (an ACTIVE — not paused — session). Extracted so
+/// it is unit-testable (#403, #369 owner-mismatch campaign).
+func performLocalStateReset(
+    writeAheadQueue: WriteAheadQueue,
+    workoutSessionManager: WorkoutSessionManager
+) async {
+    await writeAheadQueue.clearAll()
+    PausedSessionState.clear()
+    await workoutSessionManager.resetToIdle()
 }
 
 // MARK: - Preview

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -369,6 +369,33 @@ final class WorkoutSessionManagerTests: XCTestCase {
         XCTAssertNil(PausedSessionState.load(), "paused state cleared after discard")
     }
 
+    // MARK: #403 — Reset All clears an ACTIVE in-memory workout session
+
+    /// performLocalStateReset must drain the write-ahead queue, clear any paused
+    /// snapshot, AND reset the live WorkoutSessionManager to .idle — even when the
+    /// session is ACTIVE (not paused) at reset time. Pre-fix the manager kept the
+    /// old-owner session in memory, so it could enqueue owner-mismatched writes
+    /// within the same process lifetime (#403, #369 owner-mismatch campaign).
+    func testPerformLocalStateReset_clearsActiveSession() async throws {
+        let (manager, waq) = makeManagerWithWAQ()
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000) // let startSession settle to .active
+
+        let before = await manager.sessionState
+        guard case .active = before else {
+            XCTFail("precondition: expected .active before reset, got \(before)")
+            return
+        }
+
+        await performLocalStateReset(writeAheadQueue: waq, workoutSessionManager: manager)
+
+        let after = await manager.sessionState
+        XCTAssertEqual(after, .idle, "active in-memory session must be reset to .idle by Reset All (#403)")
+        XCTAssertNil(PausedSessionState.load(), "paused state cleared by reset")
+    }
+
     /// When the paused session's owner != the current auth uid, resumeSession must
     /// discard it (not replay/re-insert under the old owner → RLS 403), leave the
     /// manager idle, clear the paused snapshot, and surface a repair notice.


### PR DESCRIPTION
## Problem

`performResetAll` in `DeveloperSettingsView` drained the write-ahead queue (`writeAheadQueue.clearAll()`) and cleared `PausedSessionState`, but never reset the live `WorkoutSessionManager` actor. If a workout was **ACTIVE** (not paused) when the user tapped Reset All — and they ignored the "Quit and reopen the app" banner — the manager kept a `WorkoutSession` stamped with the **old** `auth.uid()`. Within the same process lifetime it could then enqueue owner-mismatched writes that replay RLS-403s after re-onboarding (#369 owner-mismatch campaign, slice 3 spinoff).

## Fix

Extracted the three in-memory reset side-effects into a small, single-purpose, testable helper:

```swift
func performLocalStateReset(
    writeAheadQueue: WriteAheadQueue,
    workoutSessionManager: WorkoutSessionManager
) async {
    await writeAheadQueue.clearAll()
    PausedSessionState.clear()
    await workoutSessionManager.resetToIdle()   // ← the fix: nils the active session
}
```

`performResetAll` now calls this helper instead of inlining the first two side-effects. `resetToIdle()` already existed (called on post-summary dismissal) — it nils `session` and sets `sessionState = .idle`; this fix just also invokes it on Reset All.

### Why extract (test approach)

The view's `performResetAll` is `@Environment`-backed and not directly unit-testable, and a manager-level test of the already-correct `resetToIdle()` would pass pre-fix (the bug is the *missing call*, not the method). So a genuine reproducing test required a seam. The extracted helper takes only the two actor collaborators it touches (not all of `AppDependencies`), keeping it minimal and single-purpose per CLAUDE.md "Simplicity First".

## Test (red → green)

`testPerformLocalStateReset_clearsActiveSession` starts a session to `.active` (via the existing `makeManagerWithWAQ()` harness), runs the helper, and asserts the manager lands in `.idle`.

- **Pre-fix (RED):** manager stayed `.active` → `XCTAssertEqual failed: ("active(...)") is not equal to ("idle")`.
- **Post-fix (GREEN):** passes.

Run locally (Xcode 26.5; CI pins 26.3 + iOS 26.2, unavailable locally so used newest available runtime):

```
xcodebuild test -project ProjectApex.xcodeproj -scheme ProjectApex \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' \
  -only-testing:ProjectApexTests/WorkoutSessionManagerTests
```

Result: **Executed 23 tests, with 0 failures** (full `WorkoutSessionManagerTests` class green).

## Scope

Single call site — not a cross-cutting pattern. Grepped `PausedSessionState.clear()` / `writeAheadQueue.clearAll()`: the only "Reset All"-style site outside `WorkoutSessionManager`'s own lifecycle methods is the one fixed here. No other reset path needed changes.

Closes #403