### PR TITLE
fix(#399): surface a 'couldn't start' message when workout-start auth-gate aborts

### DIFF
--- a/ProjectApex/Features/Workout/PreWorkoutView.swift
+++ b/ProjectApex/Features/Workout/PreWorkoutView.swift
@@ -668,8 +668,24 @@ struct PreWorkoutView: View {
     }
 
     private var startWorkoutButton: some View {
+        VStack(spacing: 12) {
+            startWorkoutButtonCore
+            // Inline failure: the auth gate aborts (no placeholder row) when owner
+            // auth never resolves. Surface that honestly rather than failing mute (#399).
+            if let startError = viewModel.startError, !viewModel.isStartingSession {
+                Text(startError)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Color(red: 1.0, green: 0.55, blue: 0.45))
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.top, 8)
+    }
+
+    private var startWorkoutButtonCore: some View {
         Button {
-            viewModel.startSession(trainingDay: trainingDay, programId: programId, deps: deps, weekNumber: weekNumber, startingExerciseIndex: startingExerciseIndex)
+            viewModel.startSession(trainingDay: trainingDay, programId: programId, resolveOwner: { await deps.resolvedOwnerUserId() }, weekNumber: weekNumber, startingExerciseIndex: startingExerciseIndex)
         } label: {
             HStack(spacing: 10) {
                 if viewModel.isStartingSession {
@@ -698,7 +714,6 @@ struct PreWorkoutView: View {
             .animation(.easeInOut(duration: 0.15), value: viewModel.isStartingSession)
         }
         .disabled(viewModel.isStartingSession)
-        .padding(.top, 8)
     }
 
     // MARK: - Skip Button

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -77,6 +77,12 @@ final class WorkoutViewModel {
     /// True while `startSession()` preflight is running (HealthKit + RAG fetch).
     var isStartingSession: Bool = false
 
+    /// Non-nil when the last start attempt aborted because owner auth never
+    /// resolved (offline / sign-in stall). Surfaced as an inline hint under the
+    /// Start button so the abort is no longer silent (#399). Cleared at the
+    /// start of the next tap.
+    var startError: String? = nil
+
     /// Controls the end-session-early confirmation dialog.
     var showEndSessionEarlyConfirmation: Bool = false
 
@@ -106,20 +112,28 @@ final class WorkoutViewModel {
     // MARK: - Public Actions
 
     /// Starts a new session for the given day. Awaits auth resolution so the
-    /// session is stamped with the real `auth.uid()`; aborts silently (resetting
-    /// `isStartingSession`) when auth has not resolved, so no placeholder-keyed
-    /// row is ever written (the RLS-403 owner-mismatch root cause). The
-    /// `isStartingSession` flag keeps the Start button disabled / spinner visible
-    /// during the brief await.
-    func startSession(trainingDay: TrainingDay, programId: UUID, deps: AppDependencies, weekNumber: Int = 1, startingExerciseIndex: Int = 0) {
+    /// session is stamped with the real `auth.uid()`; aborts when auth has not
+    /// resolved, so no placeholder-keyed row is ever written (the RLS-403
+    /// owner-mismatch root cause). On abort it surfaces `startError` so the user
+    /// is told why nothing happened rather than seeing a silent re-enable (#399).
+    /// The `isStartingSession` flag keeps the Start button disabled / spinner
+    /// visible during the brief await.
+    ///
+    /// `resolveOwner` is the auth-resolution seam — production passes
+    /// `{ await deps.resolvedOwnerUserId() }`; tests inject the abort/happy paths
+    /// directly without constructing the full `AppDependencies` container.
+    func startSession(trainingDay: TrainingDay, programId: UUID, resolveOwner: @escaping () async -> UUID?, weekNumber: Int = 1, startingExerciseIndex: Int = 0) {
         // Re-entrancy guard (mirrors onSetComplete/onSkipSet): the auth await below
         // widens the window between tap and session creation, so a second invocation
         // before SwiftUI re-renders the disabled state could start two sessions.
         guard !isStartingSession else { return }
         isStartingSession = true
+        // Clear any stale message from a previous failed tap.
+        startError = nil
         Task {
-            guard let userId = await deps.resolvedOwnerUserId() else {
+            guard let userId = await resolveOwner() else {
                 // Auth did not resolve — do NOT stamp a placeholder-keyed row.
+                startError = "Couldn't start — check your connection and try again."
                 isStartingSession = false
                 return
             }

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -1739,4 +1739,48 @@ final class PrescriptionGuardrailTests: XCTestCase {
         XCTAssertTrue(vm.canUseLastWeights,
             "A last-session history seed makes the manual fallback honest again")
     }
+
+    // MARK: start-session auth-gate abort surfaces a user-facing message (#399)
+
+    /// When owner resolution fails (offline / sign-in stall), startSession must
+    /// abort WITHOUT stamping a placeholder row — but it must no longer fail
+    /// mute: `isStartingSession` resets AND a user-facing `startError` is set so
+    /// PreWorkoutView can tell the user why nothing happened.
+    @MainActor
+    func test_startSession_authGateAbort_setsStartError_andResetsSpinner() async {
+        let vm = WorkoutViewModel(manager: makeManager())
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+
+        vm.startSession(
+            trainingDay: day,
+            programId: UUID(),
+            resolveOwner: { nil } // auth never resolves
+        )
+        // Let the internal Task run to completion.
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertFalse(vm.isStartingSession,
+            "Abort must re-enable the Start button (spinner off)")
+        XCTAssertNotNil(vm.startError,
+            "Abort must surface a user-facing message, not fail silently (#399)")
+    }
+
+    /// Happy path: when owner resolves, startSession must NOT set startError, and
+    /// a stale error from a previous failed tap is cleared at the start of the tap.
+    @MainActor
+    func test_startSession_ownerResolves_clearsStaleStartError() async {
+        let vm = WorkoutViewModel(manager: makeManager())
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+        vm.startError = "stale error from a previous failed tap"
+
+        vm.startSession(
+            trainingDay: day,
+            programId: UUID(),
+            resolveOwner: { UUID() } // auth resolves
+        )
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertNil(vm.startError,
+            "A successful start clears any stale error message")
+    }
 }


### PR DESCRIPTION
## What

`WorkoutViewModel.startSession` awaits owner resolution and **aborts** (without stamping a placeholder-keyed row) when auth never resolves — offline / sign-in stall. Previously the abort just reset `isStartingSession` and returned, so the **Start button silently re-enabled with no feedback**: the user tapped "Start Workout", saw a brief spinner, and landed back on the same screen with no explanation.

This surfaces a one-line inline hint on the abort path: **"Couldn't start — check your connection and try again."**

## How

- **`WorkoutViewModel`**: added observable `startError: String?`, set on the auth-gate abort branch and cleared at the start of each tap (so a stale message doesn't persist). The data-correctness behaviour is unchanged — a placeholder row is still never written.
- **`PreWorkoutView`**: renders `startError` inline under the Start button, mirroring the existing `pendingButtonGroup` "Couldn't generate the session…" hint exactly (same `Color(red: 1.0, green: 0.55, blue: 0.45)` warning treatment).
- **Testable seam**: `startSession` now takes `resolveOwner: () async -> UUID?` instead of the heavy concrete `AppDependencies`. Production passes `{ await deps.resolvedOwnerUserId() }`; the unit test injects the abort (`{ nil }`) and happy (`{ UUID() }`) paths directly without building the full DI container. Single production caller (`PreWorkoutView`) updated.

## Tests (TDD, RED → GREEN)

Added to `WorkoutSessionManagerTests.swift` (in `PrescriptionGuardrailTests`, alongside the existing `WorkoutViewModel` tests):
- `test_startSession_authGateAbort_setsStartError_andResetsSpinner` — owner resolves to `nil` → asserts `isStartingSession == false` **and** `startError != nil`. Failed (compile + logic) before the fix.
- `test_startSession_ownerResolves_clearsStaleStartError` — owner resolves → asserts a pre-set stale `startError` is cleared.

```
xcodebuild test -project ProjectApex.xcodeproj -scheme ProjectApex -testPlan ProjectApex \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' \
  -only-testing:ProjectApexTests/WorkoutSessionManagerTests \
  -only-testing:ProjectApexTests/PrescriptionGuardrailTests \
  -only-testing:ProjectApexTests/ComputePersonalRecordsTests
# Executed 43 tests, with 0 failures — ** TEST SUCCEEDED **
```

Run locally on iOS 26.5 (CI pins 26.2, which isn't installed locally; 26.5 is the newest available simulator runtime here).

Closes #399