### PR TITLE
feat(#527): capture custom + missing machines (equipment capture, S4)

### DIFF
--- a/ProjectApex/GymScanner/ScannerView.swift
+++ b/ProjectApex/GymScanner/ScannerView.swift
@@ -647,12 +647,18 @@ struct EquipmentEditSheet: View {
     var onCancel: () -> Void
 
     @State private var selectedType: EquipmentType = .dumbbellSet
+    @State private var customName: String = ""
     @State private var count: Int = 1
     @State private var notes: String = ""
 
     private var isEditing: Bool { existingItem != nil }
     private var title: String { isEditing ? "Edit Equipment" : "Add Equipment" }
     private var saveLabel: String { isEditing ? "Save" : "Add" }
+
+    /// Trimmed custom machine name; non-empty means "use a custom type".
+    private var trimmedCustomName: String {
+        customName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
     var body: some View {
         NavigationStack {
@@ -664,8 +670,17 @@ struct EquipmentEditSheet: View {
                         }
                     }
                     .pickerStyle(.menu)
+                    .disabled(!trimmedCustomName.isEmpty)
 
                     Stepper("Count: \(count)", value: $count, in: 1...50)
+                }
+
+                Section {
+                    TextField("e.g. Belt squat machine", text: $customName)
+                } header: {
+                    Text("Custom Name (optional)")
+                } footer: {
+                    Text("Can't find it in the list? Type the machine's name here and we'll add it as a custom item.")
                 }
 
                 Section("Notes (optional)") {
@@ -688,15 +703,26 @@ struct EquipmentEditSheet: View {
 
     private func populateFromExisting() {
         guard let item = existingItem else { return }
-        selectedType = item.equipmentType
         count = item.count
         notes = item.notes ?? ""
+        // A custom (unknown) machine pre-fills the name field; a known type
+        // selects the picker.
+        if case .unknown(let raw) = item.equipmentType {
+            customName = raw
+        } else {
+            selectedType = item.equipmentType
+        }
     }
 
     private func commitSave() {
+        // A non-empty custom name creates a custom EquipmentType.unknown(...);
+        // otherwise the known-type picker selection is used.
+        let type: EquipmentType = trimmedCustomName.isEmpty
+            ? selectedType
+            : .unknown(trimmedCustomName)
         let item = EquipmentItem(
             id: existingItem?.id ?? UUID(),
-            equipmentType: selectedType,
+            equipmentType: type,
             count: count,
             notes: notes.isEmpty ? nil : notes,
             detectedByVision: existingItem?.detectedByVision ?? false

--- a/ProjectApex/Models/DefaultWeightIncrements.swift
+++ b/ProjectApex/Models/DefaultWeightIncrements.swift
@@ -60,7 +60,11 @@ nonisolated enum DefaultWeightIncrements {
              .legExtension,
              .legCurl,
              .pecDeck,
-             .preacherCurl:             return machineStack
+             .preacherCurl,
+             .reverseFly,
+             .hipThrustMachine,
+             .calfRaiseMachine,
+             .tBarRow:                  return machineStack
         case .kettlebellSet:            return kettlebells
         default:                        return []
         }

--- a/ProjectApex/Models/GymProfile.swift
+++ b/ProjectApex/Models/GymProfile.swift
@@ -72,6 +72,11 @@ nonisolated enum EquipmentType: Hashable, Equatable, Sendable {
     case pecDeck
     case preacherCurl
     case cableCrossover
+    case reverseFly            // rear-delt / reverse pec deck
+    case assistedDipPullUp     // assisted dip / pull-up machine (bodyweight-assisted)
+    case hipThrustMachine
+    case calfRaiseMachine
+    case tBarRow               // T-bar / chest-supported row
     case unknown(String)
 
     // ---------------------------------------------------------------------------
@@ -107,7 +112,15 @@ nonisolated enum EquipmentType: Hashable, Equatable, Sendable {
         case .pecDeck:                return "pec_deck"
         case .preacherCurl:           return "preacher_curl"
         case .cableCrossover:         return "cable_crossover"
-        case .unknown:                return "unknown"
+        case .reverseFly:             return "reverse_fly"
+        case .assistedDipPullUp:      return "assisted_dip_pull_up"
+        case .hipThrustMachine:       return "hip_thrust_machine"
+        case .calfRaiseMachine:       return "calf_raise_machine"
+        case .tBarRow:                return "t_bar_row"
+        // Preserve the custom string so it survives LLM serialisation. The
+        // Codable persistence path (encode/init(from:)) uses the separate
+        // rawValue key, not this — see init(typeKey:) for the round-trip.
+        case .unknown(let raw):       return "unknown:\(raw)"
         }
     }
 
@@ -140,6 +153,11 @@ nonisolated enum EquipmentType: Hashable, Equatable, Sendable {
         case .pecDeck:                return "Pec Deck"
         case .preacherCurl:           return "Preacher Curl"
         case .cableCrossover:         return "Cable Crossover"
+        case .reverseFly:             return "Rear-Delt / Reverse Pec Deck"
+        case .assistedDipPullUp:      return "Assisted Dip / Pull-Up Machine"
+        case .hipThrustMachine:       return "Hip Thrust Machine"
+        case .calfRaiseMachine:       return "Calf Raise Machine"
+        case .tBarRow:                return "T-Bar / Chest-Supported Row"
         case .unknown(let raw):       return raw
         }
     }
@@ -159,10 +177,11 @@ nonisolated enum EquipmentType: Hashable, Equatable, Sendable {
         case .cableMachine, .cableMachineDual, .cableCrossover, .latPulldown, .seatedRow:
             return .cable
         case .legPress, .hackSquat, .chestPressMachine, .shoulderPressMachine,
-             .legExtension, .legCurl, .pecDeck, .preacherCurl:
+             .legExtension, .legCurl, .pecDeck, .preacherCurl,
+             .reverseFly, .hipThrustMachine, .calfRaiseMachine, .tBarRow:
             return .machine
         case .adjustableBench, .flatBench, .inclineBench, .pullUpBar,
-             .dipStation, .resistanceBands:
+             .dipStation, .resistanceBands, .assistedDipPullUp:
             return .bodyweightAndRig
         case .unknown:
             return .machine
@@ -173,7 +192,9 @@ nonisolated enum EquipmentType: Hashable, Equatable, Sendable {
     /// is ever prescribed by the AI for this equipment.
     var isNaturallyBodyweightOnly: Bool {
         switch self {
-        case .pullUpBar, .dipStation: return true
+        // Assisted dip/pull-up is bodyweight-assisted: the stack removes load
+        // rather than adding it, so the AI must never prescribe external weight.
+        case .pullUpBar, .dipStation, .assistedDipPullUp: return true
         default: return false
         }
     }
@@ -185,10 +206,19 @@ nonisolated enum EquipmentType: Hashable, Equatable, Sendable {
         .inclineBench, .pullUpBar, .dipStation, .resistanceBands, .kettlebellSet,
         .powerRack, .sqatRack, .latPulldown, .seatedRow, .chestPressMachine,
         .shoulderPressMachine, .legExtension, .legCurl, .pecDeck, .preacherCurl,
-        .cableCrossover
+        .cableCrossover, .reverseFly, .assistedDipPullUp, .hipThrustMachine,
+        .calfRaiseMachine, .tBarRow
     ]
 
     init(typeKey: String, rawValue: String? = nil) {
+        // Custom machines round-trip through the LLM-serialisation key as
+        // "unknown:<raw>" (see `typeKey`). Strip the prefix back to the raw
+        // string. Codable persistence uses the explicit `rawValue` key instead,
+        // and the bare "unknown" case below still handles that decode path.
+        if let raw = typeKey.dropPrefixIfPresent("unknown:") {
+            self = .unknown(rawValue ?? raw)
+            return
+        }
         switch typeKey {
         case "dumbbell_set":           self = .dumbbellSet
         case "barbell":                self = .barbell
@@ -217,9 +247,21 @@ nonisolated enum EquipmentType: Hashable, Equatable, Sendable {
         case "pec_deck":               self = .pecDeck
         case "preacher_curl":          self = .preacherCurl
         case "cable_crossover":        self = .cableCrossover
+        case "reverse_fly":            self = .reverseFly
+        case "assisted_dip_pull_up":   self = .assistedDipPullUp
+        case "hip_thrust_machine":     self = .hipThrustMachine
+        case "calf_raise_machine":     self = .calfRaiseMachine
+        case "t_bar_row":              self = .tBarRow
         case "unknown":                self = .unknown(rawValue ?? typeKey)
-        default:                       self = .unknown(typeKey)
+        default:                       self = .unknown(rawValue ?? typeKey)
         }
+    }
+}
+
+private extension String {
+    /// Returns the substring after `prefix` if `self` starts with it, else nil.
+    func dropPrefixIfPresent(_ prefix: String) -> String? {
+        hasPrefix(prefix) ? String(dropFirst(prefix.count)) : nil
     }
 }
 
@@ -236,9 +278,14 @@ extension EquipmentType: Codable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(typeKey, forKey: .type)
         if case .unknown(let raw) = self {
+            // Persistence keeps the stable wire format { "type": "unknown",
+            // "rawValue": "..." } unchanged. The "unknown:<raw>" form is only
+            // for the LLM-serialisation `typeKey`, not for stored JSON.
+            try container.encode("unknown", forKey: .type)
             try container.encode(raw, forKey: .rawValue)
+        } else {
+            try container.encode(typeKey, forKey: .type)
         }
     }
 

--- a/ProjectApex/Resources/Prompts/SystemPrompt_GymScan.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_GymScan.txt
@@ -13,7 +13,9 @@ You MUST use ONLY these exact equipment_type string values:
 "dip_station" | "resistance_bands" | "kettlebell_set" | "power_rack" |
 "squat_rack" | "lat_pulldown" | "seated_row" | "chest_press_machine" |
 "shoulder_press_machine" | "leg_extension" | "leg_curl" | "pec_deck" |
-"preacher_curl" | "cable_crossover"
+"preacher_curl" | "cable_crossover" | "reverse_fly" |
+"assisted_dip_pull_up" | "hip_thrust_machine" | "calf_raise_machine" |
+"t_bar_row"
 
 count = the number of individual units visible (2 benches = count 2).
 confidence = your confidence that this identification is correct (0.0-1.0).

--- a/ProjectApexTests/GymProfileTests.swift
+++ b/ProjectApexTests/GymProfileTests.swift
@@ -82,6 +82,88 @@ final class EquipmentTypeCodableTests: XCTestCase {
             XCTAssertEqual(decoded, equipmentType, "Round-trip failed for \(equipmentType)")
         }
     }
+
+    // MARK: Codable wire-format stability for unknown (Slice 4)
+
+    /// The custom-string `typeKey` change MUST NOT alter the persisted JSON
+    /// `type` field — it stays the bare "unknown" with the raw in `rawValue`.
+    /// This guards already-stored GymProfiles against the typeKey change.
+    func test_unknownCase_persistedTypeField_staysBareUnknown() throws {
+        let data = try encoder.encode(EquipmentType.unknown("Belt squat machine"))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["type"] as? String, "unknown",
+            "Persisted 'type' field must remain the bare 'unknown' (not the unknown:<raw> LLM key)")
+        XCTAssertEqual(json["rawValue"] as? String, "Belt squat machine",
+            "Raw custom name must persist in the separate 'rawValue' key")
+    }
+
+    /// Old-format JSON ({"type":"unknown","rawValue":"..."}) must still decode.
+    func test_unknownCase_legacyWireFormat_stillDecodes() throws {
+        let json = """
+        {"type":"unknown","rawValue":"atlas_stone"}
+        """
+        let decoded = try decoder.decode(
+            EquipmentType.self,
+            from: XCTUnwrap(json.data(using: .utf8))
+        )
+        XCTAssertEqual(decoded, .unknown("atlas_stone"))
+    }
+}
+
+// MARK: ─── Part 1b: EquipmentType.typeKey LLM-serialisation round-trip (Slice 4)
+
+final class EquipmentTypeTypeKeyRoundTripTests: XCTestCase {
+
+    /// Every known case must round-trip through its LLM `typeKey`:
+    /// EquipmentType(typeKey: x.typeKey) == x.
+    func test_allKnownCases_typeKeyRoundTrips() {
+        for equipmentType in EquipmentType.knownCases {
+            let key = equipmentType.typeKey
+            let rebuilt = EquipmentType(typeKey: key)
+            XCTAssertEqual(rebuilt, equipmentType,
+                "typeKey round-trip failed for \(equipmentType): key='\(key)' rebuilt=\(rebuilt)")
+        }
+    }
+
+    /// A custom machine's raw string must survive the typeKey round-trip
+    /// (the whole point of Fix 2 — it previously collapsed to "unknown").
+    func test_unknownCase_typeKeyPreservesRawString() {
+        let custom = EquipmentType.unknown("Belt squat machine")
+        XCTAssertEqual(custom.typeKey, "unknown:Belt squat machine",
+            "typeKey must embed the raw custom name, not discard it")
+        XCTAssertEqual(EquipmentType(typeKey: custom.typeKey), custom,
+            "Custom machine must round-trip via typeKey")
+    }
+
+    /// Raw strings that themselves contain a colon must round-trip intact
+    /// (only the first 'unknown:' prefix is stripped).
+    func test_unknownCase_typeKeyWithColonInRaw_roundTrips() {
+        let custom = EquipmentType.unknown("Hammer Strength: ISO row")
+        XCTAssertEqual(EquipmentType(typeKey: custom.typeKey), custom)
+    }
+
+    /// The new first-class machine cases must each map to a category and be in
+    /// knownCases (i.e. they appear in the picker), and not be `.unknown`.
+    func test_newMachineCases_areKnownAndCategorised() {
+        let newCases: [EquipmentType] = [
+            .reverseFly, .assistedDipPullUp, .hipThrustMachine,
+            .calfRaiseMachine, .tBarRow
+        ]
+        for equipmentType in newCases {
+            XCTAssertTrue(EquipmentType.knownCases.contains(equipmentType),
+                "\(equipmentType) must be in knownCases so it shows in the picker")
+            if case .unknown = equipmentType {
+                XCTFail("\(equipmentType) must not resolve to .unknown")
+            }
+            // category is non-optional; touching it asserts it is wired.
+            _ = equipmentType.category
+        }
+    }
+
+    /// Assisted dip/pull-up is bodyweight-assisted — no external weight prescribed.
+    func test_assistedDipPullUp_isBodyweightOnly() {
+        XCTAssertTrue(EquipmentType.assistedDipPullUp.isNaturallyBodyweightOnly)
+    }
 }
 
 // MARK: ─── Part 2: GymProfile Codable Round-Trip ─────────────────────────────


### PR DESCRIPTION
## Slice 4 — equipment capture (umbrella #527)

Makes the equipment model able to **capture** the long tail of gym machines, including custom ones. (Planner *using* them is S5/S6 — not this slice.) Three evidence-grounded fixes, additive and surgical.

### Fix 1 — Custom-machine entry actually works
`EquipmentEditSheet` (`ScannerView.swift`) previously had no name field, so a user could never create a custom `EquipmentType.unknown(...)`. Added a free-text **Custom Name** field: a non-empty name constructs `.unknown(<name>)`; otherwise the existing known-type picker selection is used (picker is disabled while a custom name is present). Editing an existing custom item pre-fills the name field. The "Can't find it? Add custom" link in `BulkEquipmentPickerSheet` now leads somewhere useful.

### Fix 2 — The custom string survives serialization
`EquipmentType.typeKey` for `.unknown(raw)` previously returned the literal `"unknown"`, discarding the raw string, so a custom machine reached the LLM as the useless token `"unknown"`. Now it emits `"unknown:<raw>"`, and `init(typeKey:)` strips the prefix back to `.unknown(raw)`.

**Persistence is untouched.** `typeKey` is the LLM-serialisation key, **not** a Codable stored key — the Codable path uses a separate `type`/`rawValue` `CodingKeys` mechanism. `encode(to:)` was made to keep writing the bare `{ "type": "unknown", "rawValue": "..." }` wire format explicitly, so already-stored `GymProfile`s decode identically. A guard test asserts the persisted `type` field stays bare `"unknown"`. No code anywhere compares `equipmentType.typeKey` against the literal `"unknown"` (grep-verified across the codebase).

### Fix 3 — Missing first-class machine types
Added 5 cases, each fully wired (`typeKey`, `displayName`, `category`, `knownCases`, `init(typeKey:)`, `DefaultWeightIncrements`, GymScan prompt allowed-list):

| case | typeKey | category | weight table | bodyweightOnly |
|---|---|---|---|---|
| `reverseFly` (rear-delt/reverse pec deck) | `reverse_fly` | machine | machineStack | false |
| `assistedDipPullUp` | `assisted_dip_pull_up` | bodyweightAndRig | none | **true** (assisted) |
| `hipThrustMachine` | `hip_thrust_machine` | machine | machineStack | false |
| `calfRaiseMachine` | `calf_raise_machine` | machine | machineStack | false |
| `tBarRow` (T-bar/chest-supported row) | `t_bar_row` | machine | machineStack | false |

No per-`EquipmentType` `systemImage` mapping exists (only `EquipmentCategory` carries icons), so there was nothing to wire there.

### Tests
`GymProfileTests.swift` gains: typeKey round-trip for all known cases + custom `"Belt squat machine"` + a colon-in-raw name; persisted-wire-format-stays-bare-`unknown` guard; legacy-format decode; new cases are in `knownCases` + categorised + not `.unknown`; assisted machine is bodyweight-only. All green. Existing `WorkoutProgram` / `EquipmentMerger` / `EquipmentConstraintValidation` suites pass unchanged (persistence + Vision-merge paths verified intact). `** BUILD SUCCEEDED **`.

Part of #527