### PR TITLE
fix(#436): day-identity guard on WorkoutView — never adopt/complete a session for a different day

### DIFF
--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -71,6 +71,10 @@ nonisolated enum SessionState: Sendable, Equatable {
 /// same consistent snapshot.
 nonisolated struct WorkoutUISnapshot: Sendable {
     let sessionState: SessionState
+    /// The training day the actor is currently running (nil when idle). Persists
+    /// through .sessionComplete (cleared only on resetToIdle) so the view can
+    /// verify a completion belongs to the day it was handed (#436 day-identity guard).
+    let currentTrainingDayId: UUID?
     let currentPrescription: SetPrescription?
     let currentFallbackReason: FallbackReason?
     let restSecondsRemaining: Int
@@ -1626,6 +1630,7 @@ actor WorkoutSessionManager {
 
         return WorkoutUISnapshot(
             sessionState: sessionState,
+            currentTrainingDayId: currentTrainingDayId,
             currentPrescription: currentPrescription,
             currentFallbackReason: currentFallbackReason,
             restSecondsRemaining: restSecondsRemaining,

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -186,10 +186,16 @@ struct WorkoutView: View {
             // This handles the case where the user navigated away and back — the session
             // is still live in the actor but the viewModel may have stale/nil state.
             await vm.pullState()
-            let isLive = await vm.sessionIsLive()
+            // Day-identity guard (#436): only adopt a live session if the actor is
+            // running THIS view's day. Two WorkoutView hosts share one actor; without
+            // this comparison a view for day A would begin polling — and later
+            // complete — a session the actor is actually running for day B. Mirrors
+            // the day-aware gate the pause path uses below.
+            let isLive = await vm.sessionIsLive(forDay: trainingDay.id)
             if isLive {
-                // Session already running (e.g. user returned via back button or tab switch).
-                // Restart polling so the view stays up to date, then return early.
+                // Session already running for THIS day (e.g. user returned via back
+                // button or tab switch). Restart polling so the view stays up to date,
+                // then return early.
                 vm.beginStatePolling()
                 return
             }
@@ -230,6 +236,13 @@ struct WorkoutView: View {
         }
         .onChange(of: viewModel?.sessionState) { _, newState in
             if case .sessionComplete = newState {
+                // Day-identity guard (#436): only mark THIS day complete if the actor
+                // actually ran it. With two WorkoutView hosts on one actor, a view for
+                // day A could otherwise observe day B's .sessionComplete and advance the
+                // calendar past an untrained day. liveSessionDayId survives the
+                // .sessionComplete transition (cleared only on resetToIdle), so it still
+                // names the day the actor ran here.
+                guard viewModel?.liveSessionDayId == trainingDay.id else { return }
                 onSessionCompleted?()
                 // Re-fetch streak after session completion so PostWorkoutSummaryView
                 // and the next PreWorkoutView both show the updated value.

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -47,6 +47,12 @@ final class WorkoutViewModel {
     /// All sets logged so far in this session.
     var completedSets: [SetLog] = []
 
+    /// The training day the actor is currently running (nil when idle). Survives
+    /// the .sessionComplete transition (the actor clears it only on resetToIdle).
+    /// WorkoutView compares this against the day it was handed so a completion can
+    /// only ever mark the day the actor actually ran (#436 day-identity guard).
+    var liveSessionDayId: UUID? = nil
+
     /// Last-session set logs for the live exercise (#318 U7 / G-F6). Pulled
     /// from the manager's cachedLastPerformance; nil when no history exists.
     var lastPerformanceSets: [SetLog]? = nil
@@ -274,6 +280,7 @@ final class WorkoutViewModel {
 
         let fallbackReason = snapshot.currentFallbackReason
         sessionState = snapshot.sessionState
+        liveSessionDayId = snapshot.currentTrainingDayId
         currentPrescription = snapshot.currentPrescription
         restSecondsRemaining = snapshot.restSecondsRemaining
         restExpiresAt = snapshot.restExpiresAt
@@ -503,6 +510,15 @@ final class WorkoutViewModel {
         case .idle, .sessionComplete, .error: return false
         default: return true
         }
+    }
+
+    /// Day-aware variant of `sessionIsLive()` (#436 day-identity guard). Two
+    /// WorkoutView hosts can be bound to this one actor; a session that is live
+    /// for some OTHER day must not be adopted by a view handed `dayId`. Returns
+    /// true only when a session is live AND the actor is running exactly `dayId`.
+    func sessionIsLive(forDay dayId: UUID) async -> Bool {
+        guard await sessionIsLive() else { return false }
+        return await manager.currentTrainingDayId == dayId
     }
 
     // MARK: - Derived Helpers

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -1784,3 +1784,70 @@ final class PrescriptionGuardrailTests: XCTestCase {
             "A successful start clears any stale error message")
     }
 }
+
+// MARK: - Day-identity guard (#436)
+
+/// Two WorkoutView hosts share one WorkoutSessionManager actor. When a session is
+/// live for day B, a WorkoutView handed day A must NOT (a) adopt B's session as its
+/// own, nor (b) let a completion mark day A complete. The day-aware guards on
+/// WorkoutViewModel are the testable surface for that behaviour.
+final class WorkoutDayIdentityGuardTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        PausedSessionState.clear()
+    }
+
+    override func tearDown() {
+        PausedSessionState.clear()
+        super.tearDown()
+    }
+
+    /// A session is live for day B. A view configured for a DIFFERENT day A must
+    /// not treat that session as its own: `sessionIsLive(forDay: A)` is false even
+    /// though a day-agnostic `sessionIsLive()` is true.
+    func testSessionIsLiveForDay_otherDayLive_doesNotAdopt() async throws {
+        let manager = makeManager()
+        let vm = await WorkoutViewModel(manager: manager)
+
+        let dayB = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+        let dayAId = UUID() // a different view's day — never started
+
+        await manager.startSession(trainingDay: dayB, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000) // settle to .active
+
+        let liveAtAll = await vm.sessionIsLive()
+        XCTAssertTrue(liveAtAll, "a session is live in the actor")
+
+        let liveForA = await vm.sessionIsLive(forDay: dayAId)
+        XCTAssertFalse(liveForA,
+            "view for day A must NOT adopt a session that is live for day B")
+
+        let liveForB = await vm.sessionIsLive(forDay: dayB.id)
+        XCTAssertTrue(liveForB,
+            "the view for the day the actor actually ran DOES adopt the session")
+    }
+
+    /// The completion guard reads the actor's live day id. With a session running
+    /// for day B, `pullState()` publishes `liveSessionDayId == B`, so a WorkoutView
+    /// for day A (A != B) refuses to fire its completion callback. The id survives
+    /// the .sessionComplete transition (it's only cleared on resetToIdle).
+    func testLiveSessionDayId_reflectsRunningDay_notAMismatchedDay() async throws {
+        let manager = makeManager()
+        let vm = await WorkoutViewModel(manager: manager)
+
+        let dayB = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+        let dayAId = UUID()
+
+        await manager.startSession(trainingDay: dayB, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        await vm.pullState()
+
+        let liveDayId = await MainActor.run { vm.liveSessionDayId }
+        XCTAssertEqual(liveDayId, dayB.id,
+            "live day id is the day the actor actually ran (B)")
+        XCTAssertNotEqual(liveDayId, dayAId,
+            "a WorkoutView for day A sees a mismatch and must refuse to mark A complete")
+    }
+}


### PR DESCRIPTION
## What

Tier-1 corruption-stopper from the Programme↔Workout architecture audit (umbrella #435). Two `WorkoutView` hosts are bound to one `WorkoutSessionManager` actor with no day-identity referee, which let one view adopt — and complete — a session the actor was actually running for a *different* day, advancing the calendar past an untrained day.

## Root defect

- `WorkoutView.task` early-returned into polling on **any** live session (`sessionIsLive()`) without comparing the actor's `currentTrainingDayId` to this view's `trainingDay.id`.
- `WorkoutView.onChange` fired `onSessionCompleted?()` on **any** `.sessionComplete`, with no day check — this is what advanced the calendar past an untrained day.

## Fix (surgical)

- Expose `currentTrainingDayId` on `WorkoutUISnapshot`; publish it as `WorkoutViewModel.liveSessionDayId` (set in `pullState()`). It survives the `.sessionComplete` transition — the actor clears it only on `resetToIdle`.
- Add `WorkoutViewModel.sessionIsLive(forDay:)` — true only when a session is live **and** the actor is running exactly that day.
- `WorkoutView.task` adopt path now gates on `sessionIsLive(forDay: trainingDay.id)`, mirroring the day-aware gate the **pause** path already uses.
- `WorkoutView` completion `.onChange` guards on `liveSessionDayId == trainingDay.id` before firing `onSessionCompleted`.

## Tests (TDD)

New `WorkoutDayIdentityGuardTests`:
- `testSessionIsLiveForDay_otherDayLive_doesNotAdopt` — session live for day B; a view for day A gets `false` from `sessionIsLive(forDay: A)` while the day-agnostic `sessionIsLive()` is `true`; day B's own view still adopts.
- `testLiveSessionDayId_reflectsRunningDay_notAMismatchedDay` — after `pullState()`, `liveSessionDayId == B` (not the mismatched A), so a day-A completion is refused.

Both pass; all 23 existing `WorkoutSessionManagerTests` still pass. `build-for-testing` on the iOS Simulator exits 0 with no `error:` lines (only pre-existing unrelated `SpeechServiceTests` actor-isolation warnings).

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)