### PR TITLE
fix(#442): surface FK-23503 + ensure-persist-first on session start (Q4)

### DIFF
--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -276,6 +276,41 @@ final class AppDependencies {
         )
 
         // 11. WorkoutSessionManager — needs AI inference, HealthKit, Memory, Supabase, GymFactStore, WAQ, streak, trainee model
+        //
+        // #442 (Q4) — ensure-persist-first seam. Before the manager enqueues the
+        // `workout_sessions` row, this guarantees the `programs` parent row exists on
+        // the server (the missing-parent case is the 23503 FK-fail → silent
+        // dead-letter that loses the workout). Mirrors `backfillCachedProgramIfNeeded`:
+        // persist the locally-cached program ONLY when the server genuinely has none
+        // under the resolved owner; a server program already present → no write
+        // needed; a fetch that throws (offline) → return false so `startSession`
+        // surfaces rather than enqueuing a doomed row. Idempotent + best-effort, via
+        // the shared resolve-before-stamp helper (`OnboardingProgramPersist`).
+        let supabaseForPersist = supabaseClient
+        let placeholderId = Self.placeholderUserId
+        let ensureProgramPersisted: @Sendable (UUID, UUID) async -> Bool = { _, ownerUserId in
+            guard ownerUserId != placeholderId else { return false }
+            let serverActiveProgram: ProgramRow?
+            do {
+                serverActiveProgram = try await supabaseForPersist.fetchActiveProgram(userId: ownerUserId)
+            } catch {
+                // Couldn't reach the server — surface (do NOT conclude "empty" and
+                // do NOT enqueue a session that would FK-fail).
+                return false
+            }
+            // A program already exists server-side → parent row present, no FK risk.
+            guard serverActiveProgram == nil else { return true }
+            // Server genuinely empty → backfill the locally-cached program (the
+            // local cache + persist helper are MainActor-isolated). With no local
+            // cache there is nothing this seam can persist; allow the start to
+            // proceed (the legacy path) rather than hard-blocking.
+            guard let cached = await MainActor.run(body: { Mesocycle.loadFromUserDefaults() }) else { return true }
+            return await OnboardingProgramPersist.persistIfOwnerResolved(
+                cached,
+                owner: ownerUserId,
+                client: supabaseForPersist
+            )
+        }
         let manager = WorkoutSessionManager(
             aiInference: inferenceService,
             healthKit: healthKitService,
@@ -284,7 +319,8 @@ final class AppDependencies {
             gymFactStore: gymFactStore,
             writeAheadQueue: waq,
             gymStreakService: gymStreakService,
-            traineeModelService: tmService
+            traineeModelService: tmService,
+            ensureProgramPersisted: ensureProgramPersisted
         )
         self.workoutSessionManager = manager
 

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -203,6 +203,17 @@ actor WorkoutSessionManager {
     private let gymStreakService: GymStreakService
     private let traineeModelService: TraineeModelService?
 
+    /// Ensure-persist-first seam (#442, Q4). Given `(programId, ownerUserId)`, this
+    /// idempotently guarantees the `programs` row is present on the server BEFORE
+    /// `startSession` enqueues the `workout_sessions` row — otherwise a missing
+    /// parent row makes the insert FK-fail (23503), retry ~31s, and silently
+    /// dead-letter. Returns `true` iff the program is guaranteed persisted; `false`
+    /// when it cannot complete (offline / owner unresolved), in which case
+    /// `startSession` surfaces the failure rather than enqueuing a doomed session.
+    /// Defaults to `nil` (skip the gate, preserve legacy behavior) so existing
+    /// call-sites/tests are unchanged; production wires the real persist.
+    private let ensureProgramPersisted: (@Sendable (UUID, UUID) async -> Bool)?
+
     // MARK: - Init
 
     init(
@@ -213,7 +224,8 @@ actor WorkoutSessionManager {
         gymFactStore: GymFactStore,
         writeAheadQueue: WriteAheadQueue? = nil,
         gymStreakService: GymStreakService? = nil,
-        traineeModelService: TraineeModelService? = nil
+        traineeModelService: TraineeModelService? = nil,
+        ensureProgramPersisted: (@Sendable (UUID, UUID) async -> Bool)? = nil
     ) {
         self.aiInference = aiInference
         self.healthKit = healthKit
@@ -224,6 +236,7 @@ actor WorkoutSessionManager {
         self.writeAheadQueue = waq
         self.gymStreakService = gymStreakService ?? GymStreakService(supabase: supabase)
         self.traineeModelService = traineeModelService
+        self.ensureProgramPersisted = ensureProgramPersisted
     }
 
     // MARK: - Public API
@@ -244,6 +257,21 @@ actor WorkoutSessionManager {
         // this guard runs BEFORE any mutation so a failed start leaves zero durable traces.
         guard !trainingDay.exercises.isEmpty else {
             sessionState = .error("Training day has no exercises.")
+            return
+        }
+
+        // #442 (Q4) — ensure-persist-first. Guarantee the `programs` row exists on
+        // the server BEFORE we enqueue the `workout_sessions` row. Without this, a
+        // fresh user whose program was only ever cached locally has ZERO server
+        // programs, so every session insert FK-fails (Postgres 23503,
+        // workout_sessions_program_id_fkey), retries ~31s in the WAQ, then silently
+        // dead-letters — the workout is lost with no reader. The persist is
+        // idempotent and runs under the resolved owner (placeholder/offline → no
+        // write). If it cannot complete, do NOT proceed-and-drop: surface it (mirror
+        // the empty-exercises guard — mutate nothing, no sentinel, no doomed session
+        // row) so the user is told to reconnect rather than losing the session.
+        if let ensureProgramPersisted, await ensureProgramPersisted(programId, userId) == false {
+            sessionState = .error("Couldn't sync your program — check your connection and try again.")
             return
         }
 

--- a/ProjectApex/Services/WriteAheadQueue.swift
+++ b/ProjectApex/Services/WriteAheadQueue.swift
@@ -65,11 +65,18 @@ enum WAQFlushOutcome: Sendable, Equatable {
     case transientFailure
     /// Remote end rejected the item permanently — log and remove without retry.
     case permanentFailure(String)
+    /// Postgres foreign_key_violation (SQLSTATE 23503) — e.g. a `workout_sessions`
+    /// insert whose `program_id` has no `programs` row yet (#442). Distinct from a
+    /// generic transient: it must NOT be retried-to-exhaustion-then-silently-
+    /// dead-lettered. The item is retained (retry-until-the-parent-row-exists) AND
+    /// surfaced via `foreignKeyBlockedWrites()` so the condition has a reader.
+    case foreignKeyViolation(table: String)
 
     static func == (lhs: WAQFlushOutcome, rhs: WAQFlushOutcome) -> Bool {
         switch (lhs, rhs) {
         case (.success, .success), (.transientFailure, .transientFailure): return true
         case (.permanentFailure(let l), .permanentFailure(let r)): return l == r
+        case (.foreignKeyViolation(let l), .foreignKeyViolation(let r)): return l == r
         default: return false
         }
     }
@@ -118,6 +125,14 @@ actor WriteAheadQueue {
     /// permanently rejected. Persisted separately so they survive launches and
     /// can be recovered (e.g. by session resume) instead of being silently lost.
     private(set) var deadLetter: [QueuedWrite] = []
+
+    /// Foreign-key-blocked writes (#442): items whose remote insert hit a Postgres
+    /// 23503 (e.g. `workout_sessions.program_id` referencing a not-yet-persisted
+    /// `programs` row). Surfaced — NOT dead-lettered — so the condition has a reader
+    /// and the item keeps retrying until the parent row exists. In-memory only:
+    /// the queued item itself is already persisted, so this is a transient signal
+    /// that need not survive a relaunch.
+    private(set) var foreignKeyBlocked: [QueuedWrite] = []
 
     /// Per-table flush handlers. When a table has a registered handler, the WAQ
     /// calls it instead of the default Supabase REST insert path. Registered at
@@ -231,7 +246,7 @@ actor WriteAheadQueue {
             persistQueue()
         }
 
-        while !queue.isEmpty {
+        flushLoop: while !queue.isEmpty {
             var item = queue[0]
 
             let outcome = await dispatch(item)
@@ -244,6 +259,9 @@ actor WriteAheadQueue {
             switch outcome {
             case .success:
                 queue.removeFirst()
+                // Clear any prior FK-blocked surfacing for this item — the parent
+                // row now exists and the write landed (#442).
+                foreignKeyBlocked.removeAll { $0.id == item.id }
                 // No per-item persistQueue() — deferred to end of flush. [#369 perf-27]
 
             case .permanentFailure(let reason):
@@ -251,6 +269,20 @@ actor WriteAheadQueue {
                 recordFailedWrite(item)   // persists dead-letter immediately for crash-safety
                 // No per-item persistQueue() — deferred to end of flush. [#369 perf-27]
                 Self.logger.error("[WriteAheadQueue] permanent failure (dead-lettered), item \(item.id, privacy: .public), table: \(item.table, privacy: .public) — \(reason, privacy: .public)")
+
+            case .foreignKeyViolation(let table):
+                // #442 (Q4): a 23503 means the parent row (e.g. `programs` for a
+                // `workout_sessions` insert) is not present YET — typically a fast
+                // self-correcting race once the program-persist completes. Treat it
+                // as DISTINCT from a generic transient: surface it (so the condition
+                // has a reader) and retain the item for retry WITHOUT counting
+                // against the retry-exhaustion budget, so it is never silently
+                // dead-lettered. Break out of the FIFO loop after recording — a
+                // later flush (triggered by the next enqueue / foreground / network
+                // event, once the parent row exists) retries from the head.
+                recordForeignKeyBlocked(item)
+                Self.logger.error("[WriteAheadQueue] foreign-key violation (23503) — surfaced, retained for retry: item \(item.id, privacy: .public), table: \(table, privacy: .public)")
+                break flushLoop
 
             case .transientFailure:
                 item.retryCount += 1
@@ -301,8 +333,7 @@ actor WriteAheadQueue {
         if let handler = flushHandlers[item.table] {
             return await handler(item)
         }
-        let success = await sendToSupabase(item)
-        return success ? .success : .transientFailure
+        return await sendToSupabase(item)
     }
 
     /// Returns the number of items currently in the queue.
@@ -330,6 +361,12 @@ actor WriteAheadQueue {
     /// #190) can recover them instead of suffering silent data loss.
     func failedWrites() -> [QueuedWrite] { deadLetter }
 
+    /// Returns the foreign-key-blocked writes (#442): items currently failing a
+    /// Postgres 23503 (missing parent row). Surfaced so the condition is observable
+    /// instead of silently retried-then-dead-lettered. The item also remains in the
+    /// live queue and keeps retrying until the parent row exists.
+    func foreignKeyBlockedWrites() -> [QueuedWrite] { foreignKeyBlocked }
+
     /// Removes a recovered/handled item from the dead-letter store.
     func removeFailedWrite(id: UUID) {
         deadLetter.removeAll { $0.id == id }
@@ -351,6 +388,7 @@ actor WriteAheadQueue {
         userDefaults.removeObject(forKey: Self.persistenceKey)
         deadLetter.removeAll()
         userDefaults.removeObject(forKey: Self.deadLetterKey)
+        foreignKeyBlocked.removeAll()   // #442 — surfaced store is in-memory only
     }
 
     // MARK: - Blocking Write (for session summary)
@@ -379,17 +417,32 @@ actor WriteAheadQueue {
     // MARK: - Private: Supabase Interaction
 
     /// Attempts to POST the queued item's payload to Supabase.
-    /// Returns true on success (HTTP 2xx), false on failure.
-    private func sendToSupabase(_ item: QueuedWrite) async -> Bool {
+    /// Returns `.success` on HTTP 2xx, `.foreignKeyViolation` when the failure is a
+    /// Postgres 23503 (#442 — distinct, surfaced), and `.transientFailure` for every
+    /// other failure (the existing retry-with-backoff path).
+    private func sendToSupabase(_ item: QueuedWrite) async -> WAQFlushOutcome {
         do {
             // Build a raw insert using the pre-encoded JSON data
             try await supabase.insertRawJSON(item.payload, table: item.table)
             print("[WriteAheadQueue] Flushed item \(item.id) → table: \(item.table)")
-            return true
+            return .success
         } catch {
+            if Self.isForeignKeyViolation(error) {
+                print("[WriteAheadQueue] Flush hit foreign-key violation (23503) for item \(item.id), table: \(item.table) — surfaced, retained for retry")
+                return .foreignKeyViolation(table: item.table)
+            }
             print("[WriteAheadQueue] Flush failed for item \(item.id), table: \(item.table), retry \(item.retryCount)/\(Self.maxRetries): \(error.localizedDescription)")
-            return false
+            return .transientFailure
         }
+    }
+
+    /// Detects a Postgres `foreign_key_violation` (SQLSTATE 23503) in a thrown
+    /// `SupabaseError`. PostgREST surfaces it as an HTTP error (typically 409)
+    /// whose JSON body carries `"code":"23503"`. We match on the SQLSTATE in the
+    /// body (the stable contract) rather than the HTTP status alone (#442).
+    private static func isForeignKeyViolation(_ error: Error) -> Bool {
+        guard case let SupabaseError.httpError(_, body) = error else { return false }
+        return body.contains("23503") || body.contains("foreign_key_violation")
     }
 
     // MARK: - Private: Persistence
@@ -412,6 +465,15 @@ actor WriteAheadQueue {
     private func recordFailedWrite(_ item: QueuedWrite) {
         deadLetter.append(item)
         persistDeadLetter()
+    }
+
+    /// Records a foreign-key-blocked item in the surfaced store (#442), deduped by
+    /// id so repeated 23503 retries of the same write don't grow the list unbounded.
+    /// In-memory only — the queued item is already persisted, so this is a transient
+    /// signal that need not survive a relaunch.
+    private func recordForeignKeyBlocked(_ item: QueuedWrite) {
+        guard !foreignKeyBlocked.contains(where: { $0.id == item.id }) else { return }
+        foreignKeyBlocked.append(item)
     }
 
     /// Persists the current dead-letter store to UserDefaults.

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -849,6 +849,81 @@ final class WorkoutSessionManagerTests: XCTestCase {
         )
     }
 
+    // MARK: #442 (Q4) — ensure-persist-first on session start
+
+    /// The idempotent program-persist must be AWAITED before the workout_sessions row
+    /// is enqueued. Otherwise a missing `programs` row makes the insert FK-fail (23503),
+    /// retry ~31s, and silently dead-letter. The seam records whether persist completed
+    /// at the moment the session insert is dispatched.
+    func testStartSession_awaitsProgramPersist_beforeEnqueuingSessionRow() async throws {
+        WSMBodyCaptureURLProtocol.reset()
+        let persistRan = WSMFlag()
+        let persistWasDoneAtSessionInsert = WSMFlag()
+
+        let manager = makeBodyCaptureManager(
+            ensureProgramPersisted: { _, _ in
+                persistRan.value = true
+                return true
+            },
+            onWorkoutSessionInsert: {
+                // Captured the instant the session POST is dispatched.
+                persistWasDoneAtSessionInsert.value = persistRan.value
+            }
+        )
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        XCTAssertTrue(persistRan.value, "program-persist must run during startSession")
+        XCTAssertTrue(
+            persistWasDoneAtSessionInsert.value,
+            "program-persist must complete BEFORE the workout_sessions row is enqueued/inserted"
+        )
+
+        let state = await manager.sessionState
+        guard case .active = state else {
+            XCTFail("Expected .active after a successful start, got \(state)")
+            return
+        }
+    }
+
+    /// When persistence cannot complete (offline / owner unresolved), startSession must
+    /// NOT proceed-and-drop: it surfaces the failure (.error) and enqueues NO
+    /// workout_sessions row that would FK-fail.
+    func testStartSession_persistFails_surfacesAndDoesNotEnqueueSession() async throws {
+        WSMBodyCaptureURLProtocol.reset()
+        let manager = makeBodyCaptureManager(
+            ensureProgramPersisted: { _, _ in false }   // offline / owner unresolved
+        )
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        // 1. Surfaced, not silently dropped.
+        let state = await manager.sessionState
+        guard case .error = state else {
+            XCTFail("Expected .error when program-persist cannot complete, got \(state)")
+            return
+        }
+
+        // 2. No workout_sessions row enqueued/POSTed (would FK-fail with 23503).
+        let sessionRowPosts = WSMBodyCaptureURLProtocol.captured.filter {
+            $0.path.contains("workout_sessions") && $0.method == "POST"
+        }
+        XCTAssertTrue(
+            sessionRowPosts.isEmpty,
+            "A persist-blocked start must not enqueue a workout_sessions row; captured: \(sessionRowPosts.map(\.path))"
+        )
+
+        // 3. No crash sentinel written (nothing to recover).
+        XCTAssertNil(
+            PausedSessionState.load(),
+            "A persist-blocked start must not write a PausedSessionState crash sentinel"
+        )
+    }
+
     // MARK: #318 / J-F2 — resuming an empty/exhausted day aborts without completion
 
     /// Regression pinning the CORRECTED J-F2 mechanism: resuming a day with no
@@ -1159,11 +1234,24 @@ final class WorkoutSessionManagerTests: XCTestCase {
 
 // MARK: - Body-capturing URLProtocol (#171 — inspect the PATCH payload)
 
+/// Minimal reference-type flag for cross-Task observation in tests (#442).
+private final class WSMFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = false
+    var value: Bool {
+        get { lock.lock(); defer { lock.unlock() }; return _value }
+        set { lock.lock(); _value = newValue; lock.unlock() }
+    }
+}
+
 private final class WSMBodyCaptureURLProtocol: URLProtocol, @unchecked Sendable {
     static let lock = NSLock()
     nonisolated(unsafe) static var captured: [(path: String, method: String, body: Data)] = []
+    /// Fired when a workout_sessions POST is dispatched, so a test can sample state
+    /// at the exact moment the session row insert reaches the network (#442).
+    nonisolated(unsafe) static var onWorkoutSessionInsert: (() -> Void)?
     static func reset() {
-        lock.lock(); captured = []; lock.unlock()
+        lock.lock(); captured = []; onWorkoutSessionInsert = nil; lock.unlock()
     }
 
     override class func canInit(with request: URLRequest) -> Bool { true }
@@ -1184,6 +1272,9 @@ private final class WSMBodyCaptureURLProtocol: URLProtocol, @unchecked Sendable 
             }
         }
         Self.lock.lock(); Self.captured.append((path, method, body)); Self.lock.unlock()
+        if path.contains("workout_sessions") && method == "POST" {
+            Self.onWorkoutSessionInsert?()
+        }
 
         // Return one row for workout_sessions so the PATCH's performExpectingRow
         // (return=representation) sees a match; empty array otherwise.
@@ -1198,9 +1289,15 @@ private final class WSMBodyCaptureURLProtocol: URLProtocol, @unchecked Sendable 
     override func stopLoading() {}
 }
 
-private func makeBodyCaptureManager() -> WorkoutSessionManager {
+private func makeBodyCaptureManager(
+    ensureProgramPersisted: (@Sendable (UUID, UUID) async -> Bool)? = nil,
+    onWorkoutSessionInsert: (() -> Void)? = nil
+) -> WorkoutSessionManager {
     let config = URLSessionConfiguration.ephemeral
     config.protocolClasses = [WSMBodyCaptureURLProtocol.self]
+    if let onWorkoutSessionInsert {
+        WSMBodyCaptureURLProtocol.onWorkoutSessionInsert = onWorkoutSessionInsert
+    }
     let supabase = SupabaseClient(
         supabaseURL: URL(string: "https://test.supabase.co")!,
         anonKey: "test-key",
@@ -1221,7 +1318,8 @@ private func makeBodyCaptureManager() -> WorkoutSessionManager {
         memoryService: memoryService,
         supabase: supabase,
         gymFactStore: gymFactStore,
-        writeAheadQueue: waq
+        writeAheadQueue: waq,
+        ensureProgramPersisted: ensureProgramPersisted
     )
 }
 

--- a/ProjectApexTests/WriteAheadQueueTests.swift
+++ b/ProjectApexTests/WriteAheadQueueTests.swift
@@ -482,6 +482,65 @@ final class WriteAheadQueueTests: XCTestCase {
         XCTAssertEqual(dead.count, 1, "exhausted item must be dead-lettered, not silently dropped")
     }
 
+    // MARK: #442 (Q4): FK-23503 is classified distinctly, NOT silently dead-lettered
+
+    /// A Postgres foreign_key_violation (SQLSTATE 23503 — the missing-`programs`-row
+    /// case that makes every `workout_sessions` insert FK-fail) must be classified as
+    /// a DISTINCT, surfaced outcome. It must NOT be treated as a generic transient
+    /// that exhausts retries and silently dead-letters with no reader: the item stays
+    /// recoverable (retry-until-program-exists) and is surfaced via
+    /// `foreignKeyBlockedWrites()` rather than dropped into the dead-letter sink.
+    func testFlush_foreignKeyViolation_isSurfacedNotDeadLettered() async throws {
+        let defaults = UserDefaults(suiteName: "waq.test.\(UUID().uuidString)")!
+        // Tiny base delay so the retry loop spins fast without a 31s wait.
+        let queue = WriteAheadQueue(supabase: makeMockSupabase(), userDefaults: defaults, baseRetryDelay: 0.001)
+
+        await queue.registerFlushHandler(forTable: "workout_sessions") { _ in
+            .foreignKeyViolation(table: "workout_sessions")
+        }
+        try await queue.enqueue(TestSetLogPayload.mock(), table: "workout_sessions")
+
+        // Poll until the FK-blocked item is surfaced (1s ceiling).
+        var blocked = await queue.foreignKeyBlockedWrites()
+        for _ in 0..<100 where blocked.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            blocked = await queue.foreignKeyBlockedWrites()
+        }
+        XCTAssertEqual(blocked.count, 1, "FK-23503 item must be surfaced via foreignKeyBlockedWrites()")
+
+        let dead = await queue.failedWrites()
+        XCTAssertTrue(dead.isEmpty, "FK-23503 must NOT be silently dead-lettered as a generic transient")
+    }
+
+    /// Drives a real 23503 through the HTTP path: PostgREST returns HTTP 409 with a
+    /// body carrying `"code":"23503"`. The default (handler-less) flush path must
+    /// recognise that body and classify it as a foreign-key violation — surfaced, not
+    /// retried-to-exhaustion-then-dead-lettered.
+    func testFlush_postgrest23503Body_classifiedAsForeignKeyViolation() async throws {
+        let defaults = UserDefaults(suiteName: "waq.test.\(UUID().uuidString)")!
+        WAQMockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 409,
+                httpVersion: nil, headerFields: nil
+            )!
+            let body = #"{"code":"23503","details":"Key (program_id)=(...) is not present in table \"programs\".","message":"insert or update on table \"workout_sessions\" violates foreign key constraint \"workout_sessions_program_id_fkey\""}"#
+            return (response, Data(body.utf8))
+        }
+
+        let queue = WriteAheadQueue(supabase: makeMockSupabase(), userDefaults: defaults, baseRetryDelay: 0.001)
+        try await queue.enqueue(TestSetLogPayload.mock(), table: "workout_sessions")
+
+        var blocked = await queue.foreignKeyBlockedWrites()
+        for _ in 0..<100 where blocked.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            blocked = await queue.foreignKeyBlockedWrites()
+        }
+        XCTAssertEqual(blocked.count, 1, "23503 HTTP body must be classified as a foreign-key violation and surfaced")
+
+        let dead = await queue.failedWrites()
+        XCTAssertTrue(dead.isEmpty, "23503 must NOT land in the dead-letter sink")
+    }
+
     // MARK: Test 9 (#369 perf-27): batch flush emits correct end-state + all items sent
 
     /// Verifies that flushing N items in a batch results in an empty queue and that


### PR DESCRIPTION
## What

Q4 of the Programme↔Workout defect umbrella (#435). Stops the silent-data-loss path where a missing `programs` row makes every `workout_sessions` insert FK-fail (Postgres **23503**), retry ~31s in the `WriteAheadQueue`, then dead-letter invisibly — the workout is lost with no reader.

## Two parts (both apply the locked Q4 decision)

**1. Ensure-persist-first (`WorkoutSessionManager.startSession`)**
Before the session row is enqueued, `startSession` now `await`s an idempotent program-persist seam so the `programs` parent row is guaranteed present. The seam (wired in `AppDependencies`) mirrors `backfillCachedProgramIfNeeded`: it persists the locally-cached program **only** when the server genuinely has none under the resolved owner, reusing `OnboardingProgramPersist.persistIfOwnerResolved` (resolve-before-stamp — no new persistence path invented). If persistence **cannot complete** (offline / owner unresolved) the start does **not** proceed-and-drop: it surfaces `.error` and enqueues **no** doomed session row, writing no crash sentinel (mirrors the existing empty-exercises guard). Offline is surfaced, not hard-blocked into silent loss.

**2. Classify 23503 (`WriteAheadQueue`)**
A Postgres `foreign_key_violation` (SQLSTATE 23503 — surfaced by PostgREST as an `httpError` body carrying `"23503"`) is now classified as a **distinct** `.foreignKeyViolation` outcome. It is retained for retry-until-the-parent-row-exists (NOT counted against the retry-exhaustion budget) and surfaced via `foreignKeyBlockedWrites()` — **never** silently dead-lettered as a generic transient.

## Tests (TDD — written failing first, then green)

- `WriteAheadQueueTests.testFlush_foreignKeyViolation_isSurfacedNotDeadLettered` — a `.foreignKeyViolation` outcome is surfaced, not dead-lettered.
- `WriteAheadQueueTests.testFlush_postgrest23503Body_classifiedAsForeignKeyViolation` — a real HTTP 409 / `"code":"23503"` body is classified as FK-violation through the default flush path.
- `WorkoutSessionManagerTests.testStartSession_awaitsProgramPersist_beforeEnqueuingSessionRow` — program-persist completes **before** the `workout_sessions` POST is dispatched.
- `WorkoutSessionManagerTests.testStartSession_persistFails_surfacesAndDoesNotEnqueueSession` — a blocked persist yields `.error`, no session POST, no crash sentinel.

Full `WriteAheadQueueTests` (25) + `WorkoutSessionManagerTests` (17) pass; `build-for-testing` SUCCEEDED. The default seam is `nil` (legacy behavior) so existing call-sites/previews are unchanged.

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)