### PR TITLE
feat(#468): one vocabulary for the paused state

### DIFF
--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -228,8 +228,8 @@ struct ContentView: View {
                 showTrainingTimeMigrationNotice = true
             }
         }
-        .alert("Unfinished Workout", isPresented: $showCrashRecoveryAlert) {
-            Button("Resume") {
+        .alert("Workout paused", isPresented: $showCrashRecoveryAlert) {
+            Button("Resume workout") {
                 // #441: Resume no longer seeds sticky overrides. It only adjudicates
                 // which alert to show: if the paused sentinel resolves to a real day
                 // anywhere in the mesocycle, switch to the Workout tab — which
@@ -249,7 +249,7 @@ struct ContentView: View {
                     showOrphanedRecoveryAlert = true
                 }
             }
-            Button("Abandon Session", role: .destructive) {
+            Button("Discard workout", role: .destructive) {
                 if let saved = crashRecoveryState {
                     Task {
                         await deps.workoutSessionManager.abandonSession(sessionId: saved.sessionId)
@@ -654,12 +654,12 @@ struct ContentView: View {
 
     private var crashRecoveryMessage: String {
         guard let saved = crashRecoveryState else {
-            return "You have an unfinished session. Resume it or abandon it?"
+            return "Your workout is paused. Resume where you left off, or discard it?"
         }
         let formatter = DateFormatter()
         formatter.timeStyle = .short
         formatter.dateStyle = .none
-        return "You have an unfinished session from \(formatter.string(from: saved.pausedAt)). Resume it or abandon it?"
+        return "Your workout is paused from \(formatter.string(from: saved.pausedAt)). Resume where you left off, or discard it?"
     }
 
     // MARK: - Regenerate Program

--- a/ProjectApex/Features/Program/ProgramDayDetailView.swift
+++ b/ProjectApex/Features/Program/ProgramDayDetailView.swift
@@ -222,7 +222,7 @@ struct ProgramDayDetailView: View {
                             // Paused session — amber info banner
                             statusBadge(
                                 icon: "pause.circle.fill",
-                                label: "Session Paused — tap Resume to continue",
+                                label: "Workout paused",
                                 color: Color(red: 1.00, green: 0.70, blue: 0.10)
                             )
                         } else if currentDay.status == .skipped {
@@ -591,8 +591,8 @@ struct ProgramDayDetailView: View {
                 }
             )
         }
-        .alert("Existing Paused Session", isPresented: $showExistingPausedSessionAlert) {
-            Button("Discard Paused Session", role: .destructive) {
+        .alert("Workout paused", isPresented: $showExistingPausedSessionAlert) {
+            Button("Discard workout", role: .destructive) {
                 PausedSessionState.clear()
                 switchToTab(1)
             }
@@ -661,7 +661,7 @@ struct ProgramDayDetailView: View {
                 HStack(spacing: 8) {
                     Image(systemName: "pause.circle.fill")
                         .font(.system(size: 15, weight: .semibold))
-                    Text("SESSION PAUSED")
+                    Text("WORKOUT PAUSED")
                         .font(.system(size: 13, weight: .bold))
                         .kerning(0.5)
                 }
@@ -681,7 +681,7 @@ struct ProgramDayDetailView: View {
                     HStack(spacing: 10) {
                         Image(systemName: "play.circle.fill")
                             .font(.system(size: 17, weight: .semibold))
-                        Text("Resume Session")
+                        Text("Resume workout")
                             .font(.system(size: 17, weight: .semibold))
                     }
                     .frame(maxWidth: .infinity)

--- a/ProjectApex/Features/Program/ProgramOverviewView.swift
+++ b/ProjectApex/Features/Program/ProgramOverviewView.swift
@@ -655,7 +655,7 @@ private struct DayCardView: View {
                     Image(systemName: "pause.circle.fill")
                         .font(.system(size: 14))
                         .foregroundStyle(pausedAmber)
-                        .accessibilityLabel("Session paused")
+                        .accessibilityLabel("Workout paused")
                 } else if isSkipped {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 14))

--- a/ProjectApex/Features/Workout/NowTrainingBar.swift
+++ b/ProjectApex/Features/Workout/NowTrainingBar.swift
@@ -6,7 +6,7 @@
 // own red dot, so live vs paused was indistinguishable). The pill carries the
 // distinction in THREE redundant channels so it survives colourblindness and Reduce
 // Motion: motion (a pulsing dot when live), colour (blue vs amber), and text+icon
-// ("Training" + circle vs "Paused — tap to resume" + pause glyph).
+// ("Training" + circle vs "Workout paused" + pause glyph).
 //
 // State is a pure function of the ActiveSessionCoordinator's isLive / pausedSessionExists
 // (BarState.resolve), so it is unit-testable without rendering. Tapping the pill switches
@@ -51,9 +51,14 @@ struct NowTrainingBar: View {
         state == .live ? Self.liveAccent : Self.pausedAccent
     }
 
-    private var label: String {
-        state == .live ? "Training" : "Paused — tap to resume"
+    /// Canonical pill copy. Static so it is unit-testable without rendering
+    /// (mirrors `BarState.resolve`). #468 — one vocabulary: the paused state reads
+    /// "Workout paused" everywhere; the chevron already signals tappable, so the
+    /// word "Resume" is reserved for the surface that actually resumes.
+    static func label(for state: BarState) -> String {
+        state == .live ? "Training" : "Workout paused"
     }
+    private var label: String { Self.label(for: state) }
 
     private var pill: some View {
         Button(action: onTap) {

--- a/ProjectApex/Features/Workout/PausedSessionBannerView.swift
+++ b/ProjectApex/Features/Workout/PausedSessionBannerView.swift
@@ -20,7 +20,7 @@ struct PausedSessionBannerView: View {
                 .foregroundStyle(amberColor)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text("Paused Session")
+                Text("Workout paused")
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.white)
                 Text("\(dayLabel.replacingOccurrences(of: "_", with: " ").capitalized) · Week \(weekNumber)")

--- a/ProjectApexTests/ActiveSessionCoordinatorTests.swift
+++ b/ProjectApexTests/ActiveSessionCoordinatorTests.swift
@@ -378,6 +378,14 @@ final class ActiveSessionCoordinatorTests: XCTestCase {
         XCTAssertEqual(NowTrainingBar.BarState.resolve(isLive: true,  pausedExists: true),  .live)
     }
 
+    // 10b. #468 — one vocabulary: the paused pill reads the canonical "Workout paused"
+    //      (no "tap to resume"; the verb "Resume" is reserved for the surface that
+    //      actually resumes). The live state still reads "Training".
+    func testNowTrainingBarLabel_isCanonicalVocabulary() {
+        XCTAssertEqual(NowTrainingBar.label(for: .paused), "Workout paused")
+        XCTAssertEqual(NowTrainingBar.label(for: .live), "Training")
+    }
+
     // 11. #462 — driven off the real coordinator: the bar state agrees with the
     //     single ActiveSession enum at idle / paused / live, with no disagreement.
     func testNowTrainingBarState_matchesCoordinator_idlePausedLive() async throws {


### PR DESCRIPTION
Closes #468

Final slice of the pause-mid-workout flow tightening. Pure copy sweep to the canonical vocabulary **"Workout paused" / "Resume workout" / "Discard workout"** across every surface that announces the paused state (pill, banner, day-detail badge/alert/CTA, crash-recovery alert, calendar VoiceOver label).

The two genuinely-different-state alerts ("Session Mismatch", "Session Not Found") are deliberately excluded. `NowTrainingBar.label` exposed as a testable static func with a copy assertion added to ActiveSessionCoordinatorTests.

Grep gate clean; full suite green locally (TEST SUCCEEDED, iPhone 17 Pro / iOS 26.5).

Completes the tightening alongside #465 (in-place paused screen), #466 (one pause function), #467 (banner retarget).