### PR TITLE
Persist set_logs.completion_flags — #43 Slice A (data plumbing)

### DIFF
--- a/ProjectApex/Features/Workout/ManualSessionLogView.swift
+++ b/ProjectApex/Features/Workout/ManualSessionLogView.swift
@@ -805,20 +805,26 @@ struct ManualSetLogPayload: Encodable {
     let primaryMuscle: String?
     let localDate: String
     let intent: String
+    // #43: persist user-reported completion flags. Manual logging captures no
+    // pain / form_breakdown flags today, so this serialises the (empty)
+    // SetLog.completionFlags — explicit and consistent with the live writer,
+    // and equivalent to the column's DEFAULT '{}'.
+    let completionFlags: [String]
 
     enum CodingKeys: String, CodingKey {
         case id
-        case sessionId     = "session_id"
-        case exerciseId    = "exercise_id"
-        case setNumber     = "set_number"
-        case weightKg      = "weight_kg"
-        case repsCompleted = "reps_completed"
-        case rpeFelt       = "rpe_felt"
-        case rirEstimated  = "rir_estimated"
-        case loggedAt      = "logged_at"
-        case primaryMuscle = "primary_muscle"
-        case localDate     = "local_date"
+        case sessionId       = "session_id"
+        case exerciseId      = "exercise_id"
+        case setNumber       = "set_number"
+        case weightKg        = "weight_kg"
+        case repsCompleted   = "reps_completed"
+        case rpeFelt         = "rpe_felt"
+        case rirEstimated    = "rir_estimated"
+        case loggedAt        = "logged_at"
+        case primaryMuscle   = "primary_muscle"
+        case localDate       = "local_date"
         case intent
+        case completionFlags = "completion_flags"
     }
 
     /// Slice 6 / #60 fix: intent and local_date are required by the schema.
@@ -838,6 +844,7 @@ struct ManualSetLogPayload: Encodable {
         self.primaryMuscle = log.primaryMuscle
         self.localDate     = SetLog.formatLocalDate(log.loggedAt)
         self.intent        = intent.rawValue
+        self.completionFlags = log.completionFlags.map(\.rawValue)
     }
 }
 

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -2359,20 +2359,25 @@ nonisolated struct SetLogPayload: Encodable {
     let primaryMuscle: String?
     let localDate: String
     let intent: String
+    // #43: persist user-reported completion flags (pain / form_breakdown) so
+    // cross-session AI reasoning is possible. Raw values mirror the
+    // `set_logs.completion_flags TEXT[]` column; empty array = no flags raised.
+    let completionFlags: [String]
 
     enum CodingKeys: String, CodingKey {
         case id
-        case sessionId     = "session_id"
-        case exerciseId    = "exercise_id"
-        case setNumber     = "set_number"
-        case weightKg      = "weight_kg"
-        case repsCompleted = "reps_completed"
-        case rpeFelt       = "rpe_felt"
-        case rirEstimated  = "rir_estimated"
-        case loggedAt      = "logged_at"
-        case primaryMuscle = "primary_muscle"
-        case localDate     = "local_date"
+        case sessionId       = "session_id"
+        case exerciseId      = "exercise_id"
+        case setNumber       = "set_number"
+        case weightKg        = "weight_kg"
+        case repsCompleted   = "reps_completed"
+        case rpeFelt         = "rpe_felt"
+        case rirEstimated    = "rir_estimated"
+        case loggedAt        = "logged_at"
+        case primaryMuscle   = "primary_muscle"
+        case localDate       = "local_date"
         case intent
+        case completionFlags = "completion_flags"
     }
 
     /// Slice 6 / #60 fix: intent is required by the schema (NOT NULL, no
@@ -2395,6 +2400,7 @@ nonisolated struct SetLogPayload: Encodable {
         self.primaryMuscle = log.primaryMuscle
         self.localDate = SetLog.formatLocalDate(log.loggedAt)
         self.intent = intent.rawValue
+        self.completionFlags = log.completionFlags.map(\.rawValue)
     }
 }
 

--- a/docs/migrations/down/20260622000000_add_completion_flags_to_set_logs.sql
+++ b/docs/migrations/down/20260622000000_add_completion_flags_to_set_logs.sql
@@ -1,0 +1,7 @@
+-- Reverse migration for supabase/migrations/20260622000000_add_completion_flags_to_set_logs.sql
+-- Documentation only; NOT auto-applied by `supabase db push`. Run manually
+-- (`psql -f`) if the forward migration must be rolled back.
+--
+-- #43 — drop the cross-session completion-flags column.
+
+ALTER TABLE public.set_logs DROP COLUMN IF EXISTS completion_flags;

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -164,6 +164,14 @@ const VALID_INTENTS = new Set([
   "amrap",
 ]);
 
+// SetCompletionFlag — must mirror the Swift `SetCompletionFlag` enum
+// (SetCompletionFlag.swift) and the `set_logs.completion_flags TEXT[]` column
+// (#43). Optional per set; when present, every element must be one of these.
+const VALID_COMPLETION_FLAGS = new Set([
+  "pain",
+  "form_breakdown",
+]);
+
 function jsonResponse(body: unknown, status: number): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -224,6 +232,30 @@ export function validateRequest(
             `session_payload.set_logs[${i}].intent must be one of ` +
             `warmup/top/backoff/technique/amrap (got ${JSON.stringify(intent)})`,
         };
+      }
+      // #43 — completion_flags is optional (absent → no flags raised, the
+      // column's DEFAULT '{}'). When present it must be an array of strings
+      // drawn from pain / form_breakdown — mirrors the intent invariant.
+      const completionFlags = (entry as Record<string, unknown>)
+        .completion_flags;
+      if (completionFlags !== undefined && completionFlags !== null) {
+        if (!Array.isArray(completionFlags)) {
+          return {
+            error:
+              `session_payload.set_logs[${i}].completion_flags must be an array ` +
+              `when present`,
+          };
+        }
+        for (let j = 0; j < completionFlags.length; j++) {
+          const flag = completionFlags[j];
+          if (typeof flag !== "string" || !VALID_COMPLETION_FLAGS.has(flag)) {
+            return {
+              error:
+                `session_payload.set_logs[${i}].completion_flags[${j}] must be ` +
+                `one of pain/form_breakdown (got ${JSON.stringify(flag)})`,
+            };
+          }
+        }
       }
     }
   }

--- a/supabase/functions/update-trainee-model/index_test.ts
+++ b/supabase/functions/update-trainee-model/index_test.ts
@@ -198,6 +198,91 @@ Deno.test("validateRequest_set_logs_not_array_returns_400", () => {
   assertEquals(result.error, "session_payload.set_logs must be an array");
 });
 
+// ─── D6 (#43): valid completion_flags — passes ───────────────────────────────
+Deno.test("validateRequest_set_log_valid_completion_flags_returns_ok", () => {
+  const setLogs = [
+    {
+      set_number: 1,
+      weight_kg: 80,
+      reps_completed: 8,
+      intent: "top",
+      completion_flags: ["pain", "form_breakdown"],
+    },
+  ];
+  const result = validateRequest(baseRequest({ set_logs: setLogs }));
+  assertEquals("error" in result, false);
+});
+
+// ─── D7 (#43): completion_flags absent — passes (optional, forward-compat) ───
+Deno.test("validateRequest_set_log_completion_flags_absent_returns_ok", () => {
+  const setLogs = [
+    { set_number: 1, weight_kg: 80, reps_completed: 8, intent: "top" },
+  ];
+  const result = validateRequest(baseRequest({ set_logs: setLogs }));
+  assertEquals("error" in result, false);
+});
+
+// ─── D8 (#43): empty completion_flags array — passes (no flags raised) ───────
+Deno.test("validateRequest_set_log_empty_completion_flags_returns_ok", () => {
+  const setLogs = [
+    {
+      set_number: 1,
+      weight_kg: 80,
+      reps_completed: 8,
+      intent: "top",
+      completion_flags: [],
+    },
+  ];
+  const result = validateRequest(baseRequest({ set_logs: setLogs }));
+  assertEquals("error" in result, false);
+});
+
+// ─── D9 (#43): completion_flags not an array — 400 ───────────────────────────
+Deno.test("validateRequest_set_log_completion_flags_not_array_returns_400", () => {
+  const setLogs = [
+    {
+      set_number: 1,
+      weight_kg: 80,
+      reps_completed: 8,
+      intent: "top",
+      completion_flags: "pain",
+    },
+  ];
+  const result = validateRequest(baseRequest({ set_logs: setLogs }));
+  if (!("error" in result)) {
+    throw new Error("expected error response");
+  }
+  assertEquals(
+    result.error.includes("set_logs[0].completion_flags") &&
+      result.error.includes("must be an array"),
+    true,
+    `unexpected error text: ${result.error}`,
+  );
+});
+
+// ─── D10 (#43): invalid completion_flags member — 400 ────────────────────────
+Deno.test("validateRequest_set_log_invalid_completion_flag_returns_400", () => {
+  const setLogs = [
+    {
+      set_number: 1,
+      weight_kg: 80,
+      reps_completed: 8,
+      intent: "top",
+      completion_flags: ["pain", "bogus"],
+    },
+  ];
+  const result = validateRequest(baseRequest({ set_logs: setLogs }));
+  if (!("error" in result)) {
+    throw new Error("expected error response");
+  }
+  assertEquals(
+    result.error.includes("set_logs[0].completion_flags[1]") &&
+      result.error.includes("pain/form_breakdown"),
+    true,
+    `unexpected error text: ${result.error}`,
+  );
+});
+
 // ─── Sanity: still rejects missing user_id (regression cover for the Slice
 //     9b validator behaviour) ───────────────────────────────────────────────
 Deno.test("validateRequest_invalid_user_id_returns_400", () => {

--- a/supabase/migrations/20260622000000_add_completion_flags_to_set_logs.sql
+++ b/supabase/migrations/20260622000000_add_completion_flags_to_set_logs.sql
@@ -1,0 +1,19 @@
+-- Reverse migration: docs/migrations/down/20260622000000_add_completion_flags_to_set_logs.sql
+-- (documentation only; not auto-applied by `supabase db push`)
+--
+-- #43 — persist set_logs.completion_flags for cross-session AI reasoning.
+--
+-- Slice 6 (#10) shipped SetCompletionFlag (pain / form_breakdown) client-side
+-- only — captured on the rep/RPE sheet, carried on the in-memory SetLog, and
+-- threaded into the within-session AI prompt — but never persisted. Without a
+-- column the flags evaporate at session end, so cross-session reasoning
+-- ("flagged pain on bench last week -> ease off this week") is impossible.
+--
+-- TEXT[] NOT NULL DEFAULT '{}': the empty array IS the real semantic
+-- ("no flags raised"), not a backfill placeholder, so existing rows are correct
+-- as-is and no Phase-2 default-drop is needed. Values are constrained to
+-- {pain, form_breakdown} at the Edge Function boundary (validateRequest),
+-- mirroring how set_logs.intent is validated, rather than via a DB CHECK.
+
+ALTER TABLE public.set_logs
+  ADD COLUMN IF NOT EXISTS completion_flags TEXT[] NOT NULL DEFAULT '{}';


### PR DESCRIPTION
**Part of #43 — Slice A only. Does NOT close the issue** (Slice B = cross-session read into `WorkoutContext` + the historical-pain coaching/prompt change, deferred to its own slice with a proper decision).

⚠️ **Carries a live DB migration** (auto-deploys on merge via `supabase db push`). Holding for explicit go-ahead.

## What this ships (decision-free plumbing)

Slice 6 (#10) captured `pain` / `form_breakdown` flags **client-side only** — they evaporated at session end, so cross-session reasoning was impossible. This makes them durable:

- **Migration `20260622000000_add_completion_flags_to_set_logs.sql`**: `ALTER TABLE public.set_logs ADD COLUMN IF NOT EXISTS completion_flags TEXT[] NOT NULL DEFAULT '{}'`, plus the matching reverse-migration doc under `docs/migrations/down/`. The empty array **is** the real semantic ("no flags raised"), so existing rows are correct as-is and no Phase-2 default-drop is needed.
- **`SetLogPayload` + `ManualSetLogPayload`** now serialise `completion_flags` from `SetLog.completionFlags.map(\.rawValue)`. The live writer carries real flags; manual logging has none (→ empty). `init(from:intent:)` signatures are **unchanged**, so every caller is untouched.
- **EF `validateRequest`**: `completion_flags` is optional; when present it must be a `string[]` drawn from `pain` / `form_breakdown` (mirrors the `intent` invariant). `VALID_COMPLETION_FLAGS` mirrors the Swift `SetCompletionFlag` enum.

**No `WorkoutContext` or system-prompt change** — the model does not yet read flag history. That's Slice B.

## Cross-cutting (grep-and-report per CLAUDE.md, NOT edited)

`NewSetLogPayload` (`ProgramDayDetailView`, the hand-added-set writer) is a third `set_logs` writer not named in the issue. **Left as-is** — it captures no flags, and the `NOT NULL DEFAULT '{}'` column fills the omitted field correctly. Recommend a follow-up only if hand-added sets ever capture flags.

## Test plan

- EF Deno suite (`update-trainee-model/index_test.ts`): **38 passed, 0 failed**, incl. 5 new `completion_flags` cases (valid, absent, empty, not-an-array→400, invalid-member→400).
- iOS app build (`iPhone 17 Pro`): **0 errors**.
- Backwards-safe: old rows = "no flags"; old queued WAQ payloads omit the field → DB default applies.

## Pre-merge note

Merge runs `supabase db push` (applies the migration) + `functions deploy` on the live project. The migration is additive and idempotent (`IF NOT EXISTS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)