### PR TITLE
fix(#458): read coordinator live identity from one atomic uiSnapshot()

### DIFF
--- a/ProjectApex/App/ActiveSessionCoordinator.swift
+++ b/ProjectApex/App/ActiveSessionCoordinator.swift
@@ -70,19 +70,21 @@ final class ActiveSessionCoordinator {
     /// precedence, and republishes `session` + `liveSetSummary`. Exposed (and
     /// async) so tests can drive it deterministically without waiting on the timer.
     func refresh() async {
-        let state    = await manager.sessionState
-        let activeId = await manager.currentTrainingDayId
-        let sessionId = await manager.currentSessionId
+        // One atomic actor hop for the whole live identity (state + dayId + sessionId
+        // + set progress). Reading these as separate awaits could tear — the actor can
+        // advance between hops — so a future change might publish a day from one instant
+        // and a session id from another. uiSnapshot() captures them together (#458).
+        let snapshot = await manager.uiSnapshot()
         let live: Bool
-        switch state {
+        switch snapshot.sessionState {
         case .idle, .sessionComplete, .error: live = false
         default: live = true
         }
 
-        if live, let activeId, let sessionId {
+        if live, let activeId = snapshot.currentTrainingDayId, let sessionId = snapshot.currentSessionId {
             // Live wins over any stale paused sentinel.
             session = .live(dayId: activeId, sessionId: sessionId)
-            let sets = await manager.completedSets
+            let sets = snapshot.completedSets
             let last = sets.max(by: { $0.loggedAt < $1.loggedAt })
             liveSetSummary = LiveSetSummary(
                 setsCompleted: sets.count,

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -75,6 +75,10 @@ nonisolated struct WorkoutUISnapshot: Sendable {
     /// through .sessionComplete (cleared only on resetToIdle) so the view can
     /// verify a completion belongs to the day it was handed (#436 day-identity guard).
     let currentTrainingDayId: UUID?
+    /// The session UUID for the currently active session (nil when idle/complete).
+    /// Carried so ActiveSessionCoordinator reads the whole live identity (state +
+    /// dayId + sessionId) in ONE atomic hop rather than three separate awaits (#458).
+    let currentSessionId: UUID?
     let currentPrescription: SetPrescription?
     let currentFallbackReason: FallbackReason?
     let restSecondsRemaining: Int
@@ -1691,6 +1695,7 @@ actor WorkoutSessionManager {
         return WorkoutUISnapshot(
             sessionState: sessionState,
             currentTrainingDayId: currentTrainingDayId,
+            currentSessionId: currentSessionId,
             currentPrescription: currentPrescription,
             currentFallbackReason: currentFallbackReason,
             restSecondsRemaining: restSecondsRemaining,

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -1309,6 +1309,35 @@ final class WorkoutSessionManagerTests: XCTestCase {
         XCTAssertNil(afterReset, "currentSessionId must be cleared on resetToIdle")
     }
 
+    // MARK: #458 — uiSnapshot carries the session identity for one atomic coordinator read
+
+    /// ActiveSessionCoordinator derives .live(dayId:sessionId:) every poll. Reading
+    /// state + dayId + sessionId as three separate actor awaits could tear (the actor
+    /// can advance between hops). uiSnapshot() already returns state + dayId atomically;
+    /// it must also carry currentSessionId so the coordinator reads the whole live
+    /// identity in ONE hop. This pins the new snapshot field.
+    func testUISnapshot_carriesCurrentSessionId_consistentWithState() async throws {
+        let manager = makeManager()
+        let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+
+        let idleSnap = await manager.uiSnapshot()
+        XCTAssertNil(idleSnap.currentSessionId, "currentSessionId must be nil in an idle snapshot")
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        let liveSnap = await manager.uiSnapshot()
+        let actorSessionId = await manager.currentSessionId
+        XCTAssertNotNil(liveSnap.currentSessionId, "currentSessionId must be present in a live snapshot")
+        XCTAssertEqual(liveSnap.currentSessionId, actorSessionId, "snapshot sessionId must match the actor's isolated value")
+        XCTAssertEqual(liveSnap.currentTrainingDayId, day.id, "snapshot dayId must reference the started day")
+        XCTAssertNotEqual(liveSnap.currentSessionId, liveSnap.currentTrainingDayId, "session and day UUIDs must not be conflated")
+
+        await manager.resetToIdle()
+        let resetSnap = await manager.uiSnapshot()
+        XCTAssertNil(resetSnap.currentSessionId, "currentSessionId must be nil after resetToIdle")
+    }
+
     // MARK: #369 [19] — retryInference participates in the generation guard
 
     /// A retry result that resolves AFTER the session has advanced (generation bumped


### PR DESCRIPTION
## What & why
Follow-up from #440 (keystone). `ActiveSessionCoordinator.refresh()` read `sessionState`, `currentTrainingDayId`, and `currentSessionId` as three separate actor `await`s (plus a fourth for `completedSets`), so the reads could tear — the actor can advance between hops, so a future change could publish a day from one instant and a session id from another. That re-introduced the exact anti-pattern `WorkoutUISnapshot` was built to eliminate (#369 [20]).

It was safe in practice (the `if let activeId, let sessionId` guard masked the torn case, never yielding a false `.live`), but fragile. This makes the per-tick live-identity read atomic.

## Changes
- `WorkoutUISnapshot` carries `currentSessionId` (populated in `uiSnapshot()`).
- `refresh()` reads the whole live identity — state + dayId + sessionId + set progress — from a single `uiSnapshot()` hop.
- The F4 paused-branch raw-UserDefaults existence check is unchanged (still no `PausedSessionState.load()` per tick).

## Acceptance criteria (both met)
- [x] `refresh()` reads live identity in a single actor hop.
- [x] No behavior change to the published `ActiveSession` derivation; existing `ActiveSessionCoordinatorTests` stay green.

## Tests (green — 39 incl. existing)
New `testUISnapshot_carriesCurrentSessionId_consistentWithState` (snapshot carries the session id, matching the actor when live, nil when idle/after reset). All 8 `ActiveSessionCoordinatorTests` unchanged and green.

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)