### PR TITLE
fix(#444): persist per-day TrainingDayStatus to the server + reconcile on load (Q5)

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		47BB8E712F6273F30082C5F1 /* GymProfileSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E702F6273F30082C5F0 /* GymProfileSyncTests.swift */; };
 		47BB8E8B2F6273F30082C53F /* ProgramOwnerGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */; };
 		47BB8E712F6273F30082C625 /* ProgramBackfillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E702F6273F30082C625 /* ProgramBackfillTests.swift */; };
+		44D40444AAAA0001AAAA0001 /* ProgramDayStatusSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D40444AAAA0002AAAA0002 /* ProgramDayStatusSyncTests.swift */; };
 		47BB8EA12F6273F30082C999 /* RegenerateRefusalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8EA02F6273F30082C999 /* RegenerateRefusalTests.swift */; };
 		47BB8E752F6294B00082C53F /* WorkoutSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */; };
 		47C5C1AF2F62A64E0005F99E /* WriteAheadQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */; };
@@ -104,6 +105,7 @@
 		47BB8E702F6273F30082C5F0 /* GymProfileSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymProfileSyncTests.swift; sourceTree = "<group>"; };
 		47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramOwnerGateTests.swift; sourceTree = "<group>"; };
 		47BB8E702F6273F30082C625 /* ProgramBackfillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramBackfillTests.swift; sourceTree = "<group>"; };
+		44D40444AAAA0002AAAA0002 /* ProgramDayStatusSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramDayStatusSyncTests.swift; sourceTree = "<group>"; };
 		47BB8EA02F6273F30082C999 /* RegenerateRefusalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegenerateRefusalTests.swift; sourceTree = "<group>"; };
 		47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSessionManagerTests.swift; sourceTree = "<group>"; };
 		47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteAheadQueueTests.swift; sourceTree = "<group>"; };
@@ -244,6 +246,7 @@
 				47BB8E702F6273F30082C5F0 /* GymProfileSyncTests.swift */,
 				47BB8E8A2F6273F30082C53F /* ProgramOwnerGateTests.swift */,
 				47BB8E702F6273F30082C625 /* ProgramBackfillTests.swift */,
+				44D40444AAAA0002AAAA0002 /* ProgramDayStatusSyncTests.swift */,
 				47BB8EA02F6273F30082C999 /* RegenerateRefusalTests.swift */,
 				47BB8E742F6294B00082C53F /* WorkoutSessionManagerTests.swift */,
 				47C5C1AE2F62A64E0005F99E /* WriteAheadQueueTests.swift */,
@@ -411,6 +414,7 @@
 				47BB8E712F6273F30082C5F1 /* GymProfileSyncTests.swift in Sources */,
 				47BB8E8B2F6273F30082C53F /* ProgramOwnerGateTests.swift in Sources */,
 				47BB8E712F6273F30082C625 /* ProgramBackfillTests.swift in Sources */,
+				44D40444AAAA0001AAAA0001 /* ProgramDayStatusSyncTests.swift in Sources */,
 				47BB8EA12F6273F30082C999 /* RegenerateRefusalTests.swift in Sources */,
 				478DD9F12F9928C6001D3636 /* SkipFeatureTests.swift in Sources */,
 				AAAA111100000000437438B2 /* ProgramDayDetailStartGateTests.swift in Sources */,

--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -215,7 +215,13 @@ final class ProgramViewModel {
             // off the fast path, once a real session resolves. Best-effort and
             // non-blocking: the cached program is already displayed above; this never
             // throws out of loadProgram and never slows the UI.
-            Task { await self.backfillCachedProgramIfNeeded(cached) }
+            //
+            // #444 (Q5): the same background pass also RECONCILES per-day statuses
+            // against the server (the durable record) when a server program exists,
+            // so a fresh install whose cache says pending shows completed/skipped
+            // days correctly. Backfill (server empty) and reconcile (server present)
+            // are the two mutually-exclusive outcomes of the one server fetch.
+            Task { await self.backfillOrReconcileCachedProgram(cached) }
             return
         }
 
@@ -252,7 +258,11 @@ final class ProgramViewModel {
     /// Reuses `OnboardingProgramPersist.persistIfOwnerResolved` so the
     /// placeholder-guard + resolve-before-stamp + best-effort-catch live in exactly
     /// one place (the same path #424 added).
-    private func backfillCachedProgramIfNeeded(_ cached: Mesocycle) async {
+    ///
+    /// #444 (Q5): when the fetch instead finds an active server program, this
+    /// RECONCILES per-day statuses onto the displayed cache rather than backfilling
+    /// — see `reconcileServerStatuses`.
+    private func backfillOrReconcileCachedProgram(_ cached: Mesocycle) async {
         // Resolve the real owner. nil / placeholder → do nothing; the next resolved
         // load catches it. persistIfOwnerResolved also guards the placeholder, but we
         // bail early to avoid the server fetch when there's no owner to stamp under.
@@ -260,26 +270,114 @@ final class ProgramViewModel {
             return
         }
 
-        // Only backfill when the fetch SUCCEEDS and finds NO active program. A thrown
-        // error means we couldn't reach the server — bail, do NOT conclude "empty".
+        // A thrown error means we couldn't reach the server — bail, do NOT conclude
+        // "empty" (that would spuriously re-insert) and do NOT reconcile against a
+        // record we never read.
         let serverActiveProgram: ProgramRow?
         do {
             serverActiveProgram = try await supabaseClient.fetchActiveProgram(userId: owner)
         } catch {
-            programPersistLogger.notice("backfill: server fetch failed; bailing (not 'empty') — a later load retries")
+            programPersistLogger.notice("backfill/reconcile: server fetch failed; bailing — a later load retries")
             return
         }
-        guard serverActiveProgram == nil else { return }
 
-        // Server is genuinely empty under a real owner → backfill the cached program
-        // via the shared resolve-before-stamp helper (#424). Idempotent, best-effort.
+        guard let serverProgram = serverActiveProgram else {
+            // Server is genuinely empty under a real owner → backfill the cached
+            // program via the shared resolve-before-stamp helper (#424). Idempotent.
+            let didPersist = await OnboardingProgramPersist.persistIfOwnerResolved(
+                cached,
+                owner: owner,
+                client: supabaseClient
+            )
+            if didPersist {
+                programPersistLogger.notice("backfill: re-persisted local-only program to server under resolved owner")
+            }
+            return
+        }
+
+        // Server HAS an active program → reconcile its per-day statuses onto the
+        // displayed cache (#444, Q5).
+        reconcileServerStatuses(from: serverProgram.toMesocycle(), into: cached)
+    }
+
+    /// #444 (Q5): merge the server's per-day `TrainingDayStatus` onto the cached
+    /// mesocycle, preferring the MORE-ADVANCED status per day so neither a stale
+    /// server nor a stale cache regresses real progress (terminal `.completed` /
+    /// `.skipped` and `.paused` beat `.pending` / `.generated`).
+    ///
+    /// Only the SAME mesocycle is reconciled: the server program must share the
+    /// cache's mesocycle id (the same client-generated program persisted via the
+    /// shared path), and days are matched by their stable `TrainingDay.id`. If the
+    /// server is a different program entirely, the cache is left untouched — that
+    /// is a #423/#425 backfill/regeneration concern, not a per-day status merge.
+    ///
+    /// Best-effort and non-fatal: a no-op when nothing is more advanced. Updates
+    /// the in-memory state, view state, and UserDefaults so the reconciled
+    /// progress survives the next launch.
+    private func reconcileServerStatuses(from server: Mesocycle, into cached: Mesocycle) {
+        guard server.id == cached.id else { return }
+
+        // Build a day-id → server status lookup.
+        var serverStatusByDay: [UUID: TrainingDayStatus] = [:]
+        for week in server.weeks {
+            for day in week.trainingDays {
+                serverStatusByDay[day.id] = day.status
+            }
+        }
+
+        var merged = cached
+        var changed = false
+        for wIdx in merged.weeks.indices {
+            for dIdx in merged.weeks[wIdx].trainingDays.indices {
+                let day = merged.weeks[wIdx].trainingDays[dIdx]
+                guard let serverStatus = serverStatusByDay[day.id] else { continue }
+                if Self.statusRank(serverStatus) > Self.statusRank(day.status) {
+                    merged.weeks[wIdx].trainingDays[dIdx].status = serverStatus
+                    changed = true
+                }
+            }
+        }
+
+        guard changed else { return }
+        merged.saveToUserDefaults()
+        currentMesocycle = merged
+        viewState = .loaded(merged)
+        programPersistLogger.notice("reconcile: honored more-advanced server statuses on \(merged.id.uuidString, privacy: .public)")
+    }
+
+    /// Advancement rank for `TrainingDayStatus` (higher = more advanced). Terminal
+    /// statuses outrank in-flight ones; `.completed` and `.skipped` tie (both
+    /// terminal). Used by `reconcileServerStatuses` to pick the winner per day.
+    private static func statusRank(_ status: TrainingDayStatus) -> Int {
+        switch status {
+        case .pending:   return 0
+        case .generated: return 1
+        case .paused:    return 2
+        case .completed: return 3
+        case .skipped:   return 3
+        }
+    }
+
+    /// #444 (Q5): re-persist the updated mesocycle to the server after a
+    /// `markDay*` status change so the durable server record matches local
+    /// progress (a reinstall / cache-clear otherwise reverts completed days to
+    /// pending and feeds wrong-day routing).
+    ///
+    /// Owner-gated (resolve-before-stamp; never under the placeholder/unresolved
+    /// owner — the #369 pattern) and best-effort: the in-memory + UserDefaults
+    /// update by the caller is already the local source of truth, so a failed
+    /// server write is non-fatal and arms no banner. Reuses the shared
+    /// `OnboardingProgramPersist.persistIfOwnerResolved` helper (idempotent
+    /// upsert on the client-generated program id) — the same path #424/#425 use.
+    private func persistDayStatusUpdate(_ mesocycle: Mesocycle) async {
+        let owner = await resolveOwner()
         let didPersist = await OnboardingProgramPersist.persistIfOwnerResolved(
-            cached,
+            mesocycle,
             owner: owner,
             client: supabaseClient
         )
-        if didPersist {
-            programPersistLogger.notice("backfill: re-persisted local-only program to server under resolved owner")
+        if !didPersist {
+            programPersistLogger.notice("markDay: status persist skipped (owner unresolved/placeholder) or failed; local cache intact")
         }
     }
 
@@ -806,6 +904,11 @@ final class ProgramViewModel {
         currentMesocycle = mesocycle
         viewState = .loaded(mesocycle)
         print("[ProgramViewModel] markDayCompleted ✓ — dayId: \(dayId), week \(mesocycle.weeks[wIdx].weekNumber)")
+        // #444 (Q5): persist the updated per-day status to the server so a
+        // reinstall / cache-clear can't revert it to pending. Owner-gated +
+        // best-effort; UserDefaults above remains the local source of truth.
+        let updated = mesocycle
+        Task { await self.persistDayStatusUpdate(updated) }
     }
 
     // MARK: - Pause support
@@ -822,6 +925,10 @@ final class ProgramViewModel {
         currentMesocycle = mesocycle
         viewState = .loaded(mesocycle)
         print("[ProgramViewModel] markDayPaused ✓ — dayId: \(dayId), week \(mesocycle.weeks[wIdx].weekNumber)")
+        // #444 (Q5): persist the updated per-day status to the server. Owner-gated
+        // + best-effort; UserDefaults above remains the local source of truth.
+        let updated = mesocycle
+        Task { await self.persistDayStatusUpdate(updated) }
     }
 
     // MARK: - Mark Day Skipped (Phase-1-Skip)
@@ -851,6 +958,10 @@ final class ProgramViewModel {
         currentMesocycle = mesocycle
         viewState = .loaded(mesocycle)
         print("[ProgramViewModel] markDaySkipped ✓ — dayId: \(dayId), week \(mesocycle.weeks[wIdx].weekNumber)")
+        // #444 (Q5): persist the updated per-day status to the server. Owner-gated
+        // + best-effort; UserDefaults above remains the local source of truth.
+        let updated = mesocycle
+        Task { await self.persistDayStatusUpdate(updated) }
     }
 
     // MARK: - Regenerate session (#318 U4 / J-F10)

--- a/ProjectApexTests/ProgramDayStatusSyncTests.swift
+++ b/ProjectApexTests/ProgramDayStatusSyncTests.swift
@@ -1,0 +1,299 @@
+// ProgramDayStatusSyncTests.swift
+// ProjectApexTests — #444 (Programme↔Workout cure, Q5 = Option A)
+//
+// Today `markDay*` wrote per-day `TrainingDayStatus` ONLY to UserDefaults. The
+// server `programs` blob froze statuses at generation time, so a reinstall /
+// cache-clear reverted completed days to pending and fed wrong-day routing.
+//
+// #444 (Q5 = persist-to-server + reconcile-on-load):
+//   PERSIST  — every markDayCompleted/Paused/Skipped re-persists the updated
+//              mesocycle to the server (the durable record), OWNER-GATED
+//              (resolve-before-stamp; never under the placeholder/unresolved
+//              owner) and best-effort (UserDefaults stays the local source).
+//   RECONCILE — loadProgram, when both a cached mesocycle and a server program
+//              exist, prefers the MORE-ADVANCED status per day so neither a
+//              stale server nor a stale cache regresses real progress. A day
+//              completed on the server shows completed after a fresh load even
+//              if the cache says pending.
+//
+//   1. markDayCompleted_realOwner_persistsToServer — RPC fires, stamped owner,
+//      body carries the day's .completed status.
+//   2. markDayCompleted_nilOwner_noServerWrite — unresolved owner → no RPC.
+//   3. loadProgram_serverCompletedDay_reconcilesOntoCachedPending — cache says
+//      pending, server says completed → loaded mesocycle shows completed.
+//   4. loadProgram_serverStale_doesNotRegressLocalProgress — cache says
+//      completed, server says pending → loaded mesocycle stays completed.
+
+import XCTest
+@testable import ProjectApex
+
+// MARK: - URLProtocol stub (mirrors ProgramBackfillTests: split fetch vs RPC)
+
+private final class DayStatusSyncStubURLProtocol: URLProtocol {
+    static var fetchStatusCode: Int = 200
+    static var fetchData: Data = "[]".data(using: .utf8)!
+    static var rpcStatusCode: Int = 200
+    static var rpcData: Data = "[]".data(using: .utf8)!
+
+    static var rpcRequestCount: Int = 0
+    static var rpcRequestBodies: [Data] = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    private var isRPC: Bool {
+        request.url?.absoluteString.contains("/rpc/deactivate_and_insert_program") == true
+    }
+
+    override func startLoading() {
+        if isRPC {
+            DayStatusSyncStubURLProtocol.rpcRequestCount += 1
+            if let body = request.httpBody {
+                DayStatusSyncStubURLProtocol.rpcRequestBodies.append(body)
+            } else if let stream = request.httpBodyStream {
+                stream.open()
+                var data = Data()
+                let bufferSize = 1024
+                let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+                while stream.hasBytesAvailable {
+                    let read = stream.read(buffer, maxLength: bufferSize)
+                    if read > 0 { data.append(buffer, count: read) }
+                }
+                buffer.deallocate()
+                stream.close()
+                if !data.isEmpty { DayStatusSyncStubURLProtocol.rpcRequestBodies.append(data) }
+            }
+        }
+
+        let statusCode = isRPC
+            ? DayStatusSyncStubURLProtocol.rpcStatusCode
+            : DayStatusSyncStubURLProtocol.fetchStatusCode
+        let payload = isRPC
+            ? DayStatusSyncStubURLProtocol.rpcData
+            : DayStatusSyncStubURLProtocol.fetchData
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeDayStatusSyncSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [DayStatusSyncStubURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func makeDayStatusSyncClient() -> SupabaseClient {
+    SupabaseClient(
+        supabaseURL: URL(string: "https://test.supabase.co")!,
+        anonKey: "test-anon-key",
+        urlSession: makeDayStatusSyncSession()
+    )
+}
+
+private struct DayStatusSyncThrowingProvider: LLMProvider {
+    func complete(systemPrompt: String, userPayload: String) async throws -> String {
+        throw URLError(.notConnectedToInternet)
+    }
+}
+
+// MARK: - ProgramDayStatusSyncTests
+
+final class ProgramDayStatusSyncTests: XCTestCase {
+
+    private let realOwner = UUID(uuidString: "EEEEEEEE-0000-0000-0000-000000000044")!
+
+    override func setUp() {
+        super.setUp()
+        DayStatusSyncStubURLProtocol.fetchStatusCode = 200
+        DayStatusSyncStubURLProtocol.fetchData = "[]".data(using: .utf8)!
+        DayStatusSyncStubURLProtocol.rpcStatusCode = 200
+        DayStatusSyncStubURLProtocol.rpcData = "[]".data(using: .utf8)!
+        DayStatusSyncStubURLProtocol.rpcRequestCount = 0
+        DayStatusSyncStubURLProtocol.rpcRequestBodies = []
+        Task { @MainActor in Mesocycle.clearUserDefaults() }
+    }
+
+    override func tearDown() {
+        Task { @MainActor in Mesocycle.clearUserDefaults() }
+        super.tearDown()
+    }
+
+    @MainActor
+    private func makeViewModel(
+        client: SupabaseClient,
+        resolveOwner: @escaping () async -> UUID?
+    ) -> ProgramViewModel {
+        let provider: any LLMProvider = DayStatusSyncThrowingProvider()
+        let memory = MemoryService(supabase: client, embeddingAPIKey: "test")
+        return ProgramViewModel(
+            supabaseClient: client,
+            programGenerationService: ProgramGenerationService(provider: provider),
+            macroPlanService: MacroPlanService(provider: provider),
+            sessionPlanService: SessionPlanService(
+                provider: provider,
+                memoryService: memory,
+                supabaseClient: client
+            ),
+            userId: AppDependencies.placeholderUserId,
+            resolveOwner: resolveOwner
+        )
+    }
+
+    /// Polls until the persist RPC has fired (or the timeout elapses). The
+    /// status persist runs on a detached Task off the in-memory update.
+    private func waitForRPC(count: Int, timeout: TimeInterval = 2.0) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if DayStatusSyncStubURLProtocol.rpcRequestCount >= count { return }
+            try? await Task.sleep(nanoseconds: 20_000_000) // 20ms
+        }
+    }
+
+    /// JSON body for a GET fetchActiveProgram response carrying one active program.
+    private func activeProgramFetchBody(for mesocycle: Mesocycle) throws -> Data {
+        let row = ProgramRow.forInsert(from: mesocycle, userId: realOwner)
+        return try JSONEncoder.workoutProgram.encode([row])
+    }
+
+    // MARK: 1. markDayCompleted under a real owner re-persists to the server
+
+    @MainActor
+    func test_markDayCompleted_realOwner_persistsToServer() async throws {
+        let mesocycle = Mesocycle.mockMesocycle()
+        let week = mesocycle.weeks[0]
+        let day = week.trainingDays[0]
+
+        DayStatusSyncStubURLProtocol.rpcData =
+            #"[{"program_id":"\#(mesocycle.id.uuidString)"}]"#.data(using: .utf8)!
+
+        let client = makeDayStatusSyncClient()
+        let vm = makeViewModel(client: client, resolveOwner: { self.realOwner })
+        vm.currentMesocycle = mesocycle
+
+        vm.markDayCompleted(dayId: day.id, weekId: week.id)
+
+        await waitForRPC(count: 1)
+
+        XCTAssertEqual(
+            DayStatusSyncStubURLProtocol.rpcRequestCount, 1,
+            "markDayCompleted under a real owner must re-persist the program to the server."
+        )
+        let bodyData = try XCTUnwrap(DayStatusSyncStubURLProtocol.rpcRequestBodies.last)
+        let body = try XCTUnwrap(try JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        XCTAssertEqual(
+            body["p_user_id"] as? String, realOwner.uuidString,
+            "The status persist must stamp the RESOLVED owner uid."
+        )
+        // The re-persisted blob must carry the day's NEW .completed status.
+        let json = try XCTUnwrap(body["p_mesocycle_json"] as? [String: Any])
+        let weeks = try XCTUnwrap(json["weeks"] as? [[String: Any]])
+        let days = try XCTUnwrap(weeks.first?["training_days"] as? [[String: Any]])
+        let firstDay = try XCTUnwrap(days.first)
+        XCTAssertEqual(
+            firstDay["status"] as? String, "completed",
+            "The persisted blob must carry the updated per-day status."
+        )
+    }
+
+    // MARK: 2. markDayCompleted under an unresolved owner writes nothing
+
+    @MainActor
+    func test_markDayCompleted_nilOwner_noServerWrite() async {
+        let mesocycle = Mesocycle.mockMesocycle()
+        let week = mesocycle.weeks[0]
+        let day = week.trainingDays[0]
+
+        let client = makeDayStatusSyncClient()
+        let vm = makeViewModel(client: client, resolveOwner: { nil })
+        vm.currentMesocycle = mesocycle
+
+        vm.markDayCompleted(dayId: day.id, weekId: week.id)
+
+        await waitForRPC(count: 1)
+
+        XCTAssertEqual(
+            DayStatusSyncStubURLProtocol.rpcRequestCount, 0,
+            "An unresolved owner must not persist day status — resolve-before-stamp."
+        )
+    }
+
+    // MARK: 3. loadProgram reconciles a server-completed day onto a cached pending day
+
+    @MainActor
+    func test_loadProgram_serverCompletedDay_reconcilesOntoCachedPending() async throws {
+        // Cache: day 0 is still .pending (stale).
+        let cached = Mesocycle.mockMesocycle()
+        let targetDayId = cached.weeks[0].trainingDays[0].id
+        cached.saveToUserDefaults()
+
+        // Server: SAME mesocycle (same ids) but day 0 is .completed (durable record).
+        var server = Mesocycle.mockMesocycle()
+        server.weeks[0].trainingDays[0].status = .completed
+        DayStatusSyncStubURLProtocol.fetchStatusCode = 200
+        DayStatusSyncStubURLProtocol.fetchData = try activeProgramFetchBody(for: server)
+
+        let client = makeDayStatusSyncClient()
+        let vm = makeViewModel(client: client, resolveOwner: { self.realOwner })
+
+        await vm.loadProgram()
+
+        // Reconcile runs off the fast path; poll until the cached day flips.
+        let deadline = Date().addingTimeInterval(2.0)
+        while Date() < deadline {
+            if vm.currentMesocycle?.weeks[0].trainingDays.first(where: { $0.id == targetDayId })?.status == .completed {
+                break
+            }
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+
+        let day = try XCTUnwrap(
+            vm.currentMesocycle?.weeks[0].trainingDays.first(where: { $0.id == targetDayId })
+        )
+        XCTAssertEqual(
+            day.status, .completed,
+            "A day completed on the server must show completed after a fresh load, even if the cache said pending."
+        )
+    }
+
+    // MARK: 4. loadProgram must NOT regress real local progress to a stale server
+
+    @MainActor
+    func test_loadProgram_serverStale_doesNotRegressLocalProgress() async throws {
+        // Cache: day 0 is .completed (real local progress).
+        var cached = Mesocycle.mockMesocycle()
+        let targetDayId = cached.weeks[0].trainingDays[0].id
+        cached.weeks[0].trainingDays[0].status = .completed
+        cached.saveToUserDefaults()
+
+        // Server: SAME mesocycle but day 0 is still .pending (stale).
+        let server = Mesocycle.mockMesocycle()
+        DayStatusSyncStubURLProtocol.fetchStatusCode = 200
+        DayStatusSyncStubURLProtocol.fetchData = try activeProgramFetchBody(for: server)
+
+        let client = makeDayStatusSyncClient()
+        let vm = makeViewModel(client: client, resolveOwner: { self.realOwner })
+
+        await vm.loadProgram()
+
+        // Give reconcile a chance to (incorrectly) regress before asserting.
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        let day = try XCTUnwrap(
+            vm.currentMesocycle?.weeks[0].trainingDays.first(where: { $0.id == targetDayId })
+        )
+        XCTAssertEqual(
+            day.status, .completed,
+            "A stale server must not regress a locally-completed day back to pending."
+        )
+    }
+}


### PR DESCRIPTION
## What

Slice #444 of the Programme↔Workout cure (umbrella #435), **Q5 = Option A**: persist per-day `TrainingDayStatus` to the server and reconcile on load.

Today `markDay*` wrote status **only** to UserDefaults; the server program blob froze statuses at generation time, so a reinstall / cache-clear reverted completed days to pending and fed wrong-day routing.

## How

**PERSIST** — `markDayCompleted` / `markDayPaused` / `markDaySkipped` now re-persist the updated mesocycle to the server after the in-memory + UserDefaults update, via a new `persistDayStatusUpdate` helper. It reuses the shared `OnboardingProgramPersist.persistIfOwnerResolved` mechanism (idempotent upsert on the client-generated program id — the same `deactivate_and_insert_program` RPC #424/#425 use). **Owner-gated** (resolve-before-stamp; never under the placeholder / unresolved owner — the #369 pattern) and **best-effort** (UserDefaults stays the local source; a failed write is non-fatal and arms no sync banner). No new persistence path was invented.

**RECONCILE** — `loadProgram`'s background fast-path pass (formerly backfill-only, `backfillCachedProgramIfNeeded`) is now `backfillOrReconcileCachedProgram`: the single server fetch routes to **backfill** (server empty) or **reconcile** (server present). Reconcile merges the server's per-day statuses onto the displayed cache, preferring the **more-advanced** status per day (terminal `.completed`/`.skipped` and `.paused` beat `.pending`/`.generated`) so neither a stale server nor a stale cache regresses real progress. Same-mesocycle only (matched by id); days matched by stable `TrainingDay.id`. Updates in-memory state, view state, and UserDefaults so reconciled progress survives the next launch.

## Tests (TDD)

New `ProgramDayStatusSyncTests` (4 cases, all green):
1. `markDayCompleted` under a real owner fires the persist RPC stamped with the resolved owner, carrying the day's new `.completed` status in the blob.
2. `markDayCompleted` under an unresolved owner writes nothing (resolve-before-stamp).
3. `loadProgram` reconciles a server-completed day onto a cached-pending day → loaded mesocycle shows `.completed`.
4. `loadProgram` does **not** regress a locally-completed day to a stale-pending server.

Existing `ProgramBackfillTests` (4) + `ProgramOwnerGateTests` (4) still pass — the backfill path is unchanged behaviorally.

`xcodebuild build-for-testing` succeeds; the new suite + the two regression suites run green on the iOS simulator.

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)