### PR TITLE
feat(#467): banner points straight at the Resume owner

### DIFF
--- a/ProjectApex.xcodeproj/project.pbxproj
+++ b/ProjectApex.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		A5C0FFEE0000000000ASC002 /* ActiveSessionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C0FFEE0000000000ASC001 /* ActiveSessionCoordinatorTests.swift */; };
 		DF8EC3D0BD96C780A4A12C9C /* RunDayRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF699647AABA0F76A7B2123 /* RunDayRoutingTests.swift */; };
 		PEP4660000000000PEP0001 /* PauseEntryPointsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PEP4660000000000PEP0002 /* PauseEntryPointsTests.swift */; };
+		PBR4670000000000PBR0001 /* PausedBannerResumeRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PBR4670000000000PBR0002 /* PausedBannerResumeRoutingTests.swift */; };
 		B465A0DE0000000000RP5001 /* ResolvePausedSentinelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B465A0DE0000000000RP5002 /* ResolvePausedSentinelTests.swift */; };
 		8A28FF4A9DE063DFA4183B29 /* SetPrescriptionIntentValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD27873E38E45BE2FB26D63 /* SetPrescriptionIntentValidationTests.swift */; };
 		A11FA719C0DE0001CAFE0001 /* FatigueInteractionCrossValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11FA719C0DE0002CAFE0002 /* FatigueInteractionCrossValidationTests.swift */; };
@@ -164,6 +165,7 @@
 		A5C0FFEE0000000000ASC001 /* ActiveSessionCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActiveSessionCoordinatorTests.swift; sourceTree = "<group>"; };
 		DDF699647AABA0F76A7B2123 /* RunDayRoutingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RunDayRoutingTests.swift; sourceTree = "<group>"; };
 		PEP4660000000000PEP0002 /* PauseEntryPointsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PauseEntryPointsTests.swift; sourceTree = "<group>"; };
+		PBR4670000000000PBR0002 /* PausedBannerResumeRoutingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PausedBannerResumeRoutingTests.swift; sourceTree = "<group>"; };
 		B465A0DE0000000000RP5002 /* ResolvePausedSentinelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResolvePausedSentinelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -303,6 +305,7 @@
 				A5C0FFEE0000000000ASC001 /* ActiveSessionCoordinatorTests.swift */,
 				DDF699647AABA0F76A7B2123 /* RunDayRoutingTests.swift */,
 				PEP4660000000000PEP0002 /* PauseEntryPointsTests.swift */,
+				PBR4670000000000PBR0002 /* PausedBannerResumeRoutingTests.swift */,
 				B465A0DE0000000000RP5002 /* ResolvePausedSentinelTests.swift */,
 			);
 			path = ProjectApexTests;
@@ -478,6 +481,7 @@
 				A5C0FFEE0000000000ASC002 /* ActiveSessionCoordinatorTests.swift in Sources */,
 				DF8EC3D0BD96C780A4A12C9C /* RunDayRoutingTests.swift in Sources */,
 				PEP4660000000000PEP0001 /* PauseEntryPointsTests.swift in Sources */,
+				PBR4670000000000PBR0001 /* PausedBannerResumeRoutingTests.swift in Sources */,
 				B465A0DE0000000000RP5001 /* ResolvePausedSentinelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -61,12 +61,6 @@ struct ContentView: View {
     /// True when crash recovery's paused day cannot be found anywhere in the mesocycle.
     @State private var showOrphanedRecoveryAlert: Bool = false
 
-    // MARK: - Paused-session banner navigation
-
-    /// True when the user taps "Resume" on PausedSessionBannerView — pushes
-    /// ProgramDayDetailView for the paused day within the workout tab's NavigationStack.
-    @State private var navigateToPausedDayDetail: Bool = false
-
     var body: some View {
         // Honest launch gate (#329 / O-F1, #369 slice 2): when either required key is
         // missing — neither in the Keychain nor bundled into the build — show the
@@ -343,6 +337,14 @@ struct ContentView: View {
         return nextIncomplete
     }
 
+    /// Routes the paused-session banner's "Resume" straight at the Resume owner
+    /// (#467): land on the Workout tab (index 1), where `WorkoutPausedView` renders
+    /// after #465. One hop, pointing at the owner — no detour through a pushed
+    /// `ProgramDayDetailView`. Pure seam so the routing intent stays testable.
+    static func applyBannerResume(selectedTab: inout Int) {
+        selectedTab = 1
+    }
+
     /// The Workout tab. Routes to `WorkoutView` with the first non-completed day
     /// in the mesocycle. Shows a programme-complete state when all days are done,
     /// or a no-program state when no mesocycle is loaded.
@@ -450,26 +452,11 @@ struct ContentView: View {
                             PausedSessionBannerView(
                                 dayLabel: found.day.dayLabel,
                                 weekNumber: found.week.weekNumber,
-                                onResume: { navigateToPausedDayDetail = true }
+                                onResume: { ContentView.applyBannerResume(selectedTab: &selectedTab) }
                             )
                             .padding(.horizontal, 16)
                             .padding(.top, 8)
                             .padding(.bottom, 4)
-                        }
-                    }
-                    // Navigation destination for the paused day's detail view
-                    .navigationDestination(isPresented: $navigateToPausedDayDetail) {
-                        if let saved = PausedSessionState.load(),
-                           let found = vm.findTrainingDay(byId: saved.trainingDayId, in: mesocycle) {
-                            ProgramDayDetailView(
-                                day: found.day,
-                                week: found.week,
-                                mesocycleCreatedAt: mesocycle.createdAt,
-                                programId: mesocycle.id,
-                                viewModel: vm,
-                                gymProfile: confirmedProfile
-                            )
-                            .environment(deps)
                         }
                     }
                 }

--- a/ProjectApexTests/PausedBannerResumeRoutingTests.swift
+++ b/ProjectApexTests/PausedBannerResumeRoutingTests.swift
@@ -1,0 +1,35 @@
+// PausedBannerResumeRoutingTests.swift
+// ProjectApexTests
+//
+// #467 — Pause flow: the paused-session banner points straight at the Resume
+// owner (WorkoutPausedView on the Workout tab) instead of detouring through a
+// pushed ProgramDayDetailView.
+//
+// The banner's `onResume` no longer flips a `navigateToPausedDayDetail`
+// navigation flag; it lands the user directly on the Workout tab (index 1),
+// where WorkoutPausedView renders (#465). The routing intent is extracted into
+// the pure `ContentView.applyBannerResume(selectedTab:)` seam so it is testable
+// without a live SwiftUI view — mirroring the pure `ContentView.hostDay(...)`
+// precedent in RunDayRoutingTests.
+
+import XCTest
+@testable import ProjectApex
+
+final class PausedBannerResumeRoutingTests: XCTestCase {
+
+    // Banner resume routes to the Workout tab (index 1), where WorkoutPausedView
+    // — the single owner of Resume — renders. One hop, pointing at the owner.
+    func testBannerResume_landsOnWorkoutTab() {
+        var selectedTab = 0
+        ContentView.applyBannerResume(selectedTab: &selectedTab)
+        XCTAssertEqual(selectedTab, 1,
+            "banner Resume must land on the Workout tab (index 1), not detour elsewhere")
+    }
+
+    // Idempotent: already on the Workout tab stays on the Workout tab.
+    func testBannerResume_isIdempotentWhenAlreadyOnWorkoutTab() {
+        var selectedTab = 1
+        ContentView.applyBannerResume(selectedTab: &selectedTab)
+        XCTAssertEqual(selectedTab, 1)
+    }
+}


### PR DESCRIPTION
Closes #467

## What

The paused-session banner's `onResume` took a two-hop detour around the single Resume owner (`WorkoutPausedView`): it flipped `navigateToPausedDayDetail` → pushed `ProgramDayDetailView` → which then switched to the Workout tab. This retargets `onResume` to land directly on the Workout tab (index 1), where `WorkoutPausedView` renders after #465 — one hop, pointing **at** the owner.

## Orphan removed (created by this change)

- `@State private var navigateToPausedDayDetail` and its `.navigationDestination(isPresented:)` block. Grep confirms **zero** remaining references. The day-detail stays reachable normally from the Program tab calendar; only the banner's redundant push path is removed.

## Testable seam

Routing intent extracted into the pure `ContentView.applyBannerResume(selectedTab:)` static helper (mirrors the `ContentView.hostDay` precedent), so the routing can be unit-tested without a live SwiftUI view.

## Tests

New `PausedBannerResumeRoutingTests`: banner resume lands on the Workout tab (index 1), idempotent when already there. RED before (no `applyBannerResume` member), GREEN after. `PausedBannerResumeRoutingTests` and all routing suites pass. Two pre-existing flakes (`AIInferenceServiceTests.test_networkFailure_urlError`, `PrescriptionGuardrailTests`) passed on isolated re-run — unrelated to this diff.

## Out of scope (respected)

`PausedSessionBannerView` itself is untouched; copy changes are #468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)