### PR TITLE
fix(#461): deliberate Workout-paused screen, no auto-resume on tab open

### DIFF
--- a/ProjectApex/Features/Workout/WorkoutPausedView.swift
+++ b/ProjectApex/Features/Workout/WorkoutPausedView.swift
@@ -1,0 +1,164 @@
+// Features/Workout/WorkoutPausedView.swift
+// ProjectApex — #461
+//
+// The deliberate "Workout paused" screen. Shown when the Workout tab is opened and a
+// paused sentinel matches the hosted day (actor .idle + matching PausedSessionState).
+// Replaces the old auto-resume-on-appearance behaviour: resuming is now a tap on the
+// Resume button, which calls the same #441 single resume function via `onResume`.
+//
+// Honest data only — the screen reads from the durable sentinel, which carries position
+// (exerciseIndex / currentSetNumber), the day type, and the pause timestamp. It does NOT
+// show a completed-set count or an elapsed-duration timer (those only exist after the
+// network merge inside resume), so the timing line is "Paused at <time>", not a counter.
+//
+// Copy is neutral ("Workout paused") because the single sentinel cannot distinguish a
+// user pause from an app-kill mid-session — both funnel here and both require a tap.
+
+import SwiftUI
+
+struct WorkoutPausedView: View {
+
+    let pausedState: PausedSessionState
+    let trainingDay: TrainingDay
+    /// Deliberate resume — calls the #441 single resume function in the host.
+    let onResume: () -> Void
+    /// Discard the paused session (abandons it and clears the sentinel in the host).
+    let onDiscard: () -> Void
+    /// Open the read-only plan sheet for today's day.
+    let onViewPlan: () -> Void
+
+    private static let amber = Color(red: 1.0, green: 0.65, blue: 0.0)
+    private static let accent = Color(red: 0.25, green: 0.72, blue: 1.0)
+
+    /// Short time-of-day ("4:15 PM"), no date — mirrors ContentView.crashRecoveryMessage.
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return f
+    }()
+
+    private var dayName: String {
+        trainingDay.dayLabel.replacingOccurrences(of: "_", with: " ")
+    }
+
+    private var exerciseProgress: String {
+        let total = trainingDay.exercises.count
+        let current = min(pausedState.exerciseIndex + 1, max(total, 1))
+        return "Exercise \(current) of \(total)"
+    }
+
+    var body: some View {
+        ZStack {
+            // Base background with a subtle amber wash to read as "paused".
+            Color(red: 0.04, green: 0.04, blue: 0.06).ignoresSafeArea()
+            RadialGradient(
+                colors: [Self.amber.opacity(0.14), Color.clear],
+                center: UnitPoint(x: 0.5, y: 0.12),
+                startRadius: 0,
+                endRadius: 380
+            )
+            .ignoresSafeArea()
+            .blendMode(.plusLighter)
+
+            VStack(spacing: 28) {
+                Spacer()
+
+                VStack(spacing: 16) {
+                    Image(systemName: "pause.circle.fill")
+                        .font(.system(size: 60))
+                        .foregroundStyle(Self.amber)
+
+                    Text("Workout paused")
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundStyle(.white)
+
+                    Text(dayName)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.55))
+                }
+
+                // Where you left off — position only (honest from the sentinel).
+                VStack(spacing: 10) {
+                    progressRow(icon: "figure.strengthtraining.traditional", text: exerciseProgress)
+                    progressRow(icon: "number", text: "Set \(pausedState.currentSetNumber)")
+                    progressRow(
+                        icon: "clock",
+                        text: "Paused at \(Self.timeFormatter.string(from: pausedState.pausedAt))"
+                    )
+                }
+                .padding(.horizontal, 22)
+                .padding(.vertical, 18)
+                .frame(maxWidth: .infinity)
+                .background(
+                    .white.opacity(0.05),
+                    in: RoundedRectangle(cornerRadius: 18, style: .continuous)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .stroke(.white.opacity(0.10), lineWidth: 0.5)
+                )
+                .padding(.horizontal, 32)
+
+                Spacer()
+
+                VStack(spacing: 14) {
+                    // Primary — Resume.
+                    Button(action: onResume) {
+                        Text("Resume workout")
+                            .font(.system(size: 17, weight: .bold))
+                            .foregroundStyle(Color(red: 0.04, green: 0.04, blue: 0.06))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 60)
+                            .background(Self.accent, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    }
+                    .accessibilityLabel("Resume workout")
+                    .accessibilityHint("Picks up your paused session where you left off")
+
+                    // Secondary — View today's plan.
+                    Button(action: onViewPlan) {
+                        Text("View today's plan")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.85))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 52)
+                            .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                    .stroke(.white.opacity(0.18), lineWidth: 0.5)
+                            )
+                    }
+                    .accessibilityLabel("View today's plan")
+                    .accessibilityHint("Opens the exercise plan without resuming")
+
+                    // Tertiary — Discard, destructive.
+                    Button(role: .destructive, action: onDiscard) {
+                        Text("Discard workout")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(Color(red: 1.0, green: 0.42, blue: 0.38))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 44)
+                    }
+                    .accessibilityLabel("Discard workout")
+                    .accessibilityHint("Ends the paused session without saving its remaining sets")
+                }
+                .padding(.horizontal, 32)
+                .padding(.bottom, 24)
+            }
+        }
+    }
+
+    private func progressRow(icon: String, text: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.55))
+                .frame(width: 22)
+            Text(text)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.white.opacity(0.90))
+            Spacer()
+        }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -68,6 +68,11 @@ struct WorkoutView: View {
     /// Shows a recovery dialog so the user can choose how to proceed.
     @State private var showMismatchRecoveryAlert = false
     @State private var mismatchSavedState: PausedSessionState? = nil
+    /// #461: a paused sentinel matching THIS day, resolved once on appearance.
+    /// Non-nil drives the deliberate "Workout paused" screen instead of auto-resuming.
+    /// Cleared the moment the user taps Resume or Discard (so the live/preflight render
+    /// takes over and a re-fire of `.task` does not re-surface the screen mid-resume).
+    @State private var pausedForThisDay: PausedSessionState? = nil
     /// True when the user has never completed a session (session_count == 0 in UserDefaults).
     /// Drives the first-session calibration banner in PreWorkoutView (FB-005).
     private var isFirstSession: Bool {
@@ -199,12 +204,12 @@ struct WorkoutView: View {
                 return
             }
 
-            // #441: single resume path. The coordinator-driven host guarantees this
-            // view's `trainingDay` already equals the coordinator's paused/live day, so
-            // the former explicit-resumeState (Path A) vs PausedSessionState.load()
-            // (Path B) distinction is moot. The mismatch alert is the single failure
-            // surface; the isIdle gate prevents double-resumption when the actor was
-            // already revived by an earlier path (e.g. the .task re-firing post-navigation).
+            // #461: viewing the Workout tab no longer auto-resumes a paused session.
+            // We resolve a matching paused sentinel once and surface the deliberate
+            // "Workout paused" screen; resume is a button tap that calls the SAME
+            // `performResume` (#441's single resume FUNCTION — one function, now
+            // triggered by a tap, not by appearance). The day-mismatch guard still
+            // fires the recovery alert here, exactly as before (#436).
             if let saved = PausedSessionState.load() {
                 guard saved.trainingDayId == trainingDay.id else {
                     mismatchSavedState = saved
@@ -213,7 +218,7 @@ struct WorkoutView: View {
                 }
                 let isIdle = await deps.workoutSessionManager.sessionState == .idle
                 if isIdle {
-                    performResume(saved, vm: vm)
+                    pausedForThisDay = saved
                 }
             }
         }
@@ -352,6 +357,28 @@ struct WorkoutView: View {
         switch vm.sessionState {
 
         case .idle, .preflight:
+            if let saved = pausedForThisDay {
+                // #461: a paused session for this day exists — show the deliberate
+                // paused screen. Resume / Discard both clear `pausedForThisDay` first
+                // so the live/preflight render takes over cleanly.
+                WorkoutPausedView(
+                    pausedState: saved,
+                    trainingDay: trainingDay,
+                    onResume: {
+                        pausedForThisDay = nil
+                        performResume(saved, vm: vm)
+                    },
+                    onDiscard: {
+                        pausedForThisDay = nil
+                        Task {
+                            await deps.workoutSessionManager.abandonSession(sessionId: saved.sessionId)
+                        }
+                    },
+                    onViewPlan: {
+                        vm.showSessionPlanSheet = true
+                    }
+                )
+            } else {
             PreWorkoutView(
                 viewModel: vm,
                 trainingDay: trainingDay,
@@ -381,6 +408,7 @@ struct WorkoutView: View {
                 isGeneratingSession: isGeneratingSession,
                 onGenerateSession: onGenerateSession
             )
+            }
 
         case .active(let exercise, let setNumber):
             ActiveSetView(

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -210,6 +210,9 @@ struct WorkoutView: View {
             // `performResume` (#441's single resume FUNCTION — one function, now
             // triggered by a tap, not by appearance). The day-mismatch guard still
             // fires the recovery alert here, exactly as before (#436).
+            // Re-derive from scratch each appearance so a stale value never survives a
+            // hosted-day change or a sentinel that no longer matches this day.
+            pausedForThisDay = nil
             if let saved = PausedSessionState.load() {
                 guard saved.trainingDayId == trainingDay.id else {
                     mismatchSavedState = saved
@@ -370,6 +373,11 @@ struct WorkoutView: View {
                     },
                     onDiscard: {
                         pausedForThisDay = nil
+                        // Clear the sentinel synchronously so a fast tab-switch back
+                        // cannot re-surface the just-discarded screen before the
+                        // network-gated abandonSession flush clears it (idempotent —
+                        // abandonSession clears it again after the flush).
+                        PausedSessionState.clear()
                         Task {
                             await deps.workoutSessionManager.abandonSession(sessionId: saved.sessionId)
                         }

--- a/ProjectApexTests/ActiveSessionCoordinatorTests.swift
+++ b/ProjectApexTests/ActiveSessionCoordinatorTests.swift
@@ -325,4 +325,46 @@ final class ActiveSessionCoordinatorTests: XCTestCase {
         XCTAssertFalse(coordinator.isLive, "A rejected resume must not make the coordinator go live")
         XCTAssertNotNil(PausedSessionState.load(), "A rejected resume must preserve the sentinel")
     }
+
+    // 9. #461 — polling/refresh (a tab open or the 500ms tick) must NEVER auto-revive a
+    //    paused session. The actor stays .idle across repeated refreshes; only an explicit
+    //    resumeSession transitions to live. Locks the invariant behind the on-appear fix
+    //    that moved resume from view-appearance to a deliberate tap.
+    func testRefresh_neverAutoResumesPausedSession_onlyExplicitResumeGoesLive() async throws {
+        let manager = makeManager()
+        let day = makeTrainingDay(exerciseCount: 2, setsPerExercise: 2)
+        let coordinator = ActiveSessionCoordinator(manager: manager)
+
+        let paused = PausedSessionState(
+            sessionId: UUID(),
+            trainingDayId: day.id,
+            weekId: UUID(),
+            weekNumber: 1,
+            exerciseIndex: 0,
+            currentSetNumber: 1,
+            dayType: day.dayLabel,
+            programId: UUID(),
+            userId: UUID(),
+            pausedAt: Date(),
+            exerciseSignature: PausedSessionState.exerciseSignature(for: day)
+        )
+        paused.save()
+
+        // Repeated refreshes simulate tab opens / the 500ms poll. None may revive the actor.
+        for _ in 0..<3 {
+            await coordinator.refresh()
+            let state = await manager.sessionState
+            XCTAssertEqual(state, .idle, "refresh()/poll must not auto-resume — the actor stays idle")
+            XCTAssertTrue(coordinator.pausedSessionExists, "the sentinel remains until a deliberate resume")
+            XCTAssertFalse(coordinator.isLive)
+        }
+
+        // Only an explicit resume — the deliberate tap path — transitions to live.
+        let resumed = await manager.resumeSession(pausedState: paused, trainingDay: day, completedSetLogs: [])
+        XCTAssertTrue(resumed)
+        try await Task.sleep(nanoseconds: 200_000_000)
+        await coordinator.refresh()
+        XCTAssertTrue(coordinator.isLive, "the session goes live only after the explicit resume")
+        XCTAssertFalse(coordinator.pausedSessionExists)
+    }
 }


### PR DESCRIPTION
## What

Opening the Workout tab no longer silently revives a paused workout. When a paused sentinel matches the hosted day, the tab now shows a deliberate **"Workout paused"** screen; resuming is a button tap.

Closes #461.

## Why

`WorkoutView`'s `.task` called `performResume(...)` purely on view appearance — merely viewing the tab restarted the session, with no chance to decline. This also fired for app-killed-mid-session sentinels.

## How

- **`WorkoutView.task`**: the matching-day branch no longer calls `performResume()`. It resolves the sentinel once into a new `@State pausedForThisDay` (only when the actor is `.idle`). The #436 day-mismatch guard still arms the recovery alert exactly as before.
- **`contentForState` `.idle, .preflight` case**: when `pausedForThisDay != nil`, renders the new `WorkoutPausedView` instead of `PreWorkoutView`.
- **`WorkoutPausedView`** (new): neutral "Workout paused" copy, position-only progress from the sentinel (Exercise N of M, Set K, "Paused at <time>"), and three actions — **Resume** (calls the same `performResume`, #441's single resume function, now tap-triggered), **View today's plan** (opens the existing `SessionPlanSheet`, no resume), **Discard** (`abandonSession`, which clears the sentinel). Resume/Discard clear `pausedForThisDay` first so the live/preflight render takes over cleanly.

### Invariants preserved
- **#441 single resume path**: one resume *function* (`performResume` → `vm.resumeSession`), now triggered by a tap, not by appearance.
- **#436 day-identity guard** + **#447 exercise-signature guard** + owner-mismatch repair-notice all still fire — now on the tap.
- **Live re-attach unchanged**: returning to a genuinely-still-live session still auto-attaches (`sessionIsLive(forDay:)` → `beginStatePolling()`).
- **App-killed = same rule**: no silent revive; the launch crash-recovery alert is already a router to the tab (per #441), which now lands on the paused screen.

## Tests

- New `ActiveSessionCoordinatorTests.testRefresh_neverAutoResumesPausedSession_onlyExplicitResumeGoesLive` — repeated `refresh()` (tab opens / 500 ms poll) keep the actor `.idle`; only an explicit `resumeSession` goes live. Locks the invariant.
- Full suite: **631 tests, 0 failures** (12 integration-gated skips) on iPhone 17 Pro (iOS 26).

## Scope notes
- Position-only progress by design — no completed-set count or elapsed-duration timer (those only exist after the resume network merge; the sentinel doesn't carry them).
- Neutral copy because the single sentinel can't distinguish user-pause from app-kill.

## Needs visual QA (cannot be unit-verified)
- The paused screen reads cleanly; Resume enters the session, Discard clears the sentinel and returns to `PreWorkoutView`, View-plan opens the sheet without resuming.
- Disjointness with the top `PausedSessionBannerView` (different-day banner) — never both visible.
- App-kill flow: force-kill mid-session → relaunch → Resume on launch alert → Workout tab shows the paused screen (no auto-revive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
