### PR TITLE
feat(#465): in-place pause lands on WorkoutPausedView

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		DDDD443100000000000443B2 /* DurableTrainingDayIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD443100000000000443F1 /* DurableTrainingDayIdTests.swift */; };
 		A5C0FFEE0000000000ASC002 /* ActiveSessionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C0FFEE0000000000ASC001 /* ActiveSessionCoordinatorTests.swift */; };
 		DF8EC3D0BD96C780A4A12C9C /* RunDayRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF699647AABA0F76A7B2123 /* RunDayRoutingTests.swift */; };
+		B465A0DE0000000000RP5001 /* ResolvePausedSentinelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B465A0DE0000000000RP5002 /* ResolvePausedSentinelTests.swift */; };
 		8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */; };
 		A11FA719C0DE0001CAFE0001 /* FatigueInteractionCrossValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11FA719C0DE0002CAFE0002 /* FatigueInteractionCrossValidationTests.swift */; };
 		A12FA719C0DE0001CAFE0001 /* TraineeModelSnapshotsCrossValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12FA719C0DE0002CAFE0002 /* TraineeModelSnapshotsCrossValidationTests.swift */; };
@@ -161,6 +162,7 @@
 		DDDD443100000000000443F1 /* DurableTrainingDayIdTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DurableTrainingDayIdTests.swift; sourceTree = "<group>"; };
 		A5C0FFEE0000000000ASC001 /* ActiveSessionCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActiveSessionCoordinatorTests.swift; sourceTree = "<group>"; };
 		DDF699647AABA0F76A7B2123 /* RunDayRoutingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RunDayRoutingTests.swift; sourceTree = "<group>"; };
+		B465A0DE0000000000RP5002 /* ResolvePausedSentinelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResolvePausedSentinelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -298,6 +300,7 @@
 				DDDD443100000000000443F1 /* DurableTrainingDayIdTests.swift */,
 				A5C0FFEE0000000000ASC001 /* ActiveSessionCoordinatorTests.swift */,
 				DDF699647AABA0F76A7B2123 /* RunDayRoutingTests.swift */,
+				B465A0DE0000000000RP5002 /* ResolvePausedSentinelTests.swift */,
 			);
 			path = ProjectApexTests;
 			sourceTree = "<group>";
@@ -471,6 +474,7 @@
 				DDDD443100000000000443B2 /* DurableTrainingDayIdTests.swift in Sources */,
 				A5C0FFEE0000000000ASC002 /* ActiveSessionCoordinatorTests.swift in Sources */,
 				DF8EC3D0BD96C780A4A12C9C /* RunDayRoutingTests.swift in Sources */,
+				B465A0DE0000000000RP5001 /* ResolvePausedSentinelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -220,9 +220,13 @@ struct WorkoutView: View {
                     return
                 }
                 let isIdle = await deps.workoutSessionManager.sessionState == .idle
-                if isIdle {
-                    pausedForThisDay = saved
-                }
+                // #465: same resolution the in-place `.onChange(.idle)` path uses,
+                // so both converge on one render decision.
+                pausedForThisDay = WorkoutView.resolvePausedSentinel(
+                    saved: saved,
+                    actorIsIdle: isIdle,
+                    trainingDayId: trainingDay.id
+                )
             }
         }
         .onChange(of: viewModel?.sessionState) { _, newState in
@@ -248,7 +252,20 @@ struct WorkoutView: View {
             // sentinel (e.g. an errored start, or a different paused day) from mis-marking the
             // currently-rendered day as paused (amendment 2.1).
             if case .idle = newState {
-                if PausedSessionState.load()?.trainingDayId == trainingDay.id {
+                // #465: resolve the sentinel ONCE (load() has a repairPending
+                // side-effect) and, when it names this day, surface the deliberate
+                // WorkoutPausedView in place — same @State the navigate-away path
+                // assigns — instead of letting contentForState(.idle) fall through
+                // to PreWorkoutView. The actor is idle here by construction of the
+                // .idle transition, so the live `.idle` edge always satisfies the
+                // helper's idleness requirement.
+                let saved = PausedSessionState.load()
+                if let resolved = WorkoutView.resolvePausedSentinel(
+                    saved: saved,
+                    actorIsIdle: true,
+                    trainingDayId: trainingDay.id
+                ) {
+                    pausedForThisDay = resolved
                     onSessionPaused?(trainingDay.id)
                 }
             }
@@ -544,6 +561,25 @@ struct WorkoutView: View {
 
     private var setCompleteTransition: AnyTransition {
         reduceMotion ? .opacity : .apexSetComplete
+    }
+
+    // MARK: - Paused-sentinel resolution
+
+    /// Pure decision shared by the `.task` (navigate-away-and-back) and the
+    /// `.onChange(.idle)` (in-place pause) paths (#465): a saved sentinel becomes
+    /// this view's paused screen iff the actor is idle AND the sentinel names THIS
+    /// view's day. Both call sites read `PausedSessionState.load()` exactly once
+    /// (load() has a `repairPending` side-effect, so it must not be called twice)
+    /// and feed the result here so they converge on one render decision.
+    static func resolvePausedSentinel(
+        saved: PausedSessionState?,
+        actorIsIdle: Bool,
+        trainingDayId: UUID
+    ) -> PausedSessionState? {
+        guard let saved, saved.trainingDayId == trainingDayId, actorIsIdle else {
+            return nil
+        }
+        return saved
     }
 
     // MARK: - Resume helper

--- a/ProjectApexTests/ResolvePausedSentinelTests.swift
+++ b/ProjectApexTests/ResolvePausedSentinelTests.swift
@@ -1,0 +1,87 @@
+// ResolvePausedSentinelTests.swift
+// ProjectApexTests
+//
+// #465 — Pause flow tightening (spine). Tapping "Pause workout" in place used to
+// dump the user on PreWorkoutView instead of the deliberate WorkoutPausedView,
+// because only WorkoutView's `.task` (runs on appearance) resolved the paused
+// sentinel into `pausedForThisDay`; the `.onChange(.idle)` arm never did. The fix
+// extracts a pure helper, `WorkoutView.resolvePausedSentinel`, shared by both the
+// `.task` block and the `.idle` arm so they converge on the same render decision.
+//
+// These tests pin the helper's contract: it returns the saved sentinel iff the
+// actor is idle AND the sentinel names THIS view's day, else nil.
+
+import XCTest
+@testable import ProjectApex
+
+final class ResolvePausedSentinelTests: XCTestCase {
+
+    private func sentinel(for dayId: UUID) -> PausedSessionState {
+        PausedSessionState(
+            sessionId: UUID(),
+            trainingDayId: dayId,
+            weekId: UUID(),
+            weekNumber: 1,
+            exerciseIndex: 0,
+            currentSetNumber: 1,
+            dayType: "push",
+            programId: UUID(),
+            userId: UUID(),
+            pausedAt: Date()
+        )
+    }
+
+    // The in-place-pause edge: actor went idle and a sentinel for THIS day exists.
+    // This is the case that used to resolve to nil (the bug) — it must now return
+    // the sentinel so contentForState(.idle) renders WorkoutPausedView.
+    func test_idleEdge_sentinelForThisDay_returnsSentinel() {
+        let dayId = UUID()
+        let saved = sentinel(for: dayId)
+
+        let resolved = WorkoutView.resolvePausedSentinel(
+            saved: saved,
+            actorIsIdle: true,
+            trainingDayId: dayId
+        )
+
+        XCTAssertEqual(resolved?.sessionId, saved.sessionId)
+    }
+
+    // A sentinel for a DIFFERENT day must not adopt this view's render.
+    func test_sentinelForOtherDay_returnsNil() {
+        let saved = sentinel(for: UUID())
+
+        let resolved = WorkoutView.resolvePausedSentinel(
+            saved: saved,
+            actorIsIdle: true,
+            trainingDayId: UUID()
+        )
+
+        XCTAssertNil(resolved)
+    }
+
+    // No saved sentinel → nil regardless of idleness.
+    func test_noSentinel_returnsNil() {
+        let resolved = WorkoutView.resolvePausedSentinel(
+            saved: nil,
+            actorIsIdle: true,
+            trainingDayId: UUID()
+        )
+
+        XCTAssertNil(resolved)
+    }
+
+    // Actor not idle (e.g. a live session) → do not surface the paused screen.
+    func test_actorNotIdle_returnsNil() {
+        let dayId = UUID()
+        let saved = sentinel(for: dayId)
+
+        let resolved = WorkoutView.resolvePausedSentinel(
+            saved: saved,
+            actorIsIdle: false,
+            trainingDayId: dayId
+        )
+
+        XCTAssertNil(resolved)
+    }
+}


### PR DESCRIPTION
Closes #465

## What

In-place **Pause workout** (••• menu during a live set) now lands on the deliberate amber `WorkoutPausedView` (Resume / View today's plan / Discard) instead of dumping the user on PreWorkoutView — so the same action gives the same outcome whether or not the user leaves and returns to the Workout tab.

## How

- Extract a pure helper `WorkoutView.resolvePausedSentinel(saved:actorIsIdle:trainingDayId:)` — returns the saved sentinel iff the actor is idle AND the sentinel names this view's day, else nil.
- Wire it into the existing `.onChange(.idle)` arm: read `PausedSessionState.load()` **once** (load() has a `repairPending` side-effect) and, on a match, set `pausedForThisDay` alongside the existing `onSessionPaused?` call so `contentForState(.idle)` renders `WorkoutPausedView`.
- Route the `.task` (navigate-away-and-back) path through the same helper so both call sites converge on one render decision.

## Tests

- New `ResolvePausedSentinelTests` (4 cases) — RED first (`type 'WorkoutView' has no member 'resolvePausedSentinel'`), GREEN after.
- Full suite: 385 tests, 0 assertion failures, 6 skipped.

## Scope

No new published flag, no coordinator in the render path, no render-time `load()`, no PreWorkoutView change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)