### PR TITLE
feat(workout): Brutalist exercise-complete stamp replaces old placeholder

### DIFF
--- a/ProjectApex/Features/Workout/ExerciseCompleteView.swift
+++ b/ProjectApex/Features/Workout/ExerciseCompleteView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+import UIKit
+
+/// The brief "exercise complete" moment shown after the last set of an
+/// exercise — a volt-lime stamp that slams in, the exercise name in condensed
+/// black, and a faint "next up" line so the pause reads as forward motion.
+/// Replaces the old grey-checkmark placeholder. The session manager holds this
+/// state for ~1.2s while the next exercise's AI prescription loads, then the
+/// state machine advances to the rest timer; this view owns only the visuals.
+struct ExerciseCompleteView: View {
+    let exerciseName: String
+    /// Prescribed set count for the just-finished exercise (0 hides the line).
+    let setCount: Int
+    /// Name of the next exercise, if any — drives the "Next ·" continuity line.
+    let nextExerciseName: String?
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var stamped = false
+
+    var body: some View {
+        ZStack {
+            Color(red: 0.04, green: 0.04, blue: 0.06).ignoresSafeArea()
+            RadialGradient(
+                colors: [Apex.accent.opacity(0.18), .clear],
+                center: UnitPoint(x: 0.5, y: 0.42),
+                startRadius: 0, endRadius: 360
+            )
+            .ignoresSafeArea()
+            .blendMode(.plusLighter)
+
+            VStack(spacing: 28) {
+                stamp
+                caption
+            }
+        }
+        .onAppear {
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            if reduceMotion {
+                stamped = true
+            } else {
+                withAnimation(.spring(response: 0.42, dampingFraction: 0.62)) {
+                    stamped = true
+                }
+            }
+        }
+    }
+
+    // The hero: a sharp-cornered volt-lime badge with a black checkmark that
+    // slams in (scale + spring overshoot).
+    private var stamp: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: Apex.corner, style: .continuous)
+                .fill(Apex.accent)
+                .frame(width: 132, height: 132)
+            Image(systemName: "checkmark")
+                .font(.system(size: 62, weight: .black))
+                .foregroundStyle(Apex.onAccent)
+        }
+        .scaleEffect(stamped || reduceMotion ? 1.0 : 0.5)
+        .opacity(stamped ? 1.0 : 0.0)
+    }
+
+    private var caption: some View {
+        VStack(spacing: 12) {
+            ApexSectionLabel(text: "Exercise complete", color: Apex.accent)
+            Text(exerciseName)
+                .font(.system(size: 32, weight: .black))
+                .fontWidth(.condensed)
+                .foregroundStyle(Apex.text)
+                .multilineTextAlignment(.center)
+            subline
+        }
+        .padding(.horizontal, Apex.pad)
+        .opacity(stamped ? 1.0 : 0.0)
+        .offset(y: stamped || reduceMotion ? 0 : 10)
+    }
+
+    @ViewBuilder private var subline: some View {
+        HStack(spacing: 8) {
+            if setCount > 0 {
+                ApexSectionLabel(text: "\(setCount) sets", color: Apex.textFaint)
+            }
+            if setCount > 0, nextExerciseName != nil {
+                Circle().fill(Apex.textFaint).frame(width: 3, height: 3)
+            }
+            if let next = nextExerciseName {
+                ApexSectionLabel(text: "Next · \(next)", color: Apex.textDim)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/ProjectApex/Features/Workout/WorkoutView.swift
+++ b/ProjectApex/Features/Workout/WorkoutView.swift
@@ -455,8 +455,12 @@ struct WorkoutView: View {
             )
             .transition(setCompleteTransition)
 
-        case .exerciseComplete(let completedExercise, _):
-            exerciseCompletePlaceholder(exerciseName: completedExercise.name, vm: vm)
+        case .exerciseComplete(let completedExercise, let nextExercise):
+            ExerciseCompleteView(
+                exerciseName: completedExercise.name,
+                setCount: completedExercise.sets,
+                nextExerciseName: nextExercise?.name
+            )
 
         case .sessionComplete(let summary):
             PostWorkoutSummaryView(
@@ -475,22 +479,6 @@ struct WorkoutView: View {
 
         case .error(let message):
             errorView(message: message, vm: vm)
-        }
-    }
-
-    // MARK: - Exercise Complete (transient flash state)
-
-    private func exerciseCompletePlaceholder(exerciseName: String, vm: WorkoutViewModel) -> some View {
-        ZStack {
-            apexBackground(tint: streak.tintColor)
-            VStack(spacing: 16) {
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.system(size: 64))
-                    .foregroundStyle(streak.tintColor)
-                Text("\(exerciseName) — done.")
-                    .font(.system(size: 22, weight: .semibold))
-                    .foregroundStyle(.white)
-            }
         }
     }
 


### PR DESCRIPTION
## What

The "exercise complete" moment shown after the last set of an exercise was a leftover **grey-checkmark placeholder** in plain system font — the last workout surface still on the old UI.

This replaces it with **`ExerciseCompleteView`**, in our Brutalist identity:
- A volt-lime **stamp** that slams in (scale + spring overshoot)
- The exercise name in condensed black
- A faint **"N sets · Next · &lt;next exercise&gt;"** continuity line so the pause reads as forward motion
- A success haptic on entry; honours **Reduce Motion** (plain fade, no bounce)

The state machine and ~1.2s timing are unchanged — the session manager still owns the hold window that loads the next exercise's AI prescription in the background; only the visual changed. Surfaces the previously-discarded `nextExercise` from the `.exerciseComplete` state, and removes the now-unused `exerciseCompletePlaceholder`.

## How verified
- Look signed off via the `UIPrototypes` `setcomplete` render (gallery updated); prod view mirrors it with prod design tokens.
- Main app builds clean (`xcodebuild`, iPhone 17 Pro / iOS 26.5).

## Scope
Visual + motion only. Two files: new `ExerciseCompleteView.swift`, router swap in `WorkoutView.swift`. No session logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)