### PR TITLE
fix(#439): refuse programme regeneration while a session is paused/live (Q3)

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		47BB8E712F6273F30082C5F1 /* GymProfileSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E702F6273F30082C5F0 /* GymProfileSyncTests.swift */; };
 		47BB8E8B2F6273F30082C53F /* ProgramOwnerGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */; };
 		47BB8E712F6273F30082C625 /* ProgramBackfillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E702F6273F30082C625 /* ProgramBackfillTests.swift */; };
+		47BB8EA12F6273F30082C999 /* RegenerateRefusalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8EA02F6273F30082C999 /* RegenerateRefusalTests.swift */; };
 		47BB8E752F6294B00082C53F /* WorkoutSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */; };
 		47C5C1AF2F62A64E0005F99E /* WriteAheadQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */; };
 		47C5C1B82F62BB3D0005F99E /* GymStreakServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C5C1B72F62BB3D0005F99E /* GymStreakServiceTests.swift */; };
@@ -101,6 +102,7 @@
 		47BB8E702F6273F30082C5F0 /* GymProfileSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymProfileSyncTests.swift; sourceTree = "<group>"; };
 		47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramOwnerGateTests.swift; sourceTree = "<group>"; };
 		47BB8E702F6273F30082C625 /* ProgramBackfillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramBackfillTests.swift; sourceTree = "<group>"; };
+		47BB8EA02F6273F30082C999 /* RegenerateRefusalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegenerateRefusalTests.swift; sourceTree = "<group>"; };
 		47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSessionManagerTests.swift; sourceTree = "<group>"; };
 		47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteAheadQueueTests.swift; sourceTree = "<group>"; };
 		47C5C1B72F62BB3D0005F99E /* GymStreakServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymStreakServiceTests.swift; sourceTree = "<group>"; };
@@ -240,6 +242,7 @@
 				47BB8E702F6273F30082C5F0 /* GymProfileSyncTests.swift */,
 				47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */,
 				47BB8E702F6273F30082C625 /* ProgramBackfillTests.swift */,
+				47BB8EA02F6273F30082C999 /* RegenerateRefusalTests.swift */,
 				47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */,
 				47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */,
 				47C5C1B72F62BB3D0005F99E /* GymStreakServiceTests.swift */,
@@ -405,6 +408,7 @@
 				47BB8E712F6273F30082C5F1 /* GymProfileSyncTests.swift in Sources */,
 				47BB8E8B2F6273F30082C53F /* ProgramOwnerGateTests.swift in Sources */,
 				47BB8E712F6273F30082C625 /* ProgramBackfillTests.swift in Sources */,
+				47BB8EA12F6273F30082C999 /* RegenerateRefusalTests.swift in Sources */,
 				478DD9F12F9928C6001D3636 /* SkipFeatureTests.swift in Sources */,
 				32736E74E3F688020744DE5E /* EquipmentRounderTests.swift in Sources */,
 				47C5C1AF2F62A64E0005F99E /* WriteAheadQueueTests.swift in Sources */,

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -589,6 +589,19 @@ struct ContentView: View {
             } message: {
                 Text("Generates a fresh 12-week programme. Your history is preserved.")
             }
+            // #439 (Q3 = refuse-and-prompt): regeneration refuses while a paused
+            // session sentinel exists; surface the prompt to finish/abandon first.
+            .alert(
+                "Finish Your Session First",
+                isPresented: Binding(
+                    get: { regenerateErrorMessage != nil },
+                    set: { if !$0 { regenerateErrorMessage = nil } }
+                )
+            ) {
+                Button("OK", role: .cancel) { regenerateErrorMessage = nil }
+            } message: {
+                Text(regenerateErrorMessage ?? "")
+            }
         }
     }
 
@@ -672,6 +685,14 @@ struct ContentView: View {
         guard let vm = programViewModel else { return }
         regenerateErrorMessage = nil
         await vm.regenerateProgram(gymProfile: gymProfile)
+
+        // #439 (Q3 = refuse-and-prompt): regeneration was refused because a paused
+        // session sentinel still exists. Surface the prompt and stop — the mesocycle
+        // was NOT mutated, so don't switch tabs or reload.
+        if vm.regenerationBlockedBySession {
+            regenerateErrorMessage = "Finish or abandon your paused session before starting a new programme."
+            return
+        }
 
         // Detect error state after generation completes
         if case .error(let message) = vm.viewState {

--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -126,6 +126,16 @@ final class ProgramViewModel {
     /// Incremented by ContentView to tell ProgramOverviewView to scroll to the current week.
     var scrollToCurrentWeekTrigger: Int = 0
 
+    /// #439 (Q3 = refuse-and-prompt): set true when `regenerateProgram` was asked to
+    /// run while a live/paused session sentinel (`PausedSessionState`) still exists.
+    /// Regenerating then would mint a fresh mesocycle with new day UUIDs and orphan
+    /// the sentinel — its `trainingDayId` would point at a deleted TrainingDay
+    /// ("Session Not Found" / "Session Mismatch", STATE-5/STATE-6). The guard
+    /// REFUSES (no mutation, no new UUIDs) and sets this flag so the UI can prompt
+    /// the user to finish or abandon the paused session first. Cleared on the next
+    /// regenerate attempt that is allowed to proceed.
+    var regenerationBlockedBySession: Bool = false
+
     // MARK: Sync-error state (#188)
     /// Non-nil when a background Supabase persist failed. The view renders a
     /// non-blocking banner so the user is aware the sync failed. Local-first
@@ -290,6 +300,19 @@ final class ProgramViewModel {
     ///
     /// Called from Settings → "Regenerate Program".
     func regenerateProgram(gymProfile: GymProfile) async {
+        // #439 (Q3 = refuse-and-prompt): a live/paused session sentinel pins the
+        // current mesocycle's day UUIDs. Regenerating would mint a fresh mesocycle
+        // with new UUIDs and orphan the sentinel (its trainingDayId would point at a
+        // deleted TrainingDay — "Session Not Found" / "Session Mismatch",
+        // STATE-5/STATE-6). REFUSE: do not snapshot, clear the cache, or generate.
+        // Surface the refusal so the call site can prompt the user to finish or
+        // abandon the paused session first.
+        guard PausedSessionState.load() == nil else {
+            regenerationBlockedBySession = true
+            return
+        }
+        regenerationBlockedBySession = false
+
         // 1. Snapshot completed days (flat ordered list) before clearing cache.
         let completedDaySnapshots = snapshotCompletedDays()
 

--- a/ProjectApexTests/RegenerateRefusalTests.swift
+++ b/ProjectApexTests/RegenerateRefusalTests.swift
@@ -1,0 +1,151 @@
+// RegenerateRefusalTests.swift
+// ProjectApexTests — #439 (Programme↔Workout audit, Q3 = refuse-and-prompt)
+//
+// Root defect (STATE-6 / STATE-5): regenerating the programme while a session is
+// paused/live mints a fresh mesocycle with new day UUIDs, orphaning the
+// `PausedSessionState` sentinel — its `trainingDayId` then points at a TrainingDay
+// that no longer exists, producing "Session Not Found" / "Session Mismatch".
+//
+// Locked decision Q3 = REFUSE: regenerateProgram must NOT mutate the mesocycle or
+// mint new UUIDs while a sentinel exists. It surfaces a refusal the UI can show so
+// the user is told to finish or abandon the paused session first.
+//
+//   1. pausedSessionPresent_regenerateRefuses_doesNotMutateMesocycle — sentinel set
+//      → currentMesocycle is untouched (same id), the cache is not cleared, and the
+//      refusal flag is set.
+//   2. noPausedSession_regenerateProceeds — no sentinel → regeneration runs (cache
+//      is cleared) and the refusal flag stays clear.
+
+import XCTest
+@testable import ProjectApex
+
+final class RegenerateRefusalTests: XCTestCase {
+
+    private struct RegenThrowingProvider: LLMProvider {
+        func complete(systemPrompt: String, userPayload: String) async throws -> String {
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+
+    private func makeClient() -> SupabaseClient {
+        let config = URLSessionConfiguration.ephemeral
+        return SupabaseClient(
+            supabaseURL: URL(string: "https://test.supabase.co")!,
+            anonKey: "test-anon-key",
+            urlSession: URLSession(configuration: config)
+        )
+    }
+
+    @MainActor
+    private func makeViewModel(client: SupabaseClient) -> ProgramViewModel {
+        let provider: any LLMProvider = RegenThrowingProvider()
+        let memory = MemoryService(supabase: client, embeddingAPIKey: "test")
+        return ProgramViewModel(
+            supabaseClient: client,
+            programGenerationService: ProgramGenerationService(provider: provider),
+            macroPlanService: MacroPlanService(provider: provider),
+            sessionPlanService: SessionPlanService(
+                provider: provider,
+                memoryService: memory,
+                supabaseClient: client
+            ),
+            userId: AppDependencies.placeholderUserId,
+            resolveOwner: { nil }
+        )
+    }
+
+    private func seedPausedSession() {
+        PausedSessionState(
+            sessionId: UUID(),
+            trainingDayId: UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000001")!,
+            weekId: UUID(uuidString: "AAAAAAAA-1111-0000-0000-000000000001")!,
+            weekNumber: 1,
+            exerciseIndex: 0,
+            currentSetNumber: 1,
+            dayType: "Push_A",
+            programId: UUID(uuidString: "DDDDDDDD-0000-0000-0000-000000000001")!,
+            userId: AppDependencies.placeholderUserId,
+            pausedAt: Date()
+        ).save()
+    }
+
+    private var profile: GymProfile {
+        GymProfile(
+            scanSessionId: "test",
+            equipment: [EquipmentItem(equipmentType: .barbell, count: 1, detectedByVision: false)]
+        )
+    }
+
+    override func setUp() {
+        super.setUp()
+        PausedSessionState.clear()
+        Mesocycle.clearUserDefaults()
+    }
+
+    override func tearDown() {
+        PausedSessionState.clear()
+        Mesocycle.clearUserDefaults()
+        super.tearDown()
+    }
+
+    // MARK: 1. paused session present → regenerate refuses, mesocycle untouched
+
+    @MainActor
+    func test_pausedSessionPresent_regenerateRefuses_doesNotMutateMesocycle() async {
+        let original = Mesocycle.mockMesocycle()
+        original.saveToUserDefaults()
+
+        let vm = makeViewModel(client: makeClient())
+        vm.currentMesocycle = original
+        vm.viewState = .loaded(original)
+
+        seedPausedSession()
+
+        await vm.regenerateProgram(gymProfile: profile)
+
+        // The mesocycle must NOT be replaced or mutated — same id, still cached.
+        XCTAssertEqual(
+            vm.currentMesocycle?.id, original.id,
+            "Refusal must leave the existing mesocycle in place (no new UUIDs)."
+        )
+        XCTAssertEqual(
+            Mesocycle.loadFromUserDefaults()?.id, original.id,
+            "Refusal must not clear the local mesocycle cache."
+        )
+        XCTAssertNotNil(
+            PausedSessionState.load(),
+            "Refusal must not touch the paused-session sentinel."
+        )
+        XCTAssertTrue(
+            vm.regenerationBlockedBySession,
+            "Refusal must set a flag the UI can surface."
+        )
+    }
+
+    // MARK: 2. no paused session → regeneration proceeds, flag stays clear
+
+    @MainActor
+    func test_noPausedSession_regenerateProceeds() async {
+        let original = Mesocycle.mockMesocycle()
+        original.saveToUserDefaults()
+
+        let vm = makeViewModel(client: makeClient())
+        vm.currentMesocycle = original
+        vm.viewState = .loaded(original)
+
+        // No sentinel seeded.
+        await vm.regenerateProgram(gymProfile: profile)
+
+        XCTAssertFalse(
+            vm.regenerationBlockedBySession,
+            "With no paused session, regeneration must not be blocked."
+        )
+        // generateMacroSkeleton clears the cache before generating; with a throwing
+        // provider it then ends in an error state, but the refusal guard must NOT
+        // have short-circuited it — the cache was cleared, proving it ran.
+        XCTAssertNil(
+            Mesocycle.loadFromUserDefaults(),
+            "Regeneration must proceed past the guard and clear the old cache."
+        )
+    }
+}


### PR DESCRIPTION
## What & why

Part of the Programme↔Workout architecture audit (umbrella #435). Root defect (STATE-5/STATE-6): regenerating the programme while a session is paused/live mints a fresh mesocycle with new day UUIDs, orphaning the `PausedSessionState` sentinel — its `trainingDayId` then points at a deleted `TrainingDay`, producing "Session Not Found" / "Session Mismatch".

Applies locked decision **Q3 = refuse-and-prompt**.

## Change

- `ProgramViewModel.regenerateProgram` now guards on `PausedSessionState.load()` at the top. If a sentinel exists it **refuses** — no snapshot, no cache clear, no new UUIDs — and sets a published `regenerationBlockedBySession` flag.
- `ContentView.regenerateProgram(gymProfile:)` is the single funnel for both regeneration entry points — the programme-complete screen's "Start Your Next Programme" alert and the Settings "Regenerate" path. It reads the flag and surfaces a prompt telling the user to finish or abandon the paused session first (returns early, leaving the mesocycle untouched and not switching tabs).
- The programme-complete screen gains an alert bound to `regenerateErrorMessage` so the refusal is visible there too (the existing Settings alert already renders it).

## Tests (TDD)

`ProjectApexTests/RegenerateRefusalTests.swift`:
- `test_pausedSessionPresent_regenerateRefuses_doesNotMutateMesocycle` — sentinel present → `currentMesocycle` unchanged (same id), cache not cleared, sentinel untouched, refusal flag set.
- `test_noPausedSession_regenerateProceeds` — no sentinel → flag stays clear and regeneration proceeds past the guard (old cache cleared).

Both pass locally (`xcodebuild test -only-testing:ProjectApexTests/RegenerateRefusalTests`, iPhone 17 Pro sim, ** TEST SUCCEEDED **).

## Scope notes

- The DEBUG-only `startAnyDayMode` override is untouched (that's the Q1 slice).
- Reset All is out of scope for this slice — it already clears the anon session/sentinel via the Reset-All path (#389). Only the regenerate entry points are guarded here.

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)