### PR TITLE
fix(#409) PR-B: gate gym_profiles + set-correction embeds on resolved owner

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		47BB8E622F6273750082C53F /* EquipmentConstraintValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E612F6273750082C53F /* EquipmentConstraintValidationTests.swift */; };
 		47BB8E662F6273F30082C53F /* ProgramPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E652F6273F30082C53F /* ProgramPersistenceTests.swift */; };
 		47BB8E712F6273F30082C53F /* OnboardingProgramPersistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E702F6273F30082C53F /* OnboardingProgramPersistTests.swift */; };
+		47BB8E712F6273F30082C5F1 /* GymProfileSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E702F6273F30082C5F0 /* GymProfileSyncTests.swift */; };
 		47BB8E8B2F6273F30082C53F /* ProgramOwnerGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */; };
 		47BB8E752F6294B00082C53F /* WorkoutSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */; };
 		47C5C1AF2F62A64E0005F99E /* WriteAheadQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */; };
@@ -95,6 +96,7 @@
 		47BB8E612F6273750082C53F /* EquipmentConstraintValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquipmentConstraintValidationTests.swift; sourceTree = "<group>"; };
 		47BB8E652F6273F30082C53F /* ProgramPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramPersistenceTests.swift; sourceTree = "<group>"; };
 		47BB8E702F6273F30082C53F /* OnboardingProgramPersistTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingProgramPersistTests.swift; sourceTree = "<group>"; };
+		47BB8E702F6273F30082C5F0 /* GymProfileSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymProfileSyncTests.swift; sourceTree = "<group>"; };
 		47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramOwnerGateTests.swift; sourceTree = "<group>"; };
 		47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSessionManagerTests.swift; sourceTree = "<group>"; };
 		47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteAheadQueueTests.swift; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 				47BB8E612F6273750082C53F /* EquipmentConstraintValidationTests.swift */,
 				47BB8E652F6273F30082C53F /* ProgramPersistenceTests.swift */,
 				47BB8E702F6273F30082C53F /* OnboardingProgramPersistTests.swift */,
+				47BB8E702F6273F30082C5F0 /* GymProfileSyncTests.swift */,
 				47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */,
 				47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */,
 				47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */,
@@ -393,6 +396,7 @@
 				47C5C1B82F62BB3D0005F99E /* GymStreakServiceTests.swift in Sources */,
 				47BB8E662F6273F30082C53F /* ProgramPersistenceTests.swift in Sources */,
 				47BB8E712F6273F30082C53F /* OnboardingProgramPersistTests.swift in Sources */,
+				47BB8E712F6273F30082C5F1 /* GymProfileSyncTests.swift in Sources */,
 				47BB8E8B2F6273F30082C53F /* ProgramOwnerGateTests.swift in Sources */,
 				478DD9F12F9928C6001D3636 /* SkipFeatureTests.swift in Sources */,
 				32736E74E3F688020744DE5E /* EquipmentRounderTests.swift in Sources */,

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -623,21 +623,20 @@ struct ContentView: View {
                 // and leave a duplicate active row.
                 gymProfileSyncTask?.cancel()
 
-                let userId = deps.resolvedUserId
                 let client = deps.supabaseClient
                 gymProfileSyncTask = Task {
                     guard !Task.isCancelled else { return }
-                    do {
-                        // Deactivate old row, then insert updated one (scanner pattern).
-                        // These are sequential awaits within a single Task — no race window.
-                        try await client.deactivateGymProfiles(userId: userId)
-                        guard !Task.isCancelled else { return }
-                        let row = GymProfileRow.forInsert(from: updatedProfile, userId: userId)
-                        try await client.insert(row, table: "gym_profiles")
+                    // #409 PR-B: resolve-before-stamp — gate the owned write on the
+                    // resolved owner so a pre-auth placeholder edit never reaches the
+                    // server. nil / placeholder owner skips the write (UserDefaults wins).
+                    let owner = await deps.resolvedOwnerUserId()
+                    guard !Task.isCancelled else { return }
+                    let didSync = await GymProfileSync.syncIfOwnerResolved(updatedProfile, owner: owner, client: client)
+                    if didSync {
                         print("[ContentView] GymProfile synced to Supabase — \(updatedProfile.equipment.count) items")
-                    } catch {
+                    } else {
                         // Non-fatal — UserDefaults is the local source of truth.
-                        print("[ContentView] GymProfile Supabase sync failed: \(error.localizedDescription)")
+                        print("[ContentView] GymProfile Supabase sync skipped/failed (owner unresolved or write failed)")
                     }
                 }
             },
@@ -682,6 +681,40 @@ struct ContentView: View {
         } else {
             // Success — switch to Program tab so user sees the new program
             selectedTab = 0
+        }
+    }
+}
+
+// MARK: - GymProfile Sync (#409 PR-B / #369 owner-stamping workstream)
+
+/// Resolve-before-stamp sync for the equipment-edit `gym_profiles` write.
+///
+/// `onEquipmentChanged` historically captured the SYNC `deps.resolvedUserId`,
+/// which can still be the pre-auth placeholder on a fresh launch — so an
+/// equipment edit made before auth resolved would deactivate + insert a row the
+/// user could not own (the #369 owner-mismatch failure mode). This helper gates
+/// the write on the resolved owner: a nil owner (auth unresolved / offline) or
+/// the placeholder uid is never written. UserDefaults remains the local source
+/// of truth in that case (matches the existing non-fatal behavior).
+enum GymProfileSync {
+    /// - Returns: `true` iff the server insert succeeded under a real resolved owner.
+    @discardableResult
+    static func syncIfOwnerResolved(
+        _ profile: GymProfile,
+        owner: UUID?,
+        client: SupabaseClient
+    ) async -> Bool {
+        // resolve-before-stamp: never sync a row we can't own.
+        guard let owner, owner != AppDependencies.placeholderUserId else { return false }
+        // Deactivate is best-effort: zero existing active rows (patchNoMatch) is
+        // VALID for a first edit, not an error, so it must not block the insert.
+        try? await client.deactivateGymProfiles(userId: owner)
+        do {
+            try await client.insert(GymProfileRow.forInsert(from: profile, userId: owner), table: "gym_profiles")
+            return true
+        } catch {
+            // Non-fatal: UserDefaults remains the source of truth (matches current behavior).
+            return false
         }
     }
 }

--- a/ProjectApex/Features/Program/ProgramDayDetailView.swift
+++ b/ProjectApex/Features/Program/ProgramDayDetailView.swift
@@ -1062,7 +1062,10 @@ struct ProgramDayDetailView: View {
         // Include "originally logged as X" so the AI understands this is a correction,
         // not a separate performance event.
         let memoryService = deps.memoryService
-        let userId = deps.resolvedUserId.uuidString
+        // #409 PR-B: best-effort RAG embed; skip under an unresolved/placeholder owner
+        // so a pre-auth placeholder uid never stamps correction embeddings.
+        guard let owner = await deps.resolvedOwnerUserId() else { return }
+        let userId = owner.uuidString
         let sessionIdStr = completedSessionId?.uuidString ?? ""
         let exerciseName = currentDay.exercises
             .first(where: { $0.exerciseId == updated.exerciseId })?.name ?? updated.exerciseId
@@ -1178,7 +1181,10 @@ struct ProgramDayDetailView: View {
 
         // Embed into RAG memory
         let memoryService = deps.memoryService
-        let userId = deps.resolvedUserId.uuidString
+        // #409 PR-B: best-effort RAG embed; skip under an unresolved/placeholder owner
+        // so a pre-auth placeholder uid never stamps the manual-log embedding.
+        guard let owner = await deps.resolvedOwnerUserId() else { return }
+        let userId = owner.uuidString
         let sessionIdStr = sessionId.uuidString
         let exerciseName = currentDay.exercises
             .first(where: { $0.exerciseId == newLog.exerciseId })?.name ?? newLog.exerciseId

--- a/ProjectApexTests/GymProfileSyncTests.swift
+++ b/ProjectApexTests/GymProfileSyncTests.swift
@@ -1,0 +1,195 @@
+// GymProfileSyncTests.swift
+// ProjectApexTests — #409 PR-B (#369 owner-stamping workstream)
+//
+// Gates the `gym_profiles` deactivate+insert that fires from
+// `ContentView.onEquipmentChanged` on the RESOLVED owner. Before this fix the
+// site read the sync `deps.resolvedUserId`, which can be the pre-auth
+// placeholder — so an equipment edit made before auth resolved would stamp a
+// row the user could not own (the #369 owner-mismatch failure mode).
+//
+// These tests drive the smallest unit that owns the gate
+// (`GymProfileSync.syncIfOwnerResolved`), since the SwiftUI ContentView itself
+// is not directly drivable in a unit test.
+//
+//   1. Owner is nil (auth unresolved) → no server request (no placeholder write).
+//   2. Owner is the placeholder uid    → no server request (resolve-before-stamp).
+//   3. Owner resolves to a real uid     → deactivate fires (best-effort; a
+//      zero-old-row patchNoMatch is NON-FATAL) and the insert STILL fires,
+//      stamped with that exact resolved uid.
+
+import XCTest
+@testable import ProjectApex
+
+// MARK: - URLProtocol stub (reused pattern from OnboardingProgramPersistTests)
+
+private final class GymProfileSyncStubURLProtocol: URLProtocol {
+    /// Status code returned for the deactivate PATCH (first request).
+    static var deactivateStatusCode: Int = 200
+    /// Body returned for the deactivate PATCH. An empty JSON array makes
+    /// `performExpectingRow` throw `patchNoMatch` (zero old active rows) — the
+    /// realistic "first edit, nothing to deactivate" case.
+    static var deactivateData: Data = "[]".data(using: .utf8)!
+    /// Status code returned for the insert POST (second request).
+    static var insertStatusCode: Int = 200
+    /// Body returned for the insert POST.
+    static var insertData: Data = "[]".data(using: .utf8)!
+
+    static var requestCount: Int = 0
+    static var lastRequest: URLRequest?
+    static var requests: [URLRequest] = []
+    static var requestBodies: [Data] = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let isInsert = (request.httpMethod ?? "") == "POST"
+        GymProfileSyncStubURLProtocol.requestCount += 1
+        GymProfileSyncStubURLProtocol.lastRequest = request
+        GymProfileSyncStubURLProtocol.requests.append(request)
+        if let body = request.httpBody {
+            GymProfileSyncStubURLProtocol.requestBodies.append(body)
+        } else if let stream = request.httpBodyStream {
+            stream.open()
+            var data = Data()
+            let bufferSize = 1024
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+            while stream.hasBytesAvailable {
+                let read = stream.read(buffer, maxLength: bufferSize)
+                if read > 0 { data.append(buffer, count: read) }
+            }
+            buffer.deallocate()
+            stream.close()
+            if !data.isEmpty { GymProfileSyncStubURLProtocol.requestBodies.append(data) }
+        }
+
+        let statusCode = isInsert
+            ? GymProfileSyncStubURLProtocol.insertStatusCode
+            : GymProfileSyncStubURLProtocol.deactivateStatusCode
+        let payload = isInsert
+            ? GymProfileSyncStubURLProtocol.insertData
+            : GymProfileSyncStubURLProtocol.deactivateData
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeGymProfileSyncSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [GymProfileSyncStubURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func makeGymProfileSyncClient() -> SupabaseClient {
+    SupabaseClient(
+        supabaseURL: URL(string: "https://test.supabase.co")!,
+        anonKey: "test-anon-key",
+        urlSession: makeGymProfileSyncSession()
+    )
+}
+
+// MARK: - GymProfileSyncTests
+
+final class GymProfileSyncTests: XCTestCase {
+
+    private let realOwner = UUID(uuidString: "DDDDDDDD-0000-0000-0000-000000000009")!
+
+    override func setUp() {
+        super.setUp()
+        GymProfileSyncStubURLProtocol.deactivateStatusCode = 200
+        GymProfileSyncStubURLProtocol.deactivateData = "[]".data(using: .utf8)!
+        GymProfileSyncStubURLProtocol.insertStatusCode = 200
+        GymProfileSyncStubURLProtocol.insertData = "[]".data(using: .utf8)!
+        GymProfileSyncStubURLProtocol.requestCount = 0
+        GymProfileSyncStubURLProtocol.lastRequest = nil
+        GymProfileSyncStubURLProtocol.requests = []
+        GymProfileSyncStubURLProtocol.requestBodies = []
+    }
+
+    /// Resolve-before-stamp guard: a nil owner (auth never resolved / offline)
+    /// must NOT write anything server-side.
+    func test_syncIfOwnerResolved_nilOwner_noRequests() async {
+        let profile = GymProfile.mockProfile()
+        let client = makeGymProfileSyncClient()
+
+        let didSync = await GymProfileSync.syncIfOwnerResolved(profile, owner: nil, client: client)
+
+        XCTAssertFalse(didSync, "A nil owner must skip the server sync.")
+        XCTAssertEqual(
+            GymProfileSyncStubURLProtocol.requestCount, 0,
+            "No server request may be made when the owner is unresolved."
+        )
+    }
+
+    /// Resolve-before-stamp guard: the placeholder uid must NEVER be persisted.
+    func test_syncIfOwnerResolved_placeholderOwner_noRequests() async {
+        let profile = GymProfile.mockProfile()
+        let client = makeGymProfileSyncClient()
+
+        let didSync = await GymProfileSync.syncIfOwnerResolved(
+            profile,
+            owner: AppDependencies.placeholderUserId,
+            client: client
+        )
+
+        XCTAssertFalse(didSync, "The placeholder uid must never be persisted.")
+        XCTAssertEqual(
+            GymProfileSyncStubURLProtocol.requestCount, 0,
+            "No server request may be made for the placeholder uid."
+        )
+    }
+
+    /// Happy path with a non-fatal deactivate: the deactivate PATCH returns an
+    /// empty array (zero old active rows → `patchNoMatch`), which is VALID, not an
+    /// error. The insert must STILL fire and be stamped with the resolved owner.
+    func test_syncIfOwnerResolved_realOwner_deactivatesThenInserts_nonFatalDeactivate() async throws {
+        // Deactivate returns [] → SupabaseClient.deactivateGymProfiles throws
+        // patchNoMatch; the helper swallows it (try?) and proceeds to the insert.
+        GymProfileSyncStubURLProtocol.deactivateData = "[]".data(using: .utf8)!
+        GymProfileSyncStubURLProtocol.insertStatusCode = 200
+        GymProfileSyncStubURLProtocol.insertData = "[]".data(using: .utf8)!
+
+        let profile = GymProfile.mockProfile()
+        let client = makeGymProfileSyncClient()
+
+        let didSync = await GymProfileSync.syncIfOwnerResolved(profile, owner: realOwner, client: client)
+
+        XCTAssertTrue(didSync, "A non-fatal deactivate must not block the insert under a real owner.")
+
+        // Both requests fire: the deactivate PATCH and the insert POST.
+        XCTAssertEqual(
+            GymProfileSyncStubURLProtocol.requestCount, 2,
+            "Expected a deactivate PATCH then an insert POST."
+        )
+
+        // The insert is the POST request; assert its body stamps the resolved owner.
+        let insertRequest = try XCTUnwrap(
+            GymProfileSyncStubURLProtocol.requests.first(where: { $0.httpMethod == "POST" }),
+            "The insert POST must fire even when the deactivate matched zero rows."
+        )
+        XCTAssertTrue(
+            insertRequest.url?.absoluteString.contains("/gym_profiles") == true,
+            "Insert must target gym_profiles, got \(insertRequest.url?.absoluteString ?? "nil")"
+        )
+
+        let insertBody = try XCTUnwrap(
+            GymProfileSyncStubURLProtocol.requestBodies.last,
+            "The insert must carry a body."
+        )
+        let body = try XCTUnwrap(try JSONSerialization.jsonObject(with: insertBody) as? [String: Any])
+        XCTAssertEqual(
+            body["user_id"] as? String, realOwner.uuidString,
+            "The inserted gym_profiles row must be stamped with the RESOLVED owner uid."
+        )
+    }
+}


### PR DESCRIPTION
## What

Final tail of the #369 owner-mismatch campaign (Slice 6). PR-A (#429) made `ProgramViewModel` re-resolve the owner at write time; this PR gates the **two remaining ContentView-coupled owned-write sites** on the resolved owner. Closes #409.

### Site 1 — `gym_profiles` write (`ContentView.onEquipmentChanged`)
The equipment-edit deactivate+insert captured the **sync** `deps.resolvedUserId`, which can still be the pre-auth placeholder on a fresh launch — so an edit made before auth resolved would stamp a `gym_profiles` row the user could not own.

Extracted a small testable helper `GymProfileSync.syncIfOwnerResolved(_:owner:client:)` (mirrors the `OnboardingProgramPersist` shape, lives at file scope in `ContentView.swift`):
- `nil` owner (auth unresolved / offline) or the placeholder uid → **no write** (UserDefaults stays the local source of truth, matching current non-fatal behavior).
- Real resolved owner → deactivate (best-effort) then insert, stamped with that owner.
- The deactivate is best-effort via `try?`: a zero-old-row `patchNoMatch` (first edit, nothing active to deactivate) is **valid**, not an error, and must not block the insert.

`onEquipmentChanged` now `await deps.resolvedOwnerUserId()` inside the existing `Task` (the cancellation guards are preserved).

### Site 2 — set-correction RAG embeds (`ProgramDayDetailView`)
`applySetLogEdit` and `addNewSetLog` each replaced their sync `deps.resolvedUserId.uuidString` capture with:
```swift
guard let owner = await deps.resolvedOwnerUserId() else { return }  // best-effort RAG embed; skip under unresolved/placeholder owner
let userId = owner.uuidString
```
Both methods are already `async @MainActor`, so the `await` is legal — no signature change. These embeds are fire-and-forget best-effort enrichment, so they get an **inline guard, no helper** (over-engineering for two guard lines). The guards sit after the `set_logs` PATCH/insert and the local-state update, so only the embed is skipped — the `set_logs` writes themselves are **not** owner-stamped and are left untouched per the issue scope.

## patchNoMatch handling (confirmed)
`SupabaseClient.deactivateGymProfiles` routes through `performExpectingRow`, which throws `SupabaseError.patchNoMatch` when the `Prefer: return=representation` PATCH response is an empty JSON array (zero matched rows, issue #185). The helper swallows that with `try?` so a first-edit deactivate doesn't abort the insert. The GREEN test replicates this exactly: the deactivate PATCH stub returns `[]` and the test asserts the insert STILL fires.

## Tests (TDD)
New `ProjectApexTests/GymProfileSyncTests.swift` (URLProtocol stub, mirrors `OnboardingProgramPersistTests`), wired into the `ProjectApexTests` target in `project.pbxproj`:
- `test_syncIfOwnerResolved_nilOwner_noRequests` — `owner: nil` → `requestCount == 0`.
- `test_syncIfOwnerResolved_placeholderOwner_noRequests` — placeholder uid → `requestCount == 0`.
- `test_syncIfOwnerResolved_realOwner_deactivatesThenInserts_nonFatalDeactivate` — deactivate returns `[]` (→ swallowed `patchNoMatch`); asserts the insert STILL fires AND its body's `user_id == owner.uuidString`.

RED (helper missing) → `Cannot find 'GymProfileSync' in scope`; GREEN → 3/3 pass.

The two embed gates are **guarded-by-inspection**, justified by `resolvedOwnerUserId()` already being unit-covered (PR-A and Slice-6 tests) and the embeds being best-effort fire-and-forget.

## Test command (local source of truth)
CI pins an iOS version I may not have locally; ran against the newest local runtime (iOS 26.5):
```
xcodebuild test -project ProjectApex.xcodeproj -scheme ProjectApex \
  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
  -only-testing:ProjectApexTests/GymProfileSyncTests
```
Result: **TEST SUCCEEDED** — 3/3.

## Cross-cutting grep (grep-and-report, not rewrite)
Grepped all remaining `deps.resolvedUserId` (sync) uses in app code. The remaining live hits are **reads or dev-only**, not new ungated owner-stamped writes:
- `ContentView` 121/156/183/207 — view-model/`ProgressTabView` seeds (reads; `ProgramViewModel` write-time owner fixed in PR-A).
- `ProgramDayDetailView:965` (`loadHistoricalSetLogs`) — a `fetch` (read).
- `WorkoutView` 144/156/238 — `computeStreak` + a fetch `Filter` (reads).
- `DeveloperSettingsView:635` (`performClearRAGMemory`) — a developer-settings DELETE of the resolved user's own embeddings; not an owner-stamped insert, out of #409 scope. **Flagged, not changed.**

No other ungated owner-stamped owned-write sites found.

Closes #409