### PR TITLE
fix(#447): validate exercise-set signature on resume (defense-in-depth)

### DIFF
--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -331,7 +331,8 @@ actor WorkoutSessionManager {
             dayType: trainingDay.dayLabel,
             programId: programId,
             userId: userId,
-            pausedAt: Date()
+            pausedAt: Date(),
+            exerciseSignature: PausedSessionState.exerciseSignature(for: trainingDay)   // #447
         ).save()
 
         // Write session row via WAQ so it is recoverable if the app crashes mid-workout.
@@ -596,7 +597,8 @@ actor WorkoutSessionManager {
                 dayType: session.dayType,
                 programId: session.programId,
                 userId: session.userId,
-                pausedAt: Date()
+                pausedAt: Date(),
+                exerciseSignature: PausedSessionState.exerciseSignature(for: day)   // #447
             ).save()
         }
 
@@ -785,7 +787,8 @@ actor WorkoutSessionManager {
             dayType: sess.dayType,
             programId: sess.programId,
             userId: sess.userId,
-            pausedAt: Date()
+            pausedAt: Date(),
+            exerciseSignature: PausedSessionState.exerciseSignature(for: day)   // #447
         ).save()
 
         // 3. Sync to the server WITHOUT blocking the UI (#190): pauseSession
@@ -939,12 +942,31 @@ actor WorkoutSessionManager {
     /// Resumes a previously paused session.
     /// Restores all relevant in-memory state, PATCHes the session back to "active",
     /// and fires inference for the exercise/set where the user left off.
+    /// Returns `true` when the session was resumed, `false` when resume was rejected
+    /// (e.g. the day's exercise list changed since the pause — #447). On rejection the
+    /// in-memory state is left untouched, `sessionState` is set to `.error` so the UI
+    /// routes to mismatch recovery, and the persisted sentinel is preserved so the user
+    /// can still Abandon/Save the orphaned session.
+    @discardableResult
     func resumeSession(
         pausedState: PausedSessionState,
         trainingDay: TrainingDay,
         completedSetLogs: [SetLog]
-    ) async {
-        guard case .idle = sessionState else { return }
+    ) async -> Bool {
+        guard case .idle = sessionState else { return false }
+
+        // #447 (defense-in-depth): the paused sentinel carries a signature of the day's
+        // exercise list frozen at session start. If the CURRENT day's list no longer
+        // matches, the stored exerciseIndex / set_logs→exercise mapping is stale and
+        // replaying it would mis-place sets against the wrong exercises. Reject instead
+        // of silently replaying. A nil stored signature is a legacy sentinel ("unknown")
+        // and must NOT reject — only a present-and-different signature does.
+        if let stored = pausedState.exerciseSignature,
+           stored != PausedSessionState.exerciseSignature(for: trainingDay) {
+            print("[WorkoutSessionManager] resumeSession — exercise signature mismatch (stored \(stored)); rejecting replay")
+            sessionState = .error("This workout's exercises changed since you paused. Start it fresh.")
+            return false
+        }
 
         // Restore session state
         self.trainingDay = trainingDay
@@ -1023,7 +1045,7 @@ actor WorkoutSessionManager {
         guard exerciseIndex < trainingDay.exercises.count else {
             // Edge case: all exercises were already completed before pause
             await finishSession(earlyExitReason: nil)
-            return
+            return true
         }
         let currentExercise = trainingDay.exercises[exerciseIndex]
         async let streakFetch       = gymStreakService.computeStreak(userId: pausedState.userId)
@@ -1045,6 +1067,7 @@ actor WorkoutSessionManager {
 
         // Fire inference for the current exercise/set
         await triggerInference(for: currentExercise, setNumber: currentSetNumber)
+        return true
     }
 
     /// Rebuilds the sessionHistoryToday array from set logs for exercises before `upToExerciseIndex`.

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -493,13 +493,18 @@ final class WorkoutViewModel {
 
             print("[WorkoutViewModel] resumeSession — remote:\(remoteLogs.count) waq:\(waqLogs.count) merged:\(setLogs.count) for session \(pausedState.sessionId)")
 
-            await manager.resumeSession(
+            // #447: resumeSession rejects (returns false) when the day's exercise list
+            // changed since the pause — the stored index / set_logs mapping is stale, so
+            // it must not be silently replayed. It leaves sessionState in .error, which
+            // pullState() surfaces to the UI; there is no live session to poll afterward.
+            let resumed = await manager.resumeSession(
                 pausedState: pausedState,
                 trainingDay: trainingDay,
                 completedSetLogs: setLogs
             )
             await pullState()
             isStartingSession = false
+            guard resumed else { return }
             beginStatePolling()
         }
     }

--- a/ProjectApex/Models/WorkoutSession.swift
+++ b/ProjectApex/Models/WorkoutSession.swift
@@ -385,6 +385,14 @@ nonisolated struct PausedSessionState: Codable, Sendable {
     let programId: UUID
     let userId: UUID
     let pausedAt: Date
+    /// #447: a deterministic signature of the day's ordered exercise list at session
+    /// start. On resume the live day's signature is recomputed and compared; a mismatch
+    /// means the exercise list changed since the pause (e.g. a program edit), so the
+    /// stored exerciseIndex / set_logs mapping can no longer be trusted and resume is
+    /// rejected rather than mis-replayed. Optional for Codable back-compat: a legacy
+    /// sentinel written before this field existed decodes to nil ("unknown"), which is
+    /// treated as "do not reject" so a legitimate resume is never spuriously blocked.
+    let exerciseSignature: String?
 
     // Custom decoder: weekNumber was added after initial release, so old UserDefaults
     // snapshots won't have it. Fall back to 1 rather than failing to decode entirely.
@@ -400,6 +408,8 @@ nonisolated struct PausedSessionState: Codable, Sendable {
         programId      = try c.decode(UUID.self,   forKey: .programId)
         userId         = try c.decode(UUID.self,   forKey: .userId)
         pausedAt       = try c.decode(Date.self,   forKey: .pausedAt)
+        // #447: legacy sentinels have no signature key → nil ("unknown").
+        exerciseSignature = try c.decodeIfPresent(String.self, forKey: .exerciseSignature)
     }
 
     nonisolated init(
@@ -412,7 +422,8 @@ nonisolated struct PausedSessionState: Codable, Sendable {
         dayType: String,
         programId: UUID,
         userId: UUID,
-        pausedAt: Date
+        pausedAt: Date,
+        exerciseSignature: String? = nil
     ) {
         self.sessionId       = sessionId
         self.trainingDayId   = trainingDayId
@@ -424,6 +435,17 @@ nonisolated struct PausedSessionState: Codable, Sendable {
         self.programId       = programId
         self.userId          = userId
         self.pausedAt        = pausedAt
+        self.exerciseSignature = exerciseSignature
+    }
+
+    /// #447: a deterministic, process-stable signature of a day's ordered exercise
+    /// list — the count followed by the ordered exerciseIds. Used to detect that the
+    /// day's exercises changed between pause and resume. Deterministic (no Date/random,
+    /// no Swift `Hasher` which is per-process seeded) so the stored value compares
+    /// equal across app launches.
+    nonisolated static func exerciseSignature(for day: TrainingDay) -> String {
+        let ids = day.exercises.map(\.exerciseId)
+        return "\(ids.count):" + ids.joined(separator: "|")
     }
 
     static let legacyPersistenceKey = "com.projectapex.pausedSessionState"

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -972,6 +972,155 @@ final class WorkoutSessionManagerTests: XCTestCase {
         )
     }
 
+    // MARK: #447 — resume validates the day's exercise-set signature
+
+    /// Defense-in-depth: a paused session whose stored exercise signature does NOT
+    /// match the current day's exercise list must NOT be silently replayed. The day's
+    /// exercises changed since the pause, so the stored exerciseIndex / set_logs
+    /// mapping is no longer trustworthy — resume is rejected and surfaces an error
+    /// (routing to the existing mismatch-recovery UI) rather than mis-replaying.
+    func testResumeSession_signatureMismatch_isRejectedNotReplayed() async throws {
+        let manager = makeManager()
+
+        // The day the user paused on (signature captured from THIS list).
+        let pausedDay = makeTrainingDay(exerciseCount: 2, setsPerExercise: 2)
+        // The CURRENT day — same id (UUID still matches) but a DIFFERENT exercise
+        // list (e.g. the program was edited between pause and resume).
+        let editedDay = TrainingDay(
+            id: pausedDay.id,
+            dayOfWeek: pausedDay.dayOfWeek,
+            dayLabel: pausedDay.dayLabel,
+            exercises: makeTrainingDay(exerciseCount: 3, setsPerExercise: 2).exercises,
+            sessionNotes: nil
+        )
+
+        let paused = PausedSessionState(
+            sessionId: UUID(),
+            trainingDayId: pausedDay.id,
+            weekId: UUID(),
+            weekNumber: 1,
+            exerciseIndex: 1,
+            currentSetNumber: 1,
+            dayType: pausedDay.dayLabel,
+            programId: UUID(),
+            userId: UUID(),
+            pausedAt: Date(),
+            exerciseSignature: PausedSessionState.exerciseSignature(for: pausedDay)
+        )
+
+        // Precondition: the sentinel is persisted, as it is in production at pause
+        // time — only then is "a rejected resume preserves it" a meaningful assertion.
+        paused.save()
+        XCTAssertNotNil(PausedSessionState.load(), "precondition: paused session saved")
+
+        let resumed = await manager.resumeSession(
+            pausedState: paused,
+            trainingDay: editedDay,
+            completedSetLogs: []
+        )
+
+        XCTAssertFalse(resumed, "A signature mismatch must reject the resume")
+        let state = await manager.sessionState
+        guard case .error = state else {
+            XCTFail("Signature mismatch must surface .error (mismatch recovery), got \(state)")
+            return
+        }
+        // The sentinel is preserved so the user can still Abandon/Save via the recovery UI.
+        XCTAssertNotNil(
+            PausedSessionState.load(),
+            "A rejected resume must NOT clear the sentinel — the recovery UI still needs it"
+        )
+    }
+
+    /// Happy path: a stored signature that matches the current day's exercise list
+    /// lets resume proceed normally.
+    func testResumeSession_signatureMatch_proceeds() async throws {
+        let manager = makeManager()
+        let day = makeTrainingDay(exerciseCount: 2, setsPerExercise: 2)
+
+        let paused = PausedSessionState(
+            sessionId: UUID(),
+            trainingDayId: day.id,
+            weekId: UUID(),
+            weekNumber: 1,
+            exerciseIndex: 0,
+            currentSetNumber: 1,
+            dayType: day.dayLabel,
+            programId: UUID(),
+            userId: UUID(),
+            pausedAt: Date(),
+            exerciseSignature: PausedSessionState.exerciseSignature(for: day)
+        )
+
+        let resumed = await manager.resumeSession(
+            pausedState: paused,
+            trainingDay: day,
+            completedSetLogs: []
+        )
+
+        XCTAssertTrue(resumed, "A matching signature must allow resume to proceed")
+        let state = await manager.sessionState
+        if case .error = state {
+            XCTFail("A matching signature must not error; got \(state)")
+        }
+    }
+
+    /// Back-compat: a legacy sentinel written before the signature field existed
+    /// decodes with a nil signature. A nil stored signature must NOT spuriously
+    /// reject a legitimate resume.
+    func testResumeSession_nilStoredSignature_doesNotReject() async throws {
+        let manager = makeManager()
+        let day = makeTrainingDay(exerciseCount: 2, setsPerExercise: 2)
+
+        let paused = PausedSessionState(
+            sessionId: UUID(),
+            trainingDayId: day.id,
+            weekId: UUID(),
+            weekNumber: 1,
+            exerciseIndex: 0,
+            currentSetNumber: 1,
+            dayType: day.dayLabel,
+            programId: UUID(),
+            userId: UUID(),
+            pausedAt: Date(),
+            exerciseSignature: nil   // legacy sentinel
+        )
+
+        let resumed = await manager.resumeSession(
+            pausedState: paused,
+            trainingDay: day,
+            completedSetLogs: []
+        )
+
+        XCTAssertTrue(resumed, "A nil stored signature must not reject a legitimate resume")
+    }
+
+    /// The signature is deterministic and order-sensitive: same ordered ids → same
+    /// signature; reordered or changed ids → different signature. No Date/random.
+    func testExerciseSignature_isDeterministicAndOrderSensitive() {
+        let dayA = makeTrainingDay(exerciseCount: 3, setsPerExercise: 2)
+        let sig1 = PausedSessionState.exerciseSignature(for: dayA)
+        let sig2 = PausedSessionState.exerciseSignature(for: dayA)
+        XCTAssertEqual(sig1, sig2, "Signature must be deterministic for the same list")
+
+        // A day with the same exercises but reversed order → different signature.
+        let reversed = TrainingDay(
+            id: dayA.id, dayOfWeek: dayA.dayOfWeek, dayLabel: dayA.dayLabel,
+            exercises: dayA.exercises.reversed(), sessionNotes: nil
+        )
+        XCTAssertNotEqual(
+            sig1, PausedSessionState.exerciseSignature(for: reversed),
+            "Reordering the exercise list must change the signature"
+        )
+
+        // A day with an added exercise → different signature.
+        let dayBigger = makeTrainingDay(exerciseCount: 4, setsPerExercise: 2)
+        XCTAssertNotEqual(
+            sig1, PausedSessionState.exerciseSignature(for: dayBigger),
+            "Changing the exercise count must change the signature"
+        )
+    }
+
     // MARK: #318 / U5 — skip set (G-F7): advancement must be set-number-based
 
     /// The bug-catcher (critic amendment): a SKIPPED set writes no SetLog, so


### PR DESCRIPTION
## What & why
Tier-3 (defense-in-depth) for the Programme↔Workout seam audit (parent #435, STATE-2). On resume the manager previously trusted only the day UUID — it clamped a stale `exerciseIndex` and matched old `set_logs` by `exerciseId`. If the day's exercise list changed between pause and resume (e.g. a program edit), the stored index/mapping is stale and replaying it silently mis-places sets against the wrong exercises.

This stores a deterministic exercise-set signature in `PausedSessionState` at session start; on resume the live day's signature is recomputed and compared. A mismatch **rejects** the replay instead of mis-replaying.

## Changes
- `PausedSessionState.exerciseSignature` — `Optional` for Codable back-compat: legacy sentinels written before this field decode to `nil` ("unknown") and **never** reject, so a legitimate resume is never spuriously blocked.
- `exerciseSignature(for:)` — deterministic + order-sensitive (`count:id|id|…`), deliberately **not** Swift's per-process-seeded `Hasher`, so stored values compare equal across app launches.
- `resumeSession` now returns `Bool`. On mismatch it leaves in-memory state untouched, sets `sessionState = .error` (routes to the existing mismatch-recovery UI), and **preserves the sentinel** so the user can still Abandon/Save the orphaned session.
- `WorkoutViewModel` bails out of state-polling when resume is rejected.

## Acceptance criteria (both met)
- [x] Resuming a session whose day's exercise list changed no longer silently mis-replays.
- [x] `PausedSessionState` carries an exercise-set version/hash; mismatch is detected.

## Tests (all green — `WorkoutSessionManagerTests`, 29 passed / 0 failed)
- `testResumeSession_signatureMismatch_isRejectedNotReplayed` — mismatch → reject, `.error`, sentinel preserved.
- `testResumeSession_signatureMatch_proceeds` — happy path.
- `testResumeSession_nilStoredSignature_doesNotReject` — legacy sentinel back-compat.
- `testExerciseSignature_isDeterministicAndOrderSensitive` — determinism + order/count sensitivity.

## Provenance
Recovered from a workflow run lost in a full-disk incident; the implementation existed uncommitted in its worktree and was committed, completed (the central mismatch test was left red mid-TDD because it never persisted the sentinel precondition), and verified green locally.

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)