### PR TITLE
fix(#443): durable training_day_id on workout_sessions + repair re-match (Q2)

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		7D8C4E6ADC8DEDCA31B72B1D /* ManualLogIntentGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8AB93C545B445971A78F14 /* ManualLogIntentGateTests.swift */; };
 		81F0AA99C2173497F907DCF2 /* TraineeModelInteractionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85715B1D4A477BA1FA8963B2 /* TraineeModelInteractionsTests.swift */; };
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
+		DDDD443100000000000443B2 /* DurableTrainingDayIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD443100000000000443F1 /* DurableTrainingDayIdTests.swift */; };
 		8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */; };
 		A11FA719C0DE0001CAFE0001 /* FatigueInteractionCrossValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11FA719C0DE0002CAFE0002 /* FatigueInteractionCrossValidationTests.swift */; };
 		A12FA719C0DE0001CAFE0001 /* TraineeModelSnapshotsCrossValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12FA719C0DE0002CAFE0002 /* TraineeModelSnapshotsCrossValidationTests.swift */; };
@@ -153,6 +154,7 @@
 		EEE172F80DF77608B9C048CA /* TraineeModelEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TraineeModelEnumsTests.swift; sourceTree = "<group>"; };
 		EFB324F8EA1B317B0F90575B /* ProjectApexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProjectApexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MovementPatternTests.swift; sourceTree = "<group>"; };
+		DDDD443100000000000443F1 /* DurableTrainingDayIdTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DurableTrainingDayIdTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -286,6 +288,7 @@
 				A1540154CAFE0154CAFE0022 /* CalibrationReviewStretchPayloadTests.swift */,
 				22000000000000000000F012 /* PromptLoaderTests.swift */,
 				A1C0F19329000000APIKEY03 /* BundledKeyResolutionTests.swift */,
+				DDDD443100000000000443F1 /* DurableTrainingDayIdTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -455,6 +458,7 @@
 				A1540154CAFE0154CAFE0021 /* CalibrationReviewStretchPayloadTests.swift in Sources */,
 				22000000000000000000F011 /* PromptLoaderTests.swift in Sources */,
 				A1C0F19329000000APIKEY04 /* BundledKeyResolutionTests.swift in Sources */,
+				DDDD443100000000000443B2 /* DurableTrainingDayIdTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -312,6 +312,7 @@ actor WorkoutSessionManager {
             dayType: trainingDay.dayLabel,
             completed: false,
             status: "active",
+            trainingDayId: trainingDay.id,   // #443 (Q2): durable day identity for resume/repair re-match
             setLogs: [],
             sessionNotes: [],
             summary: nil
@@ -2269,16 +2270,18 @@ nonisolated private struct WorkoutSessionPayload: Encodable {
     let sessionDate: String
     let weekNumber: Int
     let dayType: String
+    let trainingDayId: String?
     let completed: Bool
     let status: String?
 
     enum CodingKeys: String, CodingKey {
         case id
-        case userId      = "user_id"
-        case programId   = "program_id"
-        case sessionDate = "session_date"
-        case weekNumber  = "week_number"
-        case dayType     = "day_type"
+        case userId        = "user_id"
+        case programId     = "program_id"
+        case sessionDate   = "session_date"
+        case weekNumber    = "week_number"
+        case dayType       = "day_type"
+        case trainingDayId = "training_day_id"
         case completed
         case status
     }
@@ -2291,6 +2294,7 @@ nonisolated private struct WorkoutSessionPayload: Encodable {
         self.sessionDate = formatter.string(from: session.sessionDate)
         self.weekNumber = session.weekNumber
         self.dayType = session.dayType
+        self.trainingDayId = session.trainingDayId?.uuidString
         self.completed = session.completed
         self.status = session.status
     }

--- a/ProjectApex/Models/WorkoutSession.swift
+++ b/ProjectApex/Models/WorkoutSession.swift
@@ -25,6 +25,11 @@ nonisolated struct WorkoutSession: Codable, Identifiable, Sendable {
     let weekNumber: Int
     /// E.g. "Push A", "Pull B" — maps to TrainingDay.label.
     let dayType: String
+    /// Durable, server-visible TrainingDay.id stamped at session start (#443 / Q2).
+    /// (program_id, week_number, day_type) is NOT unique, so resume/repair re-match
+    /// on this column instead. Nil for rows created before this field existed
+    /// (backward-compatible / legacy).
+    let trainingDayId: UUID?
     var completed: Bool
     /// Lifecycle status string: "active", "paused", or "completed".
     /// Nil for rows created before this field was added (backward-compatible).
@@ -40,6 +45,7 @@ nonisolated struct WorkoutSession: Codable, Identifiable, Sendable {
         case sessionDate     = "session_date"
         case weekNumber      = "week_number"
         case dayType         = "day_type"
+        case trainingDayId   = "training_day_id"
         case completed
         case status
         case setLogs         = "set_logs"
@@ -58,6 +64,7 @@ nonisolated struct WorkoutSession: Codable, Identifiable, Sendable {
         dayType: String,
         completed: Bool,
         status: String? = nil,
+        trainingDayId: UUID? = nil,
         setLogs: [SetLog] = [],
         sessionNotes: [SessionNote] = [],
         summary: SessionSummary? = nil
@@ -68,6 +75,7 @@ nonisolated struct WorkoutSession: Codable, Identifiable, Sendable {
         self.sessionDate  = sessionDate
         self.weekNumber   = weekNumber
         self.dayType      = dayType
+        self.trainingDayId = trainingDayId
         self.completed    = completed
         self.status       = status
         self.setLogs      = setLogs
@@ -86,6 +94,7 @@ nonisolated struct WorkoutSession: Codable, Identifiable, Sendable {
         sessionDate  = try c.decode(Date.self,    forKey: .sessionDate)
         weekNumber   = try c.decode(Int.self,     forKey: .weekNumber)
         dayType      = try c.decode(String.self,  forKey: .dayType)
+        trainingDayId = try c.decodeIfPresent(UUID.self, forKey: .trainingDayId)
         completed    = try c.decode(Bool.self,    forKey: .completed)
         status       = try c.decodeIfPresent(String.self,         forKey: .status)
         setLogs      = try c.decodeIfPresent([SetLog].self,       forKey: .setLogs)       ?? []
@@ -483,11 +492,15 @@ nonisolated struct PausedSessionState: Codable, Sendable {
             let programId: UUID
             let weekNumber: Int
             let dayType: String
+            /// #443 (Q2): the durable TrainingDay.id stamped at session start.
+            /// Nil for legacy rows written before the column existed.
+            let trainingDayId: UUID?
             enum CodingKeys: String, CodingKey {
                 case id
-                case programId  = "program_id"
-                case weekNumber = "week_number"
-                case dayType    = "day_type"
+                case programId    = "program_id"
+                case weekNumber   = "week_number"
+                case dayType      = "day_type"
+                case trainingDayId = "training_day_id"
             }
         }
 
@@ -502,11 +515,14 @@ nonisolated struct PausedSessionState: Codable, Sendable {
             limit: 1
         ).first else { return }
 
-        // Use a random trainingDayId so the ContentView mismatch path fires,
-        // giving the user the option to Abandon the orphaned session cleanly.
+        // #443 (Q2): reuse the row's durable training_day_id so ContentView can
+        // re-match it to the live TrainingDay and offer a real Resume. Legacy rows
+        // (column null) have no recoverable identity — keep the prior behaviour
+        // there: a fresh UUID forces the ContentView mismatch path so the user can
+        // Abandon the unmatchable orphaned session cleanly.
         let state = PausedSessionState(
             sessionId:        row.id,
-            trainingDayId:    UUID(),
+            trainingDayId:    row.trainingDayId ?? UUID(),
             weekId:           UUID(),
             weekNumber:       row.weekNumber,
             exerciseIndex:    0,

--- a/ProjectApexTests/DurableTrainingDayIdTests.swift
+++ b/ProjectApexTests/DurableTrainingDayIdTests.swift
@@ -1,0 +1,280 @@
+// DurableTrainingDayIdTests.swift
+// ProjectApexTests — #443 (Q2)
+//
+// Durable, server-visible day identity for workout_sessions.
+//
+//   1. WorkoutSession (the workout_sessions row) round-trips training_day_id,
+//      including a legacy row that omits the column (decodes to nil).
+//   2. startSession stamps trainingDay.id into the enqueued session payload.
+//   3. attemptSupabaseRepair uses the recovered row's persisted training_day_id
+//      (not a fabricated random UUID); falls back to a fresh id only when the
+//      column is null (legacy rows).
+
+import XCTest
+import Foundation
+@testable import ProjectApex
+
+// MARK: - Stub URLProtocol returning a single workout_sessions row
+
+/// Returns a fixed JSON body for the next GET, so attemptSupabaseRepair's
+/// fetch resolves deterministically with no network.
+private final class RepairRowURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var responseBody: String = "[]"
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(Self.responseBody.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+private func makeStubSupabase() -> SupabaseClient {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [RepairRowURLProtocol.self]
+    return SupabaseClient(
+        supabaseURL: URL(string: "https://test.supabase.co")!,
+        anonKey: "test-key",
+        urlSession: URLSession(configuration: config)
+    )
+}
+
+final class DurableTrainingDayIdTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        PausedSessionState.clear()
+    }
+
+    override func tearDown() {
+        PausedSessionState.clear()
+        RepairRowURLProtocol.responseBody = "[]"
+        super.tearDown()
+    }
+
+    // MARK: 1. Model round-trip (incl. legacy null row)
+
+    func testWorkoutSessionRow_roundTripsTrainingDayId() throws {
+        let dayId = UUID()
+        let session = WorkoutSession(
+            id: UUID(),
+            userId: UUID(),
+            programId: UUID(),
+            sessionDate: Date(timeIntervalSince1970: 1_700_000_000),
+            weekNumber: 2,
+            dayType: "Push_A",
+            completed: false,
+            status: "active",
+            trainingDayId: dayId
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(session)
+
+        // The on-the-wire key is snake_case `training_day_id`.
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let encodedDayId = try XCTUnwrap(json["training_day_id"] as? String)
+        XCTAssertEqual(UUID(uuidString: encodedDayId), dayId)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(WorkoutSession.self, from: data)
+        XCTAssertEqual(decoded.trainingDayId, dayId)
+    }
+
+    func testWorkoutSessionRow_legacyRowWithoutColumn_decodesToNil() throws {
+        // A pre-#443 row has no training_day_id key at all.
+        let legacy = """
+        {
+          "id": "11111111-1111-4111-8111-111111111111",
+          "user_id": "22222222-2222-4222-8222-222222222222",
+          "program_id": "33333333-3333-4333-8333-333333333333",
+          "session_date": "2026-06-17T00:00:00Z",
+          "week_number": 1,
+          "day_type": "Pull_B",
+          "completed": false
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(WorkoutSession.self, from: Data(legacy.utf8))
+        XCTAssertNil(decoded.trainingDayId, "legacy row without the column decodes to nil")
+    }
+
+    // MARK: 2. startSession stamps training_day_id into the enqueued payload
+
+    func testStartSession_stampsTrainingDayIdIntoEnqueuedPayload() async throws {
+        let (manager, waq) = makeWSM443ManagerWithWAQ()
+
+        // Capture the workout_sessions payload the manager enqueues. A
+        // permanentFailure keeps the item out of the success auto-drain so the
+        // handler is guaranteed to see it.
+        let captured = PayloadBox()
+        await waq.registerFlushHandler(forTable: "workout_sessions") { write in
+            captured.store(write.payload)
+            return .permanentFailure("captured-for-test")
+        }
+
+        let day = makeWSM443TrainingDay()
+        await manager.startSession(
+            trainingDay: day,
+            programId: UUID(),
+            userId: UUID(),
+            weekNumber: 1
+        )
+
+        var payload: Data?
+        for _ in 0..<100 where payload == nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            payload = captured.value()
+        }
+        let data = try XCTUnwrap(payload, "session payload was enqueued")
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let stamped = try XCTUnwrap(json["training_day_id"] as? String)
+        XCTAssertEqual(
+            UUID(uuidString: stamped), day.id,
+            "startSession stamps trainingDay.id into training_day_id"
+        )
+    }
+
+    // MARK: 3. Repair uses the recovered row's persisted training_day_id
+
+    func testAttemptSupabaseRepair_usesPersistedTrainingDayId() async {
+        let serverDayId = UUID()
+        let programId = UUID()
+        RepairRowURLProtocol.responseBody = """
+        [{
+          "id": "44444444-4444-4444-8444-444444444444",
+          "program_id": "\(programId.uuidString)",
+          "week_number": 3,
+          "day_type": "Legs",
+          "training_day_id": "\(serverDayId.uuidString)"
+        }]
+        """
+        PausedSessionState.clear()
+
+        await PausedSessionState.attemptSupabaseRepair(userId: UUID(), supabase: makeStubSupabase())
+
+        let restored = PausedSessionState.load()
+        XCTAssertEqual(
+            restored?.trainingDayId, serverDayId,
+            "repair reuses the server row's training_day_id rather than a random UUID"
+        )
+    }
+
+    func testAttemptSupabaseRepair_legacyNullColumn_doesNotUseAFixedId() async {
+        // Legacy row: no training_day_id. Repair must still produce a paused
+        // state (so the user gets the recovery path), but with a fresh id — the
+        // ContentView mismatch path then offers Abandon for the unmatchable day.
+        RepairRowURLProtocol.responseBody = """
+        [{
+          "id": "55555555-5555-4555-8555-555555555555",
+          "program_id": "66666666-6666-4666-8666-666666666666",
+          "week_number": 1,
+          "day_type": "Push_A"
+        }]
+        """
+        PausedSessionState.clear()
+
+        await PausedSessionState.attemptSupabaseRepair(userId: UUID(), supabase: makeStubSupabase())
+
+        let restored = PausedSessionState.load()
+        XCTAssertNotNil(restored, "repair still reconstructs a paused state for a legacy row")
+        // The id is not borrowed from any other column (it's a fresh fallback).
+        XCTAssertNotEqual(restored?.trainingDayId, restored?.programId)
+        XCTAssertNotEqual(
+            restored?.trainingDayId,
+            UUID(uuidString: "55555555-5555-4555-8555-555555555555"),
+            "legacy fallback does not reuse the session id as the day id"
+        )
+    }
+}
+
+// MARK: - Local helpers (file-scoped to avoid colliding with WorkoutSessionManagerTests)
+
+/// Thread-safe box for capturing a payload from the WAQ flush handler.
+private final class PayloadBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data: Data?
+    func store(_ d: Data) { lock.lock(); if data == nil { data = d }; lock.unlock() }
+    func value() -> Data? { lock.lock(); defer { lock.unlock() }; return data }
+}
+
+private final class WSM443SucceedURLProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let response = HTTPURLResponse(url: request.url!, statusCode: 201, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("[]".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+private func makeWSM443ManagerWithWAQ() -> (WorkoutSessionManager, WriteAheadQueue) {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [WSM443SucceedURLProtocol.self]
+    let supabase = SupabaseClient(
+        supabaseURL: URL(string: "https://test.supabase.co")!,
+        anonKey: "test-key",
+        urlSession: URLSession(configuration: config)
+    )
+    let inference = AIInferenceService(
+        provider: WSM443StubProvider(),
+        gymProfile: nil,
+        maxRetries: 0
+    )
+    let memoryService = MemoryService(supabase: supabase, embeddingAPIKey: "")
+    let suiteName = "com.test.wsm443.\(UUID().uuidString)"
+    let testDefaults = UserDefaults(suiteName: suiteName)!
+    let gymFactStore = GymFactStore(userDefaults: testDefaults)
+    let waq = WriteAheadQueue(supabase: supabase, userDefaults: testDefaults)
+    let manager = WorkoutSessionManager(
+        aiInference: inference,
+        healthKit: HealthKitService(),
+        memoryService: memoryService,
+        supabase: supabase,
+        gymFactStore: gymFactStore,
+        writeAheadQueue: waq
+    )
+    return (manager, waq)
+}
+
+private struct WSM443StubProvider: LLMProvider {
+    func complete(systemPrompt: String, userPayload: String) async throws -> String {
+        """
+        {
+          "set_prescription": {
+            "weight_kg": 80.0, "reps": 8, "tempo": "3-1-1-0", "rir_target": 2,
+            "rest_seconds": 120, "coaching_cue": "Drive", "reasoning": "trend",
+            "safety_flags": [], "intent": "top", "set_framing": "Heaviest."
+          }
+        }
+        """
+    }
+}
+
+private func makeWSM443TrainingDay() -> TrainingDay {
+    let ex = PlannedExercise(
+        id: UUID(),
+        exerciseId: "exercise_0",
+        name: "Exercise 0",
+        primaryMuscle: "pectoralis_major",
+        synergists: ["triceps_brachii"],
+        equipmentRequired: .barbell,
+        sets: 2,
+        repRange: RepRange(min: 6, max: 10),
+        tempo: "3-1-1-0",
+        restSeconds: 90,
+        rirTarget: 2,
+        coachingCues: ["Focus on form"]
+    )
+    return TrainingDay(id: UUID(), dayOfWeek: 1, dayLabel: "Push_A", exercises: [ex], sessionNotes: nil)
+}

--- a/docs/migrations/down/20260617000000_add_training_day_id_to_workout_sessions.sql
+++ b/docs/migrations/down/20260617000000_add_training_day_id_to_workout_sessions.sql
@@ -1,0 +1,7 @@
+-- Reverse migration for supabase/migrations/20260617000000_add_training_day_id_to_workout_sessions.sql
+-- Documentation only; NOT auto-applied by `supabase db push`. Run manually
+-- (`psql -f`) if the forward migration must be rolled back.
+--
+-- #443 (Q2) — drop the durable day-identity column.
+
+ALTER TABLE workout_sessions DROP COLUMN IF EXISTS training_day_id;

--- a/supabase/migrations/20260617000000_add_training_day_id_to_workout_sessions.sql
+++ b/supabase/migrations/20260617000000_add_training_day_id_to_workout_sessions.sql
@@ -1,0 +1,14 @@
+-- Reverse migration: docs/migrations/down/20260617000000_add_training_day_id_to_workout_sessions.sql
+-- (documentation only; not auto-applied by `supabase db push`)
+--
+-- #443 (Q2) — durable day identity for workout_sessions.
+--
+-- (program_id, week_number, day_type) is NOT unique — normalizeDayLabel does not
+-- disambiguate two days that share a label — so resume/repair cannot reliably
+-- re-match a session to its TrainingDay. This column gives every session a
+-- durable, server-visible TrainingDay.id stamped at session start.
+--
+-- Nullable with no default and no backfill: existing rows keep NULL (legacy),
+-- and the repair path falls back to its prior behaviour for those rows.
+
+ALTER TABLE workout_sessions ADD COLUMN training_day_id uuid;


### PR DESCRIPTION
## #443 (Q2) — durable day identity for `workout_sessions`

`(program_id, week_number, day_type)` is **not unique** — `normalizeDayLabel` does not disambiguate two days that share a label — so resume/repair could never reliably re-match a session to its `TrainingDay`. This slice gives every session row a durable, server-visible `TrainingDay.id` stamped at session start, and uses it for repair re-match.

### What shipped
- **Migration** (`20260617000000_add_training_day_id_to_workout_sessions.sql`): nullable `training_day_id uuid` — no default, no backfill, no changes to existing columns. Existing rows keep `NULL` (legacy). Forward + documentation-only reverse migration per the migrations workflow. **Not applied here — CI applies on merge.**
- **Model + stamp:** `WorkoutSession` + `WorkoutSessionPayload` carry `training_day_id` (`decodeIfPresent` → `nil` for legacy rows). `WorkoutSessionManager.startSession` stamps `trainingDay.id` into the row, reusing the existing WAQ persistence path.
- **Repair re-match:** `attemptSupabaseRepair` now reuses the recovered server row's persisted `training_day_id` so `ContentView` (`findTrainingDay(byId:)`) can re-match the live `TrainingDay` and offer a real **Resume**. When the column is null (legacy rows) it falls back to a fresh UUID — the prior behaviour that forces the mismatch/Abandon path.

### Dead `weekId` — lower-risk option taken (leave it)
The `startSession` `weekId` default is a random UUID that only feeds `PausedSessionState` (a local crash-sentinel field). It is **never persisted to the server** and **never read for any resume/repair decision** (resume matches on `trainingDayId`; repair zeroes it). Neither caller (`WorkoutViewModel.startSession` → `ContentView`) has a real `week.id` at the boundary — they pass only `weekNumber` — so threading the real id would cascade signature changes through the SwiftUI views, and *removing* the field would churn a legacy-decoder `Codable` type plus ~8 prod + 4 test sites for zero functional benefit to #443. So I left the isolated local field untouched and focused the slice on the real durable identity (`training_day_id`) that resume/repair actually needs.

### Tests (TDD, all green)
- `WorkoutSession` round-trips `training_day_id`, including a null legacy row → `nil`.
- `startSession` stamps `trainingDay.id` into the enqueued payload.
- `attemptSupabaseRepair` uses the server row's `training_day_id` (not a random one); still reconstructs a state for legacy null-column rows.

Local: new `DurableTrainingDayIdTests` (5/5) + `WorkoutSessionManagerTests` & `SetLogPayloadEncoderTests` (33/33) green.

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)
