### PR TITLE
feat(#462): "Now Training" pill replacing the broken tab badge

### DIFF
--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -106,7 +106,6 @@ struct ContentView: View {
                 Label("Workout", systemImage: "figure.strengthtraining.traditional")
             }
             .tag(1)
-            .badge(workoutTabBadge)
 
             // ── Tab 2: Progress ────────────────────────────────────────────
             ProgressTabView(
@@ -127,6 +126,22 @@ struct ContentView: View {
                 Label("Settings", systemImage: "gearshape.fill")
             }
             .tag(3)
+        }
+        .overlay(alignment: .bottom) {
+            // #462: "Now Training" pill above the tab bar — replaces the colour-coded
+            // tab badge (iOS strips a Text badge's tint). Hidden on the Workout tab
+            // itself (tab 1), which already shows the full session / paused screen.
+            // .padding(.bottom) clears the tab bar; the exact value needs device QA.
+            if selectedTab != 1 {
+                NowTrainingBar(
+                    state: .resolve(
+                        isLive: deps.activeSessionCoordinator.isLive,
+                        pausedExists: deps.activeSessionCoordinator.pausedSessionExists
+                    ),
+                    onTap: { selectedTab = 1 }
+                )
+                .padding(.bottom, 56)
+            }
         }
         .environment(\.switchToTab, { selectedTab = $0 })
         .preferredColorScheme(.dark)
@@ -285,21 +300,6 @@ struct ContentView: View {
     private var loadingPlaceholder: some View {
         Color(red: 0.04, green: 0.04, blue: 0.06)
             .ignoresSafeArea()
-    }
-
-    // MARK: - Tab Badge
-
-    /// Returns a coloured dot badge for Tab 1 when a session is live or paused.
-    /// Live sessions use the phase-accent blue; paused-only sessions use amber.
-    /// Returns nil (no badge) when idle. SwiftUI renders foregroundStyle on Text badges
-    /// on iOS 16+; if the tint does not render the badge defaults to the system colour.
-    private var workoutTabBadge: Text? {
-        if deps.activeSessionCoordinator.isLive {
-            return Text("●").foregroundStyle(Color(red: 0.25, green: 0.72, blue: 1.0))
-        } else if deps.activeSessionCoordinator.pausedSessionExists {
-            return Text("●").foregroundStyle(Color(red: 1.0, green: 0.65, blue: 0.0))
-        }
-        return nil
     }
 
     // MARK: - Workout Tab

--- a/ProjectApex/Features/Workout/NowTrainingBar.swift
+++ b/ProjectApex/Features/Workout/NowTrainingBar.swift
@@ -1,0 +1,118 @@
+// Features/Workout/NowTrainingBar.swift
+// ProjectApex — #462
+//
+// A floating "Now Training" pill pinned above the tab bar, replacing the old
+// colour-coded tab badge (iOS strips a Text badge's foregroundStyle and renders its
+// own red dot, so live vs paused was indistinguishable). The pill carries the
+// distinction in THREE redundant channels so it survives colourblindness and Reduce
+// Motion: motion (a pulsing dot when live), colour (blue vs amber), and text+icon
+// ("Training" + circle vs "Paused — tap to resume" + pause glyph).
+//
+// State is a pure function of the ActiveSessionCoordinator's isLive / pausedSessionExists
+// (BarState.resolve), so it is unit-testable without rendering. Tapping the pill switches
+// to the Workout tab; it does NOT itself resume (the #461 paused screen owns resume).
+
+import SwiftUI
+
+struct NowTrainingBar: View {
+
+    enum BarState: Equatable {
+        case live
+        case paused
+        case idle
+
+        /// Live wins over a (stale) paused sentinel — mirrors the coordinator's
+        /// live-over-paused precedence (ActiveSessionCoordinator).
+        static func resolve(isLive: Bool, pausedExists: Bool) -> BarState {
+            if isLive { return .live }
+            if pausedExists { return .paused }
+            return .idle
+        }
+    }
+
+    let state: BarState
+    let onTap: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private static let liveAccent = Color(red: 0.25, green: 0.72, blue: 1.0)
+    private static let pausedAccent = Color(red: 1.0, green: 0.65, blue: 0.0)
+
+    var body: some View {
+        switch state {
+        case .idle:
+            EmptyView()
+        case .live, .paused:
+            pill
+        }
+    }
+
+    private var accent: Color {
+        state == .live ? Self.liveAccent : Self.pausedAccent
+    }
+
+    private var label: String {
+        state == .live ? "Training" : "Paused — tap to resume"
+    }
+
+    private var pill: some View {
+        Button(action: onTap) {
+            HStack(spacing: 10) {
+                indicator
+                Text(label)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(.white.opacity(0.45))
+            }
+            .padding(.horizontal, 18)
+            .padding(.vertical, 11)
+            .background(
+                // A raised dark fill (not the tab bar's chrome) so the pill reads as a
+                // distinct floating element rather than part of the tab bar.
+                Color(red: 0.13, green: 0.13, blue: 0.16),
+                in: Capsule()
+            )
+            .overlay(
+                Capsule().stroke(accent.opacity(0.45), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.40), radius: 12, y: 4)
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(state == .live ? "Workout in progress" : "Workout paused")
+        .accessibilityHint("Opens your workout")
+    }
+
+    @ViewBuilder
+    private var indicator: some View {
+        switch state {
+        case .live:
+            // Motion is the PRIMARY live signal; suppressed under Reduce Motion, where
+            // colour + the filled dot + "Training" still carry the state.
+            Image(systemName: "circle.fill")
+                .font(.system(size: 10))
+                .foregroundStyle(Self.liveAccent)
+                .symbolEffect(.pulse, options: .repeating, isActive: !reduceMotion)
+        case .paused:
+            Image(systemName: "pause.circle.fill")
+                .font(.system(size: 15))
+                .foregroundStyle(Self.pausedAccent)
+        case .idle:
+            EmptyView()
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        Color(red: 0.04, green: 0.04, blue: 0.06).ignoresSafeArea()
+        VStack(spacing: 24) {
+            NowTrainingBar(state: .live, onTap: {})
+            NowTrainingBar(state: .paused, onTap: {})
+        }
+    }
+    .preferredColorScheme(.dark)
+}

--- a/ProjectApexTests/ActiveSessionCoordinatorTests.swift
+++ b/ProjectApexTests/ActiveSessionCoordinatorTests.swift
@@ -367,4 +367,51 @@ final class ActiveSessionCoordinatorTests: XCTestCase {
         XCTAssertTrue(coordinator.isLive, "the session goes live only after the explicit resume")
         XCTAssertFalse(coordinator.pausedSessionExists)
     }
+
+    // 10. #462 — the NowTrainingBar state is a pure function of the coordinator flags.
+    //     Live wins over a (stale) paused sentinel, mirroring coordinator precedence.
+    func testNowTrainingBarState_pureResolve_allPermutations() {
+        XCTAssertEqual(NowTrainingBar.BarState.resolve(isLive: true,  pausedExists: false), .live)
+        XCTAssertEqual(NowTrainingBar.BarState.resolve(isLive: false, pausedExists: true),  .paused)
+        XCTAssertEqual(NowTrainingBar.BarState.resolve(isLive: false, pausedExists: false), .idle)
+        // Defined-but-impossible: a live actor must win over a stale paused sentinel.
+        XCTAssertEqual(NowTrainingBar.BarState.resolve(isLive: true,  pausedExists: true),  .live)
+    }
+
+    // 11. #462 — driven off the real coordinator: the bar state agrees with the
+    //     single ActiveSession enum at idle / paused / live, with no disagreement.
+    func testNowTrainingBarState_matchesCoordinator_idlePausedLive() async throws {
+        // Idle.
+        let idleManager = makeManager()
+        let idleCoordinator = ActiveSessionCoordinator(manager: idleManager)
+        await idleCoordinator.refresh()
+        XCTAssertEqual(
+            NowTrainingBar.BarState.resolve(isLive: idleCoordinator.isLive, pausedExists: idleCoordinator.pausedSessionExists),
+            .idle
+        )
+
+        // Paused (sentinel + idle actor).
+        let pausedManager = makeManager()
+        let pausedDay = makeTrainingDay()
+        savePausedSentinel(for: pausedDay)
+        let pausedCoordinator = ActiveSessionCoordinator(manager: pausedManager)
+        await pausedCoordinator.refresh()
+        XCTAssertEqual(
+            NowTrainingBar.BarState.resolve(isLive: pausedCoordinator.isLive, pausedExists: pausedCoordinator.pausedSessionExists),
+            .paused
+        )
+        PausedSessionState.clear()
+
+        // Live.
+        let liveManager = makeManager()
+        let liveDay = makeTrainingDay(exerciseCount: 1, setsPerExercise: 1)
+        await liveManager.startSession(trainingDay: liveDay, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000)
+        let liveCoordinator = ActiveSessionCoordinator(manager: liveManager)
+        await liveCoordinator.refresh()
+        XCTAssertEqual(
+            NowTrainingBar.BarState.resolve(isLive: liveCoordinator.isLive, pausedExists: liveCoordinator.pausedSessionExists),
+            .live
+        )
+    }
 }


### PR DESCRIPTION
## What

Replaces the broken colour-coded Workout-tab badge with a floating **"Now Training"** pill pinned above the tab bar.

Closes #462. Builds on #461 (the paused pill routes to #461's paused screen).

## Why

The tab badge tried to show blue (live) / amber (paused), but iOS ignores `foregroundStyle` on a `Text` tab badge and renders its own red dot for both — so live vs paused was indistinguishable. The dot also wasn't tappable.

## How

- **Removed** `workoutTabBadge` and `.badge(workoutTabBadge)` from `ContentView`.
- **`NowTrainingBar`** (new): a floating capsule with three redundant channels so the live/paused distinction survives colourblindness AND Reduce Motion:
  - **live** — a pulsing dot (`.symbolEffect(.pulse, options: .repeating, isActive: !reduceMotion)`) + "Training" + blue.
  - **paused** — a static `pause.circle.fill` + "Paused — tap to resume" + amber (reusing the app's established amber).
  - **idle** — renders nothing.
- **`BarState.resolve(isLive:pausedExists:)`** — a pure function (live wins over a stale paused sentinel), so state selection is unit-testable without rendering.
- **Attachment**: `.overlay(alignment: .bottom)` on the `TabView` (NOT `safeAreaInset` — unreliable on the iOS-26 tab bar) with `.padding(.bottom, 56)` to clear the tab bar.
- Tapping the pill switches to the Workout tab; it does **not** itself resume (the #461 paused screen owns resume).
- **VoiceOver**: one `.isButton` element, label "Workout in progress" / "Workout paused", hint "Opens your workout".

### Intentional refinement to surface (slight deviation from the issue's "visible from every tab")
The pill is **hidden on the Workout tab itself (tab 1)**. That tab already shows the full session (live) or the #461 paused screen, so a redundant "tap to open" pill there would be noise and an overlap risk — this mirrors how Apple Music hides the mini-player on the now-playing screen. It shows on Program / Progress / Settings. Easy to change to all-tabs if you'd prefer.

## Tests
- `testNowTrainingBarState_pureResolve_allPermutations` — all four `(isLive, pausedExists)` permutations, incl. the impossible `(true, true) → .live`.
- `testNowTrainingBarState_matchesCoordinator_idlePausedLive` — driven off the real coordinator at idle / paused / live.
- Full suite: **633 tests, 0 failures** (12 integration-gated skips) on iPhone 17 Pro (iOS 26).

## Needs visual QA (cannot be unit-verified)
- The `.padding(.bottom, 56)` value that clears the tab bar — confirm on a device.
- The pulse cadence reads as "live" without being distracting over a long session.
- The pill is visible/tappable from Program/Progress/Settings and doesn't block tab-bar taps.

## Out of scope
- No Live Activity / Dynamic Island (the out-of-app case) — possible future follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
