### PR TITLE
De-flake test_networkFailure_urlError (#369)

### DIFF
--- a/ProjectApexTests/AIInferenceServiceTests.swift
+++ b/ProjectApexTests/AIInferenceServiceTests.swift
@@ -511,8 +511,23 @@ final class AIInferenceServiceTests: XCTestCase {
     // MARK: ─── 4. Network failure test ────────────────────────────────────────
 
     /// NetworkFailProvider throws URLError(.notConnectedToInternet).
-    /// The result must be .fallback(.llmProviderError) with a non-empty message.
-    func test_networkFailure_urlError_returnsFallbackLLMProviderError() async {
+    /// A network failure must surface as a non-`.success` fallback.
+    ///
+    /// #369 flake fix: `.notConnectedToInternet` is classified transient
+    /// (`LLMErrorClassifier.transientURLErrorCodes`), so `prescribe()` retries
+    /// it 3× with jittered 1+2+4 s backoff *inside* the 8 s product timeout.
+    /// Which side wins that race is genuinely non-deterministic — when the
+    /// retries exhaust first the result is `.fallback(.llmProviderError)`; when
+    /// the jittered backoff (up to ~8.5 s) overruns the budget the result is
+    /// `.fallback(.timeout)`. Both are correct network-failure fallbacks, so the
+    /// test asserts the invariant that actually holds (never `.success`; a
+    /// non-empty message when an `llmProviderError` is surfaced) rather than the
+    /// timing-dependent reason. No product behaviour is changed here.
+    ///
+    /// (The ~8 s runtime and the retry-vs-timeout race stem from retrying
+    /// `.notConnectedToInternet` at all; whether that URLError code should be
+    /// transient is an ADR-0007 question, deliberately left out of scope.)
+    func test_networkFailure_urlError_returnsNetworkFallback() async {
         let service = AIInferenceService(
             provider: NetworkFailProvider(),
             gymProfile: GymProfile.mockProfile(),
@@ -523,13 +538,17 @@ final class AIInferenceServiceTests: XCTestCase {
 
         switch result {
         case .fallback(let reason):
-            guard case .llmProviderError(let message) = reason else {
-                return XCTFail("Expected .llmProviderError, got \(reason)")
+            switch reason {
+            case .llmProviderError(let message):
+                XCTAssertFalse(message.isEmpty,
+                               "llmProviderError message must not be empty.")
+            case .timeout:
+                break // acceptable — the 8 s product budget won the retry race
+            default:
+                XCTFail("Expected a network-failure fallback (llmProviderError or timeout), got \(reason)")
             }
-            XCTAssertFalse(message.isEmpty,
-                           "llmProviderError message must not be empty.")
         case .success:
-            XCTFail("Expected .fallback(.llmProviderError) on network failure.")
+            XCTFail("Expected a fallback on network failure, not .success.")
         }
     }
 


### PR DESCRIPTION
Part of #369 (pre-launch hardening — the `test_networkFailure_urlError` flake). Does **not** close the umbrella.

## Problem

`test_networkFailure_urlError_returnsFallbackLLMProviderError` asserted `.fallback(.llmProviderError)` on a `URLError(.notConnectedToInternet)`. But that code is classified **transient** (`LLMErrorClassifier.transientURLErrorCodes`), so `prescribe()` retries it 3× with jittered 1+2+4 s backoff *inside* the 8 s product timeout. The retry-exhaust path yields `.llmProviderError`; if the jittered backoff (up to ~8.5 s) overruns the 8 s budget the timeout wins and yields `.timeout`. Jitter + CI load made the outcome non-deterministic → intermittent failure (the red `Build & Test` on recent PRs).

## Fix (test-only, behaviour-preserving)

Assert the invariant that actually holds: a network failure is never `.success` and surfaces a fallback; **both** `.llmProviderError` (non-empty message) and `.timeout` are accepted as correct network-failure outcomes. Renamed to `…_returnsNetworkFallback` to match. No production code touched.

Matches the P5-H04 precedent (harden the test, don't change the retry classification). Whether `.notConnectedToInternet` should be retried at all is an ADR-0007 question, left out of scope and noted in the test docstring.

## Test plan

- `xcodebuild test -only-testing:…/test_networkFailure_urlError_returnsNetworkFallback` — **Executed 1 test, 0 failures** across **3 consecutive runs** (~7.66 s each; the runtime is the production backoff, unchanged).
- 0 build errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)