### PR TITLE
feat(#527): Brutalist onboarding flow + reskin (S1)

### DIFF
--- a/ProjectApex/Features/Onboarding/OnboardingView.swift
+++ b/ProjectApex/Features/Onboarding/OnboardingView.swift
@@ -1,17 +1,18 @@
 // OnboardingView.swift
-// ProjectApex — Onboarding Feature  (P4-T09)
+// ProjectApex — Onboarding Feature  (P4-T09 → Brutalist overhaul #527 S1)
 //
 // Full first-run onboarding sequence presented as a full-screen sheet over
-// the main TabView. Dismissed only after all required steps are complete
-// (or Step 4 gym scan is explicitly skipped with a warning).
+// the main TabView. Dismissed only after the user reaches the program-ready
+// reveal and taps Start Training.
 //
-// Steps:
-//   1 — Display name entry         → stored in Keychain + users table
-//   2 — Training profile           → training age, goal, days/week
-//   3 — Notification permission    → for rest timer / session reminders
-//   4 — Gym scanner                → ScannerView flow; skippable with warning
-//   5 — Program generation         → loading screen (LLM call)
-//   6 — Ready confirmation         → dismisses to Program tab
+// Flow (#527 — Brutalist overhaul):
+//   Intro:   Welcome → 3 "how it works" concept cards (no progress rail)
+//   Profile (one question per screen, sharp segmented rail + NN/TT counter):
+//     01 Name · 02 Experience · 03 Goal · 04 Days/week
+//     05 Bodyweight (expected) + optional Height/Age
+//     06 Sex (NEW) · 07 Injuries (NEW, optional) ·
+//     08 Equipment (presets → review) · 09 Notifications (moved late)
+//   Generating  → program-ready reveal → Start Training.
 //
 // First-run detection: KeychainService.retrieve(.userId) == nil
 // On completion (#369 slice 3): the anonymous-auth `auth.uid()` is written to
@@ -19,13 +20,16 @@
 // public.users row is keyed to that same uid so slice 5's RLS policy matches.
 // onboardingCompleted is stored in UserDefaults so subsequent launches skip
 // this view immediately.
+//
+// The camera scanner was removed from onboarding (#527): equipment is collected
+// via presets + the existing manual BulkEquipmentPickerSheet, never the camera.
 
 import SwiftUI
 import UserNotifications
 
 // MARK: - Training Profile Input Model
 
-/// Collected during Step 2. Passed into ProgramGenerationService.
+/// Collected during the profile steps. Passed into ProgramGenerationService.
 struct OnboardingProfile: Sendable {
     var displayName: String = ""
     var trainingAge: TrainingAge = .beginner
@@ -41,6 +45,15 @@ struct OnboardingProfile: Sendable {
     var age: Int? = nil
     /// Whether bodyweight input is in kg (true) or lbs (false).
     var bodyweightInKg: Bool = true
+
+    /// Biological sex (#527) — lowercase "male"/"female"; nil = prefer-not-to-say
+    /// / unset. Persisted to UserDefaults only (no `users` column — see
+    /// persistUserIfNeeded).
+    var sex: String? = nil
+
+    /// Injury / "work around" areas the user tapped (#527). Collected here for
+    /// Slice 2 to persist as user-confirmed limitations; not written yet.
+    var injuryAreas: Set<String> = []
 }
 
 enum TrainingAge: String, CaseIterable, Sendable {
@@ -66,617 +79,1025 @@ struct OnboardingView: View {
     // Called when onboarding fully completes so ContentView can switch to Program tab.
     var onCompleted: ((GymProfile?) -> Void)? = nil
 
-    @State private var step: Int = 1
+    // ── Flow steps ────────────────────────────────────────────────────────────
+    // Intro (no rail) → numbered profile (rail) → generating → ready.
+    private enum Step: Int, CaseIterable {
+        case welcome, how          // intro
+        case name, experience, goal, days, body, sex, injuries, equipment, notifications // profile (1…9)
+        case generating, ready
+    }
+
+    @State private var step: Step = .welcome
+    /// Which concept card (1…3) the "how it works" pager shows.
+    @State private var howIndex: Int = 1
+
     @State private var profile = OnboardingProfile()
-    /// Seeded from the UserDefaults cache (#318 U4) so a scan that completed
-    /// before an app kill rehydrates instead of forcing a re-scan.
+    /// Seeded from the UserDefaults cache (#318 U4) so equipment confirmed
+    /// before an app kill rehydrates instead of forcing a re-entry.
     @State private var gymProfile: GymProfile? = GymProfile.loadFromUserDefaults()
-    @State private var scanSkipped: Bool = false
+    /// True once the user has confirmed an equipment list (presets review).
+    /// Onboarding stays completable even if equipment is empty.
     @State private var notifGranted: Bool = false
     @State private var isGenerating: Bool = false
     @State private var generationError: String? = nil
-    @State private var showSkipScanAlert: Bool = false
 
-    // Step 4 inline scanner
-    @State private var showingScannerSheet: Bool = false
+    /// Equipment review-list working copy (built from a preset or rehydrated).
+    @State private var reviewItems: [EquipmentItem] = []
+    @State private var presetLabel: String = ""
+    @State private var showingEquipmentReview: Bool = false
+    @State private var showingBulkPicker: Bool = false
+
+    /// The total number of numbered profile steps shown on the rail.
+    private let railTotal = 9
 
     var body: some View {
         ZStack {
-            // Apex background
-            Color(red: 0.04, green: 0.04, blue: 0.06).ignoresSafeArea()
-            RadialGradient(
-                colors: [Color(red: 0.23, green: 0.56, blue: 1.00).opacity(0.14), Color.clear],
-                center: UnitPoint(x: 0.5, y: 0.12),
-                startRadius: 0, endRadius: 380
-            ).ignoresSafeArea().blendMode(.plusLighter)
+            Apex.bg.ignoresSafeArea()
 
-            VStack(spacing: 0) {
-                // Progress indicator
-                progressBar
-                    .padding(.top, 20)
-                    .padding(.horizontal, 32)
-
-                // Step content
-                Group {
-                    switch step {
-                    case 1: step1NameView
-                    case 2: step2ProfileView
-                    case 3: step3NotificationsView
-                    case 4: step4ScannerView
-                    case 5: step5GeneratingView
-                    case 6: step6ReadyView
-                    default: EmptyView()
-                    }
+            Group {
+                switch step {
+                case .welcome:       welcomeView
+                case .how:           howView
+                case .name:          nameView
+                case .experience:    experienceView
+                case .goal:          goalView
+                case .days:          daysView
+                case .body:          bodyView
+                case .sex:           sexView
+                case .injuries:      injuriesView
+                case .equipment:     equipmentView
+                case .notifications: notificationsView
+                case .generating:    generatingView
+                case .ready:         readyView
                 }
-                .transition(.asymmetric(
-                    insertion: .move(edge: .trailing).combined(with: .opacity),
-                    removal: .move(edge: .leading).combined(with: .opacity)
-                ))
             }
+            .transition(.asymmetric(
+                insertion: .move(edge: .trailing).combined(with: .opacity),
+                removal: .move(edge: .leading).combined(with: .opacity)
+            ))
         }
         .preferredColorScheme(.dark)
         .interactiveDismissDisabled(true)  // Prevent accidental swipe-dismiss
-        .sheet(isPresented: $showingScannerSheet) {
-            NavigationStack {
-                ScannerView { scannedProfile in
-                    gymProfile = scannedProfile
-                    scanSkipped = false
-                    showingScannerSheet = false
+        .sheet(isPresented: $showingBulkPicker) {
+            BulkEquipmentPickerSheet(
+                alreadyAdded: Set(reviewItems.map(\.equipmentType)),
+                onConfirm: { items in
+                    reviewItems.append(contentsOf: items)
+                    showingBulkPicker = false
+                },
+                onCancel: { showingBulkPicker = false }
+            )
+        }
+    }
+
+    // MARK: - Navigation helpers
+
+    private func go(to next: Step) {
+        withAnimation(.spring(response: 0.38, dampingFraction: 0.82)) { step = next }
+    }
+
+    // MARK: - Shared scaffold
+
+    /// Sharp segmented progress rail + tabular "NN / TT" counter.
+    private func rail(_ stepNumber: Int) -> some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 4) {
+                ForEach(0..<railTotal, id: \.self) { i in
+                    RoundedRectangle(cornerRadius: 1, style: .continuous)
+                        .fill(i < stepNumber ? Apex.accent : Color.white.opacity(0.12))
+                        .frame(height: 3)
                 }
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Skip") {
-                            showingScannerSheet = false
-                            showSkipScanAlert = true
+            }
+            HStack(spacing: 3) {
+                ApexNumeral(text: String(format: "%02d", stepNumber), size: 13, weight: .bold, color: Apex.textDim)
+                Text("/ \(String(format: "%02d", railTotal))")
+                    .font(.system(size: 12, weight: .semibold))
+                    .fontWidth(.condensed)
+                    .foregroundStyle(Apex.textFaint)
+            }
+            .fixedSize()
+        }
+    }
+
+    /// Bottom action bar — pinned primary button with a fade-up gradient and an
+    /// optional secondary text line.
+    private func bottomBar(
+        primary: String,
+        icon: String = "arrow.right",
+        enabled: Bool = true,
+        action: @escaping () -> Void,
+        secondary: (text: String, action: () -> Void)? = nil
+    ) -> some View {
+        VStack(spacing: 14) {
+            Button(action: action) {
+                ApexButton(title: primary, kind: enabled ? .filled : .ghost,
+                           icon: icon, tint: enabled ? nil : Apex.textFaint)
+            }
+            .buttonStyle(.plain)
+            .disabled(!enabled)
+
+            if let secondary {
+                Button(action: secondary.action) {
+                    Text(secondary.text)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Apex.textFaint)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, Apex.pad)
+        .padding(.bottom, 26)
+        .padding(.top, 22)
+        .background(
+            LinearGradient(colors: [Apex.bg.opacity(0), Apex.bg],
+                           startPoint: .top, endPoint: .bottom)
+                .ignoresSafeArea()
+        )
+    }
+
+    /// Eyebrow + condensed big title + optional subtitle.
+    private func titleBlock(eyebrow: String, title: String, subtitle: String? = nil) -> some View {
+        VStack(alignment: .leading, spacing: 9) {
+            ApexSectionLabel(text: eyebrow, color: Apex.accent)
+            Text(title)
+                .font(.system(size: 32, weight: .black))
+                .fontWidth(.condensed)
+                .foregroundStyle(Apex.text)
+                .fixedSize(horizontal: false, vertical: true)
+            if let subtitle {
+                Text(subtitle)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Apex.textDim)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 2)
+            }
+        }
+    }
+
+    /// Standard data-collection screen: back + rail header, title block, content,
+    /// pinned primary action.
+    private func profileScaffold<Content: View>(
+        stepNumber: Int,
+        back: @escaping () -> Void,
+        eyebrow: String,
+        title: String,
+        subtitle: String? = nil,
+        primary: String,
+        primaryEnabled: Bool = true,
+        primaryAction: @escaping () -> Void,
+        secondary: (text: String, action: () -> Void)? = nil,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        ZStack(alignment: .bottom) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(spacing: 14) {
+                    Button(action: back) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 16, weight: .black))
+                            .foregroundStyle(Apex.textDim)
+                    }
+                    .buttonStyle(.plain)
+                    rail(stepNumber)
+                }
+                .padding(.top, 8)
+                .padding(.bottom, 30)
+
+                titleBlock(eyebrow: eyebrow, title: title, subtitle: subtitle)
+                    .padding(.bottom, 26)
+
+                content()
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, Apex.pad)
+            .padding(.top, 8)
+
+            bottomBar(primary: primary, enabled: primaryEnabled,
+                      action: primaryAction, secondary: secondary)
+        }
+    }
+
+    /// Full-width tappable choice card (experience / goal / sex).
+    private func choiceCard(title: String, subtitle: String? = nil, selected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(title)
+                        .font(.system(size: 18, weight: .bold))
+                        .fontWidth(.condensed)
+                        .foregroundStyle(Apex.text)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(Apex.textFaint)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .multilineTextAlignment(.leading)
+                    }
+                }
+                Spacer(minLength: 8)
+                if selected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 15, weight: .black))
+                        .foregroundStyle(Apex.accent)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .apexCard(emphasized: selected)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Intro · Welcome
+
+    private var welcomeView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Spacer()
+            ApexSectionLabel(text: "Project Apex", color: Apex.accent)
+            Text("STRENGTH,\nON AUTOPILOT.")
+                .font(.system(size: 52, weight: .black))
+                .fontWidth(.condensed)
+                .foregroundStyle(Apex.text)
+                .lineSpacing(-2)
+                .padding(.top, 12)
+            Text("A coach that decides every set for you — and learns who you are while it does it.")
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(Apex.textDim)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 18)
+            Spacer()
+            Button { go(to: .how) } label: {
+                ApexButton(title: "Begin", icon: "arrow.right")
+            }
+            .buttonStyle(.plain)
+            Text("Takes about two minutes.")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Apex.textFaint)
+                .frame(maxWidth: .infinity)
+                .padding(.top, 14)
+        }
+        .padding(.horizontal, Apex.pad)
+        .padding(.bottom, 30)
+    }
+
+    // MARK: - Intro · How it works (3 concept cards)
+
+    private struct HowConcept { let n, icon, head, body, hot: String }
+    private let howCards: [HowConcept] = [
+        .init(n: "01", icon: "brain.head.profile", head: "IT'S A REAL COACH",
+              body: "Most gym apps are spreadsheets you type into. This one does the thinking — it hands you the ",
+              hot: "exact weight and reps, set by set."),
+        .init(n: "02", icon: "chart.line.uptrend.xyaxis", head: "IT LEARNS YOU",
+              body: "It builds a picture of how strong you are and how fast you recover. ",
+              hot: "Every set you log sharpens it."),
+        .init(n: "03", icon: "checkmark.seal", head: "IT'S HONEST",
+              body: "The bar only ratchets up as you get stronger — it ",
+              hot: "never quietly lowers a target."),
+    ]
+
+    private var howView: some View {
+        let idx = min(max(howIndex, 1), 3)
+        let c = howCards[idx - 1]
+        return ZStack(alignment: .bottom) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    Spacer()
+                    Button { go(to: .name) } label: {
+                        Text("Skip")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(Apex.textFaint)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.top, 8)
+                Spacer()
+                ApexNumeral(text: c.n, size: 120, weight: .black, color: Color.white.opacity(0.20))
+                    .padding(.bottom, -6)
+                Image(systemName: c.icon)
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(Apex.accent)
+                    .padding(.bottom, 18)
+                ApexSectionLabel(text: "How it works", color: Apex.textFaint)
+                Text(c.head)
+                    .font(.system(size: 34, weight: .black))
+                    .fontWidth(.condensed)
+                    .foregroundStyle(Apex.text)
+                    .padding(.top, 6)
+                (Text(c.body).foregroundColor(Apex.textDim)
+                 + Text(c.hot).foregroundColor(Apex.accent))
+                    .font(.system(size: 17, weight: .medium))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 12)
+                Spacer()
+            }
+            .padding(.horizontal, Apex.pad)
+
+            VStack(spacing: 16) {
+                HStack(spacing: 6) {
+                    ForEach(1...3, id: \.self) { i in
+                        RoundedRectangle(cornerRadius: 1)
+                            .fill(i == idx ? Apex.accent : Color.white.opacity(0.18))
+                            .frame(width: i == idx ? 22 : 8, height: 3)
+                    }
+                    Spacer()
+                }
+                Button {
+                    if idx >= 3 { go(to: .name) }
+                    else { withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) { howIndex = idx + 1 } }
+                } label: {
+                    ApexButton(title: idx >= 3 ? "Let's set up" : "Next", icon: "arrow.right")
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, Apex.pad)
+            .padding(.bottom, 26)
+            .padding(.top, 22)
+            .background(
+                LinearGradient(colors: [Apex.bg.opacity(0), Apex.bg],
+                               startPoint: .top, endPoint: .bottom)
+                    .ignoresSafeArea()
+            )
+        }
+    }
+
+    // MARK: - 01 Name
+
+    private var nameView: some View {
+        profileScaffold(
+            stepNumber: 1,
+            back: {
+                howIndex = 3
+                go(to: .how)
+            },
+            eyebrow: "Step 01",
+            title: "What should the\ncoach call you?",
+            primary: "Continue",
+            primaryEnabled: !profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            primaryAction: { go(to: .experience) }
+        ) {
+            VStack(alignment: .leading, spacing: 8) {
+                TextField("", text: $profile.displayName, prompt:
+                    Text("Alex").foregroundColor(Apex.textFaint))
+                    .font(.system(size: 30, weight: .bold))
+                    .fontWidth(.condensed)
+                    .foregroundStyle(Apex.text)
+                    .tint(Apex.accent)
+                    .autocorrectionDisabled()
+                    .textContentType(.givenName)
+                    .submitLabel(.done)
+                    .padding(.vertical, 6)
+                Rectangle().fill(Apex.accent).frame(height: 2)
+            }
+        }
+    }
+
+    // MARK: - 02 Experience
+
+    private var experienceView: some View {
+        profileScaffold(
+            stepNumber: 2,
+            back: { go(to: .name) },
+            eyebrow: "Step 02",
+            title: "How long have you\nbeen lifting?",
+            subtitle: "This sets how aggressively your program ramps.",
+            primary: "Continue",
+            primaryAction: { go(to: .goal) }
+        ) {
+            VStack(spacing: 10) {
+                experienceChoice(.beginner, "Beginner", "New to structured training, or under a year")
+                experienceChoice(.intermediate, "Intermediate", "A year or two of consistent lifting")
+                experienceChoice(.advanced, "Advanced", "Several years; you know your numbers")
+            }
+        }
+    }
+
+    private func experienceChoice(_ value: TrainingAge, _ title: String, _ subtitle: String) -> some View {
+        choiceCard(title: title, subtitle: subtitle, selected: profile.trainingAge == value) {
+            profile.trainingAge = value
+        }
+    }
+
+    // MARK: - 03 Goal
+
+    private var goalView: some View {
+        profileScaffold(
+            stepNumber: 3,
+            back: { go(to: .experience) },
+            eyebrow: "Step 03",
+            title: "What are you\ntraining for?",
+            primary: "Continue",
+            primaryAction: { go(to: .days) }
+        ) {
+            VStack(spacing: 10) {
+                goalChoice(.hypertrophy, "Build muscle", "Hypertrophy — size and shape")
+                goalChoice(.strength, "Get stronger", "Strength — heavier on the big lifts")
+                goalChoice(.endurance, "Muscular endurance", "Higher reps, more work capacity")
+                goalChoice(.general, "General fitness", "A balanced mix")
+            }
+        }
+    }
+
+    private func goalChoice(_ value: TrainingGoal, _ title: String, _ subtitle: String) -> some View {
+        choiceCard(title: title, subtitle: subtitle, selected: profile.primaryGoal == value) {
+            profile.primaryGoal = value
+        }
+    }
+
+    // MARK: - 04 Days per week
+
+    private var daysView: some View {
+        profileScaffold(
+            stepNumber: 4,
+            back: { go(to: .goal) },
+            eyebrow: "Step 04",
+            title: "How many days\na week?",
+            subtitle: "We'll shape your split around this.",
+            primary: "Continue",
+            primaryAction: { go(to: .body) }
+        ) {
+            // #369 / O-F11: include 2 — the engine supports 2-day weeks.
+            HStack(spacing: 10) {
+                ForEach([2, 3, 4, 5, 6], id: \.self) { n in
+                    let on = profile.daysPerWeek == n
+                    Button {
+                        withAnimation(.spring(response: 0.28, dampingFraction: 0.82)) {
+                            profile.daysPerWeek = n
                         }
-                        .foregroundStyle(.secondary)
+                    } label: {
+                        ApexNumeral(text: "\(n)", size: 28, weight: .black, color: on ? Apex.onAccent : Apex.text)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 64)
+                            .background(
+                                RoundedRectangle(cornerRadius: Apex.corner, style: .continuous)
+                                    .fill(on ? Apex.accent : Apex.surface)
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: Apex.corner, style: .continuous)
+                                    .stroke(on ? Color.clear : Apex.hairline, lineWidth: 1)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    // MARK: - 05 Body basics (bodyweight expected + optional height/age)
+
+    private var bodyView: some View {
+        profileScaffold(
+            stepNumber: 5,
+            back: { go(to: .days) },
+            eyebrow: "Step 05",
+            title: "What do you\nweigh?",
+            subtitle: "Your bodyweight anchors the weights the coach prescribes in your first sessions — the more accurate, the better your starting loads.",
+            primary: "Continue",
+            primaryAction: { go(to: .sex) }
+        ) {
+            VStack(alignment: .leading, spacing: 18) {
+                // Bodyweight — the expected, primary field (emphasized card).
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        ApexSectionLabel(text: "Bodyweight", color: Apex.accent)
+                        Spacer()
+                        Picker("Unit", selection: $profile.bodyweightInKg) {
+                            Text("kg").tag(true)
+                            Text("lb").tag(false)
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(width: 120)
+                    }
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        TextField(
+                            profile.bodyweightInKg ? "80" : "176",
+                            text: bodyweightBinding
+                        )
+                        .keyboardType(.decimalPad)
+                        .font(Apex.numeral(46, weight: .black))
+                        .fontWidth(.condensed)
+                        .foregroundStyle(Apex.text)
+                        .tint(Apex.accent)
+                        .fixedSize()
+                        Text(profile.bodyweightInKg ? "kg" : "lb")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundStyle(Apex.textFaint)
+                        Spacer()
+                    }
+                    Rectangle().fill(Apex.accent).frame(height: 2)
+                }
+                .padding(16)
+                .apexCard(emphasized: true)
+
+                // Optional secondary fields — clearly marked.
+                VStack(alignment: .leading, spacing: 10) {
+                    ApexSectionLabel(text: "Optional · sharpens calibration", color: Apex.textFaint)
+                    VStack(spacing: 0) {
+                        optionalRow(icon: "ruler", label: "Height", unit: "cm", binding: heightBinding)
+                        Rectangle().fill(Apex.hairline).frame(height: 1)
+                        optionalRow(icon: "person.fill", label: "Age", unit: "yrs", binding: ageBinding, keyboard: .numberPad)
+                    }
+                    .padding(.horizontal, 16)
+                    .apexCard()
+                }
+            }
+        }
+    }
+
+    private func optionalRow(icon: String, label: String, unit: String, binding: Binding<String>, keyboard: UIKeyboardType = .decimalPad) -> some View {
+        HStack(spacing: 13) {
+            Image(systemName: icon)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Apex.textDim)
+                .frame(width: 24)
+            Text(label)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(Apex.text)
+            Text("Optional")
+                .font(.system(size: 10, weight: .semibold))
+                .textCase(.uppercase)
+                .tracking(0.8)
+                .foregroundStyle(Apex.textFaint)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(Capsule().stroke(Apex.hairline, lineWidth: 1))
+            Spacer()
+            TextField("", text: binding, prompt: Text("—").foregroundColor(Apex.textFaint))
+                .keyboardType(keyboard)
+                .multilineTextAlignment(.trailing)
+                .font(Apex.numeral(22, weight: .black))
+                .fontWidth(.condensed)
+                .foregroundStyle(Apex.text)
+                .tint(Apex.accent)
+                .frame(width: 70)
+            Text(unit)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Apex.textFaint)
+        }
+        .padding(.vertical, 14)
+    }
+
+    // MARK: - 06 Sex
+
+    private var sexView: some View {
+        profileScaffold(
+            stepNumber: 6,
+            back: { go(to: .body) },
+            eyebrow: "Step 06",
+            title: "Sex",
+            subtitle: "Used only to anchor your first-session weights more accurately.",
+            primary: "Continue",
+            primaryAction: { go(to: .injuries) },
+            secondary: (text: "Prefer not to say", action: {
+                profile.sex = nil
+                go(to: .injuries)
+            })
+        ) {
+            VStack(spacing: 10) {
+                choiceCard(title: "Male", selected: profile.sex == "male") { profile.sex = "male" }
+                choiceCard(title: "Female", selected: profile.sex == "female") { profile.sex = "female" }
+            }
+        }
+    }
+
+    // MARK: - 07 Injuries (optional)
+
+    private struct InjuryArea { let name, icon: String }
+    private let injuryAreas: [InjuryArea] = [
+        .init(name: "Shoulders", icon: "figure.arms.open"),
+        .init(name: "Lower back", icon: "figure.walk"),
+        .init(name: "Knees", icon: "figure.run"),
+        .init(name: "Elbows", icon: "figure.boxing"),
+        .init(name: "Wrists", icon: "hand.raised"),
+        .init(name: "Hips", icon: "figure.flexibility"),
+        .init(name: "Neck", icon: "figure.mind.and.body"),
+        .init(name: "Ankles", icon: "shoeprints.fill"),
+    ]
+
+    private var injuriesView: some View {
+        let rows = stride(from: 0, to: injuryAreas.count, by: 2).map {
+            Array(injuryAreas[$0..<min($0 + 2, injuryAreas.count)])
+        }
+        return profileScaffold(
+            stepNumber: 7,
+            back: { go(to: .sex) },
+            eyebrow: "Step 07 · Optional",
+            title: "Anything to\nwork around?",
+            subtitle: "Tap any areas that flare up. The coach will avoid programming straight into them — you can change this anytime.",
+            primary: "Continue",
+            primaryAction: { go(to: .equipment) },
+            secondary: (text: "Nothing right now", action: {
+                profile.injuryAreas = []
+                go(to: .equipment)
+            })
+        ) {
+            VStack(spacing: 10) {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, pair in
+                    HStack(spacing: 10) {
+                        ForEach(pair, id: \.name) { area in injuryBox(area) }
+                        if pair.count == 1 { Color.clear.frame(maxWidth: .infinity) }
                     }
                 }
             }
-            .preferredColorScheme(.dark)
-        }
-        .alert("Skip Gym Scan?", isPresented: $showSkipScanAlert) {
-            Button("Cancel", role: .cancel) { }
-            Button("Skip", role: .destructive) {
-                scanSkipped = true
-                advance()
-            }
-        } message: {
-            Text("Without scanning your gym, the AI coach won't know what equipment is available. You can complete this in Settings later.")
         }
     }
 
-    // MARK: - Progress Bar
-
-    private var progressBar: some View {
-        HStack(spacing: 6) {
-            ForEach(1...5, id: \.self) { i in
-                Capsule()
-                    .fill(i <= displayStep ? Color(red: 0.23, green: 0.56, blue: 1.00) : Color.white.opacity(0.15))
-                    .frame(height: 3)
-                    .animation(.spring(response: 0.35, dampingFraction: 0.82), value: displayStep)
-            }
-        }
-    }
-
-    /// Maps internal step (1–6) to a 1–5 progress indicator.
-    /// Step 5 (generating) and 6 (ready) both show as fully filled.
-    private var displayStep: Int {
-        min(step, 5)
-    }
-
-    // MARK: - Step 1: Display Name
-
-    private var step1NameView: some View {
-        VStack(spacing: 0) {
-            Spacer()
-            VStack(spacing: 32) {
-                VStack(spacing: 12) {
-                    Text("Welcome to\nProject Apex")
-                        .font(.system(size: 38, weight: .black, design: .rounded))
-                        .foregroundStyle(.white)
-                        .multilineTextAlignment(.center)
-                    Text("Your AI-powered strength coach.\nLet's set you up in 5 steps.")
-                        .font(.system(size: 17, weight: .regular))
-                        .foregroundStyle(.white.opacity(0.60))
-                        .multilineTextAlignment(.center)
+    private func injuryBox(_ area: InjuryArea) -> some View {
+        let sel = profile.injuryAreas.contains(area.name)
+        return Button {
+            if sel { profile.injuryAreas.remove(area.name) }
+            else { profile.injuryAreas.insert(area.name) }
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: area.icon)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(sel ? Apex.onAccent : Apex.accent)
+                    .frame(width: 20)
+                Text(area.name)
+                    .font(.system(size: 16, weight: .bold))
+                    .fontWidth(.condensed)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+                    .foregroundStyle(sel ? Apex.onAccent : Apex.text)
+                Spacer(minLength: 0)
+                if sel {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 13, weight: .black))
+                        .foregroundStyle(Apex.onAccent)
                 }
-
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("What's your name?")
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundStyle(.white.opacity(0.70))
-                    TextField("", text: $profile.displayName, prompt: Text("e.g. Alex").foregroundStyle(.white.opacity(0.30)))
-                        .font(.system(size: 24, weight: .semibold, design: .rounded))
-                        .foregroundStyle(.white)
-                        .padding(16)
-                        .background(
-                            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                .fill(.white.opacity(0.07))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                        .strokeBorder(.white.opacity(0.14), lineWidth: 1)
-                                )
-                        )
-                        .autocorrectionDisabled()
-                        .textContentType(.givenName)
-                        .submitLabel(.done)
-                }
-                .padding(.horizontal, 4)
             }
-            .padding(.horizontal, 32)
+            .padding(.horizontal, 14)
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: Apex.corner, style: .continuous)
+                    .fill(sel ? Apex.accent : Apex.surface)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Apex.corner, style: .continuous)
+                    .stroke(sel ? Color.clear : Apex.hairline, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
 
-            Spacer()
+    // MARK: - 08 Equipment (presets → review)
 
-            primaryButton(title: "Continue", enabled: !profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
-                withAnimation(.spring(response: 0.38, dampingFraction: 0.80)) { step = 2 }
-            }
-            .padding(.horizontal, 32)
-            .padding(.bottom, 48)
+    /// Preset → equipment-type seed maps, built from the real EquipmentType cases.
+    private struct EquipPreset { let name, desc: String; let types: [EquipmentType] }
+    private let equipPresets: [EquipPreset] = [
+        .init(name: "Full commercial gym",
+              desc: "Racks, machines, cables, the lot",
+              types: [.barbell, .dumbbellSet, .ezCurlBar, .adjustableBench, .inclineBench,
+                      .powerRack, .smithMachine, .cableMachineDual, .cableCrossover,
+                      .latPulldown, .seatedRow, .legPress, .hackSquat, .legExtension,
+                      .legCurl, .chestPressMachine, .shoulderPressMachine, .pecDeck,
+                      .pullUpBar, .dipStation]),
+        .init(name: "Standard gym",
+              desc: "Barbell, dumbbells, key machines",
+              types: [.barbell, .dumbbellSet, .adjustableBench, .powerRack, .cableMachine,
+                      .latPulldown, .seatedRow, .legPress, .legExtension, .legCurl,
+                      .pullUpBar]),
+        .init(name: "Garage barbell gym",
+              desc: "Rack, barbell, bench, dumbbells",
+              types: [.barbell, .powerRack, .adjustableBench, .dumbbellSet, .pullUpBar,
+                      .resistanceBands]),
+        .init(name: "Home — dumbbells + bench",
+              desc: "Adjustable dumbbells and a bench",
+              types: [.dumbbellSet, .adjustableBench, .resistanceBands]),
+        .init(name: "Bodyweight only",
+              desc: "Bar, dips, bands",
+              types: [.pullUpBar, .dipStation, .resistanceBands]),
+    ]
+
+    private var equipmentView: some View {
+        if showingEquipmentReview {
+            return AnyView(equipmentReviewView)
+        } else {
+            return AnyView(equipmentPresetView)
         }
     }
 
-    // MARK: - Step 2: Training Profile
+    private var equipmentPresetView: some View {
+        ZStack(alignment: .bottom) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(spacing: 14) {
+                    Button { go(to: .injuries) } label: {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 16, weight: .black))
+                            .foregroundStyle(Apex.textDim)
+                    }
+                    .buttonStyle(.plain)
+                    rail(8)
+                }
+                .padding(.top, 8)
+                .padding(.bottom, 30)
 
-    private var step2ProfileView: some View {
-        ScrollView {
-            VStack(spacing: 0) {
-                VStack(spacing: 32) {
-                    stepHeader(
-                        icon: "figure.strengthtraining.traditional",
-                        title: "Your Training Profile",
-                        subtitle: "This helps the AI prescribe the right program intensity from day one."
+                titleBlock(eyebrow: "Step 08", title: "What's your\nsetup?",
+                           subtitle: "Pick the closest match — you'll fine-tune the list next.")
+                    .padding(.bottom, 26)
+
+                ScrollView(showsIndicators: false) {
+                    VStack(spacing: 10) {
+                        ForEach(Array(equipPresets.enumerated()), id: \.offset) { _, preset in
+                            Button { seedPreset(preset) } label: {
+                                HStack(spacing: 14) {
+                                    VStack(alignment: .leading, spacing: 3) {
+                                        Text(preset.name)
+                                            .font(.system(size: 17, weight: .bold))
+                                            .fontWidth(.condensed)
+                                            .foregroundStyle(Apex.text)
+                                        Text(preset.desc)
+                                            .font(.system(size: 12.5, weight: .medium))
+                                            .foregroundStyle(Apex.textFaint)
+                                    }
+                                    Spacer(minLength: 8)
+                                    Text("\(preset.types.count) items")
+                                        .font(.system(size: 12, weight: .semibold))
+                                        .fontWidth(.condensed)
+                                        .foregroundStyle(Apex.textFaint)
+                                }
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 14)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .contentShape(Rectangle())
+                                .apexCard()
+                            }
+                            .buttonStyle(.plain)
+                        }
+
+                        // Start from scratch — empty review list.
+                        Button { seedFromScratch() } label: {
+                            HStack {
+                                Text("Start from scratch")
+                                    .font(.system(size: 15, weight: .semibold))
+                                    .foregroundStyle(Apex.textDim)
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 13, weight: .bold))
+                                    .foregroundStyle(Apex.textFaint)
+                            }
+                            .padding(.vertical, 8)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+
+                        Color.clear.frame(height: 12)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, Apex.pad)
+            .padding(.top, 8)
+        }
+    }
+
+    private var equipmentReviewView: some View {
+        ZStack(alignment: .bottom) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(spacing: 14) {
+                    Button {
+                        withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) {
+                            showingEquipmentReview = false
+                        }
+                    } label: {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 16, weight: .black))
+                            .foregroundStyle(Apex.textDim)
+                    }
+                    .buttonStyle(.plain)
+                    rail(8)
+                }
+                .padding(.top, 8)
+                .padding(.bottom, 20)
+
+                if !presetLabel.isEmpty {
+                    ApexSectionLabel(text: "From: \(presetLabel)", color: Apex.accent)
+                }
+                Text("Your equipment")
+                    .font(.system(size: 30, weight: .black))
+                    .fontWidth(.condensed)
+                    .foregroundStyle(Apex.text)
+                    .padding(.top, 6)
+                    .padding(.bottom, 14)
+
+                // Add / search lives at the TOP — find or add anything first.
+                Button { showingBulkPicker = true } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "magnifyingglass")
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundStyle(Apex.textFaint)
+                        Text("Search or add equipment…")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(Apex.textFaint)
+                        Spacer()
+                        Image(systemName: "plus.circle.fill")
+                            .font(.system(size: 19, weight: .semibold))
+                            .foregroundStyle(Apex.accent)
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 13)
+                    .contentShape(Rectangle())
+                    .apexCard()
+                }
+                .buttonStyle(.plain)
+                .padding(.bottom, 9)
+
+                Button { showingBulkPicker = true } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "wrench.and.screwdriver")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(Apex.textDim)
+                            .frame(width: 20)
+                        Text("Add a machine we don't list")
+                            .font(.system(size: 14.5, weight: .semibold))
+                            .foregroundStyle(Apex.textDim)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12, weight: .bold))
+                            .foregroundStyle(Apex.textFaint)
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 12)
+                    .contentShape(Rectangle())
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Apex.corner, style: .continuous)
+                            .stroke(Apex.hairline, lineWidth: 1)
                     )
-                    .padding(.top, 24)
+                }
+                .buttonStyle(.plain)
+                .padding(.bottom, 16)
 
-                    VStack(spacing: 20) {
-                        profilePickerRow(
-                            label: "Experience",
-                            systemImage: "chart.bar.fill",
-                            selection: $profile.trainingAge,
-                            options: TrainingAge.allCases
-                        ) { $0.rawValue }
+                ApexSectionLabel(text: "In your gym · \(reviewItems.count)", color: Apex.textFaint)
+                    .padding(.bottom, 8)
 
-                        profilePickerRow(
-                            label: "Primary Goal",
-                            systemImage: "target",
-                            selection: $profile.primaryGoal,
-                            options: TrainingGoal.allCases
-                        ) { $0.rawValue }
-
-                        // Days per week
-                        VStack(alignment: .leading, spacing: 10) {
-                            Label("Days per Week", systemImage: "calendar")
-                                .font(.system(size: 15, weight: .semibold))
-                                .foregroundStyle(.white.opacity(0.70))
-                            HStack(spacing: 10) {
-                                // #369 / O-F11: include 2 — the engine supports 2-day weeks
-                                // (phase-advance handles daysPerWeek≥1; the macro-plan prompt
-                                // takes any integer) and the onboarding spec lists 2/3/4/5+,
-                                // but the picker previously started at 3, so 2-day-per-week
-                                // users could not onboard honestly.
-                                ForEach([2, 3, 4, 5, 6], id: \.self) { n in
+                ScrollView(showsIndicators: false) {
+                    if reviewItems.isEmpty {
+                        Text("No equipment yet — add what you have above.")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(Apex.textFaint)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 20)
+                    } else {
+                        VStack(spacing: 0) {
+                            ForEach(Array(reviewItems.enumerated()), id: \.element.id) { i, item in
+                                HStack(spacing: 12) {
+                                    Circle().fill(Apex.accent.opacity(0.8)).frame(width: 6, height: 6)
+                                    Text(item.equipmentType.displayName)
+                                        .font(.system(size: 16, weight: .medium))
+                                        .foregroundStyle(Apex.text)
+                                    Spacer()
                                     Button {
-                                        withAnimation(.spring(response: 0.28, dampingFraction: 0.80)) {
-                                            profile.daysPerWeek = n
-                                        }
+                                        reviewItems.removeAll { $0.id == item.id }
                                     } label: {
-                                        Text("\(n)")
-                                            .font(.system(size: 18, weight: .bold, design: .rounded))
-                                            .frame(maxWidth: .infinity)
-                                            .padding(.vertical, 14)
-                                            .background(
-                                                profile.daysPerWeek == n
-                                                ? Color(red: 0.23, green: 0.56, blue: 1.00)
-                                                : Color.white.opacity(0.08),
-                                                in: RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                            )
-                                            .foregroundStyle(.white)
+                                        Image(systemName: "xmark")
+                                            .font(.system(size: 12, weight: .bold))
+                                            .foregroundStyle(Apex.textFaint)
                                     }
                                     .buttonStyle(.plain)
                                 }
-                            }
-                        }
-
-                        // ── Biometric Fields (FB-003) ──────────────────────────
-
-                        // Bodyweight — optional
-                        VStack(alignment: .leading, spacing: 10) {
-                            HStack {
-                                Label("Bodyweight", systemImage: "scalemass")
-                                    .font(.system(size: 15, weight: .semibold))
-                                    .foregroundStyle(.white.opacity(0.70))
-                                Spacer()
-                                // kg / lbs toggle
-                                Picker("Unit", selection: $profile.bodyweightInKg) {
-                                    Text("kg").tag(true)
-                                    Text("lbs").tag(false)
-                                }
-                                .pickerStyle(.segmented)
-                                .frame(width: 90)
-                                .onChange(of: profile.bodyweightInKg) { _, useKg in
-                                    // Convert stored kg value when user switches unit
-                                    if let kg = profile.bodyweightKg {
-                                        if !useKg {
-                                            // Display value will be shown in lbs, storage stays kg — no conversion needed
-                                            _ = kg
-                                        }
-                                    }
+                                .padding(.vertical, 13)
+                                if i < reviewItems.count - 1 {
+                                    Rectangle().fill(Apex.hairline.opacity(0.6)).frame(height: 1)
                                 }
                             }
-                            HStack(spacing: 8) {
-                                TextField(
-                                    profile.bodyweightInKg ? "e.g. 80" : "e.g. 176",
-                                    text: Binding(
-                                        get: {
-                                            guard let kg = profile.bodyweightKg else { return "" }
-                                            let displayValue = profile.bodyweightInKg ? kg : kg * 2.20462
-                                            return displayValue.truncatingRemainder(dividingBy: 1) == 0
-                                                ? String(format: "%.0f", displayValue)
-                                                : String(format: "%.1f", displayValue)
-                                        },
-                                        set: { text in
-                                            if text.isEmpty {
-                                                profile.bodyweightKg = nil
-                                            } else if let v = Double(text.replacingOccurrences(of: ",", with: ".")) {
-                                                // Always store in kg
-                                                profile.bodyweightKg = profile.bodyweightInKg ? v : v / 2.20462
-                                            }
-                                        }
-                                    )
-                                )
-                                .keyboardType(.decimalPad)
-                                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                .foregroundStyle(.white)
-                                .padding(14)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                        .fill(.white.opacity(0.07))
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                                .strokeBorder(.white.opacity(0.14), lineWidth: 1)
-                                        )
-                                )
-                                Text(profile.bodyweightInKg ? "kg" : "lbs")
-                                    .font(.system(size: 15, weight: .medium))
-                                    .foregroundStyle(.white.opacity(0.45))
-                                    .frame(width: 32)
-                            }
-                            Text("Optional — helps the AI calibrate your starting weights")
-                                .font(.system(size: 12, weight: .regular))
-                                .foregroundStyle(.white.opacity(0.35))
                         }
-
-                        // Height
-                        VStack(alignment: .leading, spacing: 10) {
-                            Label("Height", systemImage: "ruler")
-                                .font(.system(size: 15, weight: .semibold))
-                                .foregroundStyle(.white.opacity(0.70))
-                            HStack(spacing: 8) {
-                                TextField("e.g. 178", text: Binding(
-                                    get: {
-                                        guard let cm = profile.heightCm else { return "" }
-                                        return cm.truncatingRemainder(dividingBy: 1) == 0
-                                            ? String(format: "%.0f", cm)
-                                            : String(format: "%.1f", cm)
-                                    },
-                                    set: { text in
-                                        if text.isEmpty {
-                                            profile.heightCm = nil
-                                        } else if let v = Double(text.replacingOccurrences(of: ",", with: ".")) {
-                                            profile.heightCm = v
-                                        }
-                                    }
-                                ))
-                                .keyboardType(.decimalPad)
-                                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                .foregroundStyle(.white)
-                                .padding(14)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                        .fill(.white.opacity(0.07))
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                                .strokeBorder(.white.opacity(0.14), lineWidth: 1)
-                                        )
-                                )
-                                Text("cm")
-                                    .font(.system(size: 15, weight: .medium))
-                                    .foregroundStyle(.white.opacity(0.45))
-                                    .frame(width: 32)
-                            }
-                        }
-
-                        // Age
-                        VStack(alignment: .leading, spacing: 10) {
-                            Label("Age", systemImage: "person.fill")
-                                .font(.system(size: 15, weight: .semibold))
-                                .foregroundStyle(.white.opacity(0.70))
-                            HStack(spacing: 8) {
-                                TextField("e.g. 28", text: Binding(
-                                    get: { profile.age.map { String($0) } ?? "" },
-                                    set: { text in
-                                        if text.isEmpty {
-                                            profile.age = nil
-                                        } else if let v = Int(text) {
-                                            profile.age = v
-                                        }
-                                    }
-                                ))
-                                .keyboardType(.numberPad)
-                                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                                .foregroundStyle(.white)
-                                .padding(14)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                        .fill(.white.opacity(0.07))
-                                        .overlay(
-                                            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                                .strokeBorder(.white.opacity(0.14), lineWidth: 1)
-                                        )
-                                )
-                                Text("yrs")
-                                    .font(.system(size: 15, weight: .medium))
-                                    .foregroundStyle(.white.opacity(0.45))
-                                    .frame(width: 32)
-                            }
-                        }
+                        .padding(.horizontal, 16)
+                        .apexCard()
                     }
-                    .padding(.horizontal, 4)
+                    Color.clear.frame(height: 110)
                 }
-                .padding(.horizontal, 32)
-                .padding(.bottom, 24)
-
-                HStack(spacing: 12) {
-                    backButton { withAnimation(.spring(response: 0.38, dampingFraction: 0.80)) { step = 1 } }
-                    primaryButton(title: "Continue", enabled: true) {
-                        withAnimation(.spring(response: 0.38, dampingFraction: 0.80)) { step = 3 }
-                    }
-                }
-                .padding(.horizontal, 32)
-                .padding(.bottom, 48)
+                Spacer(minLength: 0)
             }
+            .padding(.horizontal, Apex.pad)
+            .padding(.top, 8)
+
+            bottomBar(
+                primary: "Save my gym · \(reviewItems.count) items",
+                icon: "checkmark",
+                action: { confirmEquipment() }
+            )
         }
     }
 
-    // MARK: - Step 3: Notifications
+    // MARK: - 09 Notifications (moved late)
 
-    private var step3NotificationsView: some View {
-        VStack(spacing: 0) {
-            Spacer()
-            VStack(spacing: 32) {
-                stepHeader(
-                    icon: "bell.badge.fill",
-                    title: "Stay On Track",
-                    subtitle: "Allow notifications so the AI coach can alert you when your rest timer expires."
-                )
-
-                VStack(spacing: 14) {
-                    notifFeatureRow(icon: "timer", label: "Rest timer alerts — never lose track of your rest")
+    private var notificationsView: some View {
+        profileScaffold(
+            stepNumber: 9,
+            back: {
+                withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) {
+                    showingEquipmentReview = true
                 }
-                .padding(20)
-                .background(
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .fill(.white.opacity(0.06))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .strokeBorder(.white.opacity(0.10), lineWidth: 1)
-                        )
-                )
-                .padding(.horizontal, 4)
+                go(to: .equipment)
+            },
+            eyebrow: "Step 09",
+            title: "Stay on track.",
+            primary: "Allow notifications",
+            primaryAction: {
+                Task {
+                    await requestNotificationPermission()
+                    go(to: .generating)
+                }
+            },
+            secondary: (text: "Not now", action: { go(to: .generating) })
+        ) {
+            VStack(alignment: .leading, spacing: 14) {
+                Image(systemName: "bell.badge.fill")
+                    .font(.system(size: 30, weight: .semibold))
+                    .foregroundStyle(Apex.accent)
+                    .padding(.bottom, 4)
+                notifBenefit("Rest-timer alerts so you never lose track between sets.")
+                notifBenefit("A nudge when your next session is ready.")
             }
-            .padding(.horizontal, 32)
-
-            Spacer()
-
-            VStack(spacing: 12) {
-                primaryButton(title: "Allow Notifications", enabled: true) {
-                    Task {
-                        await requestNotificationPermission()
-                        withAnimation(.spring(response: 0.38, dampingFraction: 0.80)) { step = 4 }
-                    }
-                }
-                Button {
-                    withAnimation(.spring(response: 0.38, dampingFraction: 0.80)) { step = 4 }
-                } label: {
-                    Text("Not Now")
-                        .font(.system(size: 16, weight: .regular))
-                        .foregroundStyle(.white.opacity(0.40))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 14)
-                }
-            }
-            .padding(.horizontal, 32)
-            .padding(.bottom, 48)
+            .padding(18)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .apexCard()
         }
     }
 
-    // MARK: - Step 4: Gym Scanner
+    private func notifBenefit(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "checkmark")
+                .font(.system(size: 13, weight: .black))
+                .foregroundStyle(Apex.accent)
+                .padding(.top, 2)
+            Text(text)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(Apex.text)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
 
-    private var step4ScannerView: some View {
+    // MARK: - Generating
+
+    private var generatingView: some View {
         VStack(spacing: 0) {
             Spacer()
-            VStack(spacing: 32) {
-                stepHeader(
-                    icon: "camera.viewfinder",
-                    title: "Scan Your Gym",
-                    subtitle: "Walk around and photograph each piece of equipment. The AI coach uses this to guarantee every exercise fits what's available."
-                )
-
-                if let scannedProfile = gymProfile {
-                    // Profile already captured — show summary card
-                    HStack(spacing: 14) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.title2)
-                            .foregroundStyle(.green)
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Gym scanned")
-                                .font(.system(size: 16, weight: .semibold))
-                                .foregroundStyle(.white)
-                            Text("\(scannedProfile.equipment.count) equipment items confirmed")
-                                .font(.system(size: 14, weight: .regular))
-                                .foregroundStyle(.white.opacity(0.55))
-                        }
-                        Spacer()
-                        Button {
-                            showingScannerSheet = true
-                        } label: {
-                            Text("Re-scan")
-                                .font(.system(size: 13, weight: .semibold))
-                                .foregroundStyle(.white.opacity(0.60))
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 6)
-                                .background(.white.opacity(0.10), in: Capsule())
-                        }
-                    }
-                    .padding(16)
-                    .background(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .fill(Color.green.opacity(0.10))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                    .strokeBorder(Color.green.opacity(0.25), lineWidth: 1)
-                            )
-                    )
-                    .padding(.horizontal, 4)
+            ZStack {
+                if isGenerating {
+                    ApexRing(progress: 0.35, lineWidth: 4)
+                        .frame(width: 92, height: 92)
+                    Image(systemName: "brain.head.profile")
+                        .font(.system(size: 34, weight: .semibold))
+                        .foregroundStyle(Apex.accent)
+                } else if generationError != nil {
+                    Circle().stroke(Apex.hairline, lineWidth: 4).frame(width: 92, height: 92)
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 34))
+                        .foregroundStyle(Apex.amber)
                 } else {
-                    // Scanner CTA
-                    Button {
-                        showingScannerSheet = true
-                    } label: {
-                        HStack(spacing: 16) {
-                            Image(systemName: "camera.viewfinder")
-                                .font(.title2)
-                                .foregroundStyle(Color(red: 0.23, green: 0.56, blue: 1.00))
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Open Gym Scanner")
-                                    .font(.system(size: 16, weight: .semibold))
-                                    .foregroundStyle(.white)
-                                Text("Point your camera at each piece of equipment")
-                                    .font(.system(size: 13, weight: .regular))
-                                    .foregroundStyle(.white.opacity(0.50))
-                            }
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 13, weight: .semibold))
-                                .foregroundStyle(.white.opacity(0.35))
-                        }
-                        .padding(16)
-                        .background(
-                            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                .fill(.white.opacity(0.07))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                        .strokeBorder(.white.opacity(0.14), lineWidth: 1)
-                                )
-                        )
-                    }
-                    .buttonStyle(.plain)
-                    .padding(.horizontal, 4)
+                    Circle().stroke(Apex.hairline, lineWidth: 4).frame(width: 92, height: 92)
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 34, weight: .black))
+                        .foregroundStyle(Apex.accent)
                 }
             }
-            .padding(.horizontal, 32)
 
-            Spacer()
+            Text(generationError != nil ? "GENERATION\nFAILED" : "BUILDING YOUR\nPROGRAM")
+                .multilineTextAlignment(.center)
+                .font(.system(size: 30, weight: .black))
+                .fontWidth(.condensed)
+                .foregroundStyle(Apex.text)
+                .padding(.top, 28)
 
-            VStack(spacing: 12) {
-                primaryButton(
-                    title: gymProfile != nil ? "Continue" : "Start Scanning",
-                    enabled: true
-                ) {
-                    if gymProfile != nil {
-                        advance()
-                    } else {
-                        showingScannerSheet = true
-                    }
-                }
-
-                if gymProfile == nil {
-                    Button {
-                        showSkipScanAlert = true
-                    } label: {
-                        Text("Skip for now")
-                            .font(.system(size: 16, weight: .regular))
-                            .foregroundStyle(.white.opacity(0.40))
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 14)
-                    }
-                }
+            if isGenerating {
+                Text("The coach is designing your 12-week periodized plan. This can take up to a couple of minutes.")
+                    .multilineTextAlignment(.center)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Apex.textDim)
+                    .padding(.top, 12)
+                    .padding(.horizontal, 30)
+            } else if let err = generationError {
+                Text(err)
+                    .multilineTextAlignment(.center)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(Apex.amber.opacity(0.9))
+                    .padding(.top, 12)
+                    .padding(.horizontal, 30)
             }
-            .padding(.horizontal, 32)
-            .padding(.bottom, 48)
-        }
-    }
-
-    // MARK: - Step 5: Program Generation
-
-    private var step5GeneratingView: some View {
-        VStack(spacing: 0) {
-            Spacer()
-            VStack(spacing: 36) {
-                ZStack {
-                    Circle()
-                        .stroke(.white.opacity(0.08), lineWidth: 2)
-                        .frame(width: 88, height: 88)
-                    if isGenerating {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                            .tint(.white)
-                            .scaleEffect(1.5)
-                    } else if generationError != nil {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.system(size: 34))
-                            .foregroundStyle(.orange)
-                    } else {
-                        Image(systemName: "brain.head.profile")
-                            .font(.system(size: 34))
-                            .foregroundStyle(Color(red: 0.23, green: 0.56, blue: 1.00))
-                    }
-                }
-
-                VStack(spacing: 10) {
-                    Text(isGenerating ? "Building Your Program…" : (generationError != nil ? "Generation Failed" : "Program Ready"))
-                        .font(.system(size: 28, weight: .bold, design: .rounded))
-                        .foregroundStyle(.white)
-                        .multilineTextAlignment(.center)
-
-                    if isGenerating {
-                        Text("The AI coach is designing your 12-week periodized program.\nThis can take up to a couple of minutes.")
-                            .font(.system(size: 15, weight: .regular))
-                            .foregroundStyle(.white.opacity(0.50))
-                            .multilineTextAlignment(.center)
-                    } else if let err = generationError {
-                        Text(err)
-                            .font(.system(size: 14, weight: .regular))
-                            .foregroundStyle(.orange.opacity(0.85))
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal, 16)
-                    }
-                }
-            }
-            .padding(.horizontal, 32)
 
             Spacer()
 
             if generationError != nil {
-                VStack(spacing: 12) {
-                    primaryButton(title: "Try Again", enabled: true) {
-                        Task { await runProgramGeneration() }
+                VStack(spacing: 14) {
+                    Button { Task { await runProgramGeneration() } } label: {
+                        ApexButton(title: "Try again", icon: "arrow.clockwise")
                     }
-                    Button {
-                        // Skip generation — user can regenerate from Settings
-                        withAnimation(.spring(response: 0.38, dampingFraction: 0.80)) { step = 6 }
-                    } label: {
+                    .buttonStyle(.plain)
+                    Button { go(to: .ready) } label: {
                         Text("Continue without a program")
-                            .font(.system(size: 15, weight: .regular))
-                            .foregroundStyle(.white.opacity(0.35))
-                            .padding(.vertical, 14)
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(Apex.textFaint)
                     }
+                    .buttonStyle(.plain)
                 }
-                .padding(.horizontal, 32)
-                .padding(.bottom, 48)
+                .padding(.horizontal, Apex.pad)
+                .padding(.bottom, 26)
             }
         }
+        .padding(.horizontal, Apex.pad)
         .task {
             if !isGenerating && generationError == nil {
                 await runProgramGeneration()
@@ -684,178 +1105,234 @@ struct OnboardingView: View {
         }
     }
 
-    // MARK: - Step 6: Ready
+    // MARK: - Ready reveal (+ adaptive loop)
 
-    private var step6ReadyView: some View {
-        VStack(spacing: 0) {
-            Spacer()
-            VStack(spacing: 32) {
-                VStack(spacing: 16) {
+    private let adaptiveLoop: [(String, String, String)] = [
+        ("01", "YOU DO THE SET", "Log the weight and reps you hit."),
+        ("02", "IT READS YOUR STRENGTH", "Turns that into where you really are."),
+        ("03", "IT UPDATES ITS MODEL", "Adjusts how it sees you on that lift."),
+        ("04", "IT PLANS YOUR NEXT SET", "Prescribes the next target precisely."),
+    ]
+
+    private var readyView: some View {
+        let name = profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let welcomeName = name.isEmpty ? "ATHLETE" : name.uppercased()
+        let cached = Mesocycle.loadFromUserDefaults()
+        let weeks = cached?.totalWeeks
+        return ZStack(alignment: .bottom) {
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
                     Image(systemName: "checkmark.seal.fill")
-                        .font(.system(size: 72))
-                        .foregroundStyle(Color(red: 0.23, green: 0.56, blue: 1.00))
-                        .symbolEffect(.bounce)
+                        .font(.system(size: 40, weight: .bold))
+                        .foregroundStyle(Apex.accent)
+                        .padding(.top, 50)
+                    ApexSectionLabel(text: "Your program is ready", color: Apex.accent)
+                        .padding(.top, 18)
+                    Text("WELCOME, \(welcomeName).")
+                        .font(.system(size: 38, weight: .black))
+                        .fontWidth(.condensed)
+                        .foregroundStyle(Apex.text)
+                        .padding(.top, 6)
 
-                    VStack(spacing: 10) {
-                        Text("You're Ready to Train")
-                            .font(.system(size: 32, weight: .black, design: .rounded))
-                            .foregroundStyle(.white)
-                            .multilineTextAlignment(.center)
+                    // Program shape — real data where we have it.
+                    HStack(spacing: 10) {
+                        statTile(value: weeks.map(String.init) ?? "—", label: "Weeks")
+                        statTile(value: "\(profile.daysPerWeek)", label: "Days/wk")
+                        statTextTile(value: goalShort(profile.primaryGoal), label: "Focus")
+                    }
+                    .padding(.top, 22)
 
-                        let name = profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
-                        let readyMessage: String = {
-                            if generationError != nil {
-                                return "Program generation didn't finish. You can generate it from the Program tab — your answers are saved."
-                            } else if scanSkipped {
-                                return "Almost there — add your gym equipment to unlock your program."
-                            } else {
-                                return "Welcome, \(name.isEmpty ? "Athlete" : name). Your 12-week program is loaded. Head to the Program tab to review it, then start your first session."
+                    ApexSectionLabel(text: "The loop it runs on every set", color: Apex.textFaint)
+                        .padding(.top, 30)
+                        .padding(.bottom, 4)
+
+                    VStack(spacing: 0) {
+                        ForEach(Array(adaptiveLoop.enumerated()), id: \.offset) { i, s in
+                            HStack(alignment: .top, spacing: 14) {
+                                ApexNumeral(text: s.0, size: 15, weight: .black, color: Apex.onAccent)
+                                    .frame(width: 30, height: 30)
+                                    .background(RoundedRectangle(cornerRadius: Apex.corner).fill(Apex.accent))
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(s.1)
+                                        .font(.system(size: 15, weight: .bold))
+                                        .fontWidth(.condensed)
+                                        .foregroundStyle(Apex.text)
+                                    Text(s.2)
+                                        .font(.system(size: 13, weight: .medium))
+                                        .foregroundStyle(Apex.textFaint)
+                                }
+                                Spacer()
                             }
-                        }()
-                        Text(readyMessage)
-                            .font(.system(size: 16, weight: .regular))
-                            .foregroundStyle(.white.opacity(0.55))
-                            .multilineTextAlignment(.center)
+                            .padding(.vertical, 10)
+                            if i < adaptiveLoop.count - 1 {
+                                Image(systemName: "arrow.down")
+                                    .font(.system(size: 11, weight: .black))
+                                    .foregroundStyle(Apex.accent.opacity(0.7))
+                                    .frame(width: 30, alignment: .center)
+                            }
+                        }
+                        HStack(spacing: 8) {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                                .font(.system(size: 12, weight: .black))
+                            Text("repeats every set, every session")
+                                .font(.system(size: 12.5, weight: .semibold))
+                                .fontWidth(.condensed)
+                        }
+                        .foregroundStyle(Apex.accent)
+                        .padding(.top, 12)
+                        .frame(maxWidth: .infinity)
                     }
-                }
+                    .padding(16)
+                    .apexCard()
+                    .padding(.top, 8)
 
-                if scanSkipped {
-                    HStack(spacing: 12) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundStyle(.orange)
-                        Text("Gym scan skipped — visit Settings → \"Complete your setup\" to scan your equipment.")
-                            .font(.system(size: 13, weight: .regular))
-                            .foregroundStyle(.orange.opacity(0.85))
+                    if generationError != nil {
+                        HStack(spacing: 10) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(Apex.amber)
+                            Text("Program generation didn't finish — your answers are saved. Generate it from the Program tab.")
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundStyle(Apex.amber.opacity(0.9))
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .padding(14)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .apexCard()
+                        .padding(.top, 12)
                     }
-                    .padding(14)
-                    .background(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .fill(.orange.opacity(0.10))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                    .strokeBorder(.orange.opacity(0.25), lineWidth: 1)
-                            )
-                    )
-                    .padding(.horizontal, 4)
+
+                    Color.clear.frame(height: 120)
+                }
+                .padding(.horizontal, Apex.pad)
+            }
+
+            bottomBar(primary: "Start training", action: { completeOnboarding() })
+        }
+    }
+
+    private func statTile(value: String, label: String) -> some View {
+        VStack(spacing: 4) {
+            ApexNumeral(text: value, size: 34, weight: .black, color: Apex.text)
+            ApexSectionLabel(text: label, color: Apex.textFaint)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+        .apexCard()
+    }
+
+    private func statTextTile(value: String, label: String) -> some View {
+        VStack(spacing: 4) {
+            Text(value)
+                .font(.system(size: 16, weight: .black))
+                .fontWidth(.condensed)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(Apex.text)
+            ApexSectionLabel(text: label, color: Apex.textFaint)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+        .apexCard()
+    }
+
+    /// Short, uppercase focus label for the program-shape tile.
+    private func goalShort(_ goal: TrainingGoal) -> String {
+        switch goal {
+        case .hypertrophy: return "HYPER-\nTROPHY"
+        case .strength:    return "STRENGTH"
+        case .endurance:   return "ENDUR-\nANCE"
+        case .general:     return "GENERAL"
+        }
+    }
+
+    // MARK: - Bodyweight / biometric input bindings
+
+    private var bodyweightBinding: Binding<String> {
+        Binding(
+            get: {
+                guard let kg = profile.bodyweightKg else { return "" }
+                let display = profile.bodyweightInKg ? kg : kg * 2.20462
+                return display.truncatingRemainder(dividingBy: 1) == 0
+                    ? String(format: "%.0f", display)
+                    : String(format: "%.1f", display)
+            },
+            set: { text in
+                if text.isEmpty {
+                    profile.bodyweightKg = nil
+                } else if let v = Double(text.replacingOccurrences(of: ",", with: ".")) {
+                    profile.bodyweightKg = profile.bodyweightInKg ? v : v / 2.20462
                 }
             }
-            .padding(.horizontal, 32)
+        )
+    }
 
-            Spacer()
-
-            primaryButton(title: "Start Training", enabled: true) {
-                completeOnboarding()
+    private var heightBinding: Binding<String> {
+        Binding(
+            get: {
+                guard let cm = profile.heightCm else { return "" }
+                return cm.truncatingRemainder(dividingBy: 1) == 0
+                    ? String(format: "%.0f", cm)
+                    : String(format: "%.1f", cm)
+            },
+            set: { text in
+                if text.isEmpty { profile.heightCm = nil }
+                else if let v = Double(text.replacingOccurrences(of: ",", with: ".")) { profile.heightCm = v }
             }
-            .padding(.horizontal, 32)
-            .padding(.bottom, 48)
-        }
+        )
     }
 
-    // MARK: - Shared Sub-components
-
-    private func stepHeader(icon: String, title: String, subtitle: String) -> some View {
-        VStack(spacing: 16) {
-            Image(systemName: icon)
-                .font(.system(size: 44))
-                .foregroundStyle(Color(red: 0.23, green: 0.56, blue: 1.00))
-            VStack(spacing: 8) {
-                Text(title)
-                    .font(.system(size: 28, weight: .bold, design: .rounded))
-                    .foregroundStyle(.white)
-                    .multilineTextAlignment(.center)
-                Text(subtitle)
-                    .font(.system(size: 15, weight: .regular))
-                    .foregroundStyle(.white.opacity(0.55))
-                    .multilineTextAlignment(.center)
+    private var ageBinding: Binding<String> {
+        Binding(
+            get: { profile.age.map { String($0) } ?? "" },
+            set: { text in
+                if text.isEmpty { profile.age = nil }
+                else if let v = Int(text) { profile.age = v }
             }
-        }
+        )
     }
 
-    private func primaryButton(title: String, enabled: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(title)
-                .font(.system(size: 17, weight: .semibold))
-                .foregroundStyle(enabled ? .white : .white.opacity(0.35))
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 18)
-                .background(
-                    enabled
-                    ? Color(red: 0.23, green: 0.56, blue: 1.00)
-                    : Color.white.opacity(0.08),
-                    in: RoundedRectangle(cornerRadius: 16, style: .continuous)
-                )
-        }
-        .disabled(!enabled)
-        .buttonStyle(.plain)
-    }
+    // MARK: - Equipment actions
 
-    private func backButton(action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack(spacing: 6) {
-                Image(systemName: "chevron.left")
-                    .font(.system(size: 14, weight: .semibold))
-                Text("Back")
-                    .font(.system(size: 16, weight: .regular))
-            }
-            .foregroundStyle(.white.opacity(0.50))
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 18)
-            .background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-        }
-        .buttonStyle(.plain)
-    }
-
-    private func notifFeatureRow(icon: String, label: String) -> some View {
-        HStack(spacing: 14) {
-            Image(systemName: icon)
-                .font(.system(size: 18))
-                .foregroundStyle(Color(red: 0.23, green: 0.56, blue: 1.00))
-                .frame(width: 24)
-            Text(label)
-                .font(.system(size: 14, weight: .regular))
-                .foregroundStyle(.white.opacity(0.75))
-            Spacer()
-        }
-    }
-
-    private func profilePickerRow<T: Hashable>(
-        label: String,
-        systemImage: String,
-        selection: Binding<T>,
-        options: [T],
-        displayName: @escaping (T) -> String
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Label(label, systemImage: systemImage)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(.white.opacity(0.70))
-            Picker(label, selection: selection) {
-                ForEach(options, id: \.self) { opt in
-                    Text(displayName(opt)).tag(opt)
-                }
-            }
-            .pickerStyle(.menu)
-            .tint(.white)
-            .padding(.vertical, 4)
-            .padding(.horizontal, 12)
-            .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(.white.opacity(0.07))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .strokeBorder(.white.opacity(0.12), lineWidth: 1)
-                    )
+    /// Seed the review list from a preset and advance to the review screen.
+    private func seedPreset(_ preset: EquipPreset) {
+        presetLabel = preset.name
+        reviewItems = preset.types.map { type in
+            EquipmentItem(
+                equipmentType: type,
+                count: 1,
+                detectedByVision: false,
+                bodyweightOnly: type.isNaturallyBodyweightOnly ? true : nil
             )
         }
+        withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) {
+            showingEquipmentReview = true
+        }
+    }
+
+    /// Start with an empty review list.
+    private func seedFromScratch() {
+        presetLabel = ""
+        reviewItems = []
+        withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) {
+            showingEquipmentReview = true
+        }
+    }
+
+    /// Confirm the reviewed equipment into the `gymProfile` state (the same
+    /// state the old gym-scan step produced) and advance to notifications.
+    private func confirmEquipment() {
+        if reviewItems.isEmpty {
+            gymProfile = nil
+        } else {
+            gymProfile = GymProfile(
+                scanSessionId: "onboarding_\(UUID().uuidString.prefix(8))",
+                equipment: reviewItems
+            )
+            gymProfile?.saveToUserDefaults()
+        }
+        go(to: .notifications)
     }
 
     // MARK: - Actions
-
-    private func advance() {
-        withAnimation(.spring(response: 0.38, dampingFraction: 0.80)) {
-            step += 1
-        }
-    }
 
     private func requestNotificationPermission() async {
         let center = UNUserNotificationCenter.current()
@@ -876,7 +1353,7 @@ struct OnboardingView: View {
         await persistUserIfNeeded()
 
         // Persist daysPerWeek before the gymProfile guard so it is always
-        // written regardless of whether the user skipped the gym scan.
+        // written regardless of whether the user provided equipment.
         UserDefaults.standard.set(profile.daysPerWeek, forKey: UserProfileConstants.daysPerWeekKey)
 
         // Re-entry guard (#318 U4): if a program was already generated for this
@@ -885,14 +1362,14 @@ struct OnboardingView: View {
         // second skeleton LLM call.
         if let cached = Mesocycle.loadFromUserDefaults(), cached.userId == deps.resolvedUserId {
             isGenerating = false
-            withAnimation(.spring(response: 0.38, dampingFraction: 0.80)) { step = 6 }
+            go(to: .ready)
             return
         }
 
         guard let gymProf = gymProfile else {
             // No gym profile — can't generate a valid program. Advance directly to ready.
             isGenerating = false
-            withAnimation(.spring(response: 0.38, dampingFraction: 0.80)) { step = 6 }
+            go(to: .ready)
             return
         }
 
@@ -930,7 +1407,7 @@ struct OnboardingView: View {
                 client: deps.supabaseClient
             )
             isGenerating = false
-            withAnimation(.spring(response: 0.38, dampingFraction: 0.80)) { step = 6 }
+            go(to: .ready)
         } catch {
             isGenerating = false
             generationError = error.localizedDescription
@@ -950,6 +1427,15 @@ struct OnboardingView: View {
         UserDefaults.standard.set(profile.age, forKey: UserProfileConstants.ageKey)
         UserDefaults.standard.set(profile.trainingAge.rawValue, forKey: UserProfileConstants.trainingAgeKey)
         UserDefaults.standard.set(profile.primaryGoal.rawValue, forKey: UserProfileConstants.primaryGoalKey)
+        // #527: sex is persisted to UserDefaults only — the public.users table has
+        // no sex column (Settings writes sex the same way). When the user chose
+        // "Prefer not to say", profile.sex is nil and we clear any prior value.
+        UserDefaults.standard.set(profile.sex, forKey: UserProfileConstants.sexKey)
+
+        // #527 S2: the user's injury / "work-around" selection lives in
+        // profile.injuryAreas. Slice 2 owns persisting it as a user-confirmed
+        // limitation (the limitation write-path is out of scope here) — do NOT
+        // write it yet; it would land in the wrong shape without that path.
 
         // #369 slice 3: the `users` row's id MUST be the anonymous-auth
         // `auth.uid()` so slice 5's RLS policy (`id = auth.uid()`) will match.
@@ -1006,8 +1492,12 @@ struct OnboardingView: View {
     }
 
     private func completeOnboarding() {
-        // Mark scan-skipped flag so SettingsView shows the persistent prompt.
-        UserDefaults.standard.set(scanSkipped, forKey: OnboardingConstants.scanSkippedKey)
+        // #527: the camera gym-scan was removed; a user who provided no equipment
+        // still has a usable onboarding. Mark "scan skipped" when no gym profile
+        // was confirmed so SettingsView shows the persistent "complete your setup"
+        // prompt (the same affordance the old scan-skip used).
+        let noEquipment = gymProfile == nil
+        UserDefaults.standard.set(noEquipment, forKey: OnboardingConstants.scanSkippedKey)
         // Mark onboarding as completed so subsequent launches skip this view.
         UserDefaults.standard.set(true, forKey: OnboardingConstants.onboardingCompletedKey)
         onCompleted?(gymProfile)


### PR DESCRIPTION
Rewrites `OnboardingView.swift` to the approved Brutalist onboarding overhaul (Slice 1 of #527). Visual/flow redesign only — every piece of persistence, owner-resolution, networking, and completion logic is preserved verbatim.

## New flow
Intro (no rail): **Welcome** → **3 "how it works" concept cards** (ghost numerals + one volt-lime hot phrase each). Then numbered one-question-per-screen profile with a sharp segmented rail + `NN / TT` counter:

1. Name · 2. Experience (tap-cards) · 3. Goal (tap-cards) · 4. Days/week (tiles)
5. **Bodyweight — expected** (emphasized card + kg/lb toggle + why-we-ask) with Height + Age tagged Optional
6. **Sex** (NEW — Male / Female / Prefer not to say)
7. **Injuries** (NEW, optional — 2-col icon-box multi-select)
8. **Equipment** — presets → review list (search/add bar, remove, "add a machine we don't list"); reuses `BulkEquipmentPickerSheet`
9. **Notifications** — moved late, value-framed

→ **Generating** (`runProgramGeneration()` unchanged) → **Program-ready reveal** (real weeks/days/goal + adaptive-loop diagram + Start Training).

## Preserved behaviour
- `runProgramGeneration()` + re-entry/cache guards + error/retry — unchanged
- `resolvedOwnerUserId()` resolve-before-stamp, `users` upsert (encode-if-present), `update-trainee-goal` EF call, `OnboardingProgramPersist.persistIfOwnerResolved`, `completeOnboarding()` flags, the `onCompleted` callback — all intact

## Sex / injuries
- **Sex** persisted to `UserProfileConstants.sexKey` in UserDefaults only — the `public.users` table has no sex column (Settings stores it the same way); commented `// #527`.
- **Injuries** collected into `profile.injuryAreas`; the limitation write-path is left as a `// #527 S2:` TODO (Slice 2 owns it) — not persisted here.

## Camera scanner
The onboarding equipment step no longer invokes `ScannerView`'s camera path (presets + manual picker replace it). `ScannerView`/`CameraManager` files are untouched (camera-code deletion is Slice 3); Settings still references `ScannerView`.

Build: `** BUILD SUCCEEDED **` (iPhone 17 Pro, OS 26.5), 0 errors.

Part of #527