### PR TITLE
feat(#473): Brutalist pre-workout

### DIFF
--- a/ProjectApex/Features/Workout/PreWorkoutView.swift
+++ b/ProjectApex/Features/Workout/PreWorkoutView.swift
@@ -1,15 +1,16 @@
 // Features/Workout/PreWorkoutView.swift
 // ProjectApex — P3-T03 / P4-E1
 //
-// Pre-workout screen shown before a session starts.
-// Displays gym streak ring, today's training day summary, and a Start Workout CTA.
+// Pre-workout screen shown before a session starts. Restyled to the Brutalist
+// Athletic identity (#473): pure-black surface, restrained streak ring + count,
+// a today's-plan day card listing exercises, and one volt-lime primary action.
 //
 // Acceptance criteria:
-//   ✓ StreakResult ring with consecutive-day count, tier label, tier icon, colour-coded tint
+//   ✓ StreakResult ring with consecutive-day count (Brutalist single-accent: lime ring/count)
 //   ✓ Today's training day: label, exercise count, estimated duration
 //   ✓ "Start Workout" → WorkoutSessionManager.startSession() via ViewModel
 //   ✓ Preflight state: "Preparing your session…" with spinner
-//   ✓ Yesterday's session summary snippet (stub — populated in P4)
+//   ✓ Dismissable banners (welcome-back / heavy-reassessment / calibration) preserved
 
 import SwiftUI
 
@@ -102,14 +103,14 @@ struct PreWorkoutView: View {
 
     var body: some View {
         ZStack {
-            // Cinematic background with streak tint
-            apexBackground
+            // Pure-black Brutalist backdrop.
+            Apex.bg.ignoresSafeArea()
 
             if viewModel.isPreflight {
                 preflightView
             } else {
                 ScrollView(showsIndicators: false) {
-                    VStack(spacing: 32) {
+                    VStack(spacing: 22) {
                         programProgressSection
                         if isFirstSession {
                             firstSessionBanner
@@ -134,8 +135,8 @@ struct PreWorkoutView: View {
                             skipButton
                         }
                     }
-                    .padding(.horizontal, 24)
-                    .padding(.top, 32)
+                    .padding(.horizontal, Apex.pad)
+                    .padding(.top, 24)
                     .padding(.bottom, 48)
                 }
             }
@@ -157,39 +158,25 @@ struct PreWorkoutView: View {
                         Button(action: { onBack?() }) {
                             Image(systemName: "chevron.left")
                                 .font(.system(size: 17, weight: .semibold))
-                                .foregroundStyle(.white.opacity(0.80))
+                                .foregroundStyle(Apex.text.opacity(0.80))
                         }
                     } else if onCloseToTab0 != nil {
                         Button(action: { onCloseToTab0?() }) {
                             Image(systemName: "xmark")
                                 .font(.system(size: 15, weight: .semibold))
-                                .foregroundStyle(.white.opacity(0.80))
+                                .foregroundStyle(Apex.text.opacity(0.80))
                         }
                     }
                 }
             }
             ToolbarItem(placement: .principal) {
-                Text("Today's Session")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.70))
+                Text("TODAY'S SESSION")
+                    .font(.system(size: 12, weight: .semibold))
+                    .fontWidth(.condensed)
+                    .textCase(.uppercase)
+                    .tracking(1.5)
+                    .foregroundStyle(Apex.textDim)
             }
-        }
-    }
-
-    // MARK: - Background
-
-    private var apexBackground: some View {
-        ZStack {
-            Color(red: 0.04, green: 0.04, blue: 0.06)
-                .ignoresSafeArea()
-            RadialGradient(
-                colors: [streak.tintColor.opacity(0.15), Color.clear],
-                center: UnitPoint(x: 0.5, y: 0.10),
-                startRadius: 0,
-                endRadius: 380
-            )
-            .ignoresSafeArea()
-            .blendMode(.plusLighter)
         }
     }
 
@@ -200,56 +187,45 @@ struct PreWorkoutView: View {
             Spacer()
             ProgressView()
                 .progressViewStyle(.circular)
-                .tint(streak.tintColor)
+                .tint(Apex.accent)
                 .scaleEffect(1.4)
             Text("Preparing your session\u{2026}")
-                .font(.system(size: 17, weight: .medium))
-                .foregroundStyle(.white.opacity(0.60))
+                .font(.system(size: 15, weight: .medium))
+                .fontWidth(.condensed)
+                .textCase(.uppercase)
+                .tracking(1.0)
+                .foregroundStyle(Apex.textDim)
             Spacer()
         }
     }
 
-    // MARK: - Programme Progress Section
+    // MARK: - Programme Progress Section (streak ring + Day X of Y)
 
     private var programProgressSection: some View {
         let progress: CGFloat = totalDayCount > 0 ? CGFloat(completedDayCount) / CGFloat(totalDayCount) : 0
 
-        return VStack(spacing: 20) {
-            // Progress ring with Day X of Y inside
+        return VStack(spacing: 18) {
+            // Progress ring with Day X of Y inside — Brutalist single-accent: lime.
             ZStack {
-                // Track ring
-                Circle()
-                    .stroke(streak.tintColor.opacity(0.12), lineWidth: 12)
-                    .frame(width: 160, height: 160)
-
-                // Progress arc
-                Circle()
-                    .trim(from: 0, to: progress)
-                    .stroke(
-                        AngularGradient(
-                            colors: [streak.tintColor.opacity(0.5), streak.tintColor],
-                            center: .center
-                        ),
-                        style: StrokeStyle(lineWidth: 12, lineCap: .round)
-                    )
-                    .frame(width: 160, height: 160)
-                    .rotationEffect(.degrees(-90))
-                    .animation(.easeOut(duration: 0.8), value: completedDayCount)
+                ApexRing(
+                    progress: Double(progress),
+                    lineWidth: 9,
+                    color: Apex.accent,
+                    track: Apex.accent.opacity(0.12),
+                    useGradient: true
+                )
+                .frame(width: 156, height: 156)
+                .animation(.easeOut(duration: 0.8), value: completedDayCount)
 
                 // Day count inside ring — hidden until totalDayCount is known
                 if totalDayCount > 0 {
                     VStack(spacing: 2) {
-                        HStack(alignment: .firstTextBaseline, spacing: 3) {
-                            Text("Day")
-                                .font(.system(size: 13, weight: .semibold))
-                                .foregroundStyle(.white.opacity(0.55))
-                            Text("\(completedDayCount + 1)")
-                                .font(.system(size: 44, weight: .black, design: .rounded).monospacedDigit())
-                                .foregroundStyle(.white)
-                        }
+                        ApexSectionLabel(text: "Day")
+                        ApexNumeral(text: "\(completedDayCount + 1)", size: 48)
                         Text("of \(totalDayCount)")
                             .font(.system(size: 13, weight: .semibold))
-                            .foregroundStyle(streak.tintColor)
+                            .fontWidth(.condensed)
+                            .foregroundStyle(Apex.accent)
                             .tracking(0.5)
                     }
                 }
@@ -257,10 +233,7 @@ struct PreWorkoutView: View {
             .padding(.top, 8)
 
             // Subtitle label
-            Text(progressSubtitle)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.white.opacity(0.45))
-                .tracking(0.5)
+            ApexSectionLabel(text: progressSubtitle, color: Apex.textFaint)
         }
     }
 
@@ -270,36 +243,30 @@ struct PreWorkoutView: View {
         return "\(percent)% of programme complete"
     }
 
-    // MARK: - Session Info Card
+    // MARK: - Session Info Card (today's plan)
 
     private var sessionInfoCard: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Card header
             HStack {
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: 5) {
                     Text(trainingDay.dayLabel.replacingOccurrences(of: "_", with: " "))
-                        .font(.system(size: 22, weight: .semibold))
-                        .foregroundStyle(.white)
-                    Text("Week \(weekLabel)")
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(.white.opacity(0.45))
-                        .tracking(0.3)
+                        .font(.system(size: 22, weight: .heavy))
+                        .fontWidth(.condensed)
+                        .foregroundStyle(Apex.text)
+                    ApexSectionLabel(text: "Week \(weekLabel)", color: Apex.textFaint)
                 }
                 Spacer()
-                // Exercise count badge — only meaningful once the session is generated.
+                // Exercise count chip — only meaningful once the session is generated.
                 if !isPending {
-                    Text("\(trainingDay.exercises.count) exercises")
-                        .font(.system(size: 13, weight: .bold))
-                        .foregroundStyle(streak.tintColor)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                        .background(streak.tintColor.opacity(0.12), in: Capsule())
+                    ApexTagChip(text: "\(trainingDay.exercises.count) exercises")
                 }
             }
-            .padding(20)
+            .padding(18)
 
-            Divider()
-                .background(.white.opacity(0.08))
+            Rectangle()
+                .fill(Apex.hairline)
+                .frame(height: 1)
 
             if isPending {
                 // Not-yet-generated day: no exercises exist, so don't render a 0-count
@@ -307,54 +274,52 @@ struct PreWorkoutView: View {
                 HStack(spacing: 6) {
                     Image(systemName: "sparkles")
                         .font(.system(size: 12))
-                        .foregroundStyle(.white.opacity(0.35))
+                        .foregroundStyle(Apex.textFaint)
                     Text("Session not generated yet")
                         .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(.white.opacity(0.35))
+                        .foregroundStyle(Apex.textFaint)
                 }
-                .padding(.horizontal, 20)
+                .padding(.horizontal, 18)
                 .padding(.vertical, 14)
             } else {
                 // Exercise list preview (first 3 + overflow)
                 VStack(spacing: 0) {
                     let preview = Array(trainingDay.exercises.prefix(3))
                     ForEach(Array(preview.enumerated()), id: \.offset) { index, exercise in
-                        ExerciseRowPreview(exercise: exercise, tintColor: streak.tintColor)
+                        ExerciseRowPreview(index: index, exercise: exercise)
                         if index < preview.count - 1 {
-                            Divider()
-                                .background(.white.opacity(0.06))
-                                .padding(.leading, 20)
+                            Rectangle()
+                                .fill(Apex.hairline.opacity(0.6))
+                                .frame(height: 1)
+                                .padding(.leading, 18)
                         }
                     }
                     if trainingDay.exercises.count > 3 {
                         Text("+ \(trainingDay.exercises.count - 3) more exercises")
                             .font(.system(size: 13, weight: .medium))
-                            .foregroundStyle(.white.opacity(0.35))
+                            .foregroundStyle(Apex.textFaint)
                             .frame(maxWidth: .infinity, alignment: .center)
                             .padding(.vertical, 14)
                     }
                 }
 
                 // Duration estimate
-                Divider()
-                    .background(.white.opacity(0.08))
+                Rectangle()
+                    .fill(Apex.hairline)
+                    .frame(height: 1)
                 HStack(spacing: 6) {
                     Image(systemName: "clock")
                         .font(.system(size: 12))
-                        .foregroundStyle(.white.opacity(0.35))
+                        .foregroundStyle(Apex.textFaint)
                     Text("~\(estimatedDurationMinutes) min estimated")
                         .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(.white.opacity(0.35))
+                        .foregroundStyle(Apex.textFaint)
                 }
-                .padding(.horizontal, 20)
+                .padding(.horizontal, 18)
                 .padding(.vertical, 14)
             }
         }
-        .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(.white.opacity(0.10), lineWidth: 0.5)
-        )
+        .apexCard()
     }
 
     // MARK: - First Session Banner (FB-005)
@@ -363,27 +328,18 @@ struct PreWorkoutView: View {
         HStack(spacing: 12) {
             Image(systemName: "chart.bar.fill")
                 .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(Color(red: 1.0, green: 0.75, blue: 0.20))
-            VStack(alignment: .leading, spacing: 3) {
-                Text("First session")
-                    .font(.system(size: 14, weight: .bold))
-                    .foregroundStyle(.white)
+                .foregroundStyle(Apex.gold)
+            VStack(alignment: .leading, spacing: 4) {
+                ApexSectionLabel(text: "First session", color: Apex.gold)
                 Text("We'll calibrate your starting weights today.")
                     .font(.system(size: 13, weight: .regular))
-                    .foregroundStyle(.white.opacity(0.65))
+                    .foregroundStyle(Apex.textDim)
             }
             Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .background(
-            Color(red: 1.0, green: 0.75, blue: 0.20).opacity(0.10),
-            in: RoundedRectangle(cornerRadius: 14, style: .continuous)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(Color(red: 1.0, green: 0.75, blue: 0.20).opacity(0.25), lineWidth: 0.5)
-        )
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .apexCard()
     }
 
     // MARK: - Banner dismissal semantics (J-F7 / #318)
@@ -419,6 +375,18 @@ struct PreWorkoutView: View {
         )
     }
 
+    /// Dismiss "×" control shared by the dismissable banners.
+    private func bannerDismissButton(_ banner: BannerDismissals.Banner, fingerprint: String) -> some View {
+        Button {
+            dismissBanner(banner, fingerprint: fingerprint)
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Apex.textFaint)
+                .padding(6)
+        }
+    }
+
     // MARK: - Welcome Back Banner (2.4A)
 
     /// Pure message-selection for the welcome-back banner, extracted for unit testing.
@@ -438,56 +406,36 @@ struct PreWorkoutView: View {
 
     private func welcomeBackBanner(days: Int) -> some View {
         let isReturnSession = days >= 28
-        let amberColor = Color(red: 1.0, green: 0.65, blue: 0.0)
         let message = Self.welcomeBackMessage(days: days, status: trainingDay.status)
         return HStack(spacing: 12) {
             Image(systemName: isReturnSession ? "arrow.counterclockwise.circle.fill" : "hand.wave.fill")
                 .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(amberColor)
+                .foregroundStyle(Apex.amber)
             Text(message)
                 .font(.system(size: 13, weight: .regular))
-                .foregroundStyle(.white.opacity(0.80))
+                .foregroundStyle(Apex.text.opacity(0.80))
                 .fixedSize(horizontal: false, vertical: true)
             Spacer(minLength: 0)
-            Button {
-                dismissBanner(.welcomeBack, fingerprint: welcomeBackFingerprint)
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.40))
-                    .padding(6)
-            }
+            bannerDismissButton(.welcomeBack, fingerprint: welcomeBackFingerprint)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .background(
-            amberColor.opacity(0.10),
-            in: RoundedRectangle(cornerRadius: 14, style: .continuous)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(amberColor.opacity(0.25), lineWidth: 0.5)
-        )
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .apexCard()
     }
 
     // MARK: - Heavy Reassessment Banner (#258)
 
     private func heavyReassessmentBanner(_ signal: HeavyReassessmentSignal) -> some View {
-        // Distinct non-amber "progress / level-up" accent so this card reads apart
-        // from the amber firstSession/welcomeBack banners when stacked (#258).
-        let accentColor = Color(red: 0.20, green: 0.80, blue: 0.55)
-        return HStack(alignment: .top, spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             Image(systemName: "chart.line.uptrend.xyaxis")
                 .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(accentColor)
+                .foregroundStyle(Apex.text.opacity(0.85))
             VStack(alignment: .leading, spacing: 8) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(HeavyReassessmentBannerCopy.title)
-                        .font(.system(size: 14, weight: .bold))
-                        .foregroundStyle(.white)
+                VStack(alignment: .leading, spacing: 4) {
+                    ApexSectionLabel(text: HeavyReassessmentBannerCopy.title)
                     Text(HeavyReassessmentBannerCopy.body(for: signal))
                         .font(.system(size: 13, weight: .regular))
-                        .foregroundStyle(.white.opacity(0.80))
+                        .foregroundStyle(Apex.text.opacity(0.80))
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 Button {
@@ -495,49 +443,30 @@ struct PreWorkoutView: View {
                 } label: {
                     Text("Review goals")
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(accentColor)
+                        .foregroundStyle(Apex.text)
                 }
             }
             Spacer(minLength: 0)
-            Button {
-                dismissBanner(.heavyReassessment, fingerprint: heavyReassessmentFingerprint(signal))
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.40))
-                    .padding(6)
-            }
+            bannerDismissButton(.heavyReassessment, fingerprint: heavyReassessmentFingerprint(signal))
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .background(
-            accentColor.opacity(0.10),
-            in: RoundedRectangle(cornerRadius: 14, style: .continuous)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(accentColor.opacity(0.25), lineWidth: 0.5)
-        )
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .apexCard()
     }
 
     // MARK: - Calibration Review Banner (#269)
 
     private func calibrationReviewBanner(_ signal: CalibrationReviewSignal) -> some View {
-        // Distinct blue/purple accent so this card reads apart from the amber
-        // firstSession/welcomeBack banners and the green heavy-reassessment one (#269).
-        let accentColor = Color(red: 0.58, green: 0.45, blue: 0.95)
-        return HStack(alignment: .top, spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             Image(systemName: "target")
                 .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(accentColor)
+                .foregroundStyle(Apex.text.opacity(0.85))
             VStack(alignment: .leading, spacing: 8) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(CalibrationReviewBannerCopy.title(isRecalibration: signal.isRecalibration))
-                        .font(.system(size: 14, weight: .bold))
-                        .foregroundStyle(.white)
+                VStack(alignment: .leading, spacing: 4) {
+                    ApexSectionLabel(text: CalibrationReviewBannerCopy.title(isRecalibration: signal.isRecalibration))
                     Text(CalibrationReviewBannerCopy.body(for: signal))
                         .font(.system(size: 13, weight: .regular))
-                        .foregroundStyle(.white.opacity(0.80))
+                        .foregroundStyle(Apex.text.opacity(0.80))
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 Button {
@@ -545,29 +474,15 @@ struct PreWorkoutView: View {
                 } label: {
                     Text("Review targets")
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(accentColor)
+                        .foregroundStyle(Apex.text)
                 }
             }
             Spacer(minLength: 0)
-            Button {
-                dismissBanner(.calibrationReview, fingerprint: calibrationFingerprint)
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.40))
-                    .padding(6)
-            }
+            bannerDismissButton(.calibrationReview, fingerprint: calibrationFingerprint)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .background(
-            accentColor.opacity(0.10),
-            in: RoundedRectangle(cornerRadius: 14, style: .continuous)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(accentColor.opacity(0.25), lineWidth: 0.5)
-        )
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .apexCard()
     }
 
     // MARK: - Start Button
@@ -606,7 +521,7 @@ struct PreWorkoutView: View {
                 noGymProfileButton
                 Text("Set up your gym in Settings first")
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.40))
+                    .foregroundStyle(Apex.textFaint)
                     .multilineTextAlignment(.center)
             }
         }
@@ -618,53 +533,44 @@ struct PreWorkoutView: View {
             generationAttempted = true
             onGenerateSession?()
         } label: {
-            HStack(spacing: 10) {
+            ApexButton(
+                title: isGeneratingSession ? "Generating\u{2026}" : "Generate Session",
+                icon: isGeneratingSession ? nil : "wand.and.stars"
+            )
+            .opacity(isGeneratingSession ? 0.45 : 1.0)
+            .overlay {
                 if isGeneratingSession {
                     ProgressView()
                         .progressViewStyle(.circular)
-                        .tint(.white)
+                        .tint(Apex.onAccent)
                         .scaleEffect(0.85)
-                } else {
-                    Image(systemName: "wand.and.stars")
-                        .font(.system(size: 18, weight: .semibold))
                 }
-                Text(isGeneratingSession ? "Generating\u{2026}" : "Generate Session")
-                    .font(.system(size: 18, weight: .bold))
             }
-            .foregroundStyle(.white)
-            .frame(maxWidth: .infinity)
-            .frame(height: 60)
-            .background(
-                streak.tintColor.opacity(isGeneratingSession ? 0.40 : 0.85),
-                in: RoundedRectangle(cornerRadius: 18, style: .continuous)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .stroke(.white.opacity(0.20), lineWidth: 0.5)
-            )
             .animation(.easeInOut(duration: 0.15), value: isGeneratingSession)
         }
         .disabled(isGeneratingSession)
     }
 
     private var noGymProfileButton: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "wand.and.stars")
-                .font(.system(size: 18, weight: .semibold))
+        HStack(spacing: 9) {
+            Image(systemName: "wand.and.stars").font(.system(size: 16, weight: .bold))
             Text("Generate Session")
-                .font(.system(size: 18, weight: .bold))
+                .textCase(.uppercase)
+                .tracking(1.1)
+                .fontWidth(.condensed)
         }
-        .foregroundStyle(.white.opacity(0.45))
+        .font(.system(size: 17, weight: .bold))
+        .foregroundStyle(Apex.textDim)
         .frame(maxWidth: .infinity)
-        .frame(height: 60)
-        .background(
-            Color.white.opacity(0.08),
-            in: RoundedRectangle(cornerRadius: 18, style: .continuous)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(.white.opacity(0.12), lineWidth: 0.5)
-        )
+        .padding(.vertical, 17)
+        .background {
+            RoundedRectangle(cornerRadius: Apex.corner, style: .continuous)
+                .fill(Apex.surface)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Apex.corner, style: .continuous)
+                .stroke(Apex.hairline, lineWidth: 1)
+        }
     }
 
     private var startWorkoutButton: some View {
@@ -687,30 +593,19 @@ struct PreWorkoutView: View {
         Button {
             viewModel.startSession(trainingDay: trainingDay, programId: programId, resolveOwner: { await deps.resolvedOwnerUserId() }, weekNumber: weekNumber, startingExerciseIndex: startingExerciseIndex)
         } label: {
-            HStack(spacing: 10) {
+            ApexButton(
+                title: viewModel.isStartingSession ? "Loading\u{2026}" : "Start Workout",
+                icon: viewModel.isStartingSession ? nil : "play.fill"
+            )
+            .opacity(viewModel.isStartingSession ? 0.45 : 1.0)
+            .overlay {
                 if viewModel.isStartingSession {
                     ProgressView()
                         .progressViewStyle(.circular)
-                        .tint(.white)
+                        .tint(Apex.onAccent)
                         .scaleEffect(0.85)
-                } else {
-                    Image(systemName: "play.fill")
-                        .font(.system(size: 18, weight: .semibold))
                 }
-                Text(viewModel.isStartingSession ? "Loading\u{2026}" : "Start Workout")
-                    .font(.system(size: 18, weight: .bold))
             }
-            .foregroundStyle(.white)
-            .frame(maxWidth: .infinity)
-            .frame(height: 60)
-            .background(
-                streak.tintColor.opacity(viewModel.isStartingSession ? 0.40 : 0.85),
-                in: RoundedRectangle(cornerRadius: 18, style: .continuous)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .stroke(.white.opacity(0.20), lineWidth: 0.5)
-            )
             .animation(.easeInOut(duration: 0.15), value: viewModel.isStartingSession)
         }
         .disabled(viewModel.isStartingSession)
@@ -723,8 +618,8 @@ struct PreWorkoutView: View {
             showSkipConfirmation = true
         } label: {
             Text("Skip this session")
-                .font(.system(size: 15, weight: .medium))
-                .foregroundStyle(.white.opacity(0.40))
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Apex.textFaint)
         }
         .disabled(viewModel.isStartingSession)
         .alert("Skip this session?", isPresented: $showSkipConfirmation) {
@@ -756,47 +651,43 @@ struct PreWorkoutView: View {
 // MARK: - ExerciseRowPreview
 
 private struct ExerciseRowPreview: View {
+    let index: Int
     let exercise: PlannedExercise
-    let tintColor: Color
 
     var body: some View {
-        HStack(spacing: 14) {
-            // Muscle group colour dot
+        HStack(spacing: 12) {
+            // Numbered slot — Brutalist tabular index.
+            Text(String(format: "%02d", index + 1))
+                .font(Apex.numeral(13, weight: .bold))
+                .fontWidth(.condensed)
+                .foregroundStyle(Apex.textFaint)
+
+            // Muscle-group dot — accent.
             Circle()
-                .fill(muscleColor(for: exercise.primaryMuscle))
-                .frame(width: 8, height: 8)
+                .fill(Apex.accent.opacity(0.8))
+                .frame(width: 6, height: 6)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(exercise.name)
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.85))
-                Text("\(exercise.sets) sets · \(exercise.repRange.min)–\(exercise.repRange.max) reps")
-                    .font(.system(size: 12, weight: .regular))
-                    .foregroundStyle(.white.opacity(0.40))
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Apex.text)
+                Text("\(exercise.sets) × \(exercise.repRange.min)–\(exercise.repRange.max)")
+                    .font(.system(size: 12, weight: .medium))
+                    .fontWidth(.condensed)
+                    .foregroundStyle(Apex.textFaint)
             }
 
             Spacer()
 
             Text(exercise.equipmentRequired.displayName)
                 .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(.white.opacity(0.30))
+                .fontWidth(.condensed)
+                .textCase(.uppercase)
+                .tracking(0.5)
+                .foregroundStyle(Apex.textFaint)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 14)
-    }
-
-    private func muscleColor(for muscle: String) -> Color {
-        switch muscle {
-        case let m where m.contains("pectoral"):  return Color(red: 0.96, green: 0.42, blue: 0.30)
-        case let m where m.contains("lat"), let m where m.contains("back"), let m where m.contains("dorsi"):
-            return Color(red: 0.30, green: 0.70, blue: 0.96)
-        case let m where m.contains("delt"):      return Color(red: 0.70, green: 0.50, blue: 0.96)
-        case let m where m.contains("quad"), let m where m.contains("hamstring"), let m where m.contains("glute"):
-            return Color(red: 0.30, green: 0.96, blue: 0.60)
-        case let m where m.contains("bicep"), let m where m.contains("tricep"):
-            return Color(red: 0.96, green: 0.80, blue: 0.30)
-        default:                                   return Color.white.opacity(0.40)
-        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 13)
     }
 }
 


### PR DESCRIPTION
Part of #473 — Brutalist Athletic workout-screen redesign.

Restyles `PreWorkoutView` to the Brutalist identity using the merged design system (`Apex` tokens, `ApexButton`, `ApexRing`, `ApexNumeral`, `ApexSectionLabel`, `ApexTagChip`, `apexCard()`). Style reference was the already-restyled `ActiveSetView`.

## What changed (visual layer only)
- Pure-black background (`Apex.bg`), dropped the streak-tinted radial gradient.
- Streak / programme-progress ring + Day X of Y count now render in the single volt-lime accent (`ApexRing` + `ApexNumeral`). Tier coloring is dropped per the single-accent rule; the underlying `StreakResult` data is untouched.
- Today's-plan day card rebuilt on `apexCard()` with numbered, tabular `ExerciseRowPreview` rows and an `ApexTagChip` exercise count.
- The dismissable banners (first-session, welcome-back, heavy-reassessment, calibration) restyled into `apexCard()` + `ApexSectionLabel`, keeping their distinguishing icon tints restrained. Lime is reserved for the primary action only.
- Primary "Start Workout" / "Generate Session" CTAs use the lime filled `ApexButton`; secondary skip is a faint text button.
- Preflight spinner and toolbar title restyled (lime tint / condensed uppercase label).

## Preserved behavior (no logic touched)
All state, bindings, `init`/API, computed helpers, accessibility, and navigation are unchanged:
- Streak ring + consecutive-day count; day summary (label / exercise count / estimated duration).
- "Start Workout" → `viewModel.startSession(...)` with `resolveOwner` flow; preflight "Preparing your session…" spinner.
- Welcome-back (≥14 days), heavy-reassessment level-up, and first-session calibration banners — including the calibration-takes-precedence rule and the welcome-back ≥28-day copy branch.
- Banner CTAs (`onReviewGoals` → `GoalReviewView`, `onReviewCalibration` → `CalibrationReviewView`) and the durable event-fingerprinted `BannerDismissals` dismissal store.
- Pending-day "Generate Session" / no-gym-profile path, inline start/generation error lines, and the skip-session confirmation flow.

## Build
`** BUILD SUCCEEDED **` (iPhone 17 Pro, OS 26.5, Debug, CODE_SIGNING_ALLOWED=NO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011n7FKRnCe2FQYqMcsvT8Ut
