### PR TITLE
fix(#369): backfill a local-only program to the server when the owner resolves

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		47BB8E712F6273F30082C53F /* OnboardingProgramPersistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E702F6273F30082C53F /* OnboardingProgramPersistTests.swift */; };
 		47BB8E712F6273F30082C5F1 /* GymProfileSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E702F6273F30082C5F0 /* GymProfileSyncTests.swift */; };
 		47BB8E8B2F6273F30082C53F /* ProgramOwnerGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */; };
+		47BB8E712F6273F30082C625 /* ProgramBackfillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E702F6273F30082C625 /* ProgramBackfillTests.swift */; };
 		47BB8E752F6294B00082C53F /* WorkoutSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */; };
 		47C5C1AF2F62A64E0005F99E /* WriteAheadQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */; };
 		47C5C1B82F62BB3D0005F99E /* GymStreakServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C5C1B72F62BB3D0005F99E /* GymStreakServiceTests.swift */; };
@@ -98,6 +99,7 @@
 		47BB8E702F6273F30082C53F /* OnboardingProgramPersistTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingProgramPersistTests.swift; sourceTree = "<group>"; };
 		47BB8E702F6273F30082C5F0 /* GymProfileSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymProfileSyncTests.swift; sourceTree = "<group>"; };
 		47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramOwnerGateTests.swift; sourceTree = "<group>"; };
+		47BB8E702F6273F30082C625 /* ProgramBackfillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramBackfillTests.swift; sourceTree = "<group>"; };
 		47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSessionManagerTests.swift; sourceTree = "<group>"; };
 		47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteAheadQueueTests.swift; sourceTree = "<group>"; };
 		47C5C1B72F62BB3D0005F99E /* GymStreakServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymStreakServiceTests.swift; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 				47BB8E702F6273F30082C53F /* OnboardingProgramPersistTests.swift */,
 				47BB8E702F6273F30082C5F0 /* GymProfileSyncTests.swift */,
 				47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */,
+				47BB8E702F6273F30082C625 /* ProgramBackfillTests.swift */,
 				47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */,
 				47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */,
 				47C5C1B72F62BB3D0005F99E /* GymStreakServiceTests.swift */,
@@ -398,6 +401,7 @@
 				47BB8E712F6273F30082C53F /* OnboardingProgramPersistTests.swift in Sources */,
 				47BB8E712F6273F30082C5F1 /* GymProfileSyncTests.swift in Sources */,
 				47BB8E8B2F6273F30082C53F /* ProgramOwnerGateTests.swift in Sources */,
+				47BB8E712F6273F30082C625 /* ProgramBackfillTests.swift in Sources */,
 				478DD9F12F9928C6001D3636 /* SkipFeatureTests.swift in Sources */,
 				32736E74E3F688020744DE5E /* EquipmentRounderTests.swift in Sources */,
 				47C5C1AF2F62A64E0005F99E /* WriteAheadQueueTests.swift in Sources */,

--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -196,12 +196,21 @@ final class ProgramViewModel {
         if let cached = Mesocycle.loadFromUserDefaults() {
             currentMesocycle = cached
             viewState = .loaded(cached)
+            // #425: resolve-before-stamp backfill safety-net. #424 persists the
+            // onboarding program ONLY when the owner resolves at onboard time; when
+            // auth is unresolved then (offline / a QUIC sign-in stall like #392/#394)
+            // the program lives only in UserDefaults and the server `programs` table
+            // stays empty, so every later workout FK-fails on
+            // `workout_sessions_program_id_fkey`. Re-attempt the server write here,
+            // off the fast path, once a real session resolves. Best-effort and
+            // non-blocking: the cached program is already displayed above; this never
+            // throws out of loadProgram and never slows the UI.
+            Task { await self.backfillCachedProgramIfNeeded(cached) }
             return
         }
 
         // 2. Network fetch
-        // #425 will add resolve-before-stamp backfill here (re-persist a locally-cached
-        // program once the owner resolves). Read semantics unchanged for PR-A.
+        // Read semantics unchanged for PR-A.
         do {
             if let row = try await supabaseClient.fetchActiveProgram(userId: userId) {
                 let mesocycle = row.toMesocycle()
@@ -214,6 +223,53 @@ final class ProgramViewModel {
         } catch {
             // If fetch fails but no cache → show empty so user can generate
             viewState = .empty
+        }
+    }
+
+    /// #425 safety-net: re-persist a locally-cached program to the server once a
+    /// real owner resolves, but ONLY when the server genuinely has no active program.
+    ///
+    /// Best-effort and non-blocking — fired from `loadProgram`'s cache-hit fast path
+    /// on a detached Task so the cached program displays immediately. Never throws,
+    /// never touches `viewState`; UserDefaults remains the source of truth.
+    ///
+    /// Critically distinguishes "server says empty" from "couldn't reach server":
+    /// only a fetch that SUCCEEDS and returns no active program triggers the
+    /// backfill. A fetch that throws (offline / transient) bails — a later load
+    /// retries — so a transient error is never mistaken for "empty" (which would
+    /// spuriously re-insert and could shadow a real server program).
+    ///
+    /// Reuses `OnboardingProgramPersist.persistIfOwnerResolved` so the
+    /// placeholder-guard + resolve-before-stamp + best-effort-catch live in exactly
+    /// one place (the same path #424 added).
+    private func backfillCachedProgramIfNeeded(_ cached: Mesocycle) async {
+        // Resolve the real owner. nil / placeholder → do nothing; the next resolved
+        // load catches it. persistIfOwnerResolved also guards the placeholder, but we
+        // bail early to avoid the server fetch when there's no owner to stamp under.
+        guard let owner = await resolveOwner(), owner != AppDependencies.placeholderUserId else {
+            return
+        }
+
+        // Only backfill when the fetch SUCCEEDS and finds NO active program. A thrown
+        // error means we couldn't reach the server — bail, do NOT conclude "empty".
+        let serverActiveProgram: ProgramRow?
+        do {
+            serverActiveProgram = try await supabaseClient.fetchActiveProgram(userId: owner)
+        } catch {
+            programPersistLogger.notice("backfill: server fetch failed; bailing (not 'empty') — a later load retries")
+            return
+        }
+        guard serverActiveProgram == nil else { return }
+
+        // Server is genuinely empty under a real owner → backfill the cached program
+        // via the shared resolve-before-stamp helper (#424). Idempotent, best-effort.
+        let didPersist = await OnboardingProgramPersist.persistIfOwnerResolved(
+            cached,
+            owner: owner,
+            client: supabaseClient
+        )
+        if didPersist {
+            programPersistLogger.notice("backfill: re-persisted local-only program to server under resolved owner")
         }
     }
 

--- a/ProjectApexTests/ProgramBackfillTests.swift
+++ b/ProjectApexTests/ProgramBackfillTests.swift
@@ -1,0 +1,288 @@
+// ProgramBackfillTests.swift
+// ProjectApexTests — #425 (#369 owner-stamping workstream, safety-net B)
+//
+// Residual gap after #423/#424: when auth is UNRESOLVED at onboard time (offline,
+// or a QUIC sign-in stall), onboarding persists the program ONLY locally — the
+// server `programs` table stays empty — and nothing re-attempts the server write
+// once a real session later resolves. The user is left with a local-only program
+// and zero server programs, so every later workout FK-fails on
+// `workout_sessions_program_id_fkey`.
+//
+// #425 adds a best-effort backfill to `ProgramViewModel.loadProgram`'s cache-hit
+// fast path: keep showing the cached program immediately, then in the background
+// resolve the owner and — only if the server fetch SUCCEEDS and finds NO active
+// program — re-persist the cached mesocycle under the resolved owner. A fetch that
+// THROWS (offline/transient) must NOT be mistaken for "server empty"; it just
+// bails and a later load retries.
+//
+//   1. cacheHit_serverEmpty_realOwner_backfills — fetch succeeds + empty + real
+//      owner → deactivate_and_insert_program fires with p_user_id == owner.
+//   2. cacheHit_nilOwner_noServerWrite — resolveOwner = nil → no backfill RPC.
+//   3. cacheHit_serverHasProgram_noBackfill — fetch returns an active program → no
+//      redundant backfill RPC.
+//   4. cacheHit_serverFetchFails_noBackfill — fetch THROWS (500) → no backfill RPC
+//      (an error is not "empty").
+
+import XCTest
+@testable import ProjectApex
+
+// MARK: - URLProtocol stub
+//
+// Distinguishes the two endpoints the backfill touches:
+//   • GET  /rest/v1/programs?...                       → fetchActiveProgram
+//   • POST /rest/v1/rpc/deactivate_and_insert_program  → the backfill write
+// so a test can stub the fetch result independently of counting the backfill RPC.
+
+private final class ProgramBackfillStubURLProtocol: URLProtocol {
+    /// Status + body returned for the GET fetchActiveProgram request.
+    static var fetchStatusCode: Int = 200
+    static var fetchData: Data = "[]".data(using: .utf8)!
+    /// Status + body returned for the POST backfill RPC.
+    static var rpcStatusCode: Int = 200
+    static var rpcData: Data = "[]".data(using: .utf8)!
+
+    static var rpcRequestCount: Int = 0
+    static var rpcRequestBodies: [Data] = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    private var isRPC: Bool {
+        request.url?.absoluteString.contains("/rpc/deactivate_and_insert_program") == true
+    }
+
+    override func startLoading() {
+        if isRPC {
+            ProgramBackfillStubURLProtocol.rpcRequestCount += 1
+            if let body = request.httpBody {
+                ProgramBackfillStubURLProtocol.rpcRequestBodies.append(body)
+            } else if let stream = request.httpBodyStream {
+                stream.open()
+                var data = Data()
+                let bufferSize = 1024
+                let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+                while stream.hasBytesAvailable {
+                    let read = stream.read(buffer, maxLength: bufferSize)
+                    if read > 0 { data.append(buffer, count: read) }
+                }
+                buffer.deallocate()
+                stream.close()
+                if !data.isEmpty { ProgramBackfillStubURLProtocol.rpcRequestBodies.append(data) }
+            }
+        }
+
+        let statusCode = isRPC
+            ? ProgramBackfillStubURLProtocol.rpcStatusCode
+            : ProgramBackfillStubURLProtocol.fetchStatusCode
+        let payload = isRPC
+            ? ProgramBackfillStubURLProtocol.rpcData
+            : ProgramBackfillStubURLProtocol.fetchData
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeBackfillSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [ProgramBackfillStubURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func makeBackfillClient() -> SupabaseClient {
+    SupabaseClient(
+        supabaseURL: URL(string: "https://test.supabase.co")!,
+        anonKey: "test-anon-key",
+        urlSession: makeBackfillSession()
+    )
+}
+
+// MARK: - Minimal no-op LLM provider (mirrors ProgramOwnerGateTests)
+
+private struct BackfillThrowingProvider: LLMProvider {
+    func complete(systemPrompt: String, userPayload: String) async throws -> String {
+        throw URLError(.notConnectedToInternet)
+    }
+}
+
+// MARK: - ProgramBackfillTests
+
+final class ProgramBackfillTests: XCTestCase {
+
+    private let realOwner = UUID(uuidString: "EEEEEEEE-0000-0000-0000-000000000011")!
+
+    override func setUp() {
+        super.setUp()
+        ProgramBackfillStubURLProtocol.fetchStatusCode = 200
+        ProgramBackfillStubURLProtocol.fetchData = "[]".data(using: .utf8)!
+        ProgramBackfillStubURLProtocol.rpcStatusCode = 200
+        ProgramBackfillStubURLProtocol.rpcData = "[]".data(using: .utf8)!
+        ProgramBackfillStubURLProtocol.rpcRequestCount = 0
+        ProgramBackfillStubURLProtocol.rpcRequestBodies = []
+        // Local cache is the fast-path seam under test — start clean.
+        Task { @MainActor in Mesocycle.clearUserDefaults() }
+    }
+
+    override func tearDown() {
+        Task { @MainActor in Mesocycle.clearUserDefaults() }
+        super.tearDown()
+    }
+
+    /// Builds a ProgramViewModel backed by no-op services and the backfill-aware
+    /// stub client, with an injected `resolveOwner`. Mirrors
+    /// ProgramOwnerGateTests.makeViewModel.
+    @MainActor
+    private func makeViewModel(
+        client: SupabaseClient,
+        resolveOwner: @escaping () async -> UUID?
+    ) -> ProgramViewModel {
+        let provider: any LLMProvider = BackfillThrowingProvider()
+        let memory = MemoryService(supabase: client, embeddingAPIKey: "test")
+        return ProgramViewModel(
+            supabaseClient: client,
+            programGenerationService: ProgramGenerationService(provider: provider),
+            macroPlanService: MacroPlanService(provider: provider),
+            sessionPlanService: SessionPlanService(
+                provider: provider,
+                memoryService: memory,
+                supabaseClient: client
+            ),
+            userId: AppDependencies.placeholderUserId,
+            resolveOwner: resolveOwner
+        )
+    }
+
+    /// Polls until the backfill RPC has fired (or the timeout elapses). The backfill
+    /// runs on a detached Task off the fast path, so the count is not set
+    /// synchronously when `loadProgram` returns.
+    private func waitForRPC(count: Int, timeout: TimeInterval = 2.0) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if ProgramBackfillStubURLProtocol.rpcRequestCount >= count { return }
+            try? await Task.sleep(nanoseconds: 20_000_000) // 20ms
+        }
+    }
+
+    /// JSON body for a GET fetchActiveProgram response that contains one active program.
+    private func activeProgramFetchBody(for mesocycle: Mesocycle) throws -> Data {
+        let row = ProgramRow.forInsert(from: mesocycle, userId: realOwner)
+        return try JSONEncoder.workoutProgram.encode([row])
+    }
+
+    // MARK: 1. cache hit + server empty + real owner → backfill fires with that owner
+
+    @MainActor
+    func test_cacheHit_serverEmpty_realOwner_backfills() async throws {
+        let mesocycle = Mesocycle.mockMesocycle()
+        mesocycle.saveToUserDefaults()
+
+        // GET fetch SUCCEEDS and returns NO active program.
+        ProgramBackfillStubURLProtocol.fetchStatusCode = 200
+        ProgramBackfillStubURLProtocol.fetchData = "[]".data(using: .utf8)!
+        // RPC returns the inserted program id.
+        ProgramBackfillStubURLProtocol.rpcData =
+            #"[{"program_id":"\#(mesocycle.id.uuidString)"}]"#.data(using: .utf8)!
+
+        let client = makeBackfillClient()
+        let vm = makeViewModel(client: client, resolveOwner: { self.realOwner })
+
+        await vm.loadProgram()
+        // Fast path still shows the cached program immediately.
+        XCTAssertEqual(vm.viewState, .loaded(mesocycle), "Cache hit must display immediately.")
+
+        await waitForRPC(count: 1)
+
+        XCTAssertEqual(
+            ProgramBackfillStubURLProtocol.rpcRequestCount, 1,
+            "An empty server + real owner must backfill the cached program."
+        )
+        let bodyData = try XCTUnwrap(ProgramBackfillStubURLProtocol.rpcRequestBodies.last)
+        let body = try XCTUnwrap(try JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        XCTAssertEqual(
+            body["p_user_id"] as? String, realOwner.uuidString,
+            "The backfill must stamp the RESOLVED owner uid."
+        )
+        XCTAssertEqual(body["p_program_id"] as? String, mesocycle.id.uuidString)
+    }
+
+    // MARK: 2. cache hit + nil owner → no server write
+
+    @MainActor
+    func test_cacheHit_nilOwner_noServerWrite() async {
+        let mesocycle = Mesocycle.mockMesocycle()
+        mesocycle.saveToUserDefaults()
+
+        let client = makeBackfillClient()
+        let vm = makeViewModel(client: client, resolveOwner: { nil })
+
+        await vm.loadProgram()
+        XCTAssertEqual(vm.viewState, .loaded(mesocycle))
+
+        // Give any (incorrect) background work a chance to fire before asserting zero.
+        await waitForRPC(count: 1)
+
+        XCTAssertEqual(
+            ProgramBackfillStubURLProtocol.rpcRequestCount, 0,
+            "An unresolved owner must not backfill — the next resolved load catches it."
+        )
+    }
+
+    // MARK: 3. cache hit + server already has a program → no redundant backfill
+
+    @MainActor
+    func test_cacheHit_serverHasProgram_noBackfill() async throws {
+        let mesocycle = Mesocycle.mockMesocycle()
+        mesocycle.saveToUserDefaults()
+
+        // GET fetch SUCCEEDS and returns an active program already.
+        ProgramBackfillStubURLProtocol.fetchStatusCode = 200
+        ProgramBackfillStubURLProtocol.fetchData = try activeProgramFetchBody(for: mesocycle)
+
+        let client = makeBackfillClient()
+        let vm = makeViewModel(client: client, resolveOwner: { self.realOwner })
+
+        await vm.loadProgram()
+        XCTAssertEqual(vm.viewState, .loaded(mesocycle))
+
+        await waitForRPC(count: 1)
+
+        XCTAssertEqual(
+            ProgramBackfillStubURLProtocol.rpcRequestCount, 0,
+            "When the server already has an active program, no backfill may fire."
+        )
+    }
+
+    // MARK: 4. cache hit + server fetch THROWS → no backfill (error != empty)
+
+    @MainActor
+    func test_cacheHit_serverFetchFails_noBackfill() async {
+        let mesocycle = Mesocycle.mockMesocycle()
+        mesocycle.saveToUserDefaults()
+
+        // GET fetch FAILS (transient/offline) — must NOT be read as "server empty".
+        ProgramBackfillStubURLProtocol.fetchStatusCode = 500
+        ProgramBackfillStubURLProtocol.fetchData = "{}".data(using: .utf8)!
+
+        let client = makeBackfillClient()
+        let vm = makeViewModel(client: client, resolveOwner: { self.realOwner })
+
+        await vm.loadProgram()
+        XCTAssertEqual(vm.viewState, .loaded(mesocycle))
+
+        await waitForRPC(count: 1)
+
+        XCTAssertEqual(
+            ProgramBackfillStubURLProtocol.rpcRequestCount, 0,
+            "A failed fetch must not be mistaken for an empty server — no backfill."
+        )
+    }
+}


### PR DESCRIPTION
## The gap (#425, follow-up to #423/#424)

#424 made onboarding persist the program to the server **only when the owner resolves at onboard time** — the common online case. Residual gap, flagged in #424's review:

When auth is **unresolved** at onboard time (offline, or a QUIC sign-in stall like #392/#394), no server persist happens **and nothing re-attempts it** once a real session later resolves. The program lives only in UserDefaults, the server `programs` table stays empty, and every later workout FK-fails on `workout_sessions_program_id_fkey` — the original #423 broken state.

## The fix (safety-net B)

A best-effort backfill in `ProgramViewModel.loadProgram`'s **cache-hit fast path** (the `// #425` marker PR-A left):

1. Keep showing the cached program immediately — the fast path is unchanged, no UI stall.
2. In the background (detached `Task`, never throws out of `loadProgram`), resolve the owner via the injected `resolveOwner()`. `nil`/placeholder → do nothing; the next resolved load catches it.
3. Fetch the server's active program. **Critically distinguishes "server says empty" from "couldn't reach server":** only a fetch that **succeeds and returns no active program** triggers the backfill. A fetch that **throws** (offline/transient) bails — a later load retries — so a transient error is never mistaken for "empty" (which would spuriously re-insert and could shadow a real server program).
4. When the server is genuinely empty under a real owner, re-persist the cached mesocycle via the **existing** `OnboardingProgramPersist.persistIfOwnerResolved` helper (the same resolve-before-stamp + placeholder-guard + best-effort-catch path #424 added). Idempotent on the program id; UserDefaults stays the source of truth.

## Onboarding cached-re-entry guard (OnboardingView.swift:886)

The re-entry guard early-returns and skips persist when a program is already cached for the current user. Assessed: that user then lands on the main UI, which constructs `ProgramViewModel` with `resolveOwner` and calls `loadProgram()` (`ContentView.swift:161`), whose **new cache-hit backfill closes the same gap**. No second copy of the logic is needed — routed through the one shared helper.

## TDD

New `ProgramBackfillTests` with a URLProtocol stub that distinguishes the GET `fetchActiveProgram` from the POST `deactivate_and_insert_program` RPC, so the fetch result is stubbed independently of counting the backfill write:

- `cacheHit_serverEmpty_realOwner_backfills` — **RED before the fix** (fast path returned before any server interaction); asserts the RPC fires with `p_user_id == resolvedOwner`.
- `cacheHit_nilOwner_noServerWrite` — no backfill RPC.
- `cacheHit_serverHasProgram_noBackfill` — no redundant backfill RPC.
- `cacheHit_serverFetchFails_noBackfill` — fetch 500s → no backfill (error is not "empty").

Local run (source of truth) on iPhone 17 Pro (newest local sim; CI may pin a different iOS):
`xcodebuild test -scheme ProjectApex -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:ProjectApexTests/ProgramBackfillTests` → RED (1 failure) before the backfill, **GREEN (4/4)** after. Sibling persistence classes (ProgramOwnerGateTests, OnboardingProgramPersistTests, ProgramPersistenceTests, SkipFeatureTests) all pass (45/45) — no regression to the PR-A owner-gate logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #425