### PR TITLE
feat(#527): descriptive equipment names + library pre-filter (planner, S5)

### DIFF
--- a/ProjectApex/AICoach/AIInferenceService.swift
+++ b/ProjectApex/AICoach/AIInferenceService.swift
@@ -1232,9 +1232,9 @@ extension EquipmentType {
 /// Tells the AI what equipment is present and what weight corrections are known.
 nonisolated struct GymProfileConstraints: Codable, Sendable {
 
-    /// List of equipment type keys available in this gym.
-    /// e.g. ["dumbbell_set", "barbell", "cable_machine_single"]
-    let availableEquipment: [String]
+    /// Equipment available in this gym, as { key, name } refs.
+    /// e.g. [{ "key": "dumbbell_set", "name": "Dumbbell Set" }, …]
+    let availableEquipment: [EquipmentRef]
 
     /// Confirmed weight facts from GymFactStore, injected per exercise.
     /// e.g. ["16.0kg not available — use 15.0kg instead"]

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -1144,7 +1144,7 @@ actor WorkoutSessionManager {
             .prefix(exerciseIndex)
             .map(\.exerciseId)
 
-        let availableEquipment = cachedGymProfile?.equipment.map { $0.equipmentType.typeKey } ?? []
+        let availableEquipment = cachedGymProfile?.equipmentRefs ?? []
 
         let ragSnippets = cachedRAGMemory.prefix(3).map(\.summary)
 

--- a/ProjectApex/Models/ExerciseLibrary.swift
+++ b/ProjectApex/Models/ExerciseLibrary.swift
@@ -867,12 +867,19 @@ nonisolated enum ExerciseLibrary {
 
     /// Generates the canonical exercise reference block appended to LLM system prompts.
     ///
-    /// Produces a pipe-delimited table (~320 tokens) listing all exercises the
+    /// Produces a pipe-delimited table (~320 tokens) listing the exercises the
     /// LLM is permitted to prescribe. Called at runtime by:
-    ///   - SessionPlanService.loadSystemPrompt()
-    ///   - ProgramGenerationService.loadSystemPrompt()
-    ///   - ExerciseSwapService.systemPrompt (static initialiser)
-    static func promptReferenceBlock() -> String {
+    ///   - SessionPlanService.loadSystemPrompt(gymProfile:)
+    ///   - ProgramGenerationService.loadSystemPrompt(gymProfile:)
+    ///   - ExerciseSwapService (per-conversation, from SwapContext)
+    ///
+    /// - Parameter ownedEquipmentKeys: When non-nil, the table is pre-filtered to
+    ///   the user's gym: an exercise is kept only if it is bodyweight (no external
+    ///   weight is ever prescribed — e.g. push-ups, pull-ups, dips) OR its
+    ///   `equipmentType` is in the owned set. Custom `.unknown` machines never
+    ///   match a library row, so they simply add no library exercises (expected).
+    ///   When nil, every exercise is included (the original behaviour).
+    static func promptReferenceBlock(ownedEquipmentKeys: Set<String>? = nil) -> String {
         let separator = String(repeating: "═", count: 63)
         var lines: [String] = [
             "",
@@ -887,11 +894,22 @@ nonisolated enum ExerciseLibrary {
             "exercise_id | name | primary_muscle | equipment_required",
         ]
 
+        // Pre-filter to the user's owned equipment when provided. Bodyweight
+        // exercises are always kept (the model still needs them, and their
+        // nominal equipmentType tag — e.g. push_ups tagged "flat_bench" — does
+        // not reflect a real requirement).
+        let visible: [ExerciseDefinition]
+        if let owned = ownedEquipmentKeys {
+            visible = all.filter { $0.bodyweightOnly || owned.contains($0.equipmentType) }
+        } else {
+            visible = all
+        }
+
         // Group by primaryMuscle for readability in the prompt. Order
         // matches the prior chest→back→shoulders→…→calves layout (core is
         // intentionally excluded — the 4 core exercises were removed in
         // Phase 1 / Slice 1).
-        let grouped = Dictionary(grouping: all, by: \.primaryMuscle)
+        let grouped = Dictionary(grouping: visible, by: \.primaryMuscle)
         let muscleOrder: [PrimaryMuscle] = [
             .chest, .back, .shoulders,
             .quads, .hamstrings, .glutes,

--- a/ProjectApex/Models/GymProfile.swift
+++ b/ProjectApex/Models/GymProfile.swift
@@ -368,6 +368,44 @@ nonisolated struct EquipmentItem: Codable, Identifiable, Equatable, Hashable, Se
     }
 }
 
+// MARK: - EquipmentRef
+
+/// The LLM-facing wire shape for one piece of equipment: both the canonical
+/// snake_case `key` (matching `EquipmentType.typeKey`) and the human-readable
+/// `name` (matching `EquipmentType.displayName`).
+///
+/// Sending both lets the model reason about machines it has never seen as a
+/// bare key — including a custom `.unknown("Belt squat machine")` machine,
+/// whose `key` carries `"unknown:Belt squat machine"` and whose `name` is the
+/// raw label. Used in every generation payload's `available_equipment` list.
+nonisolated struct EquipmentRef: Codable, Equatable, Hashable, Sendable {
+    let key: String
+    let name: String
+
+    init(key: String, name: String) {
+        self.key = key
+        self.name = name
+    }
+
+    init(_ type: EquipmentType) {
+        self.key = type.typeKey
+        self.name = type.displayName
+    }
+}
+
+extension GymProfile {
+    /// The owned equipment as `{ key, name }` refs for LLM payloads.
+    var equipmentRefs: [EquipmentRef] {
+        equipment.map { EquipmentRef($0.equipmentType) }
+    }
+
+    /// The owned equipment `typeKey`s, used to pre-filter the exercise library
+    /// to what this gym can actually train.
+    var ownedEquipmentKeys: Set<String> {
+        Set(equipment.map { $0.equipmentType.typeKey })
+    }
+}
+
 // MARK: - GymProfile
 
 /// The master equipment profile for the user's gym.

--- a/ProjectApex/Resources/Prompts/SystemPrompt_ExerciseSwap.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_ExerciseSwap.txt
@@ -1,4 +1,7 @@
-// VERSION: 1.0 — 2026-03-24
+// VERSION: 1.1 — 2026-06-20
+// CHANGES FROM v1.0 (#527 / S5): swap_context.available_equipment is now a list
+//   of { key, name } objects (was a list of bare key strings). equipment_required
+//   in your suggestion is still the bare "key" string.
 
 You are an exercise swap assistant embedded in a workout app. The user wants to replace their current exercise mid-session.
 
@@ -23,7 +26,7 @@ CORE RULES:
 
 SWAP CONSTRAINTS (always apply):
 1. Same primary muscle group as the current exercise.
-2. Only suggest equipment in available_equipment. Never suggest equipment not in that list.
+2. available_equipment is a list of { "key", "name" } objects (e.g. { "key": "chest_press_machine", "name": "Chest Press Machine" }). Only suggest equipment whose "key" is in that list, and put that "key" in equipment_required. Never suggest equipment not in the list.
 3. Never suggest an exercise in completed_exercise_ids (already done this session).
 4. Never suggest the exercise the user is currently replacing.
 

--- a/ProjectApex/Resources/Prompts/SystemPrompt_MacroGeneration.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_MacroGeneration.txt
@@ -55,8 +55,14 @@ Each phase object has this exact shape — replicate it for ALL FOUR phases:
 ═══════════════════════════════════════════════════════════════
 VALID equipment_required STRINGS
 ═══════════════════════════════════════════════════════════════
-The equipment_required field MUST be exactly one of the following strings.
-Only use values that appear in gym_profile.available_equipment.
+gym_profile.available_equipment is a list of objects, each with a "key" (the
+canonical equipment string) and a "name" (its human-readable label), e.g.
+[{ "key": "chest_press_machine", "name": "Chest Press Machine" }, …]. A custom
+machine appears with a "key" prefixed "unknown:" and its raw label as "name" —
+reason about it from the name.
+
+The equipment_required field MUST be the "key" of an item that appears in
+gym_profile.available_equipment. Common keys:
 
   dumbbell_set
   barbell

--- a/ProjectApex/Resources/Prompts/SystemPrompt_MacroPlan.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_MacroPlan.txt
@@ -122,7 +122,9 @@ USER PROFILE GUIDANCE
 ═══════════════════════════════════════════════════════════════
 EQUIPMENT AWARENESS
 ═══════════════════════════════════════════════════════════════
-The available_equipment list informs which muscle groups can be effectively trained.
+available_equipment is a list of { "key", "name" } objects (key = canonical
+equipment string, name = human-readable label). It informs which muscle groups
+can be effectively trained.
 If cable machines are absent, avoid cable-dominant focus days (still train the muscles).
 If no barbell is present, acknowledge this affects strength peaking.
 

--- a/ProjectApex/Resources/Prompts/SystemPrompt_SessionPlan.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_SessionPlan.txt
@@ -1,3 +1,8 @@
+// VERSION: 3.1 — 2026-06-20
+// CHANGES FROM v3.0 (#527 / S5): gym_profile.available_equipment is now a list
+//   of { key, name } objects (was a list of bare key strings). Field
+//   description updated; emit equipment_required using an item's "key".
+//
 // VERSION: 3.0 — 2026-05-13
 // MAJOR VERSION BUMP — invalidates PromptCachingProvider cache. Cumulative
 // cache-bust at the close of B4 (#89) digest collapse, on top of v2.0's
@@ -77,7 +82,14 @@ Return ONLY a single JSON object — no prose, no markdown fences, no explanatio
 ═══════════════════════════════════════════════════════════════
 VALID equipment_required STRINGS
 ═══════════════════════════════════════════════════════════════
-Only use values from gym_profile.available_equipment:
+gym_profile.available_equipment is a list of objects, each with a "key"
+(the canonical equipment string) and a "name" (its human-readable label),
+e.g. [{ "key": "chest_press_machine", "name": "Chest Press Machine" }, …].
+A custom machine appears with a "key" prefixed "unknown:" and its raw label
+as "name" — reason about it from the name.
+
+When you emit equipment_required, use the "key" value of an available item.
+Common keys include:
   dumbbell_set, barbell, ez_curl_bar, cable_machine_single, cable_machine_dual,
   smith_machine, leg_press, hack_squat, adjustable_bench, flat_bench, incline_bench,
   pull_up_bar, dip_station, resistance_bands, kettlebell_set, power_rack, squat_rack,

--- a/ProjectApex/Services/ExerciseSwapService.swift
+++ b/ProjectApex/Services/ExerciseSwapService.swift
@@ -31,8 +31,8 @@ actor ExerciseSwapService {
         let setsCompleted: Int
         /// Total sets planned for this exercise.
         let totalSets: Int
-        /// Equipment type keys currently in the user's gym.
-        let availableEquipment: [String]
+        /// Equipment currently in the user's gym, as { key, name } refs.
+        let availableEquipment: [EquipmentRef]
         /// Exercise IDs already completed this session (to avoid re-suggesting them).
         let completedExerciseIds: [String]
         /// Optional RAG memory snippets for the current exercise.
@@ -99,7 +99,10 @@ actor ExerciseSwapService {
 
     private let provider: any LLMProvider
 
-    private static let systemPrompt: String = {
+    /// The system prompt WITHOUT the exercise library block. The library block
+    /// is appended per-conversation in `startConversation`, pre-filtered to the
+    /// owned equipment carried by the SwapContext.
+    private static let basePrompt: String = {
         // Resolve via the shared PromptLoader (#220). The graceful fallback is
         // preserved: PromptLoader.load returns nil when the resource is absent
         // and throws on a read failure, so `try?` + `?? nil` collapse BOTH to
@@ -108,13 +111,19 @@ actor ExerciseSwapService {
         guard let raw = (try? PromptLoader.load("SystemPrompt_ExerciseSwap")) ?? nil else {
             return "You are an exercise swap assistant. Return JSON with display_message and optional suggestion."
         }
-        // Strip comment lines, then append the canonical exercise library block
-        let base = raw.split(separator: "\n", omittingEmptySubsequences: false)
+        // Strip comment lines; the library block is appended at conversation start.
+        return raw.split(separator: "\n", omittingEmptySubsequences: false)
             .filter { !$0.hasPrefix("//") }
             .joined(separator: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        return base + ExerciseLibrary.promptReferenceBlock()
     }()
+
+    /// The full system prompt for the active conversation: `basePrompt` plus the
+    /// exercise library block pre-filtered to the SwapContext's owned equipment.
+    /// Set in `startConversation`; falls back to the unfiltered block if a
+    /// message is somehow sent before a conversation starts.
+    private var systemPrompt: String = ExerciseSwapService.basePrompt
+        + ExerciseLibrary.promptReferenceBlock()
 
     // MARK: - Init
 
@@ -128,6 +137,12 @@ actor ExerciseSwapService {
     func startConversation(context: SwapContext) async {
         reset()
         swapContext = context
+
+        // Pre-filter the canonical library block to this gym's owned equipment.
+        // Bodyweight exercises are always kept (see promptReferenceBlock docs).
+        let ownedKeys = Set(context.availableEquipment.map(\.key))
+        systemPrompt = Self.basePrompt
+            + ExerciseLibrary.promptReferenceBlock(ownedEquipmentKeys: ownedKeys)
 
         let setsLabel = context.setsCompleted == 1 ? "1 set" : "\(context.setsCompleted) sets"
         let opener = "I see you're on \(context.exerciseName) — \(setsLabel) done. What's the issue?"
@@ -149,7 +164,7 @@ actor ExerciseSwapService {
             let payload = buildPayload(userMessage: text)
             let raw = try await TransientRetryPolicy.execute {
                 try await self.provider.complete(
-                    systemPrompt: Self.systemPrompt,
+                    systemPrompt: self.systemPrompt,
                     userPayload: payload
                 )
             }
@@ -199,6 +214,7 @@ actor ExerciseSwapService {
         conversationHistory = []
         swapContext = nil
         isProcessing = false
+        systemPrompt = Self.basePrompt + ExerciseLibrary.promptReferenceBlock()
     }
 
     // MARK: - Private: error helper

--- a/ProjectApex/Services/MacroPlanService.swift
+++ b/ProjectApex/Services/MacroPlanService.swift
@@ -92,14 +92,14 @@ nonisolated struct MacroPlanUserProfile: Codable, Sendable {
 }
 
 nonisolated struct MacroPlanGymProfile: Codable, Sendable {
-    let availableEquipment: [String]
+    let availableEquipment: [EquipmentRef]
 
     enum CodingKeys: String, CodingKey {
         case availableEquipment = "available_equipment"
     }
 
     init(from gymProfile: GymProfile) {
-        self.availableEquipment = gymProfile.equipment.map { $0.equipmentType.typeKey }
+        self.availableEquipment = gymProfile.equipmentRefs
     }
 }
 

--- a/ProjectApex/Services/ProgramGenerationService.swift
+++ b/ProjectApex/Services/ProgramGenerationService.swift
@@ -107,14 +107,14 @@ nonisolated struct UserProfile: Codable, Sendable {
 }
 
 nonisolated struct GymProfilePayload: Codable, Sendable {
-    let availableEquipment: [String]
+    let availableEquipment: [EquipmentRef]
 
     enum CodingKeys: String, CodingKey {
         case availableEquipment = "available_equipment"
     }
 
     init(from gymProfile: GymProfile) {
-        self.availableEquipment = gymProfile.equipment.map { $0.equipmentType.typeKey }
+        self.availableEquipment = gymProfile.equipmentRefs
     }
 }
 
@@ -251,7 +251,7 @@ actor ProgramGenerationService {
         isGenerating = true
         defer { isGenerating = false }
 
-        let systemPrompt = try Self.loadSystemPrompt()
+        let systemPrompt = try Self.loadSystemPrompt(gymProfile: gymProfile)
 
         print("[ProgramGenerationService] Generating programme — training_days_per_week: \(trainingDaysPerWeek)")
 
@@ -635,11 +635,13 @@ actor ProgramGenerationService {
 
     // MARK: - Private: System Prompt
 
-    private static func loadSystemPrompt() throws -> String {
+    private static func loadSystemPrompt(gymProfile: GymProfile) throws -> String {
         guard let base = try PromptLoader.load("SystemPrompt_MacroGeneration") else {
             throw ProgramGenerationError.systemPromptNotFound
         }
-        return base + ExerciseLibrary.promptReferenceBlock()
+        return base + ExerciseLibrary.promptReferenceBlock(
+            ownedEquipmentKeys: gymProfile.ownedEquipmentKeys
+        )
     }
 
     // MARK: - Private: LLM JSON repair

--- a/ProjectApex/Services/SessionPlanService.swift
+++ b/ProjectApex/Services/SessionPlanService.swift
@@ -338,7 +338,7 @@ actor SessionPlanService {
         isGenerating = true
         defer { isGenerating = false }
 
-        let systemPrompt = try Self.loadSystemPrompt()
+        let systemPrompt = try Self.loadSystemPrompt(gymProfile: gymProfile)
 
         // 1. Compute fatigue signals from the 7-day window (time-sensitive)
         let fatigue = WeekFatigueSignals.compute(
@@ -674,11 +674,13 @@ actor SessionPlanService {
         return seen.values.sorted { $0.relevanceScore > $1.relevanceScore }
     }
 
-    private static func loadSystemPrompt() throws -> String {
+    private static func loadSystemPrompt(gymProfile: GymProfile) throws -> String {
         guard let base = try PromptLoader.load("SystemPrompt_SessionPlan") else {
             throw SessionPlanError.systemPromptNotFound
         }
-        return base + ExerciseLibrary.promptReferenceBlock()
+        return base + ExerciseLibrary.promptReferenceBlock(
+            ownedEquipmentKeys: gymProfile.ownedEquipmentKeys
+        )
     }
 
     private static func stripMarkdownFences(_ input: String) -> String {

--- a/ProjectApexTests/ExerciseLibraryTests.swift
+++ b/ProjectApexTests/ExerciseLibraryTests.swift
@@ -303,6 +303,66 @@ struct ExerciseLibraryTests {
         // Should not be excessively large (>10KB would be a problem for token budget)
         #expect(block.count < 10_000)
     }
+
+    // MARK: promptReferenceBlock(ownedEquipmentKeys:) — library pre-filter (#527 S5)
+
+    @Test("Filtered block keeps owned-equipment exercises, drops un-owned ones")
+    func filteredBlockKeepsOnlyOwnedEquipment() {
+        // A gym with ONLY a chest press machine.
+        let block = ExerciseLibrary.promptReferenceBlock(
+            ownedEquipmentKeys: ["chest_press_machine"]
+        )
+        // The machine chest press is owned → present.
+        #expect(block.contains("machine_chest_press"))
+        // Barbell bench press needs a barbell (not owned) → absent.
+        #expect(!block.contains("barbell_bench_press"))
+        // A dumbbell exercise (not owned) → absent.
+        #expect(!block.contains("dumbbell_bench_press"))
+    }
+
+    @Test("Filtered block always keeps bodyweight exercises")
+    func filteredBlockKeepsBodyweightExercises() {
+        // A gym with ONLY a chest press machine — no pull-up bar, no bench.
+        let block = ExerciseLibrary.promptReferenceBlock(
+            ownedEquipmentKeys: ["chest_press_machine"]
+        )
+        // Every bodyweightOnly exercise must survive regardless of its nominal
+        // equipmentType tag (e.g. push_ups is tagged "flat_bench" but needs no bench).
+        for ex in ExerciseLibrary.all where ex.bodyweightOnly {
+            #expect(
+                block.contains(ex.id),
+                "Bodyweight exercise '\(ex.id)' must survive the filter."
+            )
+        }
+    }
+
+    @Test("Empty owned set still yields bodyweight exercises only")
+    func filteredBlockEmptyOwnedKeepsBodyweight() {
+        let block = ExerciseLibrary.promptReferenceBlock(ownedEquipmentKeys: [])
+        // push_ups is bodyweightOnly → present even with zero equipment.
+        #expect(block.contains("push_ups"))
+        // barbell_bench_press needs equipment → absent.
+        #expect(!block.contains("barbell_bench_press"))
+    }
+
+    @Test("Custom unknown machine key adds no library exercises")
+    func filteredBlockCustomMachineMatchesNothing() {
+        // A custom machine's typeKey is "unknown:<raw>" — it matches no library row.
+        let owned: Set<String> = ["unknown:Belt squat machine"]
+        let block = ExerciseLibrary.promptReferenceBlock(ownedEquipmentKeys: owned)
+        // No equipment-bearing exercise survives…
+        #expect(!block.contains("barbell_bench_press"))
+        #expect(!block.contains("machine_chest_press"))
+        // …but bodyweight ones still do (the model always needs those).
+        #expect(block.contains("push_ups"))
+    }
+
+    @Test("nil owned set is the full unfiltered library (back-compat)")
+    func filteredBlockNilIsFull() {
+        let full = ExerciseLibrary.promptReferenceBlock()
+        let explicitNil = ExerciseLibrary.promptReferenceBlock(ownedEquipmentKeys: nil)
+        #expect(full == explicitNil)
+    }
 }
 
 // MARK: - Helpers

--- a/ProjectApexTests/GymProfileTests.swift
+++ b/ProjectApexTests/GymProfileTests.swift
@@ -366,3 +366,55 @@ final class GymProfileEquipmentHelperTests: XCTestCase {
         XCTAssertEqual(GymProfile.mockProfile().id, GymProfile.mockProfile().id)
     }
 }
+
+// MARK: ─── Part 5: EquipmentRef — LLM payload {key,name} shape (#527 S5) ──────
+
+final class EquipmentRefTests: XCTestCase {
+
+    /// A known equipment type encodes BOTH the canonical key and the display name.
+    func test_knownType_carriesKeyAndName() throws {
+        let ref = EquipmentRef(.chestPressMachine)
+        XCTAssertEqual(ref.key, "chest_press_machine")
+        XCTAssertEqual(ref.name, "Chest Press Machine")
+
+        let data = try JSONEncoder().encode(ref)
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        XCTAssertEqual(json["key"] as? String, "chest_press_machine")
+        XCTAssertEqual(json["name"] as? String, "Chest Press Machine")
+    }
+
+    /// A custom .unknown machine's raw label must survive into the name, and the
+    /// key keeps the "unknown:" round-trip prefix (so it never collides with a
+    /// real library row).
+    func test_customUnknownMachine_nameSurvives() throws {
+        let ref = EquipmentRef(.unknown("Belt squat machine"))
+        XCTAssertEqual(ref.key, "unknown:Belt squat machine")
+        XCTAssertEqual(ref.name, "Belt squat machine")
+
+        let data = try JSONEncoder().encode(ref)
+        let decoded = try JSONDecoder().decode(EquipmentRef.self, from: data)
+        XCTAssertEqual(decoded, ref)
+        XCTAssertEqual(decoded.name, "Belt squat machine",
+            "Custom machine name must survive the LLM payload encode/decode")
+    }
+
+    /// GymProfile.equipmentRefs produces one { key, name } ref per item.
+    func test_gymProfile_equipmentRefs_oneRefPerItem() {
+        let profile = GymProfile.mockProfile()
+        let refs = profile.equipmentRefs
+        XCTAssertEqual(refs.count, profile.equipment.count)
+        // mockProfile has a barbell → its ref carries the display name.
+        let barbell = refs.first { $0.key == "barbell" }
+        XCTAssertEqual(barbell?.name, "Barbell")
+    }
+
+    /// ownedEquipmentKeys is the set of typeKeys used to pre-filter the library.
+    func test_gymProfile_ownedEquipmentKeys() {
+        let profile = GymProfile.mockProfile()
+        let keys = profile.ownedEquipmentKeys
+        XCTAssertTrue(keys.contains("barbell"))
+        XCTAssertEqual(keys.count, Set(profile.equipment.map { $0.equipmentType.typeKey }).count)
+    }
+}

--- a/ProjectApexTests/ProgramGenerationServiceTests.swift
+++ b/ProjectApexTests/ProgramGenerationServiceTests.swift
@@ -550,12 +550,15 @@ final class ProgramGenerationServiceTests: XCTestCase {
         XCTAssertEqual(constraints["periodization_model"] as? String, "linear_periodization")
 
         let gymPayload = try XCTUnwrap(json["gym_profile"] as? [String: Any])
-        let available = try XCTUnwrap(gymPayload["available_equipment"] as? [String])
+        let available = try XCTUnwrap(gymPayload["available_equipment"] as? [[String: Any]])
         XCTAssertFalse(available.isEmpty,
                        "GymProfilePayload must list at least one equipment type.")
-        // mockProfile has a barbell
-        XCTAssertTrue(available.contains("barbell"),
-                      "GymProfilePayload must include barbell from mockProfile.")
+        // Each entry now carries BOTH the canonical key and the display name.
+        let barbell = available.first { $0["key"] as? String == "barbell" }
+        XCTAssertNotNil(barbell,
+                        "GymProfilePayload must include barbell from mockProfile.")
+        XCTAssertEqual(barbell?["name"] as? String, "Barbell",
+                       "available_equipment entries must carry the display name.")
     }
 
     // MARK: ─── 8. GymProfilePayload maps equipment type keys ─────────────────
@@ -571,9 +574,14 @@ final class ProgramGenerationServiceTests: XCTestCase {
         )
 
         for item in gymProfile.equipment {
-            XCTAssertTrue(
-                payload.availableEquipment.contains(item.equipmentType.typeKey),
+            let ref = payload.availableEquipment.first { $0.key == item.equipmentType.typeKey }
+            XCTAssertNotNil(
+                ref,
                 "GymProfilePayload must contain type key '\(item.equipmentType.typeKey)'."
+            )
+            XCTAssertEqual(
+                ref?.name, item.equipmentType.displayName,
+                "GymProfilePayload entry must carry the display name."
             )
         }
     }


### PR DESCRIPTION
## Slice 5 of the machine-reliability overhaul (#527)

Two related planner fixes so machine usage is reliable.

### Fix A — descriptive equipment names (not bare keys)
Equipment payloads now carry BOTH the canonical key and the human display name. New `EquipmentRef { key, name }` + `GymProfile.equipmentRefs` / `.ownedEquipmentKeys` helpers.

Serializers switched from `[String]` to `[EquipmentRef]`:
- `MacroPlanGymProfile` (`MacroPlanService`) → SessionPlan + MacroPlan prompts
- `GymProfilePayload` (`ProgramGenerationService`) → MacroGeneration prompt
- `ExerciseSwapService.SwapContext.availableEquipment` (built in `WorkoutSessionManager`) → ExerciseSwap prompt
- `GymProfileConstraints` (`AIInferenceService`) — see note below

Example payload entry:
```json
{ "key": "chest_press_machine", "name": "Chest Press Machine" }
```
A custom `.unknown("Belt squat machine")` machine carries `key: "unknown:Belt squat machine"`, `name: "Belt squat machine"` — so the model can reason about machines it has never seen as a bare key.

Prompt templates updated **in lockstep** with the new shape: `SystemPrompt_SessionPlan.txt`, `SystemPrompt_MacroGeneration.txt`, `SystemPrompt_MacroPlan.txt`, `SystemPrompt_ExerciseSwap.txt`. The model still **emits** `equipment_required` as a bare `key` string (unchanged); only the **input** `available_equipment` list shape changed. SessionPlan (v3.0→3.1) and ExerciseSwap (v1.0→1.1) version headers bumped.

### Fix B — pre-filter the exercise library to owned equipment
New `ExerciseLibrary.promptReferenceBlock(ownedEquipmentKeys:)` keeps an exercise only if it is **bodyweight** (`bodyweightOnly == true` — always available) OR its `equipmentType` is in the owned set. Wired into the 3 services that inject the block (SessionPlan, ProgramGeneration, ExerciseSwap). Custom `.unknown` machines match no library row, so they add no library exercises (expected).

Bodyweight stations (pull-up bar, dip station) and bodyweight exercises (push-ups, pull-ups, dips) remain available after filtering.

### Tests
- `EquipmentRefTests` — `{key,name}` encodes for a known type; custom machine name survives encode/decode; `equipmentRefs`/`ownedEquipmentKeys` helpers.
- `ExerciseLibraryTests` — filter keeps owned-only (chest-press-machine-only gym → machine chest press, NOT barbell bench / dumbbell bench), always keeps every bodyweight exercise, empty/custom-only sets keep only bodyweight, `nil` == full library.
- Updated 2 `ProgramGenerationServiceTests` that asserted the old `[String]` shape.

Build **SUCCEEDED**; focused suites green (live-API integration tests skipped per `APEX_INTEGRATION_TESTS`).

### Notes for a human eye
- **`GymProfileConstraints` (AIInferenceService) is dead code** — no construction site, no decode site, not injected into any payload, and the per-set Inference prompt has **no `available_equipment` field** (it uses only `current_exercise.equipment_type_key`). Its shape was updated for contract consistency but the change is inert. `SystemPrompt_Inference.txt` was therefore left unchanged.
- **`buildCorrectionPayload` (ProgramGenerationService)** sends a second, freeform "AVAILABLE EQUIPMENT:" text block to the LLM on equipment-violation retries, still using bare keys. Surfaced per grep-and-report; **not edited** without authorization. Recommend a follow-up to give it descriptive names too for consistency.

Part of #527