### PR TITLE
fix(#446): calendar-time DayStatus is informational-only — remove its action gating (Q6)

### DIFF
--- a/ProjectApex/Features/Program/ProgramDayDetailView.swift
+++ b/ProjectApex/Features/Program/ProgramDayDetailView.swift
@@ -145,6 +145,19 @@ struct ProgramDayDetailView: View {
         startAnyDayModeActive || dayId == nextIncompleteDayId
     }
 
+    /// #446 (Q6 = calendar-time DayStatus is informational only): the Skip-Session
+    /// affordance keys off the day's training-time status — NOT the wall-clock
+    /// `DayStatus`. A day with a real, unlogged session (`.generated`, has exercises)
+    /// is skippable regardless of where it falls on the calendar. Completed / paused /
+    /// pending / already-skipped days have nothing to skip. Pure + parameterised so it
+    /// is unit-testable and provably free of any calendar-time dependency.
+    static func isSkippableDay(
+        status: TrainingDayStatus,
+        hasExercises: Bool
+    ) -> Bool {
+        status == .generated && hasExercises
+    }
+
     init(
         day: TrainingDay,
         week: TrainingWeek,
@@ -751,8 +764,10 @@ struct ProgramDayDetailView: View {
                 }
             }
 
-            // Tertiary: Skip Session — for past unlogged days (not already skipped)
-            if !isPending && hasExercises && dayStatus == .past && currentDay.status != .skipped {
+            // Tertiary: Skip Session — for a generated, unlogged session. #446 (Q6): the
+            // gate is the day's training-time status, NOT wall-clock DayStatus, so the
+            // current pointer day is skippable regardless of its calendar position.
+            if Self.isSkippableDay(status: currentDay.status, hasExercises: hasExercises) {
                 Button(action: { showSkipDayConfirmation = true }) {
                     Text("Skip this session")
                         .font(.system(size: 14, weight: .medium))

--- a/ProjectApexTests/ProgramDayDetailStartGateTests.swift
+++ b/ProjectApexTests/ProgramDayDetailStartGateTests.swift
@@ -115,6 +115,67 @@ struct ProgramDayDetailStartGateTests {
     }
 }
 
+// MARK: - #446: Skip gate is decoupled from wall-clock DayStatus (Q6)
+
+@Suite("ProgramDayDetailView skip gate (#446)")
+struct ProgramDayDetailSkipGateTests {
+
+    @Test("Skip is offered for a generated, unlogged day regardless of calendar position")
+    func generatedDayIsSkippable() {
+        #expect(ProgramDayDetailView.isSkippableDay(
+            status: .generated,
+            hasExercises: true
+        ) == true)
+    }
+
+    @Test("Skip availability does NOT depend on wall-clock DayStatus (past/today/future identical)")
+    func skipIsIndependentOfCalendarTime() {
+        // The same training-state inputs must yield the same skip availability no matter
+        // where the day falls on the calendar — the predicate has no DayStatus parameter,
+        // so this is structurally guaranteed: one call covers every calendar position.
+        #expect(ProgramDayDetailView.isSkippableDay(
+            status: .generated,
+            hasExercises: true
+        ) == true)
+    }
+
+    @Test("Pending days are not skippable (no real session to skip)")
+    func pendingDayIsNotSkippable() {
+        #expect(ProgramDayDetailView.isSkippableDay(
+            status: .pending,
+            hasExercises: false
+        ) == false)
+    }
+
+    @Test("A day with no exercises is not skippable")
+    func noExercisesIsNotSkippable() {
+        #expect(ProgramDayDetailView.isSkippableDay(
+            status: .generated,
+            hasExercises: false
+        ) == false)
+    }
+
+    @Test("Already-skipped days are not re-skippable")
+    func skippedDayIsNotSkippable() {
+        #expect(ProgramDayDetailView.isSkippableDay(
+            status: .skipped,
+            hasExercises: true
+        ) == false)
+    }
+
+    @Test("Completed and paused days are not skippable")
+    func completedAndPausedAreNotSkippable() {
+        #expect(ProgramDayDetailView.isSkippableDay(
+            status: .completed,
+            hasExercises: true
+        ) == false)
+        #expect(ProgramDayDetailView.isSkippableDay(
+            status: .paused,
+            hasExercises: true
+        ) == false)
+    }
+}
+
 // MARK: - #438: live status read
 
 @Suite("ProgramDayDetailView live status read (#438)")


### PR DESCRIPTION
## What & why

Part of the Programme↔Workout seam fix (umbrella #435). Per locked decision **Q6**: keep the wall-clock `DayStatus` as purely **informational** banner text and strip its ability to **gate any action**.

The Skip-Session affordance in `ProgramDayDetailView` gated on `dayStatus == .past` (wall-clock). That let calendar time gate a training-time action: the current programme **pointer** day could be unskippable whenever its calendar date was today/future, even though it is the day the user is actually on.

## Change (TDD, surgical)

- Added a pure, unit-testable static predicate `ProgramDayDetailView.isSkippableDay(status:hasExercises:)` keyed on the day's **training-time** status (`.generated` + has exercises) — mirroring the existing `isStartableDay` seam. It has **no `DayStatus` parameter**, so skip availability is structurally free of any calendar-time dependency.
- Rewired the Skip-Session gate to use the predicate, dropping the `dayStatus == .past` condition. The current pointer day is now skippable regardless of its calendar position.
- Log-Past was already independent of `dayStatus` (gated only on `!isPending && hasExercises`) — left as-is.
- The informational Scheduled / Past banners remain (Q6 allows informational text). Their action-promising copy ("tap Start Workout to train this day early") was already removed in #437; remaining `dayStatus` uses drive banner **display only**, not actions.

## Tests

New `ProgramDayDetailSkipGateTests` (6 cases): generated-day-skippable, calendar-independence, pending / no-exercises / already-skipped / completed+paused all not-skippable. Full skip-gate + start-gate suites pass (10/10) on the iOS simulator.

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)