### PR TITLE
feat(#494): release-safe Reset all data in Settings

### DIFF
--- a/ProjectApex/Settings/DeveloperSettingsView.swift
+++ b/ProjectApex/Settings/DeveloperSettingsView.swift
@@ -556,50 +556,15 @@ struct DeveloperSettingsView: View {
 
     /// Wipes all persisted app state except API keys in the Keychain, then returns to onboarding.
     ///
-    /// Clears in order:
-    ///   1. All UserDefaults for this app's bundle domain (onboarding flags, scan-skipped flag, etc.)
-    ///   2. GymFactStore weight-correction facts (UserDefaults-backed)
-    ///   3. The userId Keychain entry so onboarding generates a fresh identity
-    ///   4. The Supabase anonymous-auth session (#369) — access/refresh tokens, expiry,
-    ///      and the persisted `auth.uid()`. Without this, `restoreFromKeychain()` re-pins
-    ///      the OLD identity on the next launch, so "reset" would not mint a fresh user and
-    ///      the freshly-onboarded `users` row would not match a brand-new `auth.uid()`.
-    ///      A new anonymous session (and uid) is minted on the next launch.
-    ///   (API keys — anthropicAPIKey, openAIAPIKey, supabaseAnonKey — are intentionally preserved)
+    /// The data-clearing itself lives in the shared `performFullDataReset(deps:)` free
+    /// function (single source of truth — also used by the user-facing "Reset all data" in
+    /// Settings); this method delegates to it, then runs the developer-path UI tail
+    /// (`onResetAll?()` + banner).
     @MainActor
     private func performResetAll() async {
-        // 1. Wipe all UserDefaults for this bundle (onboarding flags, scan-skipped, gym facts, etc.)
-        if let bundleID = Bundle.main.bundleIdentifier {
-            UserDefaults.standard.removePersistentDomain(forName: bundleID)
-        }
-
-        // 2. Clear GymFactStore weight corrections (belt-and-suspenders after UserDefaults wipe)
-        await deps.gymFactStore.clearAll()
-
-        // 2b. Reset the LIVE in-memory state that survives the UserDefaults wipe:
-        // the write-ahead queue actor (queue + dead-letter), any paused session, and
-        // an ACTIVE (non-paused) WorkoutSessionManager session. removePersistentDomain
-        // wiped their on-disk UserDefaults, but the in-memory WAQ actor would re-persist
-        // its stale items on the next enqueue, and an active manager session still holds
-        // the OLD auth.uid() and could enqueue owner-mismatched writes within this
-        // process lifetime — both replay RLS-403s after re-onboarding (#369 owner-mismatch
-        // campaign, slices 3 & #403). PausedSessionState.clear() also resets the in-memory
-        // repairPending flag. resetToIdle() nils the active session.
-        await performLocalStateReset(
-            writeAheadQueue: deps.writeAheadQueue,
-            workoutSessionManager: deps.workoutSessionManager
-        )
-
-        // 3. Remove the persisted userId so onboarding creates a fresh identity
-        try? keychain.delete(.userId)
-
-        // 4. Clear the persisted Supabase anonymous-auth session (#369) so the next launch
-        //    signs in fresh and mints a new auth.uid(). Otherwise the restored session
-        //    re-pins the old identity and the reset is not a true zero.
-        try? keychain.delete(.supabaseAccessToken)
-        try? keychain.delete(.supabaseRefreshToken)
-        try? keychain.delete(.supabaseSessionExpiry)
-        try? keychain.delete(.supabaseAuthUserId)
+        // Wipe all on-device data + the anonymous Supabase session via the single
+        // source of truth shared with the user-facing "Reset all data" in Settings.
+        await performFullDataReset(deps: deps)
 
         // Navigate to onboarding immediately; the fresh anon identity is established on the
         // next launch (the in-memory auth session is only re-resolved at startup), so the
@@ -651,6 +616,61 @@ struct DeveloperSettingsView: View {
         showBanner("Programme reloaded from Supabase.", isError: false)
     }
 }
+#endif
+
+// MARK: - Full data reset (shared source of truth)
+
+/// Wipes all on-device app data + the anonymous Supabase session (#369), so the
+/// next launch mints a fresh `auth.uid()`. Shared by the developer reset and the
+/// user-facing "Reset all data" in Settings — keep this the single source of truth.
+///
+/// Clears in order:
+///   1. All UserDefaults for this app's bundle domain (onboarding flags, scan-skipped flag, etc.)
+///   2. GymFactStore weight-correction facts (UserDefaults-backed)
+///   2b. The LIVE in-memory state that survives the UserDefaults wipe (WAQ queue +
+///       dead-letter, any paused session, an ACTIVE WorkoutSessionManager session) via
+///       `performLocalStateReset` — otherwise the WAQ actor re-persists stale items and an
+///       active manager session keeps enqueuing owner-mismatched writes under the OLD
+///       auth.uid() (#369 owner-mismatch campaign, slices 3 & #403).
+///   3. The userId Keychain entry so onboarding generates a fresh identity
+///   4. The Supabase anonymous-auth session (#369) — access/refresh tokens, expiry,
+///      and the persisted `auth.uid()`. Without this, `restoreFromKeychain()` re-pins
+///      the OLD identity on the next launch, so "reset" would not mint a fresh user and
+///      the freshly-onboarded `users` row would not match a brand-new `auth.uid()`.
+///      A new anonymous session (and uid) is minted on the next launch.
+///   (API keys — anthropicAPIKey, openAIAPIKey, supabaseAnonKey — are intentionally preserved)
+///
+/// This is the data-clearing only; the caller runs its own UI tail (return-to-onboarding,
+/// banner).
+@MainActor
+func performFullDataReset(deps: AppDependencies) async {
+    let keychain = KeychainService.shared
+
+    // 1. Wipe all UserDefaults for this bundle (onboarding flags, scan-skipped, gym facts, etc.)
+    if let bundleID = Bundle.main.bundleIdentifier {
+        UserDefaults.standard.removePersistentDomain(forName: bundleID)
+    }
+
+    // 2. Clear GymFactStore weight corrections (belt-and-suspenders after UserDefaults wipe)
+    await deps.gymFactStore.clearAll()
+
+    // 2b. Reset the LIVE in-memory state that survives the UserDefaults wipe.
+    await performLocalStateReset(
+        writeAheadQueue: deps.writeAheadQueue,
+        workoutSessionManager: deps.workoutSessionManager
+    )
+
+    // 3. Remove the persisted userId so onboarding creates a fresh identity
+    try? keychain.delete(.userId)
+
+    // 4. Clear the persisted Supabase anonymous-auth session (#369) so the next launch
+    //    signs in fresh and mints a new auth.uid(). Otherwise the restored session
+    //    re-pins the old identity and the reset is not a true zero.
+    try? keychain.delete(.supabaseAccessToken)
+    try? keychain.delete(.supabaseRefreshToken)
+    try? keychain.delete(.supabaseSessionExpiry)
+    try? keychain.delete(.supabaseAuthUserId)
+}
 
 // MARK: - Local in-memory reset (#403)
 
@@ -670,6 +690,7 @@ func performLocalStateReset(
 
 // MARK: - Preview
 
+#if DEBUG
 #Preview {
     NavigationStack {
         DeveloperSettingsView()

--- a/ProjectApex/Settings/SettingsView.swift
+++ b/ProjectApex/Settings/SettingsView.swift
@@ -83,7 +83,16 @@ struct SettingsView: View {
     /// Projections fetched on demand when "Review targets" is tapped.
     @State private var calibrationProjections: [PatternProjection] = []
 
+    // #494 PR5: release-safe full reset.
+    /// Controls the destructive "Reset all data" confirmation alert.
+    @State private var showResetAllConfirmation = false
+
     private static let daysPerWeekRange = 2...6
+
+    /// Destructive-action red. The production design system has no danger token
+    /// (lime stays reserved for additive/commit actions), so this destructive row
+    /// defines its own red locally rather than adding to the shared DesignSystem.
+    private let dangerRed = Color(red: 0.92, green: 0.30, blue: 0.30)
 
     /// True when the user skipped the gym scan during onboarding — drives the setup prompt.
     private var gymScanSkipped: Bool {
@@ -102,6 +111,7 @@ struct SettingsView: View {
                 programSection
             }
             developerSection
+            dataSection
             aboutSection
         }
         .listStyle(.plain)
@@ -177,6 +187,18 @@ struct SettingsView: View {
             Button("OK", role: .cancel) { }
         } message: {
             Text(regenerateErrorMessage ?? "")
+        }
+        // #494 PR5: release-safe full reset confirmation.
+        .alert("Reset all data?", isPresented: $showResetAllConfirmation) {
+            Button("Reset", role: .destructive) {
+                Task {
+                    await performFullDataReset(deps: deps)
+                    onResetAll?()
+                }
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This erases your profile, program, and history on this device. This can't be undone.")
         }
     }
 
@@ -630,6 +652,32 @@ struct SettingsView: View {
             ApexSectionLabel(text: "Developer")
         }
         #endif
+    }
+
+    /// Release-safe "Reset all data" — destructive, red, gated behind a confirm.
+    /// Wipes on-device data + the anonymous Supabase session via the shared
+    /// `performFullDataReset` (same code path as the developer reset).
+    private var dataSection: some View {
+        Section {
+            Button(role: .destructive) {
+                showResetAllConfirmation = true
+            } label: {
+                HStack(spacing: 13) {
+                    Image(systemName: "trash.fill")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(dangerRed)
+                        .frame(width: 30)
+                    Text("Reset all data")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(dangerRed)
+                }
+            }
+            .settingsCardRow(.single)
+        } header: {
+            ApexSectionLabel(text: "Data")
+        } footer: {
+            footerText("Erases your profile, program, and history on this device. Can't be undone.")
+        }
     }
 
     private var aboutSection: some View {


### PR DESCRIPTION
## What

Adds a user-facing **"Reset all data"** to Settings, available in release builds. Today a full reset only exists behind `#if DEBUG` in `DeveloperSettingsView`.

## Shared reset (single source of truth)

The reset clears the anonymous Supabase session (#369), so its logic is sensitive — it must be the **same code** as the developer reset, not a re-implementation.

- Extracted the data-clearing body of `performResetAll()` into a free `@MainActor func performFullDataReset(deps: AppDependencies) async`, placed next to `performLocalStateReset` and **outside** `#if DEBUG` so the production `SettingsView` can call it. It uses `KeychainService.shared`.
- `performResetAll()` now `await performFullDataReset(deps: deps)` then keeps its existing tail (`onResetAll?()` + the same banner) — developer-reset behaviour is unchanged.
- Both paths therefore clear exactly the same state: UserDefaults bundle domain, `GymFactStore`, in-memory WAQ/active-session (`performLocalStateReset`), `userId`, and the four #369 anonymous-Supabase keychain keys.

## New Settings entry

- New **"Data"** section, placed after Developer and before About.
- One destructive red row "Reset all data" (`trash.fill`, `.settingsCardRow(.single)`), section footer: *"Erases your profile, program, and history on this device. Can't be undone."*
- Tapping presents a destructive `.alert` (Reset / Cancel). On confirm: `await performFullDataReset(deps: deps); onResetAll?()` — same callback ContentView already uses for the developer path (clears in-memory state, returns to onboarding).
- Red is a **local** `dangerRed` color — the shared DesignSystem has no danger token and lime stays reserved for additive actions.

## Verify

`xcodebuild build … -destination 'iPhone 17 Pro, OS=26.5'` → `** BUILD SUCCEEDED **`. `#Preview`s compile.

Part of #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W29RhnNvKvyxbN3qmhT8GC