### PR TITLE
fix(#409) PR-A: ProgramViewModel re-resolves owner at write time (keystone)

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		47BB8E622F6273750082C53F /* EquipmentConstraintValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E612F6273750082C53F /* EquipmentConstraintValidationTests.swift */; };
 		47BB8E662F6273F30082C53F /* ProgramPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E652F6273F30082C53F /* ProgramPersistenceTests.swift */; };
 		47BB8E712F6273F30082C53F /* OnboardingProgramPersistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E702F6273F30082C53F /* OnboardingProgramPersistTests.swift */; };
+		47BB8E8B2F6273F30082C53F /* ProgramOwnerGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */; };
 		47BB8E752F6294B00082C53F /* WorkoutSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */; };
 		47C5C1AF2F62A64E0005F99E /* WriteAheadQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */; };
 		47C5C1B82F62BB3D0005F99E /* GymStreakServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C5C1B72F62BB3D0005F99E /* GymStreakServiceTests.swift */; };
@@ -94,6 +95,7 @@
 		47BB8E612F6273750082C53F /* EquipmentConstraintValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquipmentConstraintValidationTests.swift; sourceTree = "<group>"; };
 		47BB8E652F6273F30082C53F /* ProgramPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramPersistenceTests.swift; sourceTree = "<group>"; };
 		47BB8E702F6273F30082C53F /* OnboardingProgramPersistTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingProgramPersistTests.swift; sourceTree = "<group>"; };
+		47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramOwnerGateTests.swift; sourceTree = "<group>"; };
 		47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSessionManagerTests.swift; sourceTree = "<group>"; };
 		47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteAheadQueueTests.swift; sourceTree = "<group>"; };
 		47C5C1B72F62BB3D0005F99E /* GymStreakServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymStreakServiceTests.swift; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 				47BB8E612F6273750082C53F /* EquipmentConstraintValidationTests.swift */,
 				47BB8E652F6273F30082C53F /* ProgramPersistenceTests.swift */,
 				47BB8E702F6273F30082C53F /* OnboardingProgramPersistTests.swift */,
+				47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */,
 				47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */,
 				47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */,
 				47C5C1B72F62BB3D0005F99E /* GymStreakServiceTests.swift */,
@@ -390,6 +393,7 @@
 				47C5C1B82F62BB3D0005F99E /* GymStreakServiceTests.swift in Sources */,
 				47BB8E662F6273F30082C53F /* ProgramPersistenceTests.swift in Sources */,
 				47BB8E712F6273F30082C53F /* OnboardingProgramPersistTests.swift in Sources */,
+				47BB8E8B2F6273F30082C53F /* ProgramOwnerGateTests.swift in Sources */,
 				478DD9F12F9928C6001D3636 /* SkipFeatureTests.swift in Sources */,
 				32736E74E3F688020744DE5E /* EquipmentRounderTests.swift in Sources */,
 				47C5C1AF2F62A64E0005F99E /* WriteAheadQueueTests.swift in Sources */,

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -154,6 +154,7 @@ struct ContentView: View {
                     macroPlanService: deps.macroPlanService,
                     sessionPlanService: deps.sessionPlanService,
                     userId: deps.resolvedUserId,
+                    resolveOwner: { await deps.resolvedOwnerUserId() },
                     traineeModelService: deps.traineeModelService
                 )
                 Task {
@@ -180,6 +181,7 @@ struct ContentView: View {
                     macroPlanService: deps.macroPlanService,
                     sessionPlanService: deps.sessionPlanService,
                     userId: deps.resolvedUserId,
+                    resolveOwner: { await deps.resolvedOwnerUserId() },
                     traineeModelService: deps.traineeModelService
                 )
             }

--- a/ProjectApex/Features/Program/ProgramOverviewView.swift
+++ b/ProjectApex/Features/Program/ProgramOverviewView.swift
@@ -928,7 +928,8 @@ private extension String {
                     memoryService: MemoryService(supabase: supabase, embeddingAPIKey: ""),
                     supabaseClient: supabase
                 ),
-                userId: AppDependencies.placeholderUserId
+                userId: AppDependencies.placeholderUserId,
+                resolveOwner: { nil }
             ),
             gymProfile: nil
         )

--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -144,7 +144,17 @@ final class ProgramViewModel {
     private let traineeModelService: TraineeModelService?
 
     /// User ID sourced from AppDependencies.resolvedUserId at construction time.
+    /// Best-effort id for NON-owned-write uses only (generation LLM payloads +
+    /// history-read filters). The single owned write re-resolves the owner async at
+    /// write time via `resolveOwner` (#409) so a `programs` row is never stamped
+    /// under the pre-auth placeholder uid.
     private let userId: UUID
+
+    /// Async owner re-resolution for the single owned write (`persistProgram`).
+    /// Returns nil / the placeholder when auth has not resolved; the owned write
+    /// aborts in that case rather than stamping a uid the user can't own (#409,
+    /// mirrors `AppDependencies.resolvedOwnerUserId()`).
+    private let resolveOwner: () async -> UUID?
 
     /// Per-pattern phase state for the PATTERN PROGRESS section in ProgramOverviewView
     /// — sourced from TraineeModelDigest.perPatternSummary (B3 / #88). Empty until
@@ -159,6 +169,7 @@ final class ProgramViewModel {
         macroPlanService: MacroPlanService,
         sessionPlanService: SessionPlanService,
         userId: UUID,
+        resolveOwner: @escaping () async -> UUID?,
         traineeModelService: TraineeModelService? = nil
     ) {
         self.supabaseClient = supabaseClient
@@ -167,6 +178,7 @@ final class ProgramViewModel {
         self.sessionPlanService = sessionPlanService
         self.traineeModelService = traineeModelService
         self.userId = userId
+        self.resolveOwner = resolveOwner
     }
 
     nonisolated deinit {}
@@ -188,6 +200,8 @@ final class ProgramViewModel {
         }
 
         // 2. Network fetch
+        // #425 will add resolve-before-stamp backfill here (re-persist a locally-cached
+        // program once the owner resolves). Read semantics unchanged for PR-A.
         do {
             if let row = try await supabaseClient.fetchActiveProgram(userId: userId) {
                 let mesocycle = row.toMesocycle()
@@ -277,16 +291,34 @@ final class ProgramViewModel {
     /// - Parameters:
     ///   - mesocycle: The mesocycle to persist.
     ///   - context: A short label for the logger (e.g. "regenerateProgram").
-    private func persistProgram(_ mesocycle: Mesocycle, context: String) async {
+    ///
+    /// Internal (not private) so test targets can drive the owned write directly —
+    /// same convention as `currentMesocycle` above. The public generate paths fire
+    /// this on a detached Task that a unit test cannot deterministically await.
+    func persistProgram(_ mesocycle: Mesocycle, context: String) async {
+        // Re-resolve the owner at write time (#409). On a fresh launch the captured
+        // `userId` can still be the pre-auth placeholder; stamping the `programs` row
+        // under it produced the #369 owner-mismatch. resolveOwner mirrors
+        // AppDependencies.resolvedOwnerUserId(): nil / placeholder means auth has not
+        // resolved, so abort silently — the local cache is already saved by callers,
+        // and #425 is the dedicated resolve-before-stamp backfill safety-net. This is
+        // NOT the persistError "sync failed, tap to retry" state (retrying would just
+        // re-abort), so clear both and log a notice instead of arming a banner.
+        guard let owner = await resolveOwner(), owner != AppDependencies.placeholderUserId else {
+            persistError = nil
+            persistRetryAction = nil
+            programPersistLogger.notice("persistProgram: owner unresolved/placeholder; skipping server stamp (local cache intact)")
+            return
+        }
+
         let capturedClient = supabaseClient
-        let capturedUserId = userId
         let capturedMesocycle = mesocycle
         do {
             // Atomic server-side deactivate-old + upsert-new in one transaction
             // (#189): replaces the non-transactional PATCH-then-POST whose partial
             // failure could leave the user with zero active programs. Idempotent
             // on retry (upsert on the client-generated program id).
-            try await capturedClient.deactivateAndInsertProgram(capturedMesocycle, userId: capturedUserId)
+            try await capturedClient.deactivateAndInsertProgram(capturedMesocycle, userId: owner)
             // Success: clear any prior sync error.
             persistError = nil
             persistRetryAction = nil
@@ -295,12 +327,14 @@ final class ProgramViewModel {
                 """
                 program insert failed (\(context)): \
                 \(error.localizedDescription, privacy: .public) — \
-                user_id=\(capturedUserId.uuidString, privacy: .public), \
+                user_id=\(owner.uuidString, privacy: .public), \
                 program_id=\(capturedMesocycle.id.uuidString, privacy: .public). \
                 Local cache preserved; row will not exist server-side until a successful retry.
                 """
             )
             persistError = "Couldn't sync your program. Tap to retry."
+            // Retry re-invokes persistProgram, which RE-RESOLVES the owner on each
+            // attempt (#409) — so a retry never replays a captured/placeholder uid.
             persistRetryAction = { [weak self] in
                 await self?.persistProgram(capturedMesocycle, context: context)
             }

--- a/ProjectApexTests/ProgramOwnerGateTests.swift
+++ b/ProjectApexTests/ProgramOwnerGateTests.swift
@@ -1,0 +1,263 @@
+// ProgramOwnerGateTests.swift
+// ProjectApexTests — #409 PR-A (#369 owner-mismatch campaign, Slice 6 tail)
+//
+// ProgramViewModel was frozen to the `userId` captured at init — which on a fresh
+// launch can be the pre-auth placeholder uid. The single owned write
+// (`deactivateAndInsertProgram` inside `persistProgram`) therefore stamped the
+// `programs` row under a uid the user could not own once anon-auth resolved.
+//
+// PR-A converts the owned write to ASYNC owner re-resolution at write time via an
+// injected `resolveOwner: () async -> UUID?`. These tests drive `persistProgram`
+// directly (it is `internal` for test access — same convention as
+// `currentMesocycle`) because the public generate paths fire the persist on a
+// detached Task that a unit test cannot deterministically await.
+//
+//   1. nilOwner        → no server request (auth unresolved → silent abort).
+//   2. placeholderOwner→ no server request (resolve-before-stamp guard).
+//   3. realOwner       → RPC body stamped with the resolved owner uid.
+//   4. retry           → persistRetryAction re-resolves the owner (does not replay
+//                        a captured uid): a network-failed real-owner persist arms
+//                        the retry; re-invoking it re-resolves to a DIFFERENT owner
+//                        and stamps that one.
+
+import XCTest
+@testable import ProjectApex
+
+// MARK: - URLProtocol stub (reused pattern from ProgramPersistenceTests / OnboardingProgramPersistTests)
+
+private final class ProgramOwnerGateStubURLProtocol: URLProtocol {
+    static var stubbedStatusCode: Int = 200
+    static var stubbedData: Data = Data()
+    static var lastRequest: URLRequest?
+    static var requestBodies: [Data] = []
+    static var requestCount: Int = 0
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        ProgramOwnerGateStubURLProtocol.requestCount += 1
+        ProgramOwnerGateStubURLProtocol.lastRequest = request
+        if let body = request.httpBody {
+            ProgramOwnerGateStubURLProtocol.requestBodies.append(body)
+        } else if let stream = request.httpBodyStream {
+            stream.open()
+            var data = Data()
+            let bufferSize = 1024
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+            while stream.hasBytesAvailable {
+                let read = stream.read(buffer, maxLength: bufferSize)
+                if read > 0 { data.append(buffer, count: read) }
+            }
+            buffer.deallocate()
+            stream.close()
+            if !data.isEmpty { ProgramOwnerGateStubURLProtocol.requestBodies.append(data) }
+        }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: ProgramOwnerGateStubURLProtocol.stubbedStatusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: ProgramOwnerGateStubURLProtocol.stubbedData)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeOwnerGateSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [ProgramOwnerGateStubURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func makeOwnerGateClient() -> SupabaseClient {
+    SupabaseClient(
+        supabaseURL: URL(string: "https://test.supabase.co")!,
+        anonKey: "test-anon-key",
+        urlSession: makeOwnerGateSession()
+    )
+}
+
+// MARK: - Minimal no-op LLM provider (mirrors SkipFeatureTests.makeViewModel)
+
+private struct OwnerGateThrowingProvider: LLMProvider {
+    func complete(systemPrompt: String, userPayload: String) async throws -> String {
+        throw URLError(.notConnectedToInternet)
+    }
+}
+
+// MARK: - ProgramOwnerGateTests
+
+final class ProgramOwnerGateTests: XCTestCase {
+
+    private let realOwner = UUID(uuidString: "CCCCCCCC-0000-0000-0000-000000000009")!
+    private let secondOwner = UUID(uuidString: "CCCCCCCC-0000-0000-0000-00000000000A")!
+
+    override func setUp() {
+        super.setUp()
+        ProgramOwnerGateStubURLProtocol.stubbedStatusCode = 200
+        // The RPC RETURNS TABLE(program_id uuid) → PostgREST replies with a JSON array.
+        ProgramOwnerGateStubURLProtocol.stubbedData = "[]".data(using: .utf8)!
+        ProgramOwnerGateStubURLProtocol.lastRequest = nil
+        ProgramOwnerGateStubURLProtocol.requestBodies = []
+        ProgramOwnerGateStubURLProtocol.requestCount = 0
+    }
+
+    /// Builds a ProgramViewModel backed by no-op services and a stubbed client,
+    /// with an injected `resolveOwner`. Mirrors SkipFeatureTests.makeViewModel +
+    /// the stubbed-client pattern from ProgramPersistenceTests.
+    @MainActor
+    private func makeViewModel(
+        client: SupabaseClient,
+        resolveOwner: @escaping () async -> UUID?
+    ) -> ProgramViewModel {
+        let provider: any LLMProvider = OwnerGateThrowingProvider()
+        let memory = MemoryService(supabase: client, embeddingAPIKey: "test")
+        return ProgramViewModel(
+            supabaseClient: client,
+            programGenerationService: ProgramGenerationService(provider: provider),
+            macroPlanService: MacroPlanService(provider: provider),
+            sessionPlanService: SessionPlanService(
+                provider: provider,
+                memoryService: memory,
+                supabaseClient: client
+            ),
+            userId: AppDependencies.placeholderUserId,   // frozen id is the placeholder — the bug's setup
+            resolveOwner: resolveOwner
+        )
+    }
+
+    /// nil owner (auth never resolved / offline) → silent abort, NO server request.
+    /// FAILS before the refactor: the frozen userId issues the RPC regardless.
+    @MainActor
+    func test_nilOwner_doesNotCallServer() async {
+        let client = makeOwnerGateClient()
+        let vm = makeViewModel(client: client, resolveOwner: { nil })
+
+        await vm.persistProgram(Mesocycle.mockMesocycle(), context: "test_nilOwner")
+
+        XCTAssertEqual(
+            ProgramOwnerGateStubURLProtocol.requestCount, 0,
+            "A nil owner must skip the server stamp (no deactivate_and_insert_program)."
+        )
+        XCTAssertNil(vm.persistError, "Owner-unresolved is a silent abort, not a sync failure.")
+        XCTAssertNil(vm.persistRetryAction, "No retry is armed on an owner-unresolved abort.")
+    }
+
+    /// placeholder owner → resolve-before-stamp guard: NO server request.
+    @MainActor
+    func test_placeholderOwner_doesNotCallServer() async {
+        let client = makeOwnerGateClient()
+        let vm = makeViewModel(client: client, resolveOwner: { AppDependencies.placeholderUserId })
+
+        await vm.persistProgram(Mesocycle.mockMesocycle(), context: "test_placeholder")
+
+        XCTAssertEqual(
+            ProgramOwnerGateStubURLProtocol.requestCount, 0,
+            "The placeholder uid must never be stamped server-side."
+        )
+        XCTAssertNil(vm.persistError)
+        XCTAssertNil(vm.persistRetryAction)
+    }
+
+    /// A resolved real owner → the RPC body is stamped with THAT uid (resolve-before-stamp).
+    @MainActor
+    func test_realOwner_stampsThatUid() async throws {
+        let mesocycle = Mesocycle.mockMesocycle()
+        ProgramOwnerGateStubURLProtocol.stubbedData =
+            #"[{"program_id":"\#(mesocycle.id.uuidString)"}]"#.data(using: .utf8)!
+
+        let client = makeOwnerGateClient()
+        let vm = makeViewModel(client: client, resolveOwner: { self.realOwner })
+
+        await vm.persistProgram(mesocycle, context: "test_realOwner")
+
+        let req = try XCTUnwrap(
+            ProgramOwnerGateStubURLProtocol.lastRequest,
+            "A resolved owner must produce a server request."
+        )
+        XCTAssertEqual(req.httpMethod, "POST")
+        XCTAssertTrue(
+            req.url?.absoluteString.contains("/rpc/deactivate_and_insert_program") == true,
+            "Persist must go through the atomic RPC, got \(req.url?.absoluteString ?? "nil")"
+        )
+
+        let bodyData = try XCTUnwrap(ProgramOwnerGateStubURLProtocol.requestBodies.last)
+        let body = try XCTUnwrap(try JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        XCTAssertEqual(
+            body["p_user_id"] as? String, realOwner.uuidString,
+            "The program must be stamped with the RESOLVED owner uid, not the frozen placeholder."
+        )
+        XCTAssertEqual(body["p_program_id"] as? String, mesocycle.id.uuidString)
+    }
+
+    /// The retry must RE-RESOLVE the owner rather than replay a captured uid.
+    ///
+    /// Spec wrinkle: the prompt's "nil first → invoke persistRetryAction" can't be
+    /// taken literally — an owner-unresolved abort is SILENT (it clears
+    /// persistRetryAction to nil per the UX note), so a nil-first persist arms no
+    /// retry to invoke. `persistRetryAction` is armed only by a NETWORK failure, so
+    /// this drives the exact defect that fix targets: a real-owner persist whose RPC
+    /// 500s arms the retry; the resolver then returns a DIFFERENT owner; invoking
+    /// persistRetryAction must stamp the freshly-resolved owner — proving the retry
+    /// re-resolves rather than replaying the captured uid.
+    @MainActor
+    func test_retry_reResolvesOwner() async throws {
+        let mesocycle = Mesocycle.mockMesocycle()
+
+        // Counter-backed resolver: realOwner on the first call, secondOwner after.
+        let counter = OwnerResolveCounter(values: [realOwner, secondOwner])
+        let client = makeOwnerGateClient()
+        let vm = makeViewModel(client: client, resolveOwner: { await counter.next() })
+
+        // First persist: real owner resolves, but the RPC fails → retry armed.
+        ProgramOwnerGateStubURLProtocol.stubbedStatusCode = 500
+        ProgramOwnerGateStubURLProtocol.stubbedData = "{}".data(using: .utf8)!
+        await vm.persistProgram(mesocycle, context: "test_retry")
+
+        XCTAssertEqual(
+            ProgramOwnerGateStubURLProtocol.requestCount, 1,
+            "The first persist resolves a real owner and issues exactly one (failing) request."
+        )
+        let firstBody = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: XCTUnwrap(ProgramOwnerGateStubURLProtocol.requestBodies.last)) as? [String: Any]
+        )
+        XCTAssertEqual(firstBody["p_user_id"] as? String, realOwner.uuidString)
+        let retry = try XCTUnwrap(vm.persistRetryAction, "A network-failed persist must arm a retry.")
+
+        // Retry: the RPC now succeeds; the retry must RE-RESOLVE → secondOwner.
+        ProgramOwnerGateStubURLProtocol.stubbedStatusCode = 200
+        ProgramOwnerGateStubURLProtocol.stubbedData =
+            #"[{"program_id":"\#(mesocycle.id.uuidString)"}]"#.data(using: .utf8)!
+        await retry()
+
+        XCTAssertEqual(
+            ProgramOwnerGateStubURLProtocol.requestCount, 2,
+            "Invoking the retry must issue a second request."
+        )
+        let retryBody = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: XCTUnwrap(ProgramOwnerGateStubURLProtocol.requestBodies.last)) as? [String: Any]
+        )
+        XCTAssertEqual(
+            retryBody["p_user_id"] as? String, secondOwner.uuidString,
+            "The retry must stamp the freshly RE-RESOLVED owner, not replay the captured uid."
+        )
+    }
+}
+
+// MARK: - Counter-backed resolver
+
+/// Returns successive values on each `next()` call (last value repeats once
+/// exhausted). Actor so the `() async -> UUID?` closure can read it safely.
+private actor OwnerResolveCounter {
+    private let values: [UUID?]
+    private var index = 0
+    init(values: [UUID?]) { self.values = values }
+    func next() -> UUID? {
+        defer { if index < values.count - 1 { index += 1 } }
+        return values.isEmpty ? nil : values[min(index, values.count - 1)]
+    }
+}

--- a/ProjectApexTests/SkipFeatureTests.swift
+++ b/ProjectApexTests/SkipFeatureTests.swift
@@ -45,7 +45,8 @@ private func makeViewModel() -> ProgramViewModel {
             memoryService: memory,
             supabaseClient: supabase
         ),
-        userId: UUID()
+        userId: UUID(),
+        resolveOwner: { UUID() }
     )
 }
 


### PR DESCRIPTION
## What

`ProgramViewModel` froze `userId` at init, which on a fresh launch can be the pre-auth **placeholder** uid. Its single owned write (`SupabaseClient.deactivateAndInsertProgram` inside `persistProgram`) therefore stamped the `programs` row under a uid the user couldn't own once anon-auth resolved — the final tail of the #369 owner-mismatch campaign (Slice 6, the `ContentView`-coupled program write). This is the keystone that unblocks #425.

## Change (PR-A only — gym_profiles + ProgramDayDetailView are PR-B)

- **Async owner re-resolution at write time.** New stored `resolveOwner: () async -> UUID?` + init param, mirroring `AppDependencies.resolvedOwnerUserId()`. `persistProgram` now re-resolves the owner at the top and stamps the RPC with the *resolved* owner instead of the frozen `userId`.
- **Silent abort on unresolved/placeholder owner.** When `resolveOwner()` returns `nil` or the placeholder, the write aborts silently: it clears `persistError`/`persistRetryAction` and logs a `notice` — it does **not** arm the "sync failed, tap to retry" banner (that's a different state; retrying would just re-abort). The local cache is already saved by callers, so the program is intact, and #425 is the dedicated resolve-before-stamp backfill safety-net.
- **Retry re-resolves automatically.** `persistRetryAction` re-invokes `persistProgram`, which re-resolves on each attempt — fixing the "retry replays a captured uid" defect with no extra code.
- **`userId` is kept** for the best-effort, **non-owned** uses (generation LLM payloads in `generateProgram`/`generateMacroSkeleton`/`generateDaySession`, history-read filters in `fetchHistoricalDayLabels`, and `loadProgram`'s read) — explicitly out of scope and unchanged.
- **`loadProgram`** read semantics unchanged; a one-line comment marks where #425 will add resolve-before-stamp backfill.
- **Wiring:** `resolveOwner: { await deps.resolvedOwnerUserId() }` added at both `ContentView` construction sites (onboarding-rebuild + lazy `.task`). `SkipFeatureTests.makeViewModel` and the `ProgramOverviewView` `#Preview` updated for the new required param (the preview was an orphaned compile dependency of the new param).

## TDD

New `ProjectApexTests/ProgramOwnerGateTests.swift` drives `persistProgram` directly. `persistProgram` was widened from `private` to `internal` (same convention as `currentMesocycle`) because the public generate paths fire it on a detached `Task` a unit test cannot deterministically await.

- `nilOwner_doesNotCallServer` — `resolveOwner = { nil }` → 0 server requests; no banner armed.
- `placeholderOwner_doesNotCallServer` — `resolveOwner = { placeholder }` → 0 requests.
- `realOwner_stampsThatUid` — RPC body `p_user_id == realOwner.uuidString`.
- `retry_reResolvesOwner` — a real-owner persist whose RPC 500s arms `persistRetryAction`; the resolver then flips to a *different* owner; invoking the retry stamps the freshly re-resolved owner (proves re-resolution, not replay).

> Spec note: the prompt's "nil first → invoke `persistRetryAction`" can't be literal — a nil-owner abort is silent and clears `persistRetryAction` to nil, so there's nothing to invoke. `persistRetryAction` is armed only by a network failure, so the retry test drives that exact path while still asserting re-resolution.

**Local run** (CI pins iPhone 17 Pro / iOS 26.2, not installed here; used the newest local runtime, iOS 26.5):

```
xcodebuild test -project ProjectApex.xcodeproj -scheme ProjectApex \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' \
  -only-testing:ProjectApexTests/ProgramOwnerGateTests
```

RED before the production change: compile failure (`extra argument 'resolveOwner'` + `'persistProgram' is inaccessible due to 'private'`). GREEN after: 4/4 pass. Adjacent suites re-run green: `ProgramPersistenceTests` (16), `OnboardingProgramPersistTests` (3), `SkipFeatureTests`.

Part of #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)