### PR TITLE
feat(#527): library machine exercises + hard equipment enforcement (S6)

### DIFF
--- a/ProjectApex/Models/ExerciseLibrary.swift
+++ b/ProjectApex/Models/ExerciseLibrary.swift
@@ -177,7 +177,35 @@ nonisolated enum ExerciseLibrary {
             primaryMuscle: .back,
             synergists: ["biceps", "shoulders"],
             movementPattern: .horizontalPull,
-            equipmentType: "barbell",
+            // #527 S6: was shoe-horned onto "barbell" — now mapped to the
+            // dedicated t_bar_row EquipmentType (S4) so a gym whose only row
+            // station is a T-bar machine resolves this exercise.
+            equipmentType: "t_bar_row",
+            bodyweightOnly: false
+        ),
+        ExerciseDefinition(
+            id: "machine_assisted_pull_up",
+            name: "Assisted Pull-Up (Machine)",
+            primaryMuscle: .back,
+            synergists: ["biceps"],
+            // #527 S6: distinct from assisted_pull_up (which uses pull_up_bar +
+            // a band/partner). This is the dedicated assisted dip/pull-up
+            // machine (S4). The stack removes load rather than adding it, so
+            // bodyweightOnly: true — the AI must never prescribe external weight.
+            movementPattern: .verticalPull,
+            equipmentType: "assisted_dip_pull_up",
+            bodyweightOnly: true
+        ),
+        ExerciseDefinition(
+            id: "machine_reverse_fly",
+            name: "Machine Reverse Fly",
+            primaryMuscle: .back,
+            synergists: ["shoulders"],
+            // #527 S6: rear-delt / reverse pec deck machine (S4). Mirrors the
+            // existing cable_rear_delt_fly classification (.back) for the same
+            // movement on a different station.
+            movementPattern: .isolation,
+            equipmentType: "reverse_fly",
             bodyweightOnly: false
         ),
         ExerciseDefinition(
@@ -508,6 +536,17 @@ nonisolated enum ExerciseLibrary {
             bodyweightOnly: false
         ),
         ExerciseDefinition(
+            id: "machine_hip_thrust",
+            name: "Machine Hip Thrust",
+            primaryMuscle: .glutes,
+            synergists: ["hamstrings"],
+            // #527 S6: dedicated hip-thrust machine (S4) — was previously only
+            // expressible as the barbell hip_thrust.
+            movementPattern: .hipHinge,
+            equipmentType: "hip_thrust_machine",
+            bodyweightOnly: false
+        ),
+        ExerciseDefinition(
             id: "cable_pull_through",
             name: "Cable Pull-Through",
             primaryMuscle: .glutes,
@@ -647,6 +686,18 @@ nonisolated enum ExerciseLibrary {
             bodyweightOnly: false
         ),
         ExerciseDefinition(
+            id: "machine_assisted_dip",
+            name: "Assisted Dip (Machine)",
+            primaryMuscle: .triceps,
+            synergists: ["chest", "shoulders"],
+            // #527 S6: assisted dip on the dedicated assisted dip/pull-up
+            // machine (S4). Like machine_assisted_pull_up, the stack removes
+            // load, so bodyweightOnly: true — never prescribe external weight.
+            movementPattern: .verticalPush,
+            equipmentType: "assisted_dip_pull_up",
+            bodyweightOnly: true
+        ),
+        ExerciseDefinition(
             id: "dumbbell_overhead_tricep_extension",
             name: "Dumbbell Overhead Tricep Extension",
             primaryMuscle: .triceps,
@@ -720,6 +771,17 @@ nonisolated enum ExerciseLibrary {
             synergists: [],
             movementPattern: .isolation,
             equipmentType: "smith_machine",
+            bodyweightOnly: false
+        ),
+        ExerciseDefinition(
+            id: "machine_calf_raise",
+            name: "Calf Raise Machine",
+            primaryMuscle: .calves,
+            synergists: [],
+            // #527 S6: dedicated calf-raise machine (S4) — calf work was
+            // previously only on barbell / leg_press / smith_machine.
+            movementPattern: .isolation,
+            equipmentType: "calf_raise_machine",
             bodyweightOnly: false
         ),
 

--- a/ProjectApex/Models/GymProfile.swift
+++ b/ProjectApex/Models/GymProfile.swift
@@ -395,13 +395,16 @@ nonisolated struct EquipmentRef: Codable, Equatable, Hashable, Sendable {
 
 extension GymProfile {
     /// The owned equipment as `{ key, name }` refs for LLM payloads.
-    var equipmentRefs: [EquipmentRef] {
+    /// `nonisolated` so the non-isolated session/program generation paths can
+    /// read it (the struct is a `nonisolated Sendable` value type).
+    nonisolated var equipmentRefs: [EquipmentRef] {
         equipment.map { EquipmentRef($0.equipmentType) }
     }
 
     /// The owned equipment `typeKey`s, used to pre-filter the exercise library
-    /// to what this gym can actually train.
-    var ownedEquipmentKeys: Set<String> {
+    /// to what this gym can actually train. `nonisolated` for the same reason as
+    /// `equipmentRefs` — `SessionPlanService.generateSession` reads it off-actor.
+    nonisolated var ownedEquipmentKeys: Set<String> {
         Set(equipment.map { $0.equipmentType.typeKey })
     }
 }

--- a/ProjectApex/Services/ProgramGenerationService.swift
+++ b/ProjectApex/Services/ProgramGenerationService.swift
@@ -613,8 +613,12 @@ actor ProgramGenerationService {
             "- exerciseId: \($0.exerciseId) (week \($0.weekNumber)) requires \($0.requiredEquipment.typeKey) which is NOT available"
         }.joined(separator: "\n")
 
-        let availableKeys = gymProfile.equipment
-            .map { $0.equipmentType.typeKey }
+        // #527 S6 (S5 follow-up): emit the descriptive { key, name } form S5
+        // introduced for the JSON `available_equipment` payload, instead of bare
+        // keys, so this correction re-prompt is consistent with the rest of the
+        // equipment surface. The LLM emits equipment_required using the "key".
+        let availableEquipment = gymProfile.equipmentRefs
+            .map { "{ \"key\": \"\($0.key)\", \"name\": \"\($0.name)\" }" }
             .joined(separator: ", ")
 
         return """
@@ -628,8 +632,8 @@ actor ProgramGenerationService {
         VIOLATIONS:
         \(violationLines)
 
-        AVAILABLE EQUIPMENT:
-        \(availableKeys)
+        AVAILABLE EQUIPMENT (list of { key, name }; use the "key" in equipment_required):
+        \(availableEquipment)
         """
     }
 

--- a/ProjectApex/Services/SessionPlanService.swift
+++ b/ProjectApex/Services/SessionPlanService.swift
@@ -443,7 +443,8 @@ actor SessionPlanService {
         return buildTrainingDay(
             from: sessionPayload,
             stub: skeletonDay,
-            fatigue: fatigue
+            fatigue: fatigue,
+            ownedEquipmentKeys: gymProfile.ownedEquipmentKeys
         )
     }
 
@@ -500,10 +501,16 @@ actor SessionPlanService {
 
     // #246: relaxed from `private` to internal so SessionPlanServiceTests can drive the
     // payload→TrainingDay mapping directly (the day_label normalization seam). Nothing else touched.
+    //
+    // #527 S6: `ownedEquipmentKeys` (defaulted nil for the day_label-normalization
+    // tests that don't care about equipment) enables hard equipment enforcement —
+    // see `enforceEquipment(...)` for the SAFE drop-the-violator rule that never
+    // empties a session.
     func buildTrainingDay(
         from payload: SessionPlanPayload,
         stub: TrainingDay,
-        fatigue: WeekFatigueSignals
+        fatigue: WeekFatigueSignals,
+        ownedEquipmentKeys: Set<String>? = nil
     ) -> TrainingDay {
         // Validate exercise IDs against canonical library — log warnings for non-canonical IDs.
         // The session is not rejected; primaryMuscle will fall back to the LLM's own value.
@@ -515,7 +522,16 @@ actor SessionPlanService {
             }
         }
 
-        let exercises = payload.exercises.map { ex in
+        // #527 S6: HARD equipment enforcement (safety-first). Drop any exercise
+        // whose required equipment the user does not own — but NEVER ship an
+        // empty session (see enforceEquipment for the rail). Skipped entirely
+        // when `ownedEquipmentKeys` is nil (the pure day_label mapping tests).
+        let acceptedExercises = Self.enforceEquipment(
+            payload.exercises,
+            ownedEquipmentKeys: ownedEquipmentKeys
+        )
+
+        let exercises = acceptedExercises.map { ex in
             PlannedExercise(
                 id: UUID(),
                 exerciseId: ex.exerciseId,
@@ -547,6 +563,57 @@ actor SessionPlanService {
             sessionNotes: notes?.trimmingCharacters(in: .whitespaces),
             status: .generated
         )
+    }
+
+    // MARK: - #527 S6: Equipment enforcement (safety-first)
+
+    /// Drops exercises whose required equipment the user does not own, with a
+    /// hard safety rail: it will NEVER return an empty session.
+    ///
+    /// Rules (mirroring the S5 library pre-filter `bodyweightOnly || owned`):
+    ///   • `ownedEquipmentKeys == nil` → no enforcement (returns input unchanged).
+    ///     Used by the pure day_label-mapping tests that don't model a gym.
+    ///   • Bodyweight exercises ALWAYS pass — identified canonically via the
+    ///     library's `bodyweightOnly` flag, or (for non-library IDs) via the
+    ///     equipment type's natural bodyweight-only status. No external weight is
+    ///     ever prescribed for these, so the nominal equipment tag is irrelevant.
+    ///   • A custom `.unknown:<raw>` machine passes when that exact key is owned.
+    ///   • Otherwise the exercise passes only if its required `typeKey` is owned.
+    ///
+    /// Safety rail: if enforcement would drop EVERY exercise (empty result) while
+    /// the LLM did return some, we keep the original list and log LOUDLY rather
+    /// than ship an empty day. Prescribing equipment the user lacks is bad;
+    /// shipping no workout at all is worse (#527 S6 directive).
+    static func enforceEquipment(
+        _ exercises: [SessionPlanExercise],
+        ownedEquipmentKeys: Set<String>?
+    ) -> [SessionPlanExercise] {
+        guard let owned = ownedEquipmentKeys else { return exercises }
+
+        let accepted = exercises.filter { ex in
+            // Bodyweight always passes — same rule S5 used for the library filter.
+            let isBodyweight = (ExerciseLibrary.lookup(ex.exerciseId)?.bodyweightOnly ?? false)
+                || ex.equipmentRequired.isNaturallyBodyweightOnly
+            if isBodyweight { return true }
+            // Owned equipment (including a matching custom .unknown:<raw> key) passes.
+            return owned.contains(ex.equipmentRequired.typeKey)
+        }
+
+        let dropped = exercises.count - accepted.count
+        if dropped > 0 {
+            let names = exercises
+                .filter { ex in !accepted.contains(where: { $0.exerciseId == ex.exerciseId }) }
+                .map { "\($0.exerciseId) (\($0.equipmentRequired.typeKey))" }
+                .joined(separator: ", ")
+            print("[SessionPlanService] ⚠️ Equipment enforcement dropped \(dropped) off-equipment exercise(s): \(names)")
+        }
+
+        // Safety rail: never empty a session that the LLM actually populated.
+        if accepted.isEmpty && !exercises.isEmpty {
+            print("[SessionPlanService] ⚠️⚠️ Equipment enforcement would have EMPTIED the session — keeping the LLM's original \(exercises.count) exercise(s) to avoid shipping an empty day. The gym profile may be missing equipment the user actually has.")
+            return exercises
+        }
+        return accepted
     }
 
     // MARK: - Private: Build lift history from set logs

--- a/ProjectApexTests/ExerciseLibraryTests.swift
+++ b/ProjectApexTests/ExerciseLibraryTests.swift
@@ -36,6 +36,10 @@ private let validEquipmentTypeKeys: Set<String> = [
     "chest_press_machine", "shoulder_press_machine",
     "leg_extension", "leg_curl",
     "pec_deck", "preacher_curl", "cable_crossover",
+    // #527 S4 — new machine EquipmentType cases (this registry drifts from the
+    // enum; kept in sync manually). #527 S6 added library rows for all five.
+    "reverse_fly", "assisted_dip_pull_up", "hip_thrust_machine",
+    "calf_raise_machine", "t_bar_row",
 ]
 
 /// Synergists use a broader vocabulary than PrimaryMuscle — "forearms" is
@@ -271,6 +275,51 @@ struct ExerciseLibraryTests {
             }
         }
         #expect(collisions.isEmpty, "Normalization key/canonical ID collisions:\n\(collisions.joined(separator: "\n"))")
+    }
+
+    // MARK: #527 S6 — new machine library rows resolve for their equipment type
+
+    @Test("Every captured machine EquipmentType maps to at least one library exercise")
+    func everyMachineHasAnExercise() {
+        // The five S4 machine cases that previously had NO matching library row.
+        // Each must now resolve to ≥1 exercise tagged with that exact typeKey.
+        let machineKeys = [
+            "reverse_fly", "assisted_dip_pull_up", "hip_thrust_machine",
+            "calf_raise_machine", "t_bar_row",
+        ]
+        for key in machineKeys {
+            let matches = ExerciseLibrary.all.filter { $0.equipmentType == key }
+            #expect(!matches.isEmpty, "No library exercise maps to machine '\(key)'")
+        }
+    }
+
+    @Test("New S6 machine exercises resolve with the correct equipment + muscle")
+    func newMachineExercisesResolve() {
+        let expectations: [(id: String, equipment: String, muscle: PrimaryMuscle, bodyweight: Bool)] = [
+            ("machine_reverse_fly",      "reverse_fly",          .back,    false),
+            ("machine_assisted_pull_up", "assisted_dip_pull_up", .back,    true),
+            ("machine_assisted_dip",     "assisted_dip_pull_up", .triceps, true),
+            ("machine_hip_thrust",       "hip_thrust_machine",   .glutes,  false),
+            ("machine_calf_raise",       "calf_raise_machine",   .calves,  false),
+            ("t_bar_row",                "t_bar_row",            .back,    false),
+        ]
+        for e in expectations {
+            let def = ExerciseLibrary.lookup(e.id)
+            #expect(def != nil, "Expected new library exercise '\(e.id)' to resolve")
+            #expect(def?.equipmentType == e.equipment, "'\(e.id)' equipment mismatch")
+            #expect(def?.primaryMuscle == e.muscle, "'\(e.id)' muscle mismatch")
+            #expect(def?.bodyweightOnly == e.bodyweight, "'\(e.id)' bodyweightOnly mismatch")
+        }
+    }
+
+    @Test("Filtered block surfaces a calf-machine-only gym's exercise")
+    func filteredBlockSurfacesNewMachine() {
+        // A gym whose only equipment is the dedicated calf-raise machine must now
+        // get a real exercise for it (proves the S6 gap-fill closed the hole).
+        let block = ExerciseLibrary.promptReferenceBlock(
+            ownedEquipmentKeys: ["calf_raise_machine"]
+        )
+        #expect(block.contains("machine_calf_raise"))
     }
 
     // MARK: promptReferenceBlock()

--- a/ProjectApexTests/SessionPlanServiceTests.swift
+++ b/ProjectApexTests/SessionPlanServiceTests.swift
@@ -107,3 +107,148 @@ struct SessionPlanServiceDayLabelNormalizationTests {
         #expect(day.dayLabel == "Chest_Back")
     }
 }
+
+// MARK: - #527 S6 — hard equipment enforcement (safety-first)
+
+@Suite("SessionPlanService — equipment enforcement (#527 S6)")
+struct SessionPlanServiceEquipmentEnforcementTests {
+
+    /// Decodes a full session payload from a list of (id, name, equipmentKey)
+    /// tuples so each exercise flows through the real Codable path
+    /// (SessionPlanExercise has no memberwise init).
+    private func decodeExercises(
+        _ specs: [(id: String, name: String, equipment: String)]
+    ) throws -> [SessionPlanExercise] {
+        let exerciseJSON = specs.map { spec in
+            """
+            {
+              "exercise_id": "\(spec.id)",
+              "name": "\(spec.name)",
+              "primary_muscle": "chest",
+              "synergists": [],
+              "equipment_required": "\(spec.equipment)",
+              "sets": 3,
+              "rep_range": { "min": 8, "max": 12 },
+              "tempo": "3-1-1-0",
+              "rest_seconds": 120,
+              "rir_target": 2,
+              "coaching_cues": []
+            }
+            """
+        }.joined(separator: ",\n")
+
+        let json = """
+        {
+          "session_plan": {
+            "day_label": "Test_Day",
+            "session_notes": null,
+            "is_deload": false,
+            "is_fatigue_management_day": false,
+            "exercises": [\(exerciseJSON)]
+          }
+        }
+        """
+        return try JSONDecoder()
+            .decode(SessionPlanWrapper.self, from: Data(json.utf8))
+            .sessionPlan.exercises
+    }
+
+    @Test("nil owned set skips enforcement entirely (back-compat)")
+    func nilOwnedSkipsEnforcement() throws {
+        let exercises = try decodeExercises([
+            ("barbell_bench_press", "Barbell Bench Press", "barbell"),
+            ("cable_row", "Cable Row", "cable_machine_single"),
+        ])
+        let result = SessionPlanService.enforceEquipment(exercises, ownedEquipmentKeys: nil)
+        #expect(result.count == 2, "nil owned set must not drop anything")
+    }
+
+    @Test("Drops off-equipment exercise but keeps owned + bodyweight ones")
+    func dropsOffEquipmentKeepsOwnedAndBodyweight() throws {
+        // Owned: barbell only.
+        let owned: Set<String> = ["barbell"]
+        let exercises = try decodeExercises([
+            ("barbell_bench_press", "Barbell Bench Press", "barbell"),               // owned → keep
+            ("cable_row", "Cable Row", "cable_machine_single"),                       // NOT owned → drop
+            ("push_ups", "Push-Ups", "flat_bench"),                                   // bodyweight (library) → keep
+        ])
+        let result = SessionPlanService.enforceEquipment(exercises, ownedEquipmentKeys: owned)
+        let ids = Set(result.map(\.exerciseId))
+        #expect(ids.contains("barbell_bench_press"))
+        #expect(ids.contains("push_ups"), "Bodyweight exercise must survive even though its nominal equipment is unowned")
+        #expect(!ids.contains("cable_row"), "Off-equipment exercise must be dropped")
+        #expect(result.count == 2)
+    }
+
+    @Test("Custom .unknown machine matching an owned key is allowed")
+    func unknownMachineMatchingOwnedKeyAllowed() throws {
+        let owned: Set<String> = ["unknown:Belt squat machine"]
+        let exercises = try decodeExercises([
+            ("belt_squat", "Belt Squat", "unknown:Belt squat machine"),  // owned custom → keep
+            ("cable_row", "Cable Row", "cable_machine_single"),          // NOT owned → drop
+        ])
+        let result = SessionPlanService.enforceEquipment(exercises, ownedEquipmentKeys: owned)
+        let ids = Set(result.map(\.exerciseId))
+        #expect(ids.contains("belt_squat"), "A custom .unknown machine whose key is owned must pass")
+        #expect(!ids.contains("cable_row"))
+    }
+
+    @Test("SAFETY RAIL: never empties a populated session")
+    func neverEmptiesSession() throws {
+        // Gym owns NOTHING that matches, and none of the exercises are bodyweight.
+        let owned: Set<String> = ["dumbbell_set"]
+        let exercises = try decodeExercises([
+            ("barbell_bench_press", "Barbell Bench Press", "barbell"),
+            ("cable_row", "Cable Row", "cable_machine_single"),
+        ])
+        let result = SessionPlanService.enforceEquipment(exercises, ownedEquipmentKeys: owned)
+        // All would be dropped → the rail keeps the original list rather than ship empty.
+        #expect(result.count == 2, "Enforcement must NEVER return an empty session")
+        #expect(Set(result.map(\.exerciseId)) == Set(["barbell_bench_press", "cable_row"]))
+    }
+
+    @Test("Empty input stays empty (no rail trigger when nothing to keep)")
+    func emptyInputStaysEmpty() {
+        let result = SessionPlanService.enforceEquipment([], ownedEquipmentKeys: ["barbell"])
+        #expect(result.isEmpty)
+    }
+
+    @Test("buildTrainingDay end-to-end drops off-equipment, keeps the rest, non-empty")
+    @MainActor
+    func buildTrainingDayEnforcesEquipment() async throws {
+        let fakeURL = URL(string: "https://localhost")!
+        let supabase = SupabaseClient(supabaseURL: fakeURL, anonKey: "test")
+        let service = SessionPlanService(
+            provider: NeverCalledProvider(),
+            memoryService: MemoryService(supabase: supabase, embeddingAPIKey: "test"),
+            supabaseClient: supabase
+        )
+        let exercises = try decodeExercises([
+            ("barbell_bench_press", "Barbell Bench Press", "barbell"),         // keep
+            ("cable_row", "Cable Row", "cable_machine_single"),                // drop (unowned)
+            ("push_ups", "Push-Ups", "flat_bench"),                            // keep (bodyweight)
+        ])
+        let payload = SessionPlanPayload(
+            dayLabel: "Test_Day",
+            sessionNotes: nil,
+            isDeload: false,
+            isFatigueManagementDay: false,
+            exercises: exercises
+        )
+        let stub = TrainingDay(
+            id: UUID(), dayOfWeek: 1, dayLabel: "Push_A",
+            exercises: [], sessionNotes: nil, status: .pending
+        )
+        let fatigue = WeekFatigueSignals.compute(from: [], sessionCount: 0)
+
+        let day = await service.buildTrainingDay(
+            from: payload,
+            stub: stub,
+            fatigue: fatigue,
+            ownedEquipmentKeys: ["barbell"]
+        )
+        let ids = Set(day.exercises.map(\.exerciseId))
+        #expect(ids == Set(["barbell_bench_press", "push_ups"]))
+        #expect(!day.exercises.isEmpty)
+    }
+}


### PR DESCRIPTION
Final machine-reliability slice. Adds canonical exercises for the new machine types (so every captured machine maps to >=1 exercise), hard-enforces equipment matching in SessionPlanService with a safety rail that never empties a session, and switches the correction-retry payload to descriptive {key,name} equipment. Orchestrator finished this slice after the build agent stalled mid-test-writing: fixed a main-actor isolation error (GymProfile.equipmentRefs/ownedEquipmentKeys → nonisolated), then verified — full test target compiles, enforcement suite 6/6 green (incl. the never-empty safety rail). Part of #527.