### PR TITLE
feat(#466): collapse to one pause function

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		DDDD443100000000000443B2 /* DurableTrainingDayIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD443100000000000443F1 /* DurableTrainingDayIdTests.swift */; };
 		A5C0FFEE0000000000ASC002 /* ActiveSessionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C0FFEE0000000000ASC001 /* ActiveSessionCoordinatorTests.swift */; };
 		DF8EC3D0BD96C780A4A12C9C /* RunDayRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF699647AABA0F76A7B2123 /* RunDayRoutingTests.swift */; };
+		PEP4660000000000PEP0001 /* PauseEntryPointsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PEP4660000000000PEP0002 /* PauseEntryPointsTests.swift */; };
 		B465A0DE0000000000RP5001 /* ResolvePausedSentinelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B465A0DE0000000000RP5002 /* ResolvePausedSentinelTests.swift */; };
 		8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */; };
 		A11FA719C0DE0001CAFE0001 /* FatigueInteractionCrossValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11FA719C0DE0002CAFE0002 /* FatigueInteractionCrossValidationTests.swift */; };
@@ -162,6 +163,7 @@
 		DDDD443100000000000443F1 /* DurableTrainingDayIdTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DurableTrainingDayIdTests.swift; sourceTree = "<group>"; };
 		A5C0FFEE0000000000ASC001 /* ActiveSessionCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActiveSessionCoordinatorTests.swift; sourceTree = "<group>"; };
 		DDF699647AABA0F76A7B2123 /* RunDayRoutingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RunDayRoutingTests.swift; sourceTree = "<group>"; };
+		PEP4660000000000PEP0002 /* PauseEntryPointsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PauseEntryPointsTests.swift; sourceTree = "<group>"; };
 		B465A0DE0000000000RP5002 /* ResolvePausedSentinelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResolvePausedSentinelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -300,6 +302,7 @@
 				DDDD443100000000000443F1 /* DurableTrainingDayIdTests.swift */,
 				A5C0FFEE0000000000ASC001 /* ActiveSessionCoordinatorTests.swift */,
 				DDF699647AABA0F76A7B2123 /* RunDayRoutingTests.swift */,
+				PEP4660000000000PEP0002 /* PauseEntryPointsTests.swift */,
 				B465A0DE0000000000RP5002 /* ResolvePausedSentinelTests.swift */,
 			);
 			path = ProjectApexTests;
@@ -474,6 +477,7 @@
 				DDDD443100000000000443B2 /* DurableTrainingDayIdTests.swift in Sources */,
 				A5C0FFEE0000000000ASC002 /* ActiveSessionCoordinatorTests.swift in Sources */,
 				DF8EC3D0BD96C780A4A12C9C /* RunDayRoutingTests.swift in Sources */,
+				PEP4660000000000PEP0001 /* PauseEntryPointsTests.swift in Sources */,
 				B465A0DE0000000000RP5001 /* ResolvePausedSentinelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ProjectApex/Features/Workout/ActiveSetView.swift
+++ b/ProjectApex/Features/Workout/ActiveSetView.swift
@@ -242,7 +242,7 @@ struct ActiveSetView: View {
                     Button {
                         viewModel.onPauseSession()
                     } label: {
-                        Label("Pause Session", systemImage: "pause.circle")
+                        Label("Pause workout", systemImage: "pause.circle")
                     }
                     Button(role: .destructive) {
                         viewModel.requestEndSessionEarly()

--- a/ProjectApex/Features/Workout/InferenceRetrySheet.swift
+++ b/ProjectApex/Features/Workout/InferenceRetrySheet.swift
@@ -104,7 +104,7 @@ struct InferenceRetrySheet: View {
                         HStack(spacing: 8) {
                             Image(systemName: "pause.circle")
                                 .font(.system(size: 16, weight: .medium))
-                            Text("Pause Session")
+                            Text("Pause workout")
                                 .font(.system(size: 17, weight: .medium))
                         }
                         .frame(maxWidth: .infinity)

--- a/ProjectApex/Features/Workout/WorkoutViewModel.swift
+++ b/ProjectApex/Features/Workout/WorkoutViewModel.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 @Observable
 @MainActor
-final class WorkoutViewModel {
+class WorkoutViewModel {
 
     // MARK: - Observed state (all updated via pullState())
 
@@ -355,15 +355,17 @@ final class WorkoutViewModel {
         }
     }
 
-    /// Called when the user taps "Pause Session" on InferenceRetrySheet.
+    /// Called when the user taps "Pause workout" on InferenceRetrySheet. Thin shim
+    /// over the single `onPauseSession()` pause path — it only dismisses the retry
+    /// sheet first so the sheet does not briefly overlay the paused screen (#466).
     func onPauseFromRetrySheet() {
         showInferenceRetrySheet = false
-        Task { await manager.pauseSession(); await pullState() }
+        onPauseSession()
     }
 
     // MARK: - Pause action
 
-    /// Called when user taps "Pause Session" from the ellipsis menu during active/resting state.
+    /// Called when user taps "Pause workout" from the ellipsis menu during active/resting state.
     func onPauseSession() {
         Task { await manager.pauseSession(); await pullState() }
     }

--- a/ProjectApexTests/PauseEntryPointsTests.swift
+++ b/ProjectApexTests/PauseEntryPointsTests.swift
@@ -1,0 +1,188 @@
+// PauseEntryPointsTests.swift
+// ProjectApexTests
+//
+// #466 — Pause flow: collapse to one pause function (kill the duplicate doorway).
+//
+// There used to be two byte-identical pause paths: the ••• menu's
+// `onPauseSession()` and the AI-retry sheet's `onPauseFromRetrySheet()`. These
+// tests pin that the retry-sheet entry point is now a THIN SHIM that delegates to
+// `onPauseSession()` — one underlying pause path — while still dismissing the
+// retry sheet first so it does not briefly overlay the paused screen.
+//
+//   • Delegation: `onPauseFromRetrySheet()` calls `onPauseSession()` exactly once
+//     and clears `showInferenceRetrySheet`.
+//   • Behaviour preserved: through a real WorkoutSessionManager, the retry-sheet
+//     entry point still drives the actor through `pauseSession()` (a durable
+//     PausedSessionState is written, the actor resets to .idle).
+//
+// Mirrors the file-private real-manager harness in RunDayRoutingTests
+// (real WorkoutSessionManager actor, ephemeral UserDefaults suite, sentinel
+// clearing in setUp/tearDown).
+
+import XCTest
+import Foundation
+@testable import ProjectApex
+
+// MARK: - Local test helpers (file-private, mirroring RunDayRoutingTests)
+
+private struct PEPMockLLMProvider: LLMProvider {
+    let response: String
+    func complete(systemPrompt: String, userPayload: String) async throws -> String {
+        response
+    }
+}
+
+/// Always returns HTTP 201 — prevents real network calls and WAQ retry loops.
+private final class PEPAlwaysSucceedURLProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 201,
+            httpVersion: nil, headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("[]".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+private func makeTestSupabase() -> SupabaseClient {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [PEPAlwaysSucceedURLProtocol.self]
+    return SupabaseClient(
+        supabaseURL: URL(string: "https://test.supabase.co")!,
+        anonKey: "test-key",
+        urlSession: URLSession(configuration: config)
+    )
+}
+
+private func prescriptionJSON() -> String {
+    """
+    {
+      "set_prescription": {
+        "weight_kg": 80.0,
+        "reps": 8,
+        "tempo": "3-1-1-0",
+        "rir_target": 2,
+        "rest_seconds": 120,
+        "coaching_cue": "Drive through the bar",
+        "reasoning": "Based on recent performance trend.",
+        "safety_flags": [],
+        "intent": "top",
+        "set_framing": "Heaviest work of the day. Brace and grind."
+      }
+    }
+    """
+}
+
+private func makeManager() -> WorkoutSessionManager {
+    let inferenceService = AIInferenceService(
+        provider: PEPMockLLMProvider(response: prescriptionJSON()),
+        gymProfile: nil,
+        maxRetries: 0
+    )
+    let supabase = makeTestSupabase()
+    let memoryService = MemoryService(supabase: supabase, embeddingAPIKey: "")
+    let suiteName = "com.test.pep.\(UUID().uuidString)"
+    let testDefaults = UserDefaults(suiteName: suiteName)!
+    let gymFactStore = GymFactStore(userDefaults: testDefaults)
+    let waq = WriteAheadQueue(supabase: supabase, userDefaults: testDefaults)
+    return WorkoutSessionManager(
+        aiInference: inferenceService,
+        healthKit: HealthKitService(),
+        memoryService: memoryService,
+        supabase: supabase,
+        gymFactStore: gymFactStore,
+        writeAheadQueue: waq
+    )
+}
+
+private func makeTrainingDay() -> TrainingDay {
+    let exercise = PlannedExercise(
+        id: UUID(),
+        exerciseId: "exercise_0",
+        name: "Exercise 0",
+        primaryMuscle: "pectoralis_major",
+        synergists: ["triceps_brachii"],
+        equipmentRequired: .barbell,
+        sets: 1,
+        repRange: RepRange(min: 6, max: 10),
+        tempo: "3-1-1-0",
+        restSeconds: 90,
+        rirTarget: 2,
+        coachingCues: ["Focus on form"]
+    )
+    return TrainingDay(
+        id: UUID(),
+        dayOfWeek: 1,
+        dayLabel: "Push_A",
+        exercises: [exercise],
+        sessionNotes: nil
+    )
+}
+
+/// Spy subclass that records every call to `onPauseSession()` so the delegation
+/// from the retry-sheet shim can be observed by call count (the issue's TDD ask).
+@MainActor
+private final class SpyWorkoutViewModel: WorkoutViewModel {
+    private(set) var onPauseSessionCallCount = 0
+    override func onPauseSession() {
+        onPauseSessionCallCount += 1
+        super.onPauseSession()
+    }
+}
+
+// MARK: - PauseEntryPointsTests
+
+@MainActor
+final class PauseEntryPointsTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        PausedSessionState.clear()
+    }
+
+    override func tearDown() {
+        PausedSessionState.clear()
+        super.tearDown()
+    }
+
+    // The retry-sheet entry point is a thin shim: it delegates to the single
+    // `onPauseSession()` path and dismisses the retry sheet first.
+    func testOnPauseFromRetrySheet_delegatesToOnPauseSession_andDismissesSheet() {
+        let vm = SpyWorkoutViewModel(manager: makeManager())
+        vm.showInferenceRetrySheet = true
+
+        vm.onPauseFromRetrySheet()
+
+        XCTAssertEqual(vm.onPauseSessionCallCount, 1,
+            "onPauseFromRetrySheet must delegate to the single onPauseSession path")
+        XCTAssertFalse(vm.showInferenceRetrySheet,
+            "the retry sheet must dismiss before the actor goes idle")
+    }
+
+    // Behaviour preserved end-to-end: the shim still drives the real actor through
+    // pauseSession() — a durable paused snapshot is written and the actor resets.
+    func testOnPauseFromRetrySheet_stillPausesTheLiveSession() async throws {
+        let manager = makeManager()
+        let vm = WorkoutViewModel(manager: manager)
+        let day = makeTrainingDay()
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 200_000_000) // settle to .active
+        await vm.pullState()
+        vm.showInferenceRetrySheet = true
+
+        vm.onPauseFromRetrySheet()
+        try await Task.sleep(nanoseconds: 200_000_000) // let the pause Task run
+        await vm.pullState()
+
+        XCTAssertFalse(vm.showInferenceRetrySheet, "retry sheet must dismiss")
+        XCTAssertNotNil(PausedSessionState.load(),
+            "the pause path must persist a durable PausedSessionState")
+        XCTAssertEqual(vm.sessionState, .idle,
+            "pauseSession resets the actor to idle after saving the snapshot")
+    }
+}


### PR DESCRIPTION
Closes #466

## What
Collapse the two pause doorways into one underlying path:

- `onPauseFromRetrySheet()` is now a thin shim over `onPauseSession()`. It keeps its existing `showInferenceRetrySheet = false` dismissal so the retry sheet closes before the actor goes idle, then delegates — instead of re-implementing the byte-identical `pauseSession()` + `pullState()` body.
- Copy: the ••• menu Label (`ActiveSetView`) and the retry-sheet button (`InferenceRetrySheet`) both now read **"Pause workout"**.
- `WorkoutViewModel` relaxed from `final` so the delegation test can spy the shared `onPauseSession()` path by call count (the issue's stated TDD strategy).

## Tests (RED → GREEN)
New `PauseEntryPointsTests`:
- `testOnPauseFromRetrySheet_delegatesToOnPauseSession_andDismissesSheet` — RED before the fix (call count 0 ≠ 1), GREEN after; also asserts the sheet dismisses.
- `testOnPauseFromRetrySheet_stillPausesTheLiveSession` — drives a real `WorkoutSessionManager` to `.active`, calls the shim, asserts a durable `PausedSessionState` is written and the actor resets to `.idle` (behaviour preserved).

Full suite green: 639 tests, 0 failures, 12 skipped.

## Grep report (cross-cutting)
`grep "Pause Session"` over `ProjectApex` after the change finds:
- `InferenceRetrySheet.swift:102` — a `// Pause Session button` code comment (not user-facing copy; left untouched).
- `RestTimerView.swift:85` — a THIRD user-facing menu Label `"Pause Session"` for the same pause action, NOT named by the issue's copy bullet. Reported, not edited (per grep-and-report rule). Recommend a follow-up to align it to "Pause workout".

## Out of scope
No ••• menu reorder/promotion.