### PR TITLE
feat(#441): retire crashResumeDay sticky override; drive Workout-tab render + completion from the coordinator

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		89DC096233064C035B6D3809 /* MovementPatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */; };
 		DDDD443100000000000443B2 /* DurableTrainingDayIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD443100000000000443F1 /* DurableTrainingDayIdTests.swift */; };
 		A5C0FFEE0000000000ASC002 /* ActiveSessionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C0FFEE0000000000ASC001 /* ActiveSessionCoordinatorTests.swift */; };
+		DF8EC3D0BD96C780A4A12C9C /* RunDayRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF699647AABA0F76A7B2123 /* RunDayRoutingTests.swift */; };
 		8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */; };
 		A11FA719C0DE0001CAFE0001 /* FatigueInteractionCrossValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11FA719C0DE0002CAFE0002 /* FatigueInteractionCrossValidationTests.swift */; };
 		A12FA719C0DE0001CAFE0001 /* TraineeModelSnapshotsCrossValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12FA719C0DE0002CAFE0002 /* TraineeModelSnapshotsCrossValidationTests.swift */; };
@@ -159,6 +160,7 @@
 		FD87C13195A0D0C4C63D2120 /* MovementPatternTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MovementPatternTests.swift; sourceTree = "<group>"; };
 		DDDD443100000000000443F1 /* DurableTrainingDayIdTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DurableTrainingDayIdTests.swift; sourceTree = "<group>"; };
 		A5C0FFEE0000000000ASC001 /* ActiveSessionCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActiveSessionCoordinatorTests.swift; sourceTree = "<group>"; };
+		DDF699647AABA0F76A7B2123 /* RunDayRoutingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RunDayRoutingTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -295,6 +297,7 @@
 				A1C0F19329000000APIKEY03 /* BundledKeyResolutionTests.swift */,
 				DDDD443100000000000443F1 /* DurableTrainingDayIdTests.swift */,
 				A5C0FFEE0000000000ASC001 /* ActiveSessionCoordinatorTests.swift */,
+				DDF699647AABA0F76A7B2123 /* RunDayRoutingTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -467,6 +470,7 @@
 				A1C0F19329000000APIKEY04 /* BundledKeyResolutionTests.swift in Sources */,
 				DDDD443100000000000443B2 /* DurableTrainingDayIdTests.swift in Sources */,
 				A5C0FFEE0000000000ASC002 /* ActiveSessionCoordinatorTests.swift in Sources */,
+				DF8EC3D0BD96C780A4A12C9C /* RunDayRoutingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -335,6 +335,30 @@ struct ContentView: View {
         }
     }
 
+    /// Pure render-target resolver for the Workout tab (#441). Sources the hosted
+    /// day from the RUN day the coordinator reports (live or paused), never from
+    /// sticky view state — so leaving a resumed session without reaching Done can no
+    /// longer pin a stale day (the STATE-4 bug). Returns the coordinator's active day
+    /// when it is non-nil, differs from `nextIncomplete`, and resolves in the
+    /// mesocycle; otherwise falls back to `nextIncomplete`. Self-healing: when the
+    /// session ends the coordinator goes `.idle` → `coordinatorActiveDayId` is nil →
+    /// this returns `nextIncomplete` again automatically.
+    static func hostDay(
+        nextIncomplete: TrainingDay,
+        coordinatorActiveDayId: UUID?,
+        mesocycle: Mesocycle
+    ) -> TrainingDay {
+        guard let activeId = coordinatorActiveDayId, activeId != nextIncomplete.id else {
+            return nextIncomplete
+        }
+        for week in mesocycle.weeks {
+            if let day = week.trainingDays.first(where: { $0.id == activeId }) {
+                return day
+            }
+        }
+        return nextIncomplete
+    }
+
     /// The Workout tab. Routes to `WorkoutView` with the first non-completed day
     /// in the mesocycle. Shows a programme-complete state when all days are done,
     /// or a no-program state when no mesocycle is loaded.

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -377,33 +377,38 @@ struct ContentView: View {
                 let allDays = mesocycle.weeks.flatMap { $0.trainingDays }
                 // Skipped sessions advance the programme pointer and count toward progress (#445).
                 let completedCount = mesocycle.completedDayCount
+                // #441: the hosted day comes from the coordinator's RUN day (live or
+                // paused), never sticky view state. Self-heals to nextIncompleteDay when
+                // the session ends (coordinator → .idle → both ids nil).
+                let coordinatorActiveDayId = deps.activeSessionCoordinator.liveTrainingDayId
+                    ?? deps.activeSessionCoordinator.pausedTrainingDayId
+                let hostedDay = ContentView.hostDay(
+                    nextIncomplete: day,
+                    coordinatorActiveDayId: coordinatorActiveDayId,
+                    mesocycle: mesocycle
+                )
                 // NavigationStack is required so WorkoutView (and its children) can render
                 // their toolbar items and so WorkoutView pushed from ProgramDayDetailView
                 // has a consistent navigation context. WorkoutView no longer owns an
                 // inner NavigationStack.
                 NavigationStack {
                     WorkoutView(
-                        trainingDay: crashResumeDay ?? day,
+                        trainingDay: hostedDay,
                         programId: mesocycle.id,
                         weekNumber: week.weekNumber,
                         completedDayCount: completedCount,
                         totalDayCount: allDays.count,
-                        onSessionCompleted: {
-                            // Crash-resume path: the resumed day may differ from `day` —
-                            // find its week via the mesocycle rather than assuming `week`.
-                            if let resumeDay = crashResumeDay,
-                               let found = vm.findTrainingDay(byId: resumeDay.id, in: mesocycle) {
+                        onSessionCompleted: { runDayId in
+                            // #441: route the mark by the RUN day's id — WorkoutView's
+                            // #436 guard proves runDayId is the day the actor ran. Resolve
+                            // its week via the mesocycle rather than assuming `week`.
+                            if let found = vm.findTrainingDay(byId: runDayId, in: mesocycle) {
                                 programViewModel?.markDayCompleted(dayId: found.day.id, weekId: found.week.id)
-                            } else {
-                                programViewModel?.markDayCompleted(dayId: day.id, weekId: week.id)
                             }
                         },
-                        onSessionPaused: {
-                            if let resumeDay = crashResumeDay,
-                               let found = vm.findTrainingDay(byId: resumeDay.id, in: mesocycle) {
+                        onSessionPaused: { runDayId in
+                            if let found = vm.findTrainingDay(byId: runDayId, in: mesocycle) {
                                 programViewModel?.markDayPaused(dayId: found.day.id, weekId: found.week.id)
-                            } else {
-                                programViewModel?.markDayPaused(dayId: day.id, weekId: week.id)
                             }
                         },
                         onSessionDismissed: {
@@ -413,34 +418,24 @@ struct ContentView: View {
                             Task { @MainActor in
                                 await programViewModel?.loadProgram()
                                 selectedTab = 0
-                                crashResumeToPass = nil
-                                crashResumeDay = nil
                                 programViewModel?.scrollToCurrentWeekTrigger += 1
                             }
                         },
-                        resumeState: crashResumeToPass,
-                        onSkipSession: {
+                        onSkipSession: { runDayId in
                             // Persistent skip — advances programme_day_index, records skippedAt.
-                            // Resolve via crashResumeDay like the completed/paused siblings above
-                            // so a crash-resumed day skips THAT day, not nextIncompleteDay's.
-                            if let resumeDay = crashResumeDay,
-                               let found = vm.findTrainingDay(byId: resumeDay.id, in: mesocycle) {
+                            // Routes to the hosted day's id (skip fires pre-live).
+                            if let found = vm.findTrainingDay(byId: runDayId, in: mesocycle) {
                                 programViewModel?.markDaySkipped(dayId: found.day.id, weekId: found.week.id)
-                            } else {
-                                programViewModel?.markDaySkipped(dayId: day.id, weekId: week.id)
                             }
                         },
                         isGeneratingSession: isGeneratingSession,
-                        onGenerateSession: ((crashResumeDay ?? day).status == .pending && confirmedProfile != nil)
+                        onGenerateSession: (hostedDay.status == .pending && confirmedProfile != nil)
                             ? {
                                 // Generate this not-yet-generated day's session in place.
-                                // Resolve day+week like the completed/paused/skip siblings:
-                                // crashResumeDay takes precedence (matching the render target),
-                                // falling back to nextIncompleteDay's (day, week) pair.
+                                // Resolve the hosted day's week pair from the mesocycle.
                                 let targetDay: TrainingDay
                                 let targetWeek: TrainingWeek
-                                if let resumeDay = crashResumeDay,
-                                   let found = vm.findTrainingDay(byId: resumeDay.id, in: mesocycle) {
+                                if let found = vm.findTrainingDay(byId: hostedDay.id, in: mesocycle) {
                                     targetDay = found.day
                                     targetWeek = found.week
                                 } else {
@@ -456,15 +451,7 @@ struct ContentView: View {
                                 }
                             }
                             : nil,
-                        onCloseToTab0: { selectedTab = 0 },
-                        onResumeStateConsumed: {
-                            // One-shot — clear so subsequent tab swaps into Tab 1 don't re-apply
-                            // the same paused state on top of the now-live (or post-error)
-                            // session. crashResumeDay stays valid until the session ends
-                            // (cleared in onSessionDismissed above) because workoutTab still
-                            // needs it to select the correct trainingDay parameter.
-                            crashResumeToPass = nil
-                        }
+                        onCloseToTab0: { selectedTab = 0 }
                     )
                     // Paused-session banner — shown when a different day is paused and no
                     // session is currently live (i.e. user is on the PreWorkoutView screen).

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -58,13 +58,6 @@ struct ContentView: View {
     @State private var crashRecoveryState: PausedSessionState? = nil
     /// Controls the crash-recovery alert shown once at app launch when a sentinel exists.
     @State private var showCrashRecoveryAlert: Bool = false
-    /// When non-nil, WorkoutView should use this as an explicit resumeState (Path A),
-    /// bypassing the brittle trainingDayId == trainingDay.id guard in Path B.
-    @State private var crashResumeToPass: PausedSessionState? = nil
-    /// When the paused session's trainingDayId resolves to a mesocycle day that is NOT
-    /// nextIncompleteDay, this holds the correct matching day so WorkoutView uses the
-    /// right exercise list for the resume rather than nextIncompleteDay's list.
-    @State private var crashResumeDay: TrainingDay? = nil
     /// True when crash recovery's paused day cannot be found anywhere in the mesocycle.
     @State private var showOrphanedRecoveryAlert: Bool = false
 
@@ -228,27 +221,22 @@ struct ContentView: View {
         }
         .alert("Unfinished Workout", isPresented: $showCrashRecoveryAlert) {
             Button("Resume") {
+                // #441: Resume no longer seeds sticky overrides. It only adjudicates
+                // which alert to show: if the paused sentinel resolves to a real day
+                // anywhere in the mesocycle, switch to the Workout tab — which
+                // self-resumes via the coordinator-driven host. If it resolves nowhere,
+                // show the orphaned-recovery dialog instead.
                 guard let saved = crashRecoveryState,
                       let vm = programViewModel,
                       case .loaded(let mesocycle) = vm.viewState else {
-                    // Programme not loaded yet — fall back to Path B in WorkoutView
+                    // Programme not loaded yet — the Workout tab still self-resumes on appear.
                     selectedTab = 1
                     return
                 }
-                let nextDay = vm.nextIncompleteDay(in: mesocycle)?.day
-                if nextDay?.id == saved.trainingDayId {
-                    // Normal case: pass as explicit resumeState so Path A fires reliably
-                    crashResumeToPass = saved
-                    selectedTab = 1
-                } else if let foundResult = vm.findTrainingDay(byId: saved.trainingDayId, in: mesocycle) {
-                    // Paused day found elsewhere in the mesocycle — pass both the correct
-                    // training day and the resume state so WorkoutView uses the right exercise list.
-                    crashResumeToPass = saved
-                    crashResumeDay = foundResult.day
+                if vm.findTrainingDay(byId: saved.trainingDayId, in: mesocycle) != nil {
                     selectedTab = 1
                 } else {
                     // Paused day not found anywhere — can't properly resume.
-                    // Show the orphaned recovery dialog instead of switching tabs.
                     showOrphanedRecoveryAlert = true
                 }
             }
@@ -259,8 +247,6 @@ struct ContentView: View {
                     }
                 }
                 crashRecoveryState = nil
-                crashResumeToPass = nil
-                crashResumeDay = nil
             }
         } message: {
             Text(crashRecoveryMessage)
@@ -274,7 +260,6 @@ struct ContentView: View {
                     _ = saved  // acknowledged
                 }
                 crashRecoveryState = nil
-                crashResumeToPass = nil
                 PausedSessionState.clear()
             }
             Button("Discard", role: .destructive) {
@@ -284,7 +269,6 @@ struct ContentView: View {
                     }
                 }
                 crashRecoveryState = nil
-                crashResumeToPass = nil
             }
         } message: {
             Text("Your previous workout couldn't be matched to the current programme. You can preserve the sets that were logged, or discard the session entirely.")

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -86,10 +86,14 @@ struct WorkoutView: View {
     var totalDayCount: Int = 0
     /// Called when the session transitions to .sessionComplete (not early exit).
     /// Used by ProgramDayDetailView to mark the day as completed in the calendar.
-    var onSessionCompleted: (() -> Void)? = nil
+    /// The argument is the RUN day's id (`trainingDay.id` — proven to be the day the
+    /// actor ran by the #436 guard at the completion instant) so the host routes the
+    /// mark by id instead of a sticky pointer (#441).
+    var onSessionCompleted: ((UUID) -> Void)? = nil
     /// Called when the session is paused mid-workout.
     /// Used by ProgramDayDetailView to mark the day as paused in the calendar.
-    var onSessionPaused: (() -> Void)? = nil
+    /// Argument is the RUN day's id (#441).
+    var onSessionPaused: ((UUID) -> Void)? = nil
     /// Called after the user dismisses the PostWorkoutSummaryView (taps "Done").
     /// Fires after the reset animation completes so the tab switch is not jarring.
     var onSessionDismissed: (() -> Void)? = nil
@@ -98,7 +102,9 @@ struct WorkoutView: View {
     /// 0-based exercise index to start from when beginning a new session (0 = first exercise).
     var startingExerciseIndex: Int = 0
     /// Called when the user taps "Skip this session" on the pre-workout screen.
-    var onSkipSession: (() -> Void)? = nil
+    /// Argument is the hosted day's id (#441 — skip fires pre-live, so the hosted
+    /// `trainingDay.id` is the day to skip).
+    var onSkipSession: ((UUID) -> Void)? = nil
     /// True while a not-yet-generated day's session is being generated in place
     /// (ProgramViewModel.viewState == .generatingSession). Drives the spinner on
     /// the "Generate Session" CTA in PreWorkoutView.
@@ -243,7 +249,7 @@ struct WorkoutView: View {
                 // .sessionComplete transition (cleared only on resetToIdle), so it still
                 // names the day the actor ran here.
                 guard viewModel?.liveSessionDayId == trainingDay.id else { return }
-                onSessionCompleted?()
+                onSessionCompleted?(trainingDay.id)
                 // Re-fetch streak after session completion so PostWorkoutSummaryView
                 // and the next PreWorkoutView both show the updated value.
                 Task {
@@ -258,7 +264,7 @@ struct WorkoutView: View {
             // currently-rendered day as paused (amendment 2.1).
             if case .idle = newState {
                 if PausedSessionState.load()?.trainingDayId == trainingDay.id {
-                    onSessionPaused?()
+                    onSessionPaused?(trainingDay.id)
                 }
             }
         }
@@ -391,7 +397,8 @@ struct WorkoutView: View {
                 },
                 calibrationWatermarkFiredAt: calibrationWatermarkFiredAt,
                 calibrationWatermarkRecalibratedAtSessionCount: calibrationWatermarkRecalibratedAtSessionCount,
-                onSkipSession: onSkipSession,
+                // #441: skip fires pre-live — route to the hosted day's id.
+                onSkipSession: onSkipSession.map { skip in { skip(trainingDay.id) } },
                 onBack: onBack,
                 onCloseToTab0: onCloseToTab0,
                 isGeneratingSession: isGeneratingSession,

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -97,8 +97,6 @@ struct WorkoutView: View {
     /// Called after the user dismisses the PostWorkoutSummaryView (taps "Done").
     /// Fires after the reset animation completes so the tab switch is not jarring.
     var onSessionDismissed: (() -> Void)? = nil
-    /// When non-nil, the view resumes this paused session instead of starting fresh.
-    var resumeState: PausedSessionState? = nil
     /// 0-based exercise index to start from when beginning a new session (0 = first exercise).
     var startingExerciseIndex: Int = 0
     /// Called when the user taps "Skip this session" on the pre-workout screen.
@@ -118,11 +116,6 @@ struct WorkoutView: View {
     /// Called when the user taps the × close button on the Tab 1 entry path (idle only).
     /// Switches the tab bar to Tab 0 without touching actor state.
     var onCloseToTab0: (() -> Void)? = nil
-    /// Fires after WorkoutView has applied `resumeState` (success or error). ContentView
-    /// uses this to clear its `crashResumeToPass` one-shot so a later Tab 1 re-entry
-    /// (e.g. after the user pauses, swaps to Tab 0, then back) doesn't re-apply the
-    /// same resume on top of an already-recovered session.
-    var onResumeStateConsumed: (() -> Void)? = nil
 
     // MARK: - Body
 
@@ -206,34 +199,18 @@ struct WorkoutView: View {
                 return
             }
 
-            if let resume = resumeState {
-                // Explicit resume path — guard against a stale resumeState whose trainingDayId
-                // no longer matches the training day ContentView passed in (e.g. programme
-                // regenerated between crash and relaunch, or "found elsewhere" race).
-                guard resume.trainingDayId == trainingDay.id else {
-                    await deps.workoutSessionManager.flushWriteAheadQueue()
-                    await deps.workoutSessionManager.abandonSession(sessionId: resume.sessionId)
-                    vm.sessionState = .error("We couldn't find your previous session — it may have been reset. Your logged sets have been saved.")
-                    onResumeStateConsumed?()
-                    return
-                }
-                performResume(resume, vm: vm)
-                onResumeStateConsumed?()
-            } else if let saved = PausedSessionState.load() {
+            // #441: single resume path. The coordinator-driven host guarantees this
+            // view's `trainingDay` already equals the coordinator's paused/live day, so
+            // the former explicit-resumeState (Path A) vs PausedSessionState.load()
+            // (Path B) distinction is moot. The mismatch alert is the single failure
+            // surface; the isIdle gate prevents double-resumption when the actor was
+            // already revived by an earlier path (e.g. the .task re-firing post-navigation).
+            if let saved = PausedSessionState.load() {
                 guard saved.trainingDayId == trainingDay.id else {
-                    // Mismatch: a paused session exists but doesn't match this training day.
-                    // ContentView normally handles this via its routing logic (Path A);
-                    // this branch is a safety net for edge cases ContentView didn't catch.
                     mismatchSavedState = saved
                     showMismatchRecoveryAlert = true
                     return
                 }
-                // Crash recovery path — user accepted the recovery alert in ContentView.
-                // The PausedSessionState is still present (ContentView only clears it on Abandon).
-                // Silently resume so the user lands directly in the active session. The
-                // isIdle gate prevents double-resumption when the actor was already revived
-                // by an earlier path (e.g. ContentView's crash-recovery alert fired Path A
-                // and the .task here is now re-firing post-navigation).
                 let isIdle = await deps.workoutSessionManager.sessionState == .idle
                 if isIdle {
                     performResume(saved, vm: vm)
@@ -535,11 +512,9 @@ struct WorkoutView: View {
 
     // MARK: - Resume helper
 
-    /// Single resume call so the two resume paths (explicit `resumeState` from
-    /// ContentView's crash-recovery alert, and the fallback `PausedSessionState.load()`
-    /// branch) can't drift apart on the argument list. Failure handling stays
-    /// per-path because the two flows surface different UI (error state vs.
-    /// mismatch alert).
+    /// Single resume call for the one (#441) resume path: the durable
+    /// `PausedSessionState.load()` branch. The mismatch alert is the only failure
+    /// surface, so this helper just delegates to the view model.
     private func performResume(_ state: PausedSessionState, vm: WorkoutViewModel) {
         vm.resumeSession(
             pausedState: state,

--- a/ProjectApexTests/RunDayRoutingTests.swift
+++ b/ProjectApexTests/RunDayRoutingTests.swift
@@ -1,0 +1,399 @@
+// RunDayRoutingTests.swift
+// ProjectApexTests
+//
+// #441 — retire the sticky `crashResumeDay` / `crashResumeToPass` overrides in
+// ContentView. Completion routing and the hosted day are now sourced from the
+// RUN day (the actor's live/paused day via the coordinator + liveSessionDayId),
+// never from sticky view state. These tests pin the run-day invariants:
+//
+//   • liveSessionDayId always names the day the actor actually ran (start OR resume),
+//   • it survives .sessionComplete and is cleared on resetToIdle,
+//   • markDay* routes purely by (dayId, weekId),
+//   • the STATE-4 regression: resume B → leave without Done → start A routes to A,
+//   • the pure `ContentView.hostDay(...)` render-target helper,
+//   • resume is idempotent under a second call.
+//
+// Mirrors the file-private helpers in ActiveSessionCoordinatorTests (real
+// WorkoutSessionManager actor, ephemeral UserDefaults suite, sentinel clearing
+// in setUp/tearDown).
+
+import XCTest
+import Foundation
+@testable import ProjectApex
+
+// MARK: - Local test helpers (file-private, mirroring ActiveSessionCoordinatorTests)
+
+private struct RDRMockLLMProvider: LLMProvider {
+    let response: String
+    func complete(systemPrompt: String, userPayload: String) async throws -> String {
+        response
+    }
+}
+
+/// Always returns HTTP 201 — prevents real network calls and WAQ retry loops.
+private final class RDRAlwaysSucceedURLProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 201,
+            httpVersion: nil, headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("[]".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+private func makeTestSupabase() -> SupabaseClient {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [RDRAlwaysSucceedURLProtocol.self]
+    return SupabaseClient(
+        supabaseURL: URL(string: "https://test.supabase.co")!,
+        anonKey: "test-key",
+        urlSession: URLSession(configuration: config)
+    )
+}
+
+private func prescriptionJSON() -> String {
+    """
+    {
+      "set_prescription": {
+        "weight_kg": 80.0,
+        "reps": 8,
+        "tempo": "3-1-1-0",
+        "rir_target": 2,
+        "rest_seconds": 120,
+        "coaching_cue": "Drive through the bar",
+        "reasoning": "Based on recent performance trend.",
+        "safety_flags": [],
+        "intent": "top",
+        "set_framing": "Heaviest work of the day. Brace and grind."
+      }
+    }
+    """
+}
+
+private func makeManager() -> WorkoutSessionManager {
+    let inferenceService = AIInferenceService(
+        provider: RDRMockLLMProvider(response: prescriptionJSON()),
+        gymProfile: nil,
+        maxRetries: 0
+    )
+    let supabase = makeTestSupabase()
+    let memoryService = MemoryService(supabase: supabase, embeddingAPIKey: "")
+    let suiteName = "com.test.rdr.\(UUID().uuidString)"
+    let testDefaults = UserDefaults(suiteName: suiteName)!
+    let gymFactStore = GymFactStore(userDefaults: testDefaults)
+    let waq = WriteAheadQueue(supabase: supabase, userDefaults: testDefaults)
+    return WorkoutSessionManager(
+        aiInference: inferenceService,
+        healthKit: HealthKitService(),
+        memoryService: memoryService,
+        supabase: supabase,
+        gymFactStore: gymFactStore,
+        writeAheadQueue: waq
+    )
+}
+
+private func makeTrainingDay(
+    label: String = "Push_A",
+    exerciseCount: Int = 2,
+    setsPerExercise: Int = 2
+) -> TrainingDay {
+    let exercises = (0..<exerciseCount).map { i in
+        PlannedExercise(
+            id: UUID(),
+            exerciseId: "exercise_\(i)",
+            name: "Exercise \(i)",
+            primaryMuscle: "pectoralis_major",
+            synergists: ["triceps_brachii"],
+            equipmentRequired: .barbell,
+            sets: setsPerExercise,
+            repRange: RepRange(min: 6, max: 10),
+            tempo: "3-1-1-0",
+            restSeconds: 90,
+            rirTarget: 2,
+            coachingCues: ["Focus on form"]
+        )
+    }
+    return TrainingDay(
+        id: UUID(),
+        dayOfWeek: 1,
+        dayLabel: label,
+        exercises: exercises,
+        sessionNotes: nil
+    )
+}
+
+/// Creates a ProgramViewModel backed by no-op services (mirrors SkipFeatureTests'
+/// factory). Only the pure mark/route methods are exercised — no network calls.
+@MainActor
+private func makeProgramViewModel() -> ProgramViewModel {
+    let supabase = makeTestSupabase()
+    let provider: any LLMProvider = RDRMockLLMProvider(response: "{}")
+    let memory = MemoryService(supabase: supabase, embeddingAPIKey: "test")
+    return ProgramViewModel(
+        supabaseClient: supabase,
+        programGenerationService: ProgramGenerationService(provider: provider),
+        macroPlanService: MacroPlanService(provider: provider),
+        sessionPlanService: SessionPlanService(
+            provider: provider,
+            memoryService: memory,
+            supabaseClient: supabase
+        ),
+        userId: UUID(),
+        resolveOwner: { UUID() }
+    )
+}
+
+/// Builds a single-week mesocycle from the supplied days so the pure `hostDay`
+/// helper has a real lookup surface.
+private func makeMesocycle(days: [TrainingDay]) -> Mesocycle {
+    let week = TrainingWeek(
+        id: UUID(),
+        weekNumber: 1,
+        phase: .accumulation,
+        trainingDays: days
+    )
+    return Mesocycle(
+        id: UUID(),
+        userId: UUID(),
+        createdAt: Date(),
+        isActive: true,
+        weeks: [week],
+        totalWeeks: 12,
+        periodizationModel: "linear_periodization"
+    )
+}
+
+// MARK: - RunDayRoutingTests
+
+@MainActor
+final class RunDayRoutingTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        PausedSessionState.clear()
+    }
+
+    override func tearDown() {
+        PausedSessionState.clear()
+        super.tearDown()
+    }
+
+    // 1. After a fresh start, liveSessionDayId equals the started day.
+    func testLiveSessionDayId_afterStartSession_equalsStartedDay() async throws {
+        let manager = makeManager()
+        let vm = WorkoutViewModel(manager: manager)
+        let dayA = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+
+        await manager.startSession(trainingDay: dayA, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+        await vm.pullState()
+
+        XCTAssertEqual(vm.liveSessionDayId, dayA.id,
+            "liveSessionDayId must name the day the actor actually started")
+    }
+
+    // 2. After a resume, liveSessionDayId equals the RESUMED day — not nextIncompleteDay.
+    func testLiveSessionDayId_afterResume_equalsResumedDay_notNextIncompleteDay() async throws {
+        let manager = makeManager()
+        let vm = WorkoutViewModel(manager: manager)
+        // dayA would be nextIncompleteDay; dayB is the paused day we resume.
+        let dayA = makeTrainingDay(label: "Push_A", exerciseCount: 1, setsPerExercise: 1)
+        let dayB = makeTrainingDay(label: "Pull_B", exerciseCount: 2, setsPerExercise: 2)
+        XCTAssertNotEqual(dayA.id, dayB.id)
+
+        let paused = PausedSessionState(
+            sessionId: UUID(),
+            trainingDayId: dayB.id,
+            weekId: UUID(),
+            weekNumber: 1,
+            exerciseIndex: 0,
+            currentSetNumber: 1,
+            dayType: dayB.dayLabel,
+            programId: UUID(),
+            userId: UUID(),
+            pausedAt: Date(),
+            exerciseSignature: PausedSessionState.exerciseSignature(for: dayB)
+        )
+
+        let resumed = await manager.resumeSession(
+            pausedState: paused, trainingDay: dayB, completedSetLogs: []
+        )
+        XCTAssertTrue(resumed, "precondition: resume must succeed for a matching signature")
+        try await Task.sleep(nanoseconds: 200_000_000)
+        await vm.pullState()
+
+        XCTAssertEqual(vm.liveSessionDayId, dayB.id,
+            "after resume the live day is the resumed day B")
+        XCTAssertNotEqual(vm.liveSessionDayId, dayA.id,
+            "the resumed day must NOT be confused with nextIncompleteDay (A)")
+    }
+
+    // 3. liveSessionDayId survives the .sessionComplete transition.
+    func testLiveSessionDayId_survivesSessionComplete() async throws {
+        let manager = makeManager()
+        let vm = WorkoutViewModel(manager: manager)
+        let dayA = makeTrainingDay(exerciseCount: 1, setsPerExercise: 2)
+
+        await manager.startSession(trainingDay: dayA, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // Log one set so endSessionEarly produces a real summary (not the zero-set → idle guard).
+        await manager.completeSet(actualReps: 8, rpeFelt: 7, intent: .top)
+        await manager.endSessionEarly()
+        await vm.pullState()
+
+        if case .sessionComplete = vm.sessionState {} else {
+            XCTFail("Expected .sessionComplete after endSessionEarly, got \(vm.sessionState)")
+        }
+        XCTAssertEqual(vm.liveSessionDayId, dayA.id,
+            "liveSessionDayId must survive .sessionComplete (cleared only on resetToIdle)")
+    }
+
+    // 4. markDay* routes purely by (dayId, weekId) — marking B leaves A untouched.
+    func testMarkDayCompleted_routesByDayId_notProgrammePointer() async {
+        let dayA = makeTrainingDay(label: "Push_A")
+        let dayB = makeTrainingDay(label: "Pull_B")
+        let meso = makeMesocycle(days: [dayA, dayB])
+        let week = meso.weeks[0]
+
+        let vm = makeProgramViewModel()
+        vm.currentMesocycle = meso   // markDay* reads currentMesocycle, not viewState
+        vm.viewState = .loaded(meso)
+
+        // Mark B complete by id; nextIncompleteDay (A) must stay non-terminal.
+        vm.markDayCompleted(dayId: dayB.id, weekId: week.id)
+
+        guard case .loaded(let updated) = vm.viewState else {
+            XCTFail("viewState should remain .loaded"); return
+        }
+        let updatedA = updated.weeks[0].trainingDays.first { $0.id == dayA.id }
+        let updatedB = updated.weeks[0].trainingDays.first { $0.id == dayB.id }
+        XCTAssertEqual(updatedB?.status, .completed, "B was marked complete by its id")
+        XCTAssertFalse(updatedA?.isTerminal ?? true,
+            "A (nextIncompleteDay) must be untouched — routing is by id, not programme pointer")
+    }
+
+    // 5. THE STATE-4 regression: resume B (live=B) → leave without Done (resetToIdle)
+    //    → start fresh A → liveSessionDayId == A, never the stale B.
+    func testResumeThenAbandonWithoutDone_nextSessionRoutesToOwnDay() async throws {
+        let manager = makeManager()
+        let vm = WorkoutViewModel(manager: manager)
+        let dayA = makeTrainingDay(label: "Push_A", exerciseCount: 1, setsPerExercise: 1)
+        let dayB = makeTrainingDay(label: "Pull_B", exerciseCount: 2, setsPerExercise: 2)
+
+        // Resume B.
+        let paused = PausedSessionState(
+            sessionId: UUID(),
+            trainingDayId: dayB.id,
+            weekId: UUID(),
+            weekNumber: 1,
+            exerciseIndex: 0,
+            currentSetNumber: 1,
+            dayType: dayB.dayLabel,
+            programId: UUID(),
+            userId: UUID(),
+            pausedAt: Date(),
+            exerciseSignature: PausedSessionState.exerciseSignature(for: dayB)
+        )
+        let resumed = await manager.resumeSession(
+            pausedState: paused, trainingDay: dayB, completedSetLogs: []
+        )
+        XCTAssertTrue(resumed)
+        try await Task.sleep(nanoseconds: 200_000_000)
+        await vm.pullState()
+        XCTAssertEqual(vm.liveSessionDayId, dayB.id, "precondition: live day is the resumed B")
+
+        // Leave WITHOUT reaching Done — the actor goes back to idle.
+        await manager.resetToIdle()
+        await vm.pullState()
+        XCTAssertNil(vm.liveSessionDayId, "after leaving without Done the actor is idle")
+
+        // Start a fresh session for A.
+        await manager.startSession(trainingDay: dayA, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+        await vm.pullState()
+
+        XCTAssertEqual(vm.liveSessionDayId, dayA.id,
+            "STATE-4: the next session must route to its OWN day A, never the stale resumed B")
+        XCTAssertNotEqual(vm.liveSessionDayId, dayB.id)
+    }
+
+    // 6a. Pure helper: nil coordinator active id → falls back to nextIncompleteDay.
+    func testHostDay_fallsBackToNextIncomplete_whenCoordinatorActiveDayIdNil() {
+        let dayA = makeTrainingDay(label: "Push_A")
+        let dayB = makeTrainingDay(label: "Pull_B")
+        let meso = makeMesocycle(days: [dayA, dayB])
+
+        let host = ContentView.hostDay(
+            nextIncomplete: dayA,
+            coordinatorActiveDayId: nil,
+            mesocycle: meso
+        )
+        XCTAssertEqual(host.id, dayA.id,
+            "a nil coordinator active id hosts nextIncompleteDay")
+    }
+
+    // 6b. Pure helper: a coordinator active id that differs and resolves → hosts that day.
+    func testHostDay_returnsCoordinatorDay_whenDiffersAndResolvable() {
+        let dayA = makeTrainingDay(label: "Push_A")
+        let dayB = makeTrainingDay(label: "Pull_B")
+        let meso = makeMesocycle(days: [dayA, dayB])
+
+        // Coordinator is live/paused for B while nextIncompleteDay is A.
+        let host = ContentView.hostDay(
+            nextIncomplete: dayA,
+            coordinatorActiveDayId: dayB.id,
+            mesocycle: meso
+        )
+        XCTAssertEqual(host.id, dayB.id,
+            "when the coordinator's day differs from nextIncomplete AND resolves, host it")
+
+        // An unresolvable id falls back to nextIncompleteDay.
+        let hostUnresolvable = ContentView.hostDay(
+            nextIncomplete: dayA,
+            coordinatorActiveDayId: UUID(),
+            mesocycle: meso
+        )
+        XCTAssertEqual(hostUnresolvable.id, dayA.id,
+            "an unresolvable coordinator id falls back to nextIncompleteDay")
+    }
+
+    // 7. Resume is idempotent under a second call — the second resume returns false.
+    func testResume_isIdempotentUnderSecondCall_doesNotDoubleResume() async throws {
+        let manager = makeManager()
+        let dayB = makeTrainingDay(label: "Pull_B", exerciseCount: 2, setsPerExercise: 2)
+
+        let paused = PausedSessionState(
+            sessionId: UUID(),
+            trainingDayId: dayB.id,
+            weekId: UUID(),
+            weekNumber: 1,
+            exerciseIndex: 0,
+            currentSetNumber: 1,
+            dayType: dayB.dayLabel,
+            programId: UUID(),
+            userId: UUID(),
+            pausedAt: Date(),
+            exerciseSignature: PausedSessionState.exerciseSignature(for: dayB)
+        )
+
+        let first = await manager.resumeSession(
+            pausedState: paused, trainingDay: dayB, completedSetLogs: []
+        )
+        XCTAssertTrue(first, "first resume succeeds")
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        let second = await manager.resumeSession(
+            pausedState: paused, trainingDay: dayB, completedSetLogs: []
+        )
+        XCTAssertFalse(second, "a second resume against an already-live actor must be a no-op")
+
+        let liveDay = await manager.currentTrainingDayId
+        XCTAssertEqual(liveDay, dayB.id, "the single live session is still for the resumed day B")
+    }
+}


### PR DESCRIPTION
## What & why
Final piece of the Programme↔Workout seam cure (parent #435; findings STATE-5/STATE-4). Builds on #440's `ActiveSessionCoordinator`.

`crashResumeDay` was a sticky `@State` cleared only after reaching the Done button. If a user resumed a "found-elsewhere" day (setting `crashResumeDay`) then left without finishing — paused, swapped tabs, the view re-hosted `nextIncompleteDay` — `crashResumeDay` stayed non-nil, so a later completion/pause/skip of `nextIncompleteDay` routed through the `if let crashResumeDay` fork and marked the **wrong (stale) day** (STATE-4). The render target `crashResumeDay ?? day` re-hosted the stale day too.

This deletes the sticky overrides entirely and sources BOTH the hosted day and completion routing from the single coordinator/actor run-day, so the divergence that caused wrong-day completion is structurally impossible, not merely patched.

## Changes
- New pure, unit-testable `ContentView.hostDay(nextIncomplete:coordinatorActiveDayId:mesocycle:)` — hosts the coordinator's live/paused day when it differs from `nextIncompleteDay` and is resolvable, else `nextIncompleteDay`. Self-healing: coordinator `.idle` → falls back automatically (no sticky state to forget to clear). Wired at the render target and the generate-CTA gate.
- Completion callbacks (`onSessionCompleted`/`onSessionPaused`/`onSkipSession`) changed to `((UUID) -> Void)?` and invoked with the run day (`trainingDay.id`), which the #436 guard proves is the actor's run day at the completion instant. ContentView resolves the week via `findTrainingDay(byId:)` and marks by id — no `crashResumeDay` fork.
- Single resume path: Path A (explicit `resumeState`) deleted; only the durable `PausedSessionState.load()` path remains, with the `isIdle` anti-double-resume gate and the mismatch alert as the single failure surface. `resumeState`/`onResumeStateConsumed` params removed.
- Crash-recovery "Unfinished Workout" alert kept (still adjudicates resume-vs-orphaned); "Resume" stops seeding sticky state and just sets `selectedTab = 1` — the tab self-resumes on appear.
- `crashResumeDay` / `crashResumeToPass` and all their assignments deleted.

## Acceptance criteria (both met)
- [x] `crashResumeDay` no longer exists; `markDay*` route to the run day.
- [x] Single resume path; leaving a resumed session without Done no longer misroutes completion.

## Tests (green — 46 incl. existing)
New `RunDayRoutingTests` (8): run-day identity for fresh + resumed + post-complete sessions, mark-by-id, the STATE-4 leave-without-Done regression, and the pure `hostDay` helper (the genuinely red-first test). Note: the routing fix itself is ContentView (View) code not directly unit-testable; independent adversarial review manually reconstructed the STATE-4 scenario against the new code and confirmed the misroute is now structurally impossible.

## Follow-up / out of scope
Pre-existing NIT (predates #441): the paused banner compares against `day.id` not `hostedDay.id` — a brief cosmetic only, hidden by live-wins suppression.

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)