### PR TITLE
Bound PatternProfile.recentSessionDates to last 10 on EF write (#292)

### DIFF
--- a/supabase/functions/_shared/constants.ts
+++ b/supabase/functions/_shared/constants.ts
@@ -45,6 +45,19 @@ export const TOP_SET_REP_VALIDITY_MAX = 10;
  */
 export const TOP_SET_RETENTION_COUNT = 10;
 
+/**
+ * Bounded retention for `PatternProfile.recentSessionDates` on the EF write
+ * (#292). Without a cap the array grows unbounded — one entry appended per
+ * session-apply forever, bloating `model_json` JSONB indefinitely. Every
+ * consumer needs only recent entries: cadence (mean of recent inter-session
+ * gaps), `priorSessionLoggedAt` and the prescription-accuracy gap (last two),
+ * and the iOS digest (formatted list + last date). Per-pattern `sessionCount`
+ * is an independent accumulator since #284 (ADR-0020), so trimming does not
+ * affect confidence advancement; its one-time idempotent backfill reads the
+ * pre-update array upstream of the cap. 10 matches TOP_SET_RETENTION_COUNT.
+ */
+export const RECENT_SESSION_DATES_RETENTION_COUNT = 10;
+
 // ─── Recovery curves (ADR-0010) ──────────────────────────────────────────────
 
 /**

--- a/supabase/functions/_shared/constants_test.ts
+++ b/supabase/functions/_shared/constants_test.ts
@@ -19,6 +19,7 @@ import {
   TOP_SET_REP_VALIDITY_MIN,
   TOP_SET_REP_VALIDITY_MAX,
   TOP_SET_RETENTION_COUNT,
+  RECENT_SESSION_DATES_RETENTION_COUNT,
   // Recovery
   RECOVERY_TAU_NM_HOURS,
   RECOVERY_TAU_METABOLIC_HOURS,
@@ -111,6 +112,10 @@ Deno.test("ADR-0005: top-set rep validity max is 10 not 8 or 12", () => {
 
 Deno.test("ADR-0005: top-set retention count is 10 (upper end of typical 7..10)", () => {
   assertEquals(TOP_SET_RETENTION_COUNT, 10);
+});
+
+Deno.test("#292: recent-session-dates retention count is 10", () => {
+  assertEquals(RECENT_SESSION_DATES_RETENTION_COUNT, 10);
 });
 
 // ─── Recovery curves (ADR-0010) ──────────────────────────────────────────────

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -125,6 +125,7 @@ import {
   CLASSIFIER_BOOTSTRAP_MAX_NOTES,
   CLASSIFIER_BOOTSTRAP_MAX_SESSIONS,
   MAJOR_PATTERNS,
+  RECENT_SESSION_DATES_RETENTION_COUNT,
   TOP_SET_RETENTION_COUNT,
 } from "../_shared/constants.ts";
 import {
@@ -926,9 +927,13 @@ export function applyPerPatternRules(
 
     const baseRecentDates =
       (profile.recentSessionDates as string[] | undefined) ?? [];
-    const recentDates = wasTrainedThisSession
+    // #292: bound the stored history to the most recent N. slice(-N) on an
+    // array already ≤N is a no-op, so this is idempotent and also trims any
+    // pre-cap (historically unbounded) entries the next time the pattern is
+    // written. Safe for every consumer — see RECENT_SESSION_DATES_RETENTION_COUNT.
+    const recentDates = (wasTrainedThisSession
       ? [...baseRecentDates, incomingLoggedAt.toISOString()]
-      : baseRecentDates;
+      : baseRecentDates).slice(-RECENT_SESSION_DATES_RETENTION_COUNT);
 
     const cadenceDays = sessionsCadenceDays(recentDates);
     // ADR-0011 Option-B threshold input: derive daysPerWeek from cadence.

--- a/supabase/functions/update-trainee-model/index_test.ts
+++ b/supabase/functions/update-trainee-model/index_test.ts
@@ -637,6 +637,74 @@ Deno.test("Slice 4 (e): UNTRAINED pattern (wasTrainedThisSession=false) with an 
   assertEquals(result.patterns[SQUAT_PATTERN].transitionModeUntil, null);
 });
 
+// ─── #292: recentSessionDates is bounded to the last N on write ──────────────
+//
+// Without a cap the array grew one entry per session-apply forever. The cap
+// (RECENT_SESSION_DATES_RETENTION_COUNT = 10) is applied to the final written
+// value, so it both bounds new growth and trims any pre-cap historical excess
+// the next time a pattern is written — trained or not.
+
+const twelveDates = () =>
+  Array.from(
+    { length: 12 },
+    (_, i) => `2026-01-${String(i + 1).padStart(2, "0")}T10:00:00Z`,
+  );
+
+Deno.test("#292: a TRAINED pattern with >N prior dates is trimmed to the last N (newest = incoming, oldest dropped)", () => {
+  const result = applyPerPatternRules(
+    squatProfile(twelveDates()),
+    new Set([SQUAT_PATTERN]),
+    INCOMING_FEB16,
+    10,
+    {},
+    [squatSetLog()],
+  );
+  const dates = result.patterns[SQUAT_PATTERN].recentSessionDates as string[];
+  assertEquals(dates.length, 10);
+  // newest entry is the incoming session date
+  assertEquals(dates[dates.length - 1], INCOMING_FEB16.toISOString());
+  // 12 history + 1 incoming = 13 → the three oldest are dropped
+  assertEquals(dates.includes("2026-01-03T10:00:00Z"), false);
+  assertEquals(dates.includes("2026-01-04T10:00:00Z"), true);
+});
+
+Deno.test("#292: a TRAINED pattern at/under N is fully preserved with the incoming date appended", () => {
+  const history = [
+    "2026-01-05T10:00:00Z",
+    "2026-01-08T10:00:00Z",
+    "2026-01-12T10:00:00Z",
+  ];
+  const result = applyPerPatternRules(
+    squatProfile(history),
+    new Set([SQUAT_PATTERN]),
+    INCOMING_FEB16,
+    10,
+    {},
+    [squatSetLog()],
+  );
+  const dates = result.patterns[SQUAT_PATTERN].recentSessionDates as string[];
+  assertEquals(dates, [...history, INCOMING_FEB16.toISOString()]);
+});
+
+Deno.test("#292: an UNTRAINED pattern with >N historical dates is trimmed on write without appending", () => {
+  const result = applyPerPatternRules(
+    squatProfile(twelveDates()),
+    new Set(), // not trained this apply
+    INCOMING_FEB16,
+    10,
+    {},
+    [],
+  );
+  const dates = result.patterns[SQUAT_PATTERN].recentSessionDates as string[];
+  assertEquals(dates.length, 10);
+  // no append: the incoming date is absent and the newest historical is retained
+  assertEquals(dates.includes(INCOMING_FEB16.toISOString()), false);
+  assertEquals(dates[dates.length - 1], "2026-01-12T10:00:00Z");
+  // last 10 of 12 → the two oldest are dropped
+  assertEquals(dates.includes("2026-01-02T10:00:00Z"), false);
+  assertEquals(dates.includes("2026-01-03T10:00:00Z"), true);
+});
+
 Deno.test("Slice 4 (f): deload-end + absence in the SAME apply compose via max-of-untils (absence reads the LOCAL until — no clobber)", () => {
   // currentPhase=deload at/above threshold → phase-advance fires deload-end.
   // PRE-append last date is also >=28d old → absence fires too.


### PR DESCRIPTION
## Summary

Closes #292.

`PatternProfile.recentSessionDates` grew unbounded in the `update-trainee-model` Edge Function write — one entry appended per session-apply, forever, steadily bloating each user's `model_json` JSONB. This bounds the stored history to the most recent **10** entries.

- New tested-default constant `RECENT_SESSION_DATES_RETENTION_COUNT = 10` (mirrors `TOP_SET_RETENTION_COUNT`).
- `applyPerPatternRules` applies `.slice(-N)` to the **final** written value, uniformly across the trained (append) and untrained branches — so it both bounds new growth and trims any pre-cap historical excess the next time a pattern is written. `.slice(-N)` on a ≤N array is a no-op → idempotent.

## Why it's safe for every consumer

- **cadence** (`sessionsCadenceDays`), **`priorSessionLoggedAt`**, and the **prescription-accuracy gap** all need only recent entries.
- The one consumer that reads `.length` — the per-pattern `sessionCount` backfill (#284 / ADR-0020) — has been an **independent accumulator** since #284, and its idempotent one-time backfill reads the **pre-update** array upstream of the cap. Trimming therefore cannot affect confidence advancement.
- iOS digest uses the formatted list + `.max()` (last date) only.

No SQL migration, no Swift change.

## Test plan

- `deno test` on `_shared/constants_test.ts` + `update-trainee-model/index_test.ts` (CI flags): **94 passed, 0 failed**.
- New tests: trim-on-append (oldest dropped, newest = incoming), preserve-under-cap (full array + append), trim-untrained-history (cleanup without append), and the tested-default.
- Audited DB-backed `orchestrator_test.ts`/`smoke_test.ts` seeds (all ≤4 dates, length-1 post-apply assertions) — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)