### PR TITLE
feat(#527): persist onboarding injuries as user-confirmed limitations (S2)

### DIFF
--- a/ProjectApex/Features/Onboarding/OnboardingView.swift
+++ b/ProjectApex/Features/Onboarding/OnboardingView.swift
@@ -1433,9 +1433,9 @@ struct OnboardingView: View {
         UserDefaults.standard.set(profile.sex, forKey: UserProfileConstants.sexKey)
 
         // #527 S2: the user's injury / "work-around" selection lives in
-        // profile.injuryAreas. Slice 2 owns persisting it as a user-confirmed
-        // limitation (the limitation write-path is out of scope here) — do NOT
-        // write it yet; it would land in the wrong shape without that path.
+        // profile.injuryAreas. It is persisted below, alongside the goal write,
+        // as user-confirmed limitations via the update-trainee-goal EF's
+        // `confirmed_limitations` field (see the goalPayload build).
 
         // #369 slice 3: the `users` row's id MUST be the anonymous-auth
         // `auth.uid()` so slice 5's RLS policy (`id = auth.uid()`) will match.
@@ -1472,6 +1472,10 @@ struct OnboardingView: View {
         // until the next onboarding retry or DeveloperSettingsView reset).
         let isoFormatter = ISO8601DateFormatter()
         isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        // #527 S2: map the injury areas tapped on the "anything to work around?"
+        // screen to user-confirmed limitations carried on the same goal write.
+        let confirmedLimitations = OnboardingInjuryMapping
+            .confirmedLimitations(from: profile.injuryAreas)
         let goalPayload = TraineeGoalUpsertPayload(
             userId: userId,
             goal: GoalUpsertBody(
@@ -1481,7 +1485,8 @@ struct OnboardingView: View {
             ),
             acknowledgeTriggeringSessionCount: nil,
             stretchEdits: nil,
-            acknowledgeCalibrationReview: nil
+            acknowledgeCalibrationReview: nil,
+            confirmedLimitations: confirmedLimitations.isEmpty ? nil : confirmedLimitations
         )
         if let encoded = try? JSONEncoder().encode(goalPayload) {
             _ = try? await deps.supabaseClient.invokeFunction(
@@ -1632,6 +1637,12 @@ struct TraineeGoalUpsertPayload: Codable, Sendable {
     /// calibration banner does not reappear after a session sync. Omitted from
     /// the wire when nil.
     let acknowledgeCalibrationReview: Bool?
+    /// #527 S2: OPTIONAL. User-confirmed injuries from the onboarding "anything
+    /// to work around?" screen. When non-nil the EF appends each as a
+    /// user-confirmed `activeLimitations` entry so the planner avoids
+    /// programming into it from session 1. Synthesized `encodeIfPresent` OMITS
+    /// the key when nil, so other call sites keep their exact wire shape.
+    let confirmedLimitations: [ConfirmedLimitationBody]?
 
     enum CodingKeys: String, CodingKey {
         case userId = "user_id"
@@ -1639,6 +1650,74 @@ struct TraineeGoalUpsertPayload: Codable, Sendable {
         case acknowledgeTriggeringSessionCount = "acknowledge_triggering_session_count"
         case stretchEdits = "stretch_edits"
         case acknowledgeCalibrationReview = "acknowledge_calibration_review"
+        case confirmedLimitations = "confirmed_limitations"
+    }
+}
+
+/// #527 S2: a single user-confirmed limitation in the goal-upsert payload.
+/// Mirrors the EF's `ConfirmedLimitation` shape — a joint-scoped `subject`
+/// tagged union (`{kind, value}`) + `severity`. The default member-name
+/// CodingKeys give the validator the `{subject, severity}` wire shape it
+/// expects; the nested `subject` carries `{kind, value}` verbatim.
+struct ConfirmedLimitationBody: Codable, Sendable {
+    let subject: LimitationSubjectBody
+    let severity: String
+}
+
+/// #527 S2: the `subject` tagged union for a confirmed limitation. Onboarding
+/// only ever declares joint-scoped limitations (`kind == "joint"`); `value` is
+/// a `BodyJoint` rawValue (e.g. "shoulder", "lower_back").
+struct LimitationSubjectBody: Codable, Sendable {
+    let kind: String
+    let value: String
+}
+
+// MARK: - Onboarding injury → confirmed-limitation mapping (#527 S2)
+
+/// Maps the human-readable area labels from the onboarding "anything to work
+/// around?" screen onto the `BodyJoint` vocabulary the coach's limitation
+/// system uses, producing user-confirmed `ConfirmedLimitationBody` payloads.
+///
+/// `internal` (not `private`) so the EF-contract / mapping parity test can
+/// exercise it directly.
+enum OnboardingInjuryMapping {
+    /// Area label (as stored in `OnboardingProfile.injuryAreas`) → `BodyJoint`
+    /// rawValue. Keys are the exact `InjuryArea.name` strings the injuries
+    /// screen offers; values are the canonical joint rawValues the planner reads.
+    static let areaToJoint: [String: String] = [
+        "Shoulders":  "shoulder",
+        "Lower back": "lower_back",
+        "Knees":      "knee",
+        "Elbows":     "elbow",
+        "Wrists":     "wrist",
+        "Hips":       "hip",
+        "Neck":       "neck",
+        "Ankles":     "ankle",
+    ]
+
+    /// Severity stamped on a user-declared injury. `moderate` so the planner
+    /// substitutes the affected movement (per SystemPrompt_SessionPlan ACTIVE
+    /// LIMITATIONS) rather than merely lightening it — "avoid programming into"
+    /// a self-reported injury from session 1. User-confirmed entries are NOT
+    /// capped at the AI-inferred `.mild` ceiling (a user report is at least as
+    /// trustworthy as an inference).
+    static let onboardingSeverity = "moderate"
+
+    /// Maps the tapped areas to confirmed-limitation payloads. Unknown labels
+    /// (none expected — the screen is a closed set) are dropped. Output is
+    /// sorted by joint rawValue for deterministic encoding.
+    static func confirmedLimitations(
+        from areas: Set<String>
+    ) -> [ConfirmedLimitationBody] {
+        areas
+            .compactMap { areaToJoint[$0] }
+            .sorted()
+            .map {
+                ConfirmedLimitationBody(
+                    subject: LimitationSubjectBody(kind: "joint", value: $0),
+                    severity: onboardingSeverity
+                )
+            }
     }
 }
 

--- a/ProjectApex/Features/Workout/CalibrationReviewView.swift
+++ b/ProjectApex/Features/Workout/CalibrationReviewView.swift
@@ -82,7 +82,8 @@ struct CalibrationReviewView: View {
             goal: goal,
             acknowledgeTriggeringSessionCount: nil,
             stretchEdits: raised.isEmpty ? nil : raised,
-            acknowledgeCalibrationReview: true
+            acknowledgeCalibrationReview: true,
+            confirmedLimitations: nil
         )
     }
 

--- a/ProjectApex/Features/Workout/GoalReviewView.swift
+++ b/ProjectApex/Features/Workout/GoalReviewView.swift
@@ -79,7 +79,8 @@ struct GoalReviewView: View {
             ),
             acknowledgeTriggeringSessionCount: triggeringSessionCount,
             stretchEdits: nil,
-            acknowledgeCalibrationReview: nil
+            acknowledgeCalibrationReview: nil,
+            confirmedLimitations: nil
         )
     }
 

--- a/ProjectApexTests/OnboardingGoalPayloadTests.swift
+++ b/ProjectApexTests/OnboardingGoalPayloadTests.swift
@@ -57,7 +57,8 @@ final class OnboardingGoalPayloadTests: XCTestCase {
             ),
             acknowledgeTriggeringSessionCount: acknowledge,
             stretchEdits: nil,
-            acknowledgeCalibrationReview: nil
+            acknowledgeCalibrationReview: nil,
+            confirmedLimitations: nil
         )
         let data = try JSONEncoder().encode(payload)
         return try XCTUnwrap(
@@ -206,6 +207,132 @@ final class OnboardingGoalPayloadTests: XCTestCase {
         XCTAssertNotNil(
             updatedAt.range(of: Self.efISODateRegex, options: .regularExpression),
             "goal.updatedAt '\(updatedAt)' must match the EF ISO_DATE_RE"
+        )
+    }
+}
+
+// MARK: - Onboarding injury → confirmed-limitation mapping (#527 S2)
+
+/// Locks the contract that the onboarding injuries screen's tapped areas map
+/// to user-confirmed limitations the EF (`update-trainee-goal`,
+/// `confirmed_limitations`) and planner accept:
+///   • every area label maps to a canonical `BodyJoint` rawValue;
+///   • the payload encodes to the EF's `{subject:{kind,value}, severity}` shape;
+///   • the limitation is user-confirmed at full (not `.mild`-capped) severity;
+///   • the wire field is OMITTED when no injury was tapped (onboarding stays
+///     {user_id, goal}).
+final class OnboardingInjuryMappingTests: XCTestCase {
+
+    func test_allEightAreaLabels_mapToCanonicalJoints() {
+        // Every label the injuries screen offers must have a mapping — an
+        // unmapped label would silently drop a declared injury.
+        let expected: [String: String] = [
+            "Shoulders":  "shoulder",
+            "Lower back": "lower_back",
+            "Knees":      "knee",
+            "Elbows":     "elbow",
+            "Wrists":     "wrist",
+            "Hips":       "hip",
+            "Neck":       "neck",
+            "Ankles":     "ankle",
+        ]
+        XCTAssertEqual(
+            OnboardingInjuryMapping.areaToJoint, expected,
+            "the eight injuries-screen labels must map to the canonical BodyJoint rawValues"
+        )
+    }
+
+    func test_confirmedLimitations_buildsUserConfirmedJointEntries() throws {
+        let limitations = OnboardingInjuryMapping.confirmedLimitations(
+            from: ["Shoulders", "Lower back"]
+        )
+        XCTAssertEqual(limitations.count, 2)
+
+        // Deterministic order (sorted by joint rawValue): lower_back, shoulder.
+        XCTAssertEqual(limitations.map(\.subject.value), ["lower_back", "shoulder"])
+        for lim in limitations {
+            XCTAssertEqual(lim.subject.kind, "joint", "onboarding declares joint-scoped limitations")
+            // moderate (not .mild) — user-confirmed is not capped at the
+            // AI-inferred ceiling; the planner substitutes the movement.
+            XCTAssertEqual(lim.severity, "moderate")
+        }
+    }
+
+    func test_confirmedLimitations_emptyAreas_yieldsEmpty() {
+        XCTAssertTrue(
+            OnboardingInjuryMapping.confirmedLimitations(from: []).isEmpty,
+            "no tapped areas → no limitations"
+        )
+    }
+
+    func test_payload_withInjuries_encodesEFConfirmedLimitationsShape() throws {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let limitations = OnboardingInjuryMapping.confirmedLimitations(
+            from: ["Knees"]
+        )
+        let payload = TraineeGoalUpsertPayload(
+            userId: UUID(),
+            goal: GoalUpsertBody(
+                statement: "Hypertrophy",
+                focusAreas: [],
+                updatedAt: isoFormatter.string(from: Date())
+            ),
+            acknowledgeTriggeringSessionCount: nil,
+            stretchEdits: nil,
+            acknowledgeCalibrationReview: nil,
+            confirmedLimitations: limitations
+        )
+        let data = try JSONEncoder().encode(payload)
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+
+        // The EF reads top-level snake_case `confirmed_limitations`.
+        let arr = try XCTUnwrap(
+            json["confirmed_limitations"] as? [[String: Any]],
+            "confirmed_limitations must encode as a top-level array of objects"
+        )
+        XCTAssertNil(
+            json["confirmedLimitations"],
+            "no camelCase `confirmedLimitations` may leak to the wire"
+        )
+        XCTAssertEqual(arr.count, 1)
+        let entry = arr[0]
+        XCTAssertEqual(Set(entry.keys), ["subject", "severity"],
+            "EF validator reads {subject, severity}")
+        XCTAssertEqual(entry["severity"] as? String, "moderate")
+        let subject = try XCTUnwrap(entry["subject"] as? [String: Any])
+        XCTAssertEqual(Set(subject.keys), ["kind", "value"],
+            "EF validator reads subject.{kind, value}")
+        XCTAssertEqual(subject["kind"] as? String, "joint")
+        XCTAssertEqual(subject["value"] as? String, "knee")
+    }
+
+    func test_payload_noInjuries_omitsConfirmedLimitationsKey() throws {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        // The onboarding call site passes nil when no area was tapped, keeping
+        // the wire shape exactly {user_id, goal}.
+        let payload = TraineeGoalUpsertPayload(
+            userId: UUID(),
+            goal: GoalUpsertBody(
+                statement: "Hypertrophy",
+                focusAreas: [],
+                updatedAt: isoFormatter.string(from: Date())
+            ),
+            acknowledgeTriggeringSessionCount: nil,
+            stretchEdits: nil,
+            acknowledgeCalibrationReview: nil,
+            confirmedLimitations: nil
+        )
+        let data = try JSONEncoder().encode(payload)
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        XCTAssertEqual(
+            Set(json.keys), ["user_id", "goal"],
+            "nil confirmed_limitations must omit the key (onboarding stays {user_id, goal})"
         )
     }
 }

--- a/supabase/functions/update-trainee-goal/index.ts
+++ b/supabase/functions/update-trainee-goal/index.ts
@@ -33,6 +33,7 @@ import postgres from "postgres";
 import { MAJOR_PATTERNS } from "../_shared/constants.ts";
 import { checkOwnership } from "../_shared/jwt-owner.ts";
 import type { PatternProjection } from "../_shared/calibration-projection.ts";
+import type { ActiveLimitation } from "../_shared/note-classifier.ts";
 import {
   isRenegotiation,
   rederiveStretchOnRenegotiation,
@@ -49,6 +50,39 @@ const MAJOR_PATTERN_SET: ReadonlySet<string> = new Set(MAJOR_PATTERNS);
 export interface StretchEdit {
   pattern: string;
   stretch: number;
+}
+
+/**
+ * #527 S2: the BodyJoint rawValues a user-confirmed onboarding limitation may
+ * target. Mirrors the Swift `BodyJoint` enum (TraineeModelEnums.swift) — the
+ * onboarding injuries screen offers exactly these eight joints. Onboarding only
+ * ever sends joint-scoped limitations (not pattern / muscle), so this is the
+ * full accepted `subject.value` set for `subject.kind === "joint"`.
+ */
+const BODY_JOINT_SET: ReadonlySet<string> = new Set([
+  "shoulder",
+  "elbow",
+  "wrist",
+  "hip",
+  "knee",
+  "ankle",
+  "lower_back",
+  "neck",
+]);
+
+const SEVERITY_SET: ReadonlySet<string> = new Set(["mild", "moderate", "severe"]);
+
+/**
+ * #527 S2: a single user-confirmed limitation declared during onboarding.
+ * Joint-scoped only (the onboarding "anything to work around?" screen tracks
+ * joints). `subject.value` must be a `BODY_JOINT_SET` member; `severity` must be
+ * a valid `Severity`. The EF stamps `onsetDate`, `evidenceCount`,
+ * `userConfirmed`, and `sessionsWithoutReMention` server-side — the client
+ * never sets those.
+ */
+export interface ConfirmedLimitation {
+  subject: { kind: "joint"; value: string };
+  severity: string;
 }
 
 function jsonResponse(body: unknown, status: number): Response {
@@ -82,6 +116,12 @@ export interface UpdateTraineeGoalRequest {
   // calibration banner does not reappear after a session sync rehydrates the
   // local cache. Absent for onboarding / goal-review saves.
   acknowledge_calibration_review?: boolean;
+  // #527 S2: OPTIONAL. User-confirmed injuries collected at onboarding. When
+  // present, each entry is appended to `model_json.activeLimitations` as a
+  // user-confirmed limitation (the planner avoids programming into it from
+  // session 1). Absent for goal-review / calibration-review saves (only
+  // onboarding sends it, and only when the user tapped at least one area).
+  confirmed_limitations?: ConfirmedLimitation[];
 }
 
 const ISO_DATE_RE =
@@ -99,6 +139,7 @@ export function validateRequest(
     acknowledge_triggering_session_count,
     stretch_edits,
     acknowledge_calibration_review,
+    confirmed_limitations,
   } = body as Record<string, unknown>;
   if (typeof user_id !== "string" || !UUID_RE.test(user_id)) {
     return { error: "user_id must be a UUID string" };
@@ -175,6 +216,51 @@ export function validateRequest(
   ) {
     return { error: "acknowledge_calibration_review must be a boolean" };
   }
+  // #527 S2: OPTIONAL confirmed_limitations. Absent → valid exactly as before
+  // (back-compat: goal-review / calibration saves never send it). Present →
+  // an array of { subject: { kind: "joint", value: <BodyJoint rawValue> },
+  // severity: <Severity> }. The server stamps the remaining ActiveLimitation
+  // fields (onsetDate / evidenceCount / userConfirmed / sessionsWithoutReMention)
+  // at write time — the client cannot set them.
+  let validatedLimitations: ConfirmedLimitation[] | undefined;
+  if (confirmed_limitations !== undefined) {
+    if (!Array.isArray(confirmed_limitations)) {
+      return { error: "confirmed_limitations must be an array" };
+    }
+    validatedLimitations = [];
+    for (let i = 0; i < confirmed_limitations.length; i++) {
+      const lim = confirmed_limitations[i];
+      if (typeof lim !== "object" || lim === null || Array.isArray(lim)) {
+        return { error: `confirmed_limitations[${i}] must be an object` };
+      }
+      const lr = lim as Record<string, unknown>;
+      const subject = lr.subject;
+      if (typeof subject !== "object" || subject === null || Array.isArray(subject)) {
+        return { error: `confirmed_limitations[${i}].subject must be an object` };
+      }
+      const sr = subject as Record<string, unknown>;
+      if (sr.kind !== "joint") {
+        return {
+          error: `confirmed_limitations[${i}].subject.kind must be "joint"`,
+        };
+      }
+      if (typeof sr.value !== "string" || !BODY_JOINT_SET.has(sr.value)) {
+        return {
+          error:
+            `confirmed_limitations[${i}].subject.value must be a body joint`,
+        };
+      }
+      if (typeof lr.severity !== "string" || !SEVERITY_SET.has(lr.severity)) {
+        return {
+          error: `confirmed_limitations[${i}].severity must be a severity`,
+        };
+      }
+      validatedLimitations.push({
+        subject: { kind: "joint", value: sr.value },
+        severity: lr.severity,
+      });
+    }
+  }
   const validated: UpdateTraineeGoalRequest = {
     user_id,
     goal: {
@@ -193,6 +279,9 @@ export function validateRequest(
   if (acknowledge_calibration_review !== undefined) {
     validated.acknowledge_calibration_review =
       acknowledge_calibration_review as boolean;
+  }
+  if (validatedLimitations !== undefined) {
+    validated.confirmed_limitations = validatedLimitations;
   }
   return validated;
 }
@@ -293,9 +382,98 @@ export async function upsertGoal(
         WHERE user_id = ${req.user_id}
       `;
     }
+
+    // #527 S2: append onboarding-declared injuries as user-confirmed
+    // limitations. Runs inside the same transaction so it commits atomically
+    // with the goal write (the INSERT path above always created the row, so the
+    // append has a row to merge into).
+    if (
+      req.confirmed_limitations !== undefined &&
+      req.confirmed_limitations.length > 0
+    ) {
+      await applyConfirmedLimitations(
+        req.user_id,
+        req.confirmed_limitations,
+        tx,
+      );
+    }
   });
 
   return { ok: true, goal: req.goal };
+}
+
+/**
+ * #527 S2: append user-confirmed injuries (from onboarding) to
+ * `model_json.activeLimitations`. Each entry becomes a full `ActiveLimitation`
+ * with `userConfirmed: true` — so the planner treats it at full weight from
+ * session 1, and the session-apply lifecycle (`updateLimitationLifecycle`)
+ * never auto-clears it.
+ *
+ * Idempotent on re-onboarding: subjects already present (matched by
+ * `subject.kind` + `subject.value`) are skipped, so a replayed onboarding write
+ * does not duplicate or reset a limitation the session pipeline has since
+ * accumulated evidence on. The existing entry — including any user clear or
+ * server-side state — is left untouched.
+ *
+ * Runs inside the caller's transaction (`tx`) with a `FOR UPDATE` read so a
+ * concurrent session-apply (which also writes `activeLimitations`) cannot
+ * clobber the append, and so it commits or rolls back atomically with the rest
+ * of the `upsertGoal` sequence.
+ */
+export async function applyConfirmedLimitations(
+  userId: string,
+  limitations: ConfirmedLimitation[],
+  tx: Sql,
+): Promise<void> {
+  if (limitations.length === 0) return;
+  const rows = await tx`
+    SELECT model_json FROM public.trainee_models
+    WHERE user_id = ${userId}
+    FOR UPDATE
+  `;
+  if (rows.length === 0) return;
+  const modelJson = (rows[0].model_json ?? {}) as Record<string, unknown>;
+  const existing = (modelJson.activeLimitations as ActiveLimitation[]) ?? [];
+
+  // Key existing limitations by subject so a re-onboarding replay is a no-op
+  // for already-recorded injuries.
+  const existingKeys = new Set(
+    existing.map((l) => `${l.subject.kind}:${l.subject.value}`),
+  );
+
+  const now = new Date().toISOString();
+  const toAppend: ActiveLimitation[] = [];
+  for (const lim of limitations) {
+    const key = `${lim.subject.kind}:${lim.subject.value}`;
+    if (existingKeys.has(key)) continue;
+    existingKeys.add(key); // dedupe within this batch too
+    toAppend.push({
+      subject: lim.subject,
+      severity: lim.severity as ActiveLimitation["severity"],
+      onsetDate: now,
+      // User confirmation is its own evidence; the AI-inferred ≥2 corroboration
+      // gate does not apply (userConfirmed bypasses the .mild ceiling). 1 = the
+      // single user report.
+      evidenceCount: 1,
+      userConfirmed: true,
+      notes: null,
+      sessionsWithoutReMention: 0,
+    });
+  }
+  if (toAppend.length === 0) return;
+
+  const merged = [...existing, ...toAppend];
+  await tx`
+    UPDATE public.trainee_models
+    SET model_json = jsonb_set(
+      COALESCE(model_json, '{}'::jsonb),
+      '{activeLimitations}',
+      ${tx.json(merged)},
+      true
+    ),
+    updated_at = NOW()
+    WHERE user_id = ${userId}
+  `;
 }
 
 /**

--- a/supabase/functions/update-trainee-goal/index_test.ts
+++ b/supabase/functions/update-trainee-goal/index_test.ts
@@ -266,6 +266,102 @@ Deno.test("validateRequest_ack_calibration_review_nonBoolean_returns_400", () =>
   assertEquals(result.error.includes("acknowledge_calibration_review"), true);
 });
 
+// ─── #527 S2: confirmed_limitations validation ───────────────────────────────
+
+Deno.test("validateRequest_confirmed_limitations_absent_still_valid", () => {
+  // Back-compat: goal-review / calibration saves omit the field; valid as before.
+  const result = validateRequest(baseRequest());
+  assertEquals("error" in result, false);
+  if ("error" in result) return;
+  assertEquals(result.confirmed_limitations, undefined);
+});
+
+Deno.test("validateRequest_confirmed_limitations_valid_accepted", () => {
+  const result = validateRequest(
+    baseRequest({
+      confirmed_limitations: [
+        { subject: { kind: "joint", value: "shoulder" }, severity: "moderate" },
+        { subject: { kind: "joint", value: "lower_back" }, severity: "mild" },
+      ],
+    }),
+  );
+  assertEquals("error" in result, false);
+  if ("error" in result) return;
+  assertEquals(result.confirmed_limitations?.length, 2);
+  assertEquals(result.confirmed_limitations?.[0].subject.value, "shoulder");
+  assertEquals(result.confirmed_limitations?.[0].severity, "moderate");
+});
+
+Deno.test("validateRequest_confirmed_limitations_all_eight_joints_accepted", () => {
+  const joints = [
+    "shoulder", "elbow", "wrist", "hip", "knee", "ankle", "lower_back", "neck",
+  ];
+  const result = validateRequest(
+    baseRequest({
+      confirmed_limitations: joints.map((j) => ({
+        subject: { kind: "joint", value: j },
+        severity: "moderate",
+      })),
+    }),
+  );
+  assertEquals("error" in result, false);
+});
+
+Deno.test("validateRequest_confirmed_limitations_non_array_returns_400", () => {
+  const result = validateRequest(
+    baseRequest({
+      confirmed_limitations: { subject: { kind: "joint", value: "knee" }, severity: "mild" },
+    }),
+  );
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("confirmed_limitations"), true);
+});
+
+Deno.test("validateRequest_confirmed_limitations_non_object_entry_returns_400", () => {
+  const result = validateRequest(
+    baseRequest({ confirmed_limitations: ["knee"] }),
+  );
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("confirmed_limitations[0]"), true);
+});
+
+Deno.test("validateRequest_confirmed_limitations_non_joint_kind_returns_400", () => {
+  // Onboarding only declares joint-scoped limitations; pattern/muscle rejected.
+  const result = validateRequest(
+    baseRequest({
+      confirmed_limitations: [
+        { subject: { kind: "pattern", value: "squat" }, severity: "mild" },
+      ],
+    }),
+  );
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("kind"), true);
+});
+
+Deno.test("validateRequest_confirmed_limitations_unknown_joint_returns_400", () => {
+  const result = validateRequest(
+    baseRequest({
+      confirmed_limitations: [
+        { subject: { kind: "joint", value: "spleen" }, severity: "mild" },
+      ],
+    }),
+  );
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("value"), true);
+});
+
+Deno.test("validateRequest_confirmed_limitations_bad_severity_returns_400", () => {
+  const result = validateRequest(
+    baseRequest({
+      confirmed_limitations: [
+        { subject: { kind: "joint", value: "knee" }, severity: "agony" },
+      ],
+    }),
+  );
+  if (!("error" in result)) throw new Error("expected error");
+  assertEquals(result.error.includes("severity"), true);
+});
+
 // ─── #369 slice 4: handleRequest JWT-`sub` ownership check (closes the IDOR) ──
 //
 // The handler derives the caller from the verified JWT `sub` (decode-only; the

--- a/supabase/functions/update-trainee-goal/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-goal/orchestrator_test.ts
@@ -699,6 +699,128 @@ goalTest(
   },
 );
 
+// ─── #527 S2: confirmed_limitations write-path — append onboarding injuries as
+// user-confirmed activeLimitations. ─────────────────────────────────────────
+
+const SHOULDER_LIMITATION = {
+  subject: { kind: "joint" as const, value: "shoulder" },
+  severity: "moderate",
+};
+const KNEE_LIMITATION = {
+  subject: { kind: "joint" as const, value: "knee" },
+  severity: "moderate",
+};
+
+goalTest(
+  "#527 S2 (1): goal-save WITH confirmed_limitations → activeLimitations carries a user-confirmed entry AND the goal is written",
+  async () => {
+    const userId = await seedFreshUserWithoutRow();
+
+    await upsertGoal(
+      { user_id: userId, goal: GOAL_A, confirmed_limitations: [SHOULDER_LIMITATION] },
+      sql,
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const m = rows[0].model_json as Record<string, unknown>;
+    assertEquals(m.goal, GOAL_A);
+    const active = m.activeLimitations as Array<Record<string, unknown>>;
+    assertEquals(active.length, 1);
+    const lim = active[0];
+    assertEquals(lim.subject, { kind: "joint", value: "shoulder" });
+    assertEquals(lim.severity, "moderate");
+    assertEquals(lim.userConfirmed, true, "onboarding injuries are user-confirmed");
+    assertEquals(lim.evidenceCount, 1);
+    assertEquals(lim.sessionsWithoutReMention, 0);
+    assertExists(lim.onsetDate);
+  },
+);
+
+goalTest(
+  "#527 S2 (2): idempotent on re-onboarding → replaying the same injury does NOT duplicate or reset the existing limitation",
+  async () => {
+    // Seed an existing user-confirmed shoulder limitation that the session
+    // pipeline has since accumulated evidence on.
+    const seededLimitation = {
+      subject: { kind: "joint", value: "shoulder" },
+      severity: "moderate",
+      onsetDate: "2026-05-01T00:00:00.000Z",
+      evidenceCount: 4,
+      userConfirmed: true,
+      notes: null,
+      sessionsWithoutReMention: 0,
+    };
+    const userId = await seedFreshUserWithExistingModel({
+      goal: GOAL_A,
+      activeLimitations: [seededLimitation],
+    });
+
+    await upsertGoal(
+      { user_id: userId, goal: GOAL_A, confirmed_limitations: [SHOULDER_LIMITATION] },
+      sql,
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const m = rows[0].model_json as Record<string, unknown>;
+    const active = m.activeLimitations as Array<Record<string, unknown>>;
+    // Subject already present → skipped; the accumulated entry is untouched.
+    assertEquals(active.length, 1);
+    assertEquals(active[0], seededLimitation);
+  },
+);
+
+goalTest(
+  "#527 S2 (3): append preserves other top-level model_json keys (re-onboarding must not destroy session state)",
+  async () => {
+    const seed = {
+      goal: GOAL_A,
+      patterns: {
+        squat: { currentPhase: "accumulation", sessionsInPhase: 3, trend: "progressing" },
+      },
+    };
+    const userId = await seedFreshUserWithExistingModel(seed);
+
+    await upsertGoal(
+      { user_id: userId, goal: GOAL_A, confirmed_limitations: [KNEE_LIMITATION] },
+      sql,
+    );
+
+    const cmp = await sql`
+      SELECT (model_json -> 'patterns') = ${sql.json(seed.patterns)}::jsonb AS patterns_equal
+      FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    assertEquals(cmp[0].patterns_equal, true, "patterns subtree must be untouched");
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const m = rows[0].model_json as Record<string, unknown>;
+    const active = m.activeLimitations as Array<Record<string, unknown>>;
+    assertEquals(active.length, 1);
+    assertEquals(active[0].subject, { kind: "joint", value: "knee" });
+  },
+);
+
+goalTest(
+  "#527 S2 (4): goal-save WITHOUT confirmed_limitations → activeLimitations untouched (remains absent)",
+  async () => {
+    const userId = await seedFreshUserWithExistingModel({ goal: GOAL_A });
+
+    await upsertGoal({ user_id: userId, goal: GOAL_A }, sql);
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const m = rows[0].model_json as Record<string, unknown>;
+    // No limitations sent → the conditional write never ran → key stays absent.
+    assertEquals("activeLimitations" in m, false);
+  },
+);
+
 // Sentinel "test" that runs last — closes the shared pool so the connection
 // lifecycle stays local to this file rather than relying on process-exit.
 Deno.test({


### PR DESCRIPTION
## What & why

S1 added an optional onboarding **"anything to work around?"** injuries screen that collects tapped body areas into `profile.injuryAreas`, but onboarding completion **dropped** the selection (the `// #527 S2:` TODO in `OnboardingView.persistUserIfNeeded()`). Slice 2 wires it to the coach's existing limitation system so the planner avoids programming into a user-declared injury **from session 1**.

## How

The trainee model's `activeLimitations` live in `trainee_models.model_json` (JSONB) under the **ADR-0006 single-writer invariant** — iOS never writes `model_json` directly; a server-side Edge Function does. So the write rides the **same `update-trainee-goal` EF onboarding already calls for the goal** (mirroring the existing optional `stretch_edits` / `acknowledge_*` extension pattern).

**Edge Function (`update-trainee-goal`)**
- New OPTIONAL `confirmed_limitations` field — array of `{ subject: { kind: "joint", value: <BodyJoint rawValue> }, severity }`.
- Validated: joint-scoped only, `value` ∈ the 8 `BodyJoint` rawValues, `severity` ∈ `mild|moderate|severe`. Absent → valid exactly as before (back-compat for goal-review / calibration saves).
- `applyConfirmedLimitations` appends each as a full `ActiveLimitation` with `userConfirmed: true` into `model_json.activeLimitations`, **inside the existing `upsertGoal` transaction** (atomic with the goal write, `FOR UPDATE` read).
- **Idempotent on re-onboarding**: subjects already present are skipped, so an entry the session pipeline has accumulated evidence on is never reset/duplicated.

**iOS (`OnboardingView`)**
- `OnboardingInjuryMapping` maps the 8 injury-screen labels → `BodyJoint` rawValues (`Lower back` → `lower_back`, `Shoulders` → `shoulder`, etc.) and builds `ConfirmedLimitationBody` payloads carried on the goal write.
- The field is **omitted from the wire when no area was tapped** (onboarding stays `{user_id, goal}`).
- The three other `TraineeGoalUpsertPayload` call sites get `confirmedLimitations: nil` (matches the existing optional-field convention).

## Mapping & severity decisions

| Onboarding label | `subject` |
|---|---|
| Shoulders | `joint(shoulder)` |
| Lower back | `joint(lower_back)` |
| Knees | `joint(knee)` |
| Elbows | `joint(elbow)` |
| Wrists | `joint(wrist)` |
| Hips | `joint(hip)` |
| Neck | `joint(neck)` |
| Ankles | `joint(ankle)` |

- **severity = `moderate`** — user-confirmed is NOT capped at the AI-inferred `.mild` ceiling, and `moderate` makes the planner **substitute** the affected movement (per `SystemPrompt_SessionPlan` ACTIVE LIMITATIONS rules) rather than merely lighten it, matching "avoid programming into" the injury. **Flagged for review** — see below.
- `userConfirmed = true`, `evidenceCount = 1` (the single user report; the ≥2 corroboration gate is inference-only), `sessionsWithoutReMention = 0` (ignored for user-confirmed — these never auto-clear).

## Ambiguity surfaced

The limitation model is richer than a `{region, severity, confirmed}` tuple — `ActiveLimitation` carries `onsetDate`, `evidenceCount`, `userConfirmed`, `notes`, `sessionsWithoutReMention`. All extra fields have sensible server-stamped defaults for a user-confirmed entry (the client only sends `subject` + `severity`; the EF stamps the rest), so no client-facing complexity leaked.

**One judgment call for the orchestrator/human:** severity = `moderate` vs `mild`. `mild` keeps the exercise (10–15% load cut); `moderate` substitutes the movement away from the joint. I chose `moderate` because the screen copy says the coach will "avoid programming straight into" the area, and the task said "avoid programming into" + "not capped at the inferred .mild ceiling." If the intended UX is "lighten, don't remove," flip `OnboardingInjuryMapping.onboardingSeverity` to `"mild"` (single-line change, no other edits).

## Tests

- **EF validator** (`index_test.ts`): 8 new `confirmed_limitations` cases — **39/39 green** locally (`deno test`).
- **EF DB-integration** (`orchestrator_test.ts`): 4 new write-path cases (append, idempotent re-onboarding, preserves sibling keys, absent → no-op). **CI-only** (need local Postgres :54322; locally they fail with `ECONNREFUSED`, confirming wiring not logic).
- **iOS** (`OnboardingInjuryMappingTests`): 5 new mapping + wire-shape cases — **11/11 green** (`xcodebuild test`).
- **Build**: `** BUILD SUCCEEDED **`.

## Not changed

Inference machinery (`note-classifier` lifecycle: `.mild` cap, ≥2 corroboration, auto-clear) untouched. All other onboarding persistence behavior preserved.

Part of #527