### PR TITLE
feat(#494): Sex field wired into coach calibration

### DIFF
--- a/ProjectApex/AICoach/AIInferenceService.swift
+++ b/ProjectApex/AICoach/AIInferenceService.swift
@@ -86,6 +86,9 @@ nonisolated struct UserProfileContext: Codable, Sendable {
     let heightCm: Double?
     /// Age in years. Informs rest duration and conservative RIR targets for older users.
     let age: Int?
+    /// Biological sex ("male"/"female"). Optional — anchors first-session pressing
+    /// loads relative to bodyweight. Absent = unset (coach falls back to default).
+    let sex: String?
     /// Training age label: "Beginner (< 1 yr)", "Intermediate (1–3 yrs)", "Advanced (3+ yrs)".
     let trainingAge: String?
 
@@ -93,6 +96,7 @@ nonisolated struct UserProfileContext: Codable, Sendable {
         case bodyweightKg  = "bodyweight_kg"
         case heightCm      = "height_cm"
         case age
+        case sex
         case trainingAge   = "training_age"
     }
 }
@@ -738,6 +742,7 @@ extension WorkoutContext {
                 bodyweightKg: 80.0,
                 heightCm: 178.0,
                 age: 28,
+                sex: nil,
                 trainingAge: "Intermediate (1–3 yrs)"
             ),
             isFirstSession: false,

--- a/ProjectApex/AICoach/InferenceSpike.swift
+++ b/ProjectApex/AICoach/InferenceSpike.swift
@@ -173,6 +173,7 @@ enum InferenceSpike {
                 bodyweightKg: 82.0,
                 heightCm: 180.0,
                 age: 30,
+                sex: nil,
                 trainingAge: "Intermediate (1–3 yrs)"
             ),
             isFirstSession: false,

--- a/ProjectApex/Features/Onboarding/OnboardingView.swift
+++ b/ProjectApex/Features/Onboarding/OnboardingView.swift
@@ -1064,6 +1064,9 @@ enum UserProfileConstants {
     static let bodyweightKgKey  = "com.projectapex.user.bodyweightKg"
     static let heightCmKey      = "com.projectapex.user.heightCm"
     static let ageKey           = "com.projectapex.user.age"
+    /// Biological sex used by the AI coach to calibrate first-session pressing
+    /// loads. Stored lowercase ("male"/"female"); absent = unset (#494 PR4).
+    static let sexKey           = "com.projectapex.user.sex"
     static let trainingAgeKey   = "com.projectapex.user.trainingAge"
     /// Primary training goal selected during onboarding (TrainingGoal.rawValue).
     /// Read by GenerationUserProfile.assemble as the fallback goal source when

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -2278,10 +2278,11 @@ actor WorkoutSessionManager {
         let bodyweight = defaults.object(forKey: UserProfileConstants.bodyweightKgKey) as? Double
         let height     = defaults.object(forKey: UserProfileConstants.heightCmKey) as? Double
         let age        = defaults.object(forKey: UserProfileConstants.ageKey) as? Int
+        let sex        = defaults.string(forKey: UserProfileConstants.sexKey)
         let trainingAge = defaults.string(forKey: UserProfileConstants.trainingAgeKey)
 
         // Only return a profile if we have at least one meaningful field.
-        guard bodyweight != nil || height != nil || age != nil || trainingAge != nil else {
+        guard bodyweight != nil || height != nil || age != nil || sex != nil || trainingAge != nil else {
             return nil
         }
 
@@ -2289,6 +2290,7 @@ actor WorkoutSessionManager {
             bodyweightKg: bodyweight,
             heightCm: height,
             age: age,
+            sex: sex,
             trainingAge: trainingAge
         )
     }

--- a/ProjectApex/Resources/Prompts/SystemPrompt_Inference.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_Inference.txt
@@ -214,8 +214,9 @@ How to react:
 FIRST-SESSION CALIBRATION: If is_first_session is true, prescribe ~60% estimated 1RM.
 Use user_profile.bodyweight_kg and training_age as anchors.
 
-USER PROFILE: Use bodyweight_kg, training_age, age, height_cm to calibrate absolute weights.
+USER PROFILE: Use bodyweight_kg, training_age, age, height_cm, sex to calibrate absolute weights.
 Beginner bench: ~50–60% BW. Intermediate: ~80–100% BW. Advanced: ~100–130%+ BW.
+When sex is "female", anchor upper-body pressing lower relative to bodyweight (lower-body stays closer to parity); adjust first-session absolute loads down accordingly. If sex is absent, do not assume.
 
 EXERCISE SWAPS: The session_log may contain sets tagged with exercise_swap from a previously
 swapped exercise. These sets belong to the old exercise — do NOT use them to calibrate weight

--- a/ProjectApex/Settings/SettingsView.swift
+++ b/ProjectApex/Settings/SettingsView.swift
@@ -68,6 +68,9 @@ struct SettingsView: View {
     @State private var bodyweightText: String = ""
     @State private var heightText: String = ""
     @State private var ageText: String = ""
+    /// Biological sex stored lowercase ("male"/"female") in `UserProfileConstants.sexKey`.
+    /// nil = unset; existing users keep their current (sex-agnostic) coach behaviour (#494 PR4).
+    @State private var sex: String? = nil
     @State private var trainingAge: TrainingAge = .beginner
 
     // #494 PR3: Program controls.
@@ -349,6 +352,21 @@ struct SettingsView: View {
                 UserDefaults.standard.set(age, forKey: UserProfileConstants.ageKey)
             }
 
+            // Sex — stored lowercase ("male"/"female"); nil = unset (#494 PR4).
+            HStack(spacing: 13) {
+                boxedIcon("figure.stand")
+                Picker("Sex", selection: $sex) {
+                    Text("Male").tag(String?.some("male"))
+                    Text("Female").tag(String?.some("female"))
+                }
+                .font(.system(size: 16, weight: .medium))
+                .tint(Apex.textDim)
+            }
+            .onChange(of: sex) { _, v in
+                UserDefaults.standard.set(v, forKey: UserProfileConstants.sexKey)
+            }
+            .settingsCardRow(.middle)
+
             // Training age
             HStack(spacing: 13) {
                 boxedIcon("chart.bar.fill")
@@ -418,6 +436,7 @@ struct SettingsView: View {
         if let a = defaults.object(forKey: UserProfileConstants.ageKey) as? Int {
             ageText = String(a)
         }
+        sex = defaults.string(forKey: UserProfileConstants.sexKey)
         if let ta = defaults.string(forKey: UserProfileConstants.trainingAgeKey),
            let match = TrainingAge.allCases.first(where: { $0.rawValue == ta }) {
             trainingAge = match

--- a/ProjectApexTests/AIInferenceServiceTests.swift
+++ b/ProjectApexTests/AIInferenceServiceTests.swift
@@ -643,7 +643,7 @@ final class AIInferenceServiceTests: XCTestCase {
             ),
             biometrics: Biometrics(bodyweightKg: 80.0, restingHeartRate: 52, readinessScore: 8, sleepHours: 7.5),
             streakResult: nil,
-            userProfile: UserProfileContext(bodyweightKg: 80.0, heightCm: 178.0, age: 28, trainingAge: "Intermediate (1–3 yrs)"),
+            userProfile: UserProfileContext(bodyweightKg: 80.0, heightCm: 178.0, age: 28, sex: nil, trainingAge: "Intermediate (1–3 yrs)"),
             isFirstSession: false,
             currentExercise: CurrentExercise(
                 name: exerciseName,


### PR DESCRIPTION
Adds a **Sex** field to the Training Profile (Settings) and wires it end-to-end into the AI coach's first-session calibration as a real input the prompt consumes.

## End-to-end chain
1. **Settings** (`SettingsView.swift`) — new Sex `Picker` (Male/Female) between Age and Experience; writes lowercase `"male"`/`"female"` to `UserProfileConstants.sexKey`. Card positions corrected (Bodyweight `.first`, Height/Age/Sex `.middle`, Experience `.last`).
2. **Constant** (`OnboardingView.swift`) — `UserProfileConstants.sexKey`.
3. **Read** (`WorkoutSessionManager.loadUserProfileFromDefaults()`) — reads the key, adds `sex != nil` to the guard, passes `sex:` into the context.
4. **Context** (`AIInferenceService.swift` `UserProfileContext`) — new `sex: String?` serializing as `"sex"`.
5. **Prompt** (`SystemPrompt_Inference.txt`) — calibration block now lists `sex` as an anchor and adjusts first-session pressing loads for female lifters.

## Behaviour
- Default is **unset (nil)**: existing users are unaffected; nil `sex` is omitted/null in the payload and the coach keeps today's sex-agnostic behaviour. No onboarding backfill.
- Visual-only Settings change; matches the Brutalist restyle (boxed icon + condensed picker, lime reserved).
- Build: `** BUILD SUCCEEDED **` (iPhone 17 Pro, OS 26.5).
- Three other `UserProfileContext(...)` call sites (sample-context builder, InferenceSpike, one test fixture) got `sex: nil` to keep the build green.

Part of #494
