### PR TITLE
feat(progress): premium dark redesign of the Progress screen

### DIFF
--- a/ProjectApex/Features/Progress/ProgressDesignTokens.swift
+++ b/ProjectApex/Features/Progress/ProgressDesignTokens.swift
@@ -1,0 +1,49 @@
+// ProgressDesignTokens.swift
+// ProjectApex — Features/Progress
+//
+// Local design-token set for the redesigned Progress tab — a premium dark
+// "strength instrument". The Phase-3 global tokens were deleted in PR #426;
+// these are scoped to Progress only. Palette: mint accent + an isolated gold
+// reserved for PRs, on near-black. Direction chosen by the multi-agent design
+// panel (lens A — premium dashboard).
+
+import SwiftUI
+
+enum ProgressDesignTokens {
+
+    // MARK: - Colours
+    static let bg       = Color(red: 0.039, green: 0.043, blue: 0.051) // #0A0B0D screen
+    static let surface1 = Color(red: 0.082, green: 0.090, blue: 0.106) // #15171B hero card
+    static let surface2 = Color(red: 0.118, green: 0.129, blue: 0.153) // #1E2127 other cards
+    static let accent   = Color(red: 0.212, green: 0.878, blue: 0.627) // #36E0A0 mint
+    static let up       = Color(red: 0.212, green: 0.878, blue: 0.627) // positive / progressing
+    static let down     = Color(red: 1.000, green: 0.420, blue: 0.420) // #FF6B6B negative / declining
+    static let neutral  = Color(red: 0.541, green: 0.565, blue: 0.600) // #8A9099 muted text / plateau
+    static let prGold   = Color(red: 0.961, green: 0.769, blue: 0.318) // #F5C451 PR markers only
+    static let amber    = Color(red: 0.910, green: 0.690, blue: 0.294) // #E8B04B force-deload caution
+
+    /// Faint fill for empty heatmap cells (must read against `surface2`).
+    static let emptyCell = Color.white.opacity(0.06)
+    /// Hairline grid lines inside charts.
+    static let gridLine  = Color.white.opacity(0.06)
+
+    // MARK: - Radii
+    static let cardRadius: CGFloat = 20
+    static let chipRadius: CGFloat = 12
+    static let cellRadius: CGFloat = 3
+
+    // MARK: - Spacing
+    static let screenPadding: CGFloat = 16
+    static let sectionGap:    CGFloat = 28
+    static let cardPadding:   CGFloat = 18
+    static let heroPadding:   CGFloat = 20
+
+    // MARK: - Type scale (SF; rounded + monospacedDigit for numerics)
+    static let screenTitle = Font.system(size: 34, weight: .bold)
+    static let hero        = Font.system(size: 48, weight: .bold,     design: .rounded).monospacedDigit()
+    static let heroUnit    = Font.system(size: 22, weight: .semibold, design: .rounded)
+    static let cardTitle   = Font.system(size: 20, weight: .semibold)
+    static let statNumber  = Font.system(size: 22, weight: .semibold, design: .rounded).monospacedDigit()
+    static let bodyText    = Font.system(size: 15, weight: .regular)
+    static let caption     = Font.system(size: 12, weight: .medium)
+}

--- a/ProjectApex/Features/Progress/ProgressView.swift
+++ b/ProjectApex/Features/Progress/ProgressView.swift
@@ -1,22 +1,40 @@
 // ProgressView.swift
 // ProjectApex — Features/Progress
 //
-// Four-section progress tab:
-//   1. Per-pattern trend banners (amber = plateaued or force-deload cue,
-//      red = declining) — sourced from TraineeModelDigest per ADR-0009 /
-//      ADR-0011 (B1 / #86)
-//   2. Key Lifts Summary — horizontal scroll cards
-//   3. Strength Trend Chart — Swift Charts line chart, exercise picker
-//   4. Weekly Volume by Muscle Group — stacked bar chart, 8 weeks
-//   5. Session Consistency Heatmap — 12-week GitHub-style grid
+// Redesigned Progress tab — a premium dark "strength instrument".
+// Direction decided by an independent multi-agent design panel (lens A,
+// double axis-winner on craft + hierarchy), synthesised with grafts from the
+// other lenses. Presentation-only: ProgressViewModel is untouched; every value
+// shown is derived from its existing published arrays.
+//
+// Layout, top → bottom:
+//   0. Title + (optional) error line
+//   1. Hero + trend card — count-up e1RM, signed 4-wk delta, range pills,
+//      gradient area trend chart with gold PR markers + pulsing live dot,
+//      tappable exercise chip-rail
+//   2. Key-lift 2×2 grid — muscle-dot, e1RM, sparkline, delta; taps drive the hero
+//   3. Volume — progressive disclosure (total + sparkline → stacked bars + legend)
+//   4. Consistency — streak caption + 12-week heatmap
+//   5. Coaching signals — calm per-pattern rows
+//
+// Motion: hero count-up (honestly gated on a real positive delta), staggered
+// section entrance, chart left-to-right draw-in, pulsing live dot, pulsing
+// streak flame, spring volume disclosure, heatmap cell pop-in, press feedback,
+// and earned haptics.
 
 import SwiftUI
 import Charts
+#if canImport(UIKit)
+import UIKit
+#endif
+
+private typealias DT = ProgressDesignTokens
+
+// MARK: - Entry point (init signature preserved for ContentView)
 
 struct ProgressTabView: View {
 
     @State private var vm: ProgressViewModel
-    @Environment(AppDependencies.self) private var deps
 
     init(
         supabaseClient: SupabaseClient,
@@ -32,304 +50,659 @@ struct ProgressTabView: View {
 
     var body: some View {
         NavigationStack {
-            ZStack {
-                Color(red: 0.04, green: 0.04, blue: 0.06).ignoresSafeArea()
-
-                if vm.isLoading {
-                    SwiftUI.ProgressView()
-                        .tint(.white)
-                } else {
-                    ScrollView {
-                        LazyVStack(spacing: 24) {
-                            trendBanners
-                            keyLiftsSummarySection
-                            strengthTrendSection
-                            weeklyVolumeSection
-                            consistencyHeatmapSection
-                        }
-                        .padding(.horizontal, 16)
-                        .padding(.bottom, 32)
-                    }
-                }
-            }
-            .navigationTitle("Progress")
-            .navigationBarTitleDisplayMode(.large)
-            .toolbarBackground(Color(red: 0.04, green: 0.04, blue: 0.06), for: .navigationBar)
-            .toolbarColorScheme(.dark, for: .navigationBar)
-            .task {
-                await vm.loadAll()
-            }
+            ProgressScreenContent(vm: vm)
+                .toolbar(.hidden, for: .navigationBar)
+                .task { await vm.loadAll() }
         }
-    }
-
-    // MARK: - Trend Banners
-
-    @ViewBuilder
-    private var trendBanners: some View {
-        // Surface plateaued/declining patterns and any pattern with the
-        // force-deload counter ≥ 2 (rotation/rebuild cue per ADR-0011 §d).
-        let alerts = vm.patternTrends.filter {
-            $0.trend != .progressing || $0.consecutiveForceDeloadsOnPattern >= 2
-        }
-        if !alerts.isEmpty {
-            VStack(spacing: 8) {
-                ForEach(alerts, id: \.pattern) { summary in
-                    TrendBannerView(summary: summary)
-                }
-            }
-        }
-    }
-
-    // MARK: - Key Lifts Summary
-
-    private var keyLiftsSummarySection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sectionHeader("Key Lifts")
-            if vm.keyLifts.isEmpty {
-                emptyDataCard("Complete workouts to see key lift progress")
-            } else {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 12) {
-                        ForEach(vm.keyLifts) { lift in
-                            KeyLiftCard(lift: lift)
-                        }
-                    }
-                    .padding(.horizontal, 2)
-                }
-            }
-        }
-    }
-
-    // MARK: - Strength Trend Chart
-
-    private var strengthTrendSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sectionHeader("Strength Trend")
-            let exerciseOptions = vm.trendData.keys.sorted()
-            if exerciseOptions.isEmpty {
-                emptyDataCard("Train at least 2 sessions per exercise to see trends")
-            } else {
-                VStack(alignment: .leading, spacing: 8) {
-                    Picker("Exercise", selection: Binding(
-                        get: { vm.selectedTrendExercise ?? exerciseOptions[0] },
-                        set: { vm.selectedTrendExercise = $0 }
-                    )) {
-                        ForEach(exerciseOptions, id: \.self) { id in
-                            Text(exerciseName(for: id)).tag(id)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .tint(Color(red: 0.30, green: 0.96, blue: 0.60))
-
-                    if let selectedId = vm.selectedTrendExercise ?? exerciseOptions.first,
-                       let points = vm.trendData[selectedId], !points.isEmpty {
-                        StrengthTrendChart(points: points)
-                    }
-                }
-                .padding(16)
-                .background(Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 12))
-            }
-        }
-    }
-
-    // MARK: - Weekly Volume Chart
-
-    private var weeklyVolumeSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sectionHeader("Weekly Volume")
-            if vm.weeklyVolume.isEmpty || vm.weeklyVolume.allSatisfy({ $0.setsByMuscle.isEmpty }) {
-                emptyDataCard("Log workouts to track weekly volume per muscle group")
-            } else {
-                VStack(alignment: .leading, spacing: 12) {
-                    WeeklyVolumeChart(data: vm.weeklyVolume)
-                        .frame(height: 200)
-                    volumeLegend
-                }
-                .padding(16)
-                .background(Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 12))
-            }
-        }
-    }
-
-    private var volumeLegend: some View {
-        let muscles = Array(
-            Set(vm.weeklyVolume.flatMap { $0.setsByMuscle.keys })
-        ).sorted()
-        return FlowLayout(spacing: 8) {
-            ForEach(muscles, id: \.self) { muscle in
-                HStack(spacing: 4) {
-                    Circle()
-                        .fill(MuscleColor.color(for: muscle))
-                        .frame(width: 8, height: 8)
-                    Text(muscle.capitalized)
-                        .font(.caption2)
-                        .foregroundStyle(.white.opacity(0.60))
-                }
-            }
-        }
-    }
-
-    // MARK: - Consistency Heatmap
-
-    private var consistencyHeatmapSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sectionHeader("Consistency")
-            if vm.heatmapData.isEmpty {
-                emptyDataCard("Log sessions to see your training consistency")
-            } else {
-                ConsistencyHeatmap(cells: vm.heatmapData)
-                    .padding(16)
-                    .background(Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 12))
-            }
-        }
-    }
-
-    // MARK: - Shared helpers
-
-    private func sectionHeader(_ title: String) -> some View {
-        Text(title)
-            .font(.title3.bold())
-            .foregroundStyle(.white)
-    }
-
-    private func emptyDataCard(_ message: String) -> some View {
-        Text(message)
-            .font(.subheadline)
-            .foregroundStyle(.white.opacity(0.40))
-            .multilineTextAlignment(.center)
-            .frame(maxWidth: .infinity)
-            .padding(24)
-            .background(Color.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 12))
-    }
-
-    private func exerciseName(for id: String) -> String {
-        ExerciseLibrary.lookup(id)?.name
-            ?? id.split(separator: "_")
-                .map { $0.prefix(1).uppercased() + $0.dropFirst() }
-                .joined(separator: " ")
+        .preferredColorScheme(.dark)
     }
 }
 
-// MARK: - KeyLiftCard
+// MARK: - Screen content
 
-private struct KeyLiftCard: View {
-    let lift: KeyLiftSummary
+struct ProgressScreenContent: View {
+
+    @Bindable var vm: ProgressViewModel
+
+    @State private var range: TrendRange = .eightWeeks
+    @State private var shownE1RM: Double = 0
+    @State private var deltaShown = false
+    @State private var volumeExpanded = false
+    @State private var appeared = false
 
     var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: DT.sectionGap) {
+                titleHeader
+                    .modifier(SectionEntrance(index: 0, appeared: appeared))
+
+                if vm.isLoading {
+                    HeroSkeleton()
+                        .modifier(SectionEntrance(index: 1, appeared: appeared))
+                } else if let lift = focus {
+                    heroCard(lift)
+                        .modifier(SectionEntrance(index: 1, appeared: appeared))
+                    keyLiftGrid
+                        .modifier(SectionEntrance(index: 2, appeared: appeared))
+                    if hasVolume {
+                        volumeCard
+                            .modifier(SectionEntrance(index: 3, appeared: appeared))
+                    }
+                    if !vm.heatmapData.isEmpty {
+                        consistencyCard
+                            .modifier(SectionEntrance(index: 4, appeared: appeared))
+                    }
+                    if !vm.patternTrends.isEmpty {
+                        patternCard
+                            .modifier(SectionEntrance(index: 5, appeared: appeared))
+                    }
+                } else {
+                    emptyState
+                        .modifier(SectionEntrance(index: 1, appeared: appeared))
+                }
+            }
+            .padding(.horizontal, DT.screenPadding)
+            .padding(.top, 8)
+            .padding(.bottom, 44)
+        }
+        .scrollIndicators(.hidden)
+        .background(DT.bg.ignoresSafeArea())
+        .animation(.easeInOut(duration: 0.35), value: vm.isLoading)
+        .onAppear {
+            // Flip on the next runloop so the false→true change animates the entrance.
+            DispatchQueue.main.async { appeared = true }
+            if let lift = focus { animateHero(lift) }
+        }
+        .onChange(of: focus?.exerciseId) { _, _ in
+            if let lift = focus { animateHero(lift) }
+        }
+    }
+
+    // MARK: Title
+
+    private var titleHeader: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text(lift.name)
-                .font(.caption.bold())
-                .foregroundStyle(.white.opacity(0.65))
-                .lineLimit(2)
-                .frame(width: 110, alignment: .leading)
-
-            Text(String(format: "%.1f kg", lift.currentE1RM))
-                .font(.title3.bold())
+            Text("Progress")
+                .font(DT.screenTitle)
                 .foregroundStyle(.white)
+            if let err = vm.errorMessage {
+                Text(err)
+                    .font(DT.caption)
+                    .foregroundStyle(DT.down)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
 
+    // MARK: 1 — Hero + trend card
+
+    private func heroCard(_ lift: KeyLiftSummary) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(lift.name.uppercased())
+                        .font(DT.caption)
+                        .tracking(0.6)
+                        .foregroundStyle(DT.neutral)
+                        .lineLimit(1)
+
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        CountingNumber(value: shownE1RM)
+                            .font(DT.hero)
+                            .foregroundStyle(.white)
+                        Text("kg")
+                            .font(DT.heroUnit)
+                            .foregroundStyle(DT.neutral)
+                    }
+
+                    deltaOrHolding(lift)
+                        .opacity(deltaShown ? 1 : 0)
+                        .offset(y: deltaShown ? 0 : 8)
+                }
+                Spacer(minLength: 0)
+            }
+
+            HStack {
+                Spacer()
+                rangePills
+            }
+
+            StrengthTrendChart(points: windowedPoints(lift))
+                .id(lift.exerciseId + range.rawValue)   // re-create → re-run draw-in on focus/range change
+                .frame(height: 190)
+
+            chipRail
+        }
+        .padding(DT.heroPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DT.surface1, in: RoundedRectangle(cornerRadius: DT.cardRadius))
+    }
+
+    @ViewBuilder
+    private func deltaOrHolding(_ lift: KeyLiftSummary) -> some View {
+        if let d = lift.deltaVs4WeeksAgo, abs(d) >= 0.05 {
+            let positive = d > 0
+            HStack(spacing: 6) {
+                HStack(spacing: 4) {
+                    Image(systemName: positive ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 11, weight: .bold))
+                    Text("\(positive ? "+" : "")\(fmt(d)) kg")
+                        .font(DT.caption)
+                }
+                .foregroundStyle(positive ? DT.up : DT.down)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background((positive ? DT.up : DT.down).opacity(0.14), in: Capsule())
+
+                Text("vs 4 wks")
+                    .font(DT.caption)
+                    .foregroundStyle(DT.neutral)
+            }
+        } else {
+            Text("Holding at \(fmt(lift.currentE1RM)) kg")
+                .font(DT.caption)
+                .foregroundStyle(DT.neutral)
+        }
+    }
+
+    private var rangePills: some View {
+        HStack(spacing: 6) {
+            ForEach(TrendRange.allCases) { r in
+                Button {
+                    withAnimation(.snappy) { range = r }
+                } label: {
+                    Text(r.rawValue)
+                        .font(DT.caption)
+                        .foregroundStyle(range == r ? DT.bg : DT.neutral)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(range == r ? DT.accent : DT.surface2, in: Capsule())
+                }
+                .buttonStyle(PressableStyle())
+            }
+        }
+    }
+
+    private var chipRail: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(vm.keyLifts) { lift in
+                    let selected = focus?.exerciseId == lift.exerciseId
+                    Button {
+                        withAnimation(.snappy) { vm.selectedTrendExercise = lift.exerciseId }
+                    } label: {
+                        Text(lift.name)
+                            .font(DT.caption)
+                            .foregroundStyle(selected ? DT.bg : .white.opacity(0.8))
+                            .lineLimit(1)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(selected ? DT.accent : DT.surface2, in: Capsule())
+                    }
+                    .buttonStyle(PressableStyle())
+                }
+            }
+            .padding(.horizontal, 2)
+        }
+    }
+
+    // MARK: 2 — Key-lift grid
+
+    private var keyLiftGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)],
+            spacing: 12
+        ) {
+            ForEach(vm.keyLifts) { lift in
+                Button {
+                    withAnimation(.snappy) { vm.selectedTrendExercise = lift.exerciseId }
+                } label: {
+                    KeyLiftCard(
+                        lift: lift,
+                        points: vm.trendData[lift.exerciseId] ?? [],
+                        selected: focus?.exerciseId == lift.exerciseId
+                    )
+                }
+                .buttonStyle(PressableStyle())
+            }
+        }
+    }
+
+    // MARK: 3 — Volume (progressive disclosure)
+
+    private var volumeCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Button {
+                withAnimation(.spring(response: 0.45, dampingFraction: 0.82)) {
+                    volumeExpanded.toggle()
+                }
+            } label: {
+                HStack(alignment: .center) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("VOLUME")
+                            .font(DT.caption).tracking(0.6)
+                            .foregroundStyle(DT.neutral)
+                        HStack(alignment: .firstTextBaseline, spacing: 4) {
+                            Text("\(latestVolumeTotal)")
+                                .font(DT.statNumber)
+                                .foregroundStyle(.white)
+                            Text("sets this week")
+                                .font(.system(size: 12))
+                                .foregroundStyle(DT.neutral)
+                        }
+                    }
+                    Spacer()
+                    if !volumeExpanded {
+                        VolumeSummarySparkline(totals: weeklyTotals)
+                            .frame(width: 96, height: 30)
+                    }
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(DT.neutral)
+                        .rotationEffect(.degrees(volumeExpanded ? 180 : 0))
+                }
+            }
+            .buttonStyle(.plain)
+
+            if volumeExpanded {
+                VStack(alignment: .leading, spacing: 12) {
+                    VolumeBars(data: sortedVolume)
+                        .frame(height: 170)
+                    MuscleLegend(muscles: presentMuscles)
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(DT.cardPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DT.surface2, in: RoundedRectangle(cornerRadius: DT.cardRadius))
+    }
+
+    // MARK: 4 — Consistency
+
+    private var consistencyCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 6) {
+                Image(systemName: "flame.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(DT.prGold)
+                    .symbolEffect(.pulse, options: .repeating)
+                Text(streakLabel)
+                    .font(DT.cardTitle)
+                    .foregroundStyle(.white)
+                Spacer()
+            }
+            HeatmapGrid(cells: vm.heatmapData)
+            heatmapLegend
+        }
+        .padding(DT.cardPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DT.surface2, in: RoundedRectangle(cornerRadius: DT.cardRadius))
+    }
+
+    private var heatmapLegend: some View {
+        HStack(spacing: 14) {
+            legendDot(DT.emptyCell, "None")
+            legendDot(DT.accent.opacity(0.7), "Session")
             HStack(spacing: 4) {
-                Image(systemName: trendIcon)
-                    .foregroundStyle(trendColor)
-                    .font(.caption)
-                if let delta = lift.deltaVs4WeeksAgo {
-                    Text(deltaLabel(delta))
-                        .font(.caption)
-                        .foregroundStyle(trendColor)
+                RoundedRectangle(cornerRadius: 2)
+                    .strokeBorder(DT.prGold, lineWidth: 1)
+                    .frame(width: 10, height: 10)
+                Text("PR").font(DT.caption).foregroundStyle(DT.neutral)
+            }
+            Spacer()
+        }
+    }
+
+    private func legendDot(_ color: Color, _ label: String) -> some View {
+        HStack(spacing: 4) {
+            RoundedRectangle(cornerRadius: 2).fill(color).frame(width: 10, height: 10)
+            Text(label).font(DT.caption).foregroundStyle(DT.neutral)
+        }
+    }
+
+    // MARK: 5 — Coaching signals
+
+    private var patternCard: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("COACHING SIGNALS")
+                .font(DT.caption).tracking(0.6)
+                .foregroundStyle(DT.neutral)
+                .padding(.bottom, 6)
+            ForEach(Array(vm.patternTrends.enumerated()), id: \.element.pattern) { index, summary in
+                PatternRow(summary: summary)
+                if index < vm.patternTrends.count - 1 {
+                    Divider().overlay(Color.white.opacity(0.06))
                 }
             }
         }
-        .padding(12)
-        .frame(width: 134)
-        .background(Color.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 12))
+        .padding(DT.cardPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DT.surface2, in: RoundedRectangle(cornerRadius: DT.cardRadius))
+    }
+
+    // MARK: Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "chart.line.uptrend.xyaxis")
+                .font(.system(size: 34, weight: .light))
+                .foregroundStyle(DT.accent)
+            Text("Your progress starts here")
+                .font(DT.cardTitle)
+                .foregroundStyle(.white)
+            Text("Complete a few workouts and your strongest lifts, trends, and streak will appear.")
+                .font(DT.bodyText)
+                .foregroundStyle(DT.neutral)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 40)
+        .padding(.horizontal, 24)
+        .background(DT.surface2, in: RoundedRectangle(cornerRadius: DT.cardRadius))
+    }
+
+    // MARK: - Derived values (presentation-only; VM untouched)
+
+    /// The lift the hero focuses on. Honours an explicit chip/grid selection,
+    /// else auto-picks the biggest *positive* 4-wk gain (never opens on a
+    /// decline), then any progressing lift, then the first available.
+    private var focus: KeyLiftSummary? {
+        if let sel = vm.selectedTrendExercise,
+           let match = vm.keyLifts.first(where: { $0.exerciseId == sel }) {
+            return match
+        }
+        let positives = vm.keyLifts.filter { ($0.deltaVs4WeeksAgo ?? 0) > 0 }
+        if let best = positives.max(by: { ($0.deltaVs4WeeksAgo ?? 0) < ($1.deltaVs4WeeksAgo ?? 0) }) {
+            return best
+        }
+        if let progressing = vm.keyLifts.first(where: { $0.trend == .up }) {
+            return progressing
+        }
+        return vm.keyLifts.first
+    }
+
+    private func windowedPoints(_ lift: KeyLiftSummary) -> [TrendPoint] {
+        let pts = vm.trendData[lift.exerciseId] ?? []
+        guard let cutoff = range.cutoff else { return pts }
+        let filtered = pts.filter { $0.date >= cutoff }
+        return filtered.count >= 2 ? filtered : pts
+    }
+
+    private func focusHasPR(_ lift: KeyLiftSummary) -> Bool {
+        windowedPoints(lift).last?.isAllTimeBest == true
+    }
+
+    private var sortedVolume: [WeeklyVolumeRow] {
+        vm.weeklyVolume.sorted { $0.weekStart < $1.weekStart }
+    }
+
+    private var hasVolume: Bool {
+        !vm.weeklyVolume.isEmpty && !vm.weeklyVolume.allSatisfy { $0.setsByMuscle.isEmpty }
+    }
+
+    private var latestVolumeTotal: Int {
+        sortedVolume.last?.setsByMuscle.values.reduce(0, +) ?? 0
+    }
+
+    private var weeklyTotals: [WeekTotal] {
+        sortedVolume.enumerated().map { idx, row in
+            WeekTotal(id: idx, label: row.weekLabel, value: row.setsByMuscle.values.reduce(0, +))
+        }
+    }
+
+    private var presentMuscles: [String] {
+        Array(Set(vm.weeklyVolume.flatMap { $0.setsByMuscle.keys })).sorted()
+    }
+
+    /// Consecutive most-recent weeks (heatmap col 11 → 0) with any session.
+    private var currentStreakWeeks: Int {
+        var weeksWith = Set<Int>()
+        for cell in vm.heatmapData where cell.sessionCount > 0 { weeksWith.insert(cell.weekIndex) }
+        var streak = 0
+        for week in stride(from: 11, through: 0, by: -1) {
+            if weeksWith.contains(week) { streak += 1 } else { break }
+        }
+        return streak
+    }
+
+    private var streakLabel: String {
+        let n = currentStreakWeeks
+        return n <= 0 ? "Build your streak" : "\(n)-week streak"
+    }
+
+    // MARK: - Hero motion
+
+    private func animateHero(_ lift: KeyLiftSummary) {
+        let target = lift.currentE1RM
+        let delta = lift.deltaVs4WeeksAgo ?? 0
+        deltaShown = false
+
+        if delta > 0 {
+            // Count up from the real value 4 weeks ago — semantically honest.
+            shownE1RM = max(0, target - delta)
+            withAnimation(.easeOut(duration: 0.9)) { shownE1RM = target }
+            Haptics.impact(.soft)
+            if focusHasPR(lift) { Haptics.success() }
+        } else {
+            // Holding / declining — no count-up, no celebratory haptic.
+            shownE1RM = target
+        }
+
+        withAnimation(.easeOut(duration: 0.5).delay(0.25)) { deltaShown = true }
+    }
+
+    private func fmt(_ value: Double) -> String { String(format: "%.1f", value) }
+}
+
+// MARK: - Trend range
+
+private enum TrendRange: String, CaseIterable, Identifiable {
+    case eightWeeks = "8w"
+    case all = "All"
+
+    var id: String { rawValue }
+
+    /// Range floor. `all` = no floor. Capped to what the VM's ~90-day fetch
+    /// can actually fill (no empty 6m/1y windows).
+    var cutoff: Date? {
+        switch self {
+        case .eightWeeks: return Calendar.current.date(byAdding: .day, value: -56, to: Date())
+        case .all:        return nil
+        }
+    }
+}
+
+// MARK: - Hero strength chart
+
+private struct StrengthTrendChart: View {
+    let points: [TrendPoint]
+    @State private var reveal: CGFloat = 0
+
+    var body: some View {
+        Chart {
+            ForEach(points) { p in
+                AreaMark(
+                    x: .value("Date", p.date),
+                    y: .value("e1RM", p.e1RM)
+                )
+                .interpolationMethod(.catmullRom)
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [DT.accent.opacity(0.28), DT.accent.opacity(0.02)],
+                        startPoint: .top, endPoint: .bottom
+                    )
+                )
+            }
+            ForEach(points) { p in
+                LineMark(
+                    x: .value("Date", p.date),
+                    y: .value("e1RM", p.e1RM)
+                )
+                .interpolationMethod(.catmullRom)
+                .foregroundStyle(DT.accent)
+                .lineStyle(StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round))
+            }
+            ForEach(points.filter(\.isAllTimeBest)) { p in
+                PointMark(x: .value("Date", p.date), y: .value("e1RM", p.e1RM))
+                    .symbolSize(170)
+                    .foregroundStyle(DT.prGold.opacity(0.22))
+                PointMark(x: .value("Date", p.date), y: .value("e1RM", p.e1RM))
+                    .symbolSize(56)
+                    .foregroundStyle(DT.prGold)
+            }
+        }
+        .chartYAxis {
+            AxisMarks { _ in
+                AxisGridLine().foregroundStyle(DT.gridLine)
+            }
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 3)) { _ in
+                AxisValueLabel(format: .dateTime.month(.abbreviated))
+                    .foregroundStyle(DT.neutral)
+            }
+        }
+        .chartPlotStyle { $0.background(Color.clear) }
+        .chartOverlay { proxy in
+            GeometryReader { geo in
+                if let last = points.last,
+                   let anchor = proxy.plotFrame,
+                   let px = proxy.position(forX: last.date),
+                   let py = proxy.position(forY: last.e1RM) {
+                    let rect = geo[anchor]
+                    PulsingDot(color: DT.accent)
+                        .position(x: rect.minX + px, y: rect.minY + py)
+                        .opacity(reveal >= 1 ? 1 : 0)
+                }
+            }
+        }
+        .mask(alignment: .leading) {
+            GeometryReader { geo in
+                Rectangle().frame(width: geo.size.width * reveal)
+            }
+        }
+        .onAppear {
+            reveal = 0
+            withAnimation(.easeInOut(duration: 0.85)) { reveal = 1 }
+        }
+    }
+}
+
+// MARK: - Key-lift card
+
+private struct KeyLiftCard: View {
+    let lift: KeyLiftSummary
+    let points: [TrendPoint]
+    let selected: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                Circle().fill(muscleColor).frame(width: 8, height: 8)
+                Text(lift.name)
+                    .font(DT.caption)
+                    .foregroundStyle(.white.opacity(0.7))
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+
+            HStack(alignment: .firstTextBaseline, spacing: 3) {
+                Text(fmt(lift.currentE1RM))
+                    .font(DT.statNumber)
+                    .foregroundStyle(.white)
+                Text("kg")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(DT.neutral)
+            }
+
+            if points.count >= 2 {
+                LiftSparkline(points: points).frame(height: 26)
+            } else {
+                Color.clear.frame(height: 26)
+            }
+
+            HStack(spacing: 4) {
+                Image(systemName: trendIcon).font(.system(size: 11, weight: .bold))
+                Text(deltaText).font(DT.caption)
+            }
+            .foregroundStyle(trendColor)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DT.surface2, in: RoundedRectangle(cornerRadius: DT.cardRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: DT.cardRadius)
+                .strokeBorder(selected ? DT.accent : .clear, lineWidth: 1.5)
+        }
+    }
+
+    private var muscleColor: Color {
+        if let muscle = ExerciseLibrary.primaryMuscle(for: lift.exerciseId) {
+            return MuscleColor.color(for: muscle)
+        }
+        return DT.neutral
+    }
+
+    private var deltaText: String {
+        guard let d = lift.deltaVs4WeeksAgo, abs(d) >= 0.05 else { return "—" }
+        return "\(d > 0 ? "+" : "")\(fmt(d)) kg"
     }
 
     private var trendIcon: String {
         switch lift.trend {
-        case .up:   return "arrow.up.right"
-        case .down: return "arrow.down.right"
-        case .flat: return "arrow.right"
+        case .up:   "chevron.up"
+        case .down: "chevron.down"
+        case .flat: "minus"
         }
     }
 
     private var trendColor: Color {
         switch lift.trend {
-        case .up:   return Color(red: 0.30, green: 0.96, blue: 0.60)
-        case .down: return Color(red: 0.96, green: 0.36, blue: 0.36)
-        case .flat: return .white.opacity(0.45)
+        case .up:   DT.up
+        case .down: DT.down
+        case .flat: DT.neutral
         }
     }
 
-    private func deltaLabel(_ delta: Double) -> String {
-        let sign = delta >= 0 ? "+" : ""
-        return "\(sign)\(String(format: "%.1f", delta)) kg"
-    }
+    private func fmt(_ value: Double) -> String { String(format: "%.1f", value) }
 }
 
-// MARK: - StrengthTrendChart
+// MARK: - Sparklines
 
-private struct StrengthTrendChart: View {
+private struct LiftSparkline: View {
     let points: [TrendPoint]
-
     var body: some View {
-        let allTimeBest = points.filter(\.isAllTimeBest).map(\.e1RM).max()
-
-        Chart {
-            ForEach(points) { point in
-                LineMark(
-                    x: .value("Date", point.date),
-                    y: .value("e1RM (kg)", point.e1RM)
-                )
+        Chart(points) { p in
+            LineMark(x: .value("Date", p.date), y: .value("e1RM", p.e1RM))
                 .interpolationMethod(.catmullRom)
-                .foregroundStyle(Color(red: 0.30, green: 0.96, blue: 0.60))
-                .lineStyle(StrokeStyle(lineWidth: 2))
-
-                PointMark(
-                    x: .value("Date", point.date),
-                    y: .value("e1RM (kg)", point.e1RM)
-                )
-                .foregroundStyle(point.isAllTimeBest
-                    ? Color(red: 1.0, green: 0.84, blue: 0.0)
-                    : Color(red: 0.30, green: 0.96, blue: 0.60))
-                .symbolSize(point.isAllTimeBest ? 80 : 40)
-            }
-
-            if let best = allTimeBest {
-                RuleMark(y: .value("All-time best", best))
-                    .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
-                    .foregroundStyle(.white.opacity(0.25))
-                    .annotation(position: .trailing, alignment: .leading) {
-                        Text("PR")
-                            .font(.caption2)
-                            .foregroundStyle(.white.opacity(0.45))
-                    }
-            }
+                .foregroundStyle(DT.accent)
+                .lineStyle(StrokeStyle(lineWidth: 1.5, lineCap: .round))
         }
-        .chartXAxis {
-            AxisMarks(values: .stride(by: .month)) { _ in
-                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                    .foregroundStyle(.white.opacity(0.10))
-                AxisValueLabel(format: .dateTime.month(.abbreviated))
-                    .foregroundStyle(.white.opacity(0.45))
-            }
-        }
-        .chartYAxis {
-            AxisMarks { _ in
-                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                    .foregroundStyle(.white.opacity(0.10))
-                AxisValueLabel()
-                    .foregroundStyle(.white.opacity(0.45))
-            }
-        }
-        .chartPlotStyle { plot in
-            plot.background(Color.clear)
-        }
-        .frame(height: 180)
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartPlotStyle { $0.background(Color.clear) }
     }
 }
 
-// MARK: - WeeklyVolumeChart
+private struct VolumeSummarySparkline: View {
+    let totals: [WeekTotal]
+    var body: some View {
+        Chart(totals) { t in
+            LineMark(x: .value("Week", t.label), y: .value("Sets", t.value))
+                .interpolationMethod(.catmullRom)
+                .foregroundStyle(DT.accent)
+                .lineStyle(StrokeStyle(lineWidth: 1.5, lineCap: .round))
+        }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartPlotStyle { $0.background(Color.clear) }
+    }
+}
 
-private struct WeeklyVolumeChart: View {
+// MARK: - Volume bars + legend
+
+private struct VolumeBars: View {
     let data: [WeeklyVolumeRow]
 
     private var muscles: [String] {
@@ -338,17 +711,12 @@ private struct WeeklyVolumeChart: View {
 
     var body: some View {
         Chart {
-            RuleMark(y: .value("Target", 10))
-                .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
-                .foregroundStyle(.white.opacity(0.20))
-
             ForEach(data) { row in
                 ForEach(muscles, id: \.self) { muscle in
-                    let count = row.setsByMuscle[muscle] ?? 0
                     BarMark(
                         x: .value("Week", row.weekLabel),
-                        y: .value("Sets", count),
-                        stacking: .standard
+                        y: .value("Sets", row.setsByMuscle[muscle] ?? 0),
+                        width: .ratio(0.62)
                     )
                     .foregroundStyle(MuscleColor.color(for: muscle))
                 }
@@ -356,105 +724,280 @@ private struct WeeklyVolumeChart: View {
         }
         .chartXAxis {
             AxisMarks { _ in
-                AxisValueLabel()
-                    .foregroundStyle(.white.opacity(0.45))
+                AxisValueLabel().foregroundStyle(DT.neutral)
             }
         }
         .chartYAxis {
-            AxisMarks { _ in
-                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                    .foregroundStyle(.white.opacity(0.10))
-                AxisValueLabel()
-                    .foregroundStyle(.white.opacity(0.45))
+            AxisMarks(values: .automatic(desiredCount: 3)) { _ in
+                AxisGridLine().foregroundStyle(DT.gridLine)
+                AxisValueLabel().foregroundStyle(DT.neutral)
             }
         }
-        .chartPlotStyle { plot in
-            plot.background(Color.clear)
+        .chartPlotStyle { $0.background(Color.clear) }
+    }
+}
+
+private struct MuscleLegend: View {
+    let muscles: [String]
+    var body: some View {
+        FlowLayout(spacing: 8) {
+            ForEach(muscles, id: \.self) { muscle in
+                HStack(spacing: 4) {
+                    Circle().fill(MuscleColor.color(for: muscle)).frame(width: 8, height: 8)
+                    Text(muscle.capitalized)
+                        .font(.caption2)
+                        .foregroundStyle(DT.neutral)
+                }
+            }
         }
     }
 }
 
-// MARK: - ConsistencyHeatmap
+// MARK: - Consistency heatmap
 
-private struct ConsistencyHeatmap: View {
+private struct HeatmapGrid: View {
     let cells: [HeatmapCell]
 
+    @State private var shown = false
     private let dayLabels = ["M", "T", "W", "T", "F", "S", "S"]
-    private let cellSize: CGFloat = 14
-    private let cellSpacing: CGFloat = 3
+    private let size: CGFloat = 14
+    private let gap: CGFloat = 3
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .top, spacing: cellSpacing) {
-                // Day-of-week row labels
-                VStack(spacing: cellSpacing) {
-                    ForEach(0..<7, id: \.self) { dayIdx in
-                        Text(dayLabels[dayIdx])
-                            .font(.system(size: 9))
-                            .foregroundStyle(.white.opacity(0.35))
-                            .frame(width: 12, height: cellSize)
-                    }
+        HStack(alignment: .top, spacing: gap) {
+            VStack(spacing: gap) {
+                ForEach(0..<7, id: \.self) { day in
+                    Text(dayLabels[day])
+                        .font(.system(size: 9))
+                        .foregroundStyle(DT.neutral)
+                        .frame(width: 12, height: size)
                 }
-                // 12 week columns
-                HStack(spacing: cellSpacing) {
-                    ForEach(0..<12, id: \.self) { weekIdx in
-                        VStack(spacing: cellSpacing) {
-                            ForEach(0..<7, id: \.self) { dayIdx in
-                                let cell = cells.first { $0.weekIndex == weekIdx && $0.dayOfWeek == dayIdx }
-                                RoundedRectangle(cornerRadius: 3)
-                                    .fill(cellColor(for: cell))
-                                    .frame(width: cellSize, height: cellSize)
-                            }
+            }
+            HStack(spacing: gap) {
+                ForEach(0..<12, id: \.self) { week in
+                    VStack(spacing: gap) {
+                        ForEach(0..<7, id: \.self) { day in
+                            let cell = cells.first { $0.weekIndex == week && $0.dayOfWeek == day }
+                            cellView(cell)
+                                .opacity(shown ? 1 : 0)
+                                .scaleEffect(shown ? 1 : 0.5)
+                                .animation(
+                                    .spring(response: 0.4, dampingFraction: 0.7)
+                                        .delay(Double(week) * 0.025),
+                                    value: shown
+                                )
                         }
                     }
                 }
             }
-
-            HStack(spacing: 12) {
-                legendItem(color: .white.opacity(0.05), label: "None")
-                legendItem(color: Color(red: 0.20, green: 0.65, blue: 0.35), label: "Session")
-                legendItem(color: Color(red: 1.0, green: 0.84, blue: 0.0), label: "PR")
-            }
+            Spacer(minLength: 0)
         }
+        .onAppear { shown = true }
     }
 
-    private func cellColor(for cell: HeatmapCell?) -> Color {
-        guard let cell else { return .white.opacity(0.05) }
-        if cell.hasPR          { return Color(red: 1.0, green: 0.84, blue: 0.0) }
-        if cell.sessionCount > 0 { return Color(red: 0.20, green: 0.65, blue: 0.35) }
-        return .white.opacity(0.05)
+    @ViewBuilder
+    private func cellView(_ cell: HeatmapCell?) -> some View {
+        let shape = RoundedRectangle(cornerRadius: DT.cellRadius)
+        shape
+            .fill(fill(for: cell))
+            .frame(width: size, height: size)
+            .overlay {
+                if cell?.hasPR == true {
+                    shape.strokeBorder(DT.prGold, lineWidth: 1)
+                }
+            }
     }
 
-    private func legendItem(color: Color, label: String) -> some View {
-        HStack(spacing: 4) {
-            RoundedRectangle(cornerRadius: 2)
-                .fill(color)
-                .frame(width: 10, height: 10)
-            Text(label)
-                .font(.caption2)
-                .foregroundStyle(.white.opacity(0.45))
+    private func fill(for cell: HeatmapCell?) -> Color {
+        guard let cell, cell.sessionCount > 0 else { return DT.emptyCell }
+        switch cell.sessionCount {
+        case 1:  return DT.accent.opacity(0.35)
+        case 2:  return DT.accent.opacity(0.70)
+        default: return DT.accent
         }
     }
 }
 
-// MARK: - FlowLayout
+// MARK: - Pattern row
 
-/// Simple left-to-right wrapping layout for the muscle legend chips.
+private struct PatternRow: View {
+    let summary: PatternSummary
+
+    var body: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(summary.pattern.displayName)
+                    .font(DT.bodyText)
+                    .foregroundStyle(.white)
+                Text(summary.currentPhase.rawValue.capitalized)
+                    .font(DT.caption)
+                    .foregroundStyle(DT.neutral)
+            }
+            Spacer(minLength: 0)
+
+            if summary.consecutiveForceDeloadsOnPattern >= 2 {
+                Text("Deload ×\(summary.consecutiveForceDeloadsOnPattern)")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(DT.amber)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(DT.amber.opacity(0.14), in: Capsule())
+            }
+            if summary.inTransitionMode {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.system(size: 12))
+                    .foregroundStyle(DT.neutral)
+            }
+            Text(confidenceLabel)
+                .font(DT.caption)
+                .foregroundStyle(DT.neutral)
+            Image(systemName: trendIcon)
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(trendColor)
+        }
+        .padding(.vertical, 8)
+    }
+
+    private var confidenceLabel: String {
+        switch summary.confidence {
+        case .bootstrapping: "New"
+        case .calibrating:   "Calibrating"
+        case .established:   "Established"
+        case .seasoned:      "Seasoned"
+        }
+    }
+
+    private var trendIcon: String {
+        switch summary.trend {
+        case .progressing: "chevron.up"
+        case .plateaued:   "minus"
+        case .declining:   "chevron.down"
+        }
+    }
+
+    private var trendColor: Color {
+        switch summary.trend {
+        case .progressing: DT.up
+        case .plateaued:   DT.neutral
+        case .declining:   DT.down
+        }
+    }
+}
+
+// MARK: - Loading skeleton
+
+private struct HeroSkeleton: View {
+    @State private var shimmer = false
+    var body: some View {
+        RoundedRectangle(cornerRadius: DT.cardRadius)
+            .fill(DT.surface1)
+            .frame(height: 320)
+            .overlay {
+                LinearGradient(
+                    colors: [.clear, .white.opacity(0.06), .clear],
+                    startPoint: .leading, endPoint: .trailing
+                )
+                .frame(width: 160)
+                .offset(x: shimmer ? 280 : -280)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: DT.cardRadius))
+            .onAppear {
+                withAnimation(.linear(duration: 1.25).repeatForever(autoreverses: false)) {
+                    shimmer = true
+                }
+            }
+    }
+}
+
+// MARK: - Motion primitives
+
+/// A `Text` whose value animates digit-by-digit when changed inside an
+/// animation transaction (true rolling count-up).
+private struct CountingNumber: View, Animatable {
+    var value: Double
+    var animatableData: Double {
+        get { value }
+        set { value = newValue }
+    }
+    var body: some View {
+        Text(String(format: "%.1f", value))
+    }
+}
+
+private struct PulsingDot: View {
+    let color: Color
+    @State private var pulse = false
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(color.opacity(0.35))
+                .frame(width: 22, height: 22)
+                .scaleEffect(pulse ? 1.35 : 0.7)
+                .opacity(pulse ? 0 : 0.7)
+            Circle()
+                .fill(color)
+                .frame(width: 9, height: 9)
+                .overlay(Circle().stroke(DT.bg, lineWidth: 2))
+        }
+        .onAppear {
+            withAnimation(.easeOut(duration: 1.4).repeatForever(autoreverses: false)) {
+                pulse = true
+            }
+        }
+    }
+}
+
+private struct PressableStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.96 : 1)
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: configuration.isPressed)
+    }
+}
+
+private struct SectionEntrance: ViewModifier {
+    let index: Int
+    let appeared: Bool
+    func body(content: Content) -> some View {
+        content
+            .opacity(appeared ? 1 : 0)
+            .offset(y: appeared ? 0 : 16)
+            .animation(.easeOut(duration: 0.5).delay(Double(index) * 0.07), value: appeared)
+    }
+}
+
+private enum Haptics {
+    static func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        #if canImport(UIKit)
+        UIImpactFeedbackGenerator(style: style).impactOccurred()
+        #endif
+    }
+    static func success() {
+        #if canImport(UIKit)
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        #endif
+    }
+}
+
+// MARK: - Small value types
+
+private struct WeekTotal: Identifiable {
+    let id: Int
+    let label: String
+    let value: Int
+}
+
+/// Left-to-right wrapping layout for the muscle legend chips.
 private struct FlowLayout: Layout {
     var spacing: CGFloat = 8
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
         let maxWidth = proposal.width ?? .infinity
-        var x: CGFloat = 0
-        var y: CGFloat = 0
-        var rowHeight: CGFloat = 0
-
+        var x: CGFloat = 0, y: CGFloat = 0, rowHeight: CGFloat = 0
         for view in subviews {
             let size = view.sizeThatFits(.unspecified)
             if x + size.width > maxWidth && x > 0 {
-                x = 0
-                y += rowHeight + spacing
-                rowHeight = 0
+                x = 0; y += rowHeight + spacing; rowHeight = 0
             }
             x += size.width + spacing
             rowHeight = max(rowHeight, size.height)
@@ -463,16 +1006,11 @@ private struct FlowLayout: Layout {
     }
 
     func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        var x = bounds.minX
-        var y = bounds.minY
-        var rowHeight: CGFloat = 0
-
+        var x = bounds.minX, y = bounds.minY, rowHeight: CGFloat = 0
         for view in subviews {
             let size = view.sizeThatFits(.unspecified)
             if x + size.width > bounds.maxX && x > bounds.minX {
-                x = bounds.minX
-                y += rowHeight + spacing
-                rowHeight = 0
+                x = bounds.minX; y += rowHeight + spacing; rowHeight = 0
             }
             view.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
             x += size.width + spacing
@@ -481,16 +1019,118 @@ private struct FlowLayout: Layout {
     }
 }
 
-// MARK: - Preview
+// MARK: - Previews
 
-#Preview {
-    ProgressTabView(
-        supabaseClient: SupabaseClient(
-            supabaseURL: URL(string: "https://example.supabase.co")!,
-            anonKey: "preview"
-        ),
-        userId: UUID()
-    )
-    .environment(AppDependencies())
-    .preferredColorScheme(.dark)
+#if DEBUG
+extension ProgressViewModel {
+
+    /// Populates a view model with realistic mock data for previews — no network.
+    static func makeMock(loading: Bool = false, newUser: Bool = false) -> ProgressViewModel {
+        let vm = ProgressViewModel(
+            supabaseClient: SupabaseClient(
+                supabaseURL: URL(string: "https://example.supabase.co")!,
+                anonKey: "preview"
+            ),
+            userId: UUID()
+        )
+        vm.isLoading = loading
+        if loading { return vm }
+
+        vm.keyLifts = [
+            KeyLiftSummary(exerciseId: "barbell_bench_press", name: "Bench Press",   currentE1RM: 100.0, deltaVs4WeeksAgo: newUser ? nil : 4.5,  trend: newUser ? .flat : .up),
+            KeyLiftSummary(exerciseId: "barbell_back_squat",  name: "Back Squat",    currentE1RM: 142.5, deltaVs4WeeksAgo: newUser ? nil : 7.5,  trend: newUser ? .flat : .up),
+            KeyLiftSummary(exerciseId: "barbell_deadlift",    name: "Deadlift",      currentE1RM: 180.0, deltaVs4WeeksAgo: newUser ? nil : 0.0,  trend: .flat),
+            KeyLiftSummary(exerciseId: "overhead_press",      name: "Overhead Press",currentE1RM: 60.0,  deltaVs4WeeksAgo: newUser ? nil : -2.5, trend: newUser ? .flat : .down),
+            KeyLiftSummary(exerciseId: "romanian_deadlift",   name: "Romanian DL",   currentE1RM: 120.0, deltaVs4WeeksAgo: newUser ? nil : 5.0,  trend: newUser ? .flat : .up),
+        ]
+
+        vm.trendData = [
+            "barbell_back_squat":  Self.mockTrend(from: 120, to: 142.5, weeks: 12, lastIsPR: true),
+            "barbell_bench_press": Self.mockTrend(from: 88,  to: 100,   weeks: 12, lastIsPR: false, midPR: 6),
+            "barbell_deadlift":    Self.mockTrend(from: 180, to: 180,   weeks: 10, lastIsPR: false),
+            "overhead_press":      Self.mockTrend(from: 64,  to: 60,    weeks: 9,  lastIsPR: false),
+            "romanian_deadlift":   Self.mockTrend(from: 108, to: 120,   weeks: 11, lastIsPR: true),
+        ]
+        vm.selectedTrendExercise = nil
+
+        let cal = Calendar.current
+        let muscles = ["chest", "back", "quads", "hamstrings", "shoulders"]
+        vm.weeklyVolume = (0..<8).map { i in
+            let start = cal.date(byAdding: .weekOfYear, value: -(7 - i), to: Date())!
+            var sets: [String: Int] = [:]
+            for (m, muscle) in muscles.enumerated() {
+                sets[muscle] = 9 + ((i + m) % 4) * 3 + (i == 7 ? 3 : 0)
+            }
+            return WeeklyVolumeRow(weekLabel: "W\(8 - i)", weekStart: start, setsByMuscle: sets)
+        }
+
+        var heat: [HeatmapCell] = []
+        let prCells: Set<[Int]> = [[7, 2], [9, 4], [11, 1], [6, 0]]
+        for week in 0..<12 {
+            for day in 0..<7 {
+                let active = week >= 6 ? (day % 2 == 0 || day == 3) : (week % 2 == 0 && day == 2)
+                heat.append(HeatmapCell(
+                    weekIndex: week, dayOfWeek: day,
+                    sessionCount: active ? 1 : 0,
+                    hasPR: prCells.contains([week, day])
+                ))
+            }
+        }
+        vm.heatmapData = heat
+
+        vm.patternTrends = [
+            PatternSummary(mockPattern: .squat,          phase: .accumulation,    confidence: .seasoned,  trend: .progressing, transition: false, forceDeloads: 0),
+            PatternSummary(mockPattern: .hipHinge,       phase: .intensification, confidence: .established, trend: .plateaued,  transition: true,  forceDeloads: 0),
+            PatternSummary(mockPattern: .verticalPush,   phase: .deload,          confidence: .calibrating, trend: .declining, transition: false, forceDeloads: 2),
+        ]
+        return vm
+    }
+
+    private static func mockTrend(from start: Double, to end: Double, weeks: Int, lastIsPR: Bool, midPR: Int? = nil) -> [TrendPoint] {
+        let cal = Calendar.current
+        var best = 0.0
+        return (0..<weeks).map { i in
+            let frac = weeks <= 1 ? 1 : Double(i) / Double(weeks - 1)
+            let raw = start + (end - start) * frac
+            let value = (raw * 2).rounded() / 2
+            let date = cal.date(byAdding: .day, value: -(weeks - 1 - i) * 7, to: Date())!
+            var isPR = value > best
+            if isPR { best = value }
+            if let m = midPR, i == m { isPR = true }
+            if i == weeks - 1 { isPR = lastIsPR }
+            return TrendPoint(date: date, e1RM: value, isAllTimeBest: isPR)
+        }
+    }
 }
+
+extension PatternSummary {
+    /// Preview-only convenience initialiser. Keeps the model file untouched.
+    init(mockPattern pattern: MovementPattern, phase: MesocyclePhase, confidence: AxisConfidence, trend: ProgressionTrend, transition: Bool, forceDeloads: Int) {
+        self.pattern = pattern
+        self.currentPhase = phase
+        self.confidence = confidence
+        self.rpeOffset = 0
+        self.trend = trend
+        self.inTransitionMode = transition
+        self.consecutiveForceDeloadsOnPattern = forceDeloads
+    }
+}
+
+#Preview("Progress — populated") {
+    ProgressScreenContent(vm: .makeMock())
+        .background(DT.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Progress — loading") {
+    ProgressScreenContent(vm: .makeMock(loading: true))
+        .background(DT.bg)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Progress — new user") {
+    ProgressScreenContent(vm: .makeMock(newUser: true))
+        .background(DT.bg)
+        .preferredColorScheme(.dark)
+}
+#endif


### PR DESCRIPTION
## What
Presentation-only redesign of the live (4-tab \`ContentView\`) Progress tab — a premium dark "strength instrument". Direction chosen by an independent multi-agent design panel.

- Hero + trend card (count-up e1RM, signed 4-wk delta, range pills, gradient area chart with gold PR markers + pulsing live dot, tappable exercise chip-rail)
- Key-lift 2×2 grid, progressive-disclosure volume card, 12-week consistency heatmap, calm per-pattern coaching rows
- New \`ProgressDesignTokens.swift\`; staggered entrance, chart draw-in, spring disclosure, earned haptics

## Scope
**\`ProgressViewModel\` is untouched** — every value shown derives from its existing published arrays. Built clean on iPhone 17 Pro.

## Status
⚠️ **Awaiting your sign-off before merge** (product/UX call). This is PR 1 of 2 — the data-layer "Tier-1 trustworthy wins" (trust-grade e1RM, volume-vs-target, confidence chip, plateau chip) stack on top in a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)