### PR TITLE
fix(#445): collapse duplicated .completed||.skipped completion predicate into one helper

### DIFF
--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -351,8 +351,8 @@ struct ContentView: View {
             }()
             if let (day, week) = vm.nextIncompleteDay(in: mesocycle) {
                 let allDays = mesocycle.weeks.flatMap { $0.trainingDays }
-                // Skipped sessions advance the programme pointer and count toward progress.
-                let completedCount = allDays.filter { $0.status == .completed || $0.status == .skipped }.count
+                // Skipped sessions advance the programme pointer and count toward progress (#445).
+                let completedCount = mesocycle.completedDayCount
                 // NavigationStack is required so WorkoutView (and its children) can render
                 // their toolbar items and so WorkoutView pushed from ProgramDayDetailView
                 // has a consistent navigation context. WorkoutView no longer owns an

--- a/ProjectApex/Features/Program/ProgramOverviewView.swift
+++ b/ProjectApex/Features/Program/ProgramOverviewView.swift
@@ -422,9 +422,9 @@ struct ProgramOverviewView: View {
         ]
 
         // Count completed+skipped sessions across all days for the progress label.
-        // Skipped sessions advance the programme pointer, so they count toward progress.
+        // Skipped sessions advance the programme pointer, so they count toward progress (#445).
         let allDays = mesocycle.weeks.flatMap { $0.trainingDays }
-        let completedCount = allDays.filter { $0.status == .completed || $0.status == .skipped }.count
+        let completedCount = mesocycle.completedDayCount
         let totalDays = allDays.count
         // Session-based completion fraction — updates immediately when a day is marked done.
         let sessionProgress = totalDays > 0 ? Double(completedCount) / Double(totalDays) : 0.0

--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -357,7 +357,7 @@ final class ProgramViewModel {
     private func snapshotCompletedDays() -> [TrainingDay] {
         guard let mesocycle = currentMesocycle else { return [] }
         return mesocycle.weeks.flatMap { week in
-            week.trainingDays.filter { $0.status == .completed || $0.status == .skipped }
+            week.trainingDays.filter(\.isTerminal)
         }
     }
 
@@ -899,7 +899,7 @@ final class ProgramViewModel {
     func currentWeekIndex(in mesocycle: Mesocycle) -> Int {
         for (wIdx, week) in mesocycle.weeks.enumerated() {
             for day in week.trainingDays {
-                if day.status != .completed && day.status != .skipped {
+                if !day.isTerminal {
                     return wIdx
                 }
             }
@@ -928,7 +928,7 @@ final class ProgramViewModel {
         for week in mesocycle.weeks {
             for day in week.trainingDays {
                 // Skip permanently-skipped and completed days; also skip soft-deferred days.
-                if day.status != .completed && day.status != .skipped && !skippedDayIds.contains(day.id) {
+                if !day.isTerminal && !skippedDayIds.contains(day.id) {
                     return (day, week)
                 }
             }

--- a/ProjectApex/Models/WorkoutProgram.swift
+++ b/ProjectApex/Models/WorkoutProgram.swift
@@ -181,6 +181,12 @@ nonisolated struct TrainingDay: Codable, Identifiable, Sendable {
         status       = (try? c.decode(TrainingDayStatus.self, forKey: .status)) ?? .generated
         skippedAt    = try c.decodeIfPresent(Date.self, forKey: .skippedAt)
     }
+
+    /// #445: canonical "this day counts as done" predicate.
+    /// `.completed` and `.skipped` are the two terminal statuses — both advance the
+    /// programme pointer and count toward progress. This is the single source of truth;
+    /// progress UI, snapshot grafting, and next-incomplete-day search all route through it.
+    var isTerminal: Bool { status == .completed || status == .skipped }
 }
 
 // MARK: - TrainingWeek
@@ -254,6 +260,12 @@ nonisolated struct Mesocycle: Codable, Identifiable, Sendable {
         case weeks
         case totalWeeks        = "total_weeks"
         case periodizationModel = "periodization_model"
+    }
+
+    /// #445: count of terminal (`.completed` / `.skipped`) days across all weeks.
+    /// Drives the progress label/fraction in the calendar, overview, and pre-workout screens.
+    var completedDayCount: Int {
+        weeks.reduce(0) { $0 + $1.trainingDays.filter(\.isTerminal).count }
     }
 }
 

--- a/ProjectApexTests/WorkoutProgramTests.swift
+++ b/ProjectApexTests/WorkoutProgramTests.swift
@@ -261,4 +261,51 @@ final class WorkoutProgramTests: XCTestCase {
         XCTAssertTrue(lastWeek.isDeload,
                       "isDeload must be re-derived as true after decoding a deload week")
     }
+
+    // MARK: ─── #445: canonical "day is done" predicate ──────────────────────
+
+    /// `.completed` and `.skipped` are the two terminal statuses (both advance the
+    /// programme pointer). `.pending`, `.generated`, `.active`, `.paused` are not.
+    func test_trainingDay_isTerminal_onlyForCompletedOrSkipped() {
+        let cases: [(TrainingDayStatus, Bool)] = [
+            (.completed, true),
+            (.skipped,   true),
+            (.pending,   false),
+            (.generated, false),
+            (.paused,    false)
+        ]
+        for (status, expected) in cases {
+            let day = TrainingDay(
+                id: UUID(),
+                dayOfWeek: 1,
+                dayLabel: "Test",
+                exercises: [],
+                sessionNotes: nil,
+                status: status
+            )
+            XCTAssertEqual(day.isTerminal, expected,
+                           "isTerminal must be \(expected) for status .\(status.rawValue)")
+        }
+    }
+
+    /// `completedDayCount` counts only terminal (.completed / .skipped) days across all
+    /// weeks — pending and paused days do not count. This is the single source of truth
+    /// the progress UI and snapshot logic share.
+    func test_mesocycle_completedDayCount_countsOnlyTerminalDays() {
+        let day = { (status: TrainingDayStatus) in
+            TrainingDay(id: UUID(), dayOfWeek: 1, dayLabel: "D",
+                        exercises: [], sessionNotes: nil, status: status)
+        }
+        let week = TrainingWeek(
+            id: UUID(),
+            weekNumber: 1,
+            phase: .accumulation,
+            trainingDays: [day(.completed), day(.skipped), day(.pending), day(.paused)]
+        )
+        var mock = Mesocycle.mockMesocycle()
+        mock.weeks = [week]
+
+        XCTAssertEqual(mock.completedDayCount, 2,
+                       "completedDayCount must count .completed + .skipped only (1 + 1)")
+    }
 }


### PR DESCRIPTION
## What

Part of the Programme↔Workout jumbled-screens umbrella (#435). Slice #445 — trivial, AFK consolidation.

Four sites independently re-implemented the "this day counts as done" predicate (`.completed || .skipped`). This collapses them into two canonical helpers so the rule lives in one place.

## Helpers added (ProjectApex/Models/WorkoutProgram.swift)

- `TrainingDay.isTerminal` — `status == .completed || status == .skipped`
- `Mesocycle.completedDayCount` — count of terminal days across all weeks

## Sites routed through the helpers

- `ContentView.swift` — progress `completedCount` → `mesocycle.completedDayCount`
- `ProgramOverviewView.swift` — progress `completedCount` → `mesocycle.completedDayCount`
- `ProgramViewModel.snapshotCompletedDays` — graft filter → `.filter(\.isTerminal)`
- `ProgramViewModel.currentWeekIndex` / `nextIncompleteDay` — negated form → `!day.isTerminal`

Single-status UI checks in `ProgramDayDetailView` (e.g. the skipped badge) are left as-is — they are not the composite "done" predicate.

## Tests (ProjectApexTests/WorkoutProgramTests.swift)

- `test_trainingDay_isTerminal_onlyForCompletedOrSkipped` — asserts terminal only for `.completed`/`.skipped`, false for `.pending`/`.generated`/`.paused`
- `test_mesocycle_completedDayCount_countsOnlyTerminalDays` — mixed completed/skipped/pending/paused mesocycle returns 2

Verified locally: `WorkoutProgramTests` 18/18 pass on iPhone 17 Pro simulator; full test build succeeds.

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)