### PR TITLE
feat(#538): brutalist bottom nav bar

### DIFF
--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -13,7 +13,6 @@
 //   skips through all steps. Subsequent launches skip directly to the Program tab.
 
 import SwiftUI
-import UIKit
 
 struct ContentView: View {
 
@@ -76,7 +75,12 @@ struct ContentView: View {
     }
 
     @ViewBuilder
-    private var mainContent: some View {
+    /// The four primary tabs. Each hides the native tab bar with a PER-TAB
+    /// `.toolbar(.hidden, for: .tabBar)`: container-level hiding does NOT suppress
+    /// the iOS 26 floating tab bar, so without this the system bar collides with the
+    /// bespoke `ApexTabBar` that `mainContent` adds. Tab order matches the `.tag`
+    /// values used by `switchToTab` and the "Now Training" pill everywhere.
+    private var tabContent: some View {
         TabView(selection: $selectedTab) {
 
             // ── Tab 0: Program ─────────────────────────────────────────────
@@ -90,6 +94,7 @@ struct ContentView: View {
                     loadingPlaceholder
                 }
             }
+            .toolbar(.hidden, for: .tabBar)
             .tabItem {
                 Label("Program", systemImage: "calendar")
             }
@@ -97,6 +102,7 @@ struct ContentView: View {
 
             // ── Tab 1: Workout ─────────────────────────────────────────────
             workoutTab
+            .toolbar(.hidden, for: .tabBar)
             .tabItem {
                 Label("Workout", systemImage: "figure.strengthtraining.traditional")
             }
@@ -108,6 +114,7 @@ struct ContentView: View {
                 userId: deps.resolvedUserId,
                 traineeModelService: deps.traineeModelService
             )
+            .toolbar(.hidden, for: .tabBar)
             .tabItem {
                 Label("Progress", systemImage: "chart.line.uptrend.xyaxis")
             }
@@ -117,16 +124,27 @@ struct ContentView: View {
             NavigationStack {
                 settingsRootView
             }
+            .toolbar(.hidden, for: .tabBar)
             .tabItem {
                 Label("Settings", systemImage: "gearshape.fill")
             }
             .tag(3)
         }
-        .overlay(alignment: .bottom) {
-            // #462: "Now Training" pill above the tab bar — replaces the colour-coded
-            // tab badge (iOS strips a Text badge's tint). Hidden on the Workout tab
-            // itself (tab 1), which already shows the full session / paused screen.
-            // .padding(.bottom) clears the tab bar; the exact value needs device QA.
+    }
+
+    private var mainContent: some View {
+        // #538: the native UITabBar is replaced by the bespoke Brutalist ApexTabBar.
+        // The native bar is hidden PER-TAB inside `tabContent` (container-level hiding
+        // does not suppress the iOS 26 floating bar); the custom bar is re-added here as
+        // a VStack sibling so each tab's content sits ABOVE it. (Adding it via a bottom
+        // `.safeAreaInset` instead lets tab content underlap the bar — verified in the
+        // prototype harness.) `.ignoresSafeArea(.bottom)` lets the bar's black fill the
+        // home-indicator zone while its own bottom padding keeps the labels above it.
+        VStack(spacing: 0) {
+            tabContent
+
+            // #462: "Now Training" pill above the tab bar. Hidden on the Workout
+            // tab itself (tab 1), which already shows the full session / paused screen.
             if selectedTab != 1 {
                 NowTrainingBar(
                     state: .resolve(
@@ -135,12 +153,13 @@ struct ContentView: View {
                     ),
                     onTap: { selectedTab = 1 }
                 )
-                .padding(.bottom, 56)
+                .padding(.bottom, 8)
             }
+            ApexTabBar(selection: $selectedTab)
         }
+        .ignoresSafeArea(.container, edges: .bottom)
         .environment(\.switchToTab, { selectedTab = $0 })
         .preferredColorScheme(.dark)
-        .onAppear { Self.applyBrutalistTabBarAppearance() }
         .fullScreenCover(isPresented: $showOnboarding) {
             OnboardingView { completedProfile in
                 // Persist the scanned profile so Settings / Program tabs see it immediately.
@@ -470,28 +489,6 @@ struct ContentView: View {
         } else {
             noWorkoutView
         }
-    }
-
-    /// Theme the tab bar to the Brutalist identity: opaque black bar, white
-    /// selected item, dim-white unselected. Applied process-globally (the app
-    /// has no other tab bar). NOTE: the selected/unselected treatment is a design
-    /// call pending real-device QA — there was no prior tab-bar appearance.
-    private static func applyBrutalistTabBarAppearance() {
-        let appearance = UITabBarAppearance()
-        appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = UIColor.black
-        let dim = UIColor.white.withAlphaComponent(0.32)
-        let selected = UIColor.white
-        for layout in [appearance.stackedLayoutAppearance,
-                       appearance.inlineLayoutAppearance,
-                       appearance.compactInlineLayoutAppearance] {
-            layout.normal.iconColor = dim
-            layout.normal.titleTextAttributes = [.foregroundColor: dim]
-            layout.selected.iconColor = selected
-            layout.selected.titleTextAttributes = [.foregroundColor: selected]
-        }
-        UITabBar.appearance().standardAppearance = appearance
-        UITabBar.appearance().scrollEdgeAppearance = appearance
     }
 
     private var noWorkoutView: some View {

--- a/ProjectApex/DesignSystem/ApexTabBar.swift
+++ b/ProjectApex/DesignSystem/ApexTabBar.swift
@@ -1,0 +1,68 @@
+// DesignSystem/ApexTabBar.swift
+// ProjectApex — #538 Brutalist bottom navigation.
+//
+// Bespoke Brutalist bottom tab bar replacing the native UITabBar chrome: pure
+// black, a hard top hairline, condensed slab labels, and a top-edge WHITE block
+// over the active tab. Monochrome by design — volt-lime stays strictly for
+// actions (the action dock / primary buttons), never navigation.
+//
+// Visual only: it binds to ContentView's `selectedTab` index; tab order matches
+// the TabView's tags (0 Program · 1 Workout · 2 Progress · 3 Settings).
+
+import SwiftUI
+
+struct ApexTabBar: View {
+
+    @Binding var selection: Int
+
+    /// (title, SF Symbol) per tab — order MUST match ContentView's `.tag` values.
+    private let tabs: [(title: String, icon: String)] = [
+        ("PROGRAM",  "calendar"),
+        ("WORKOUT",  "figure.strengthtraining.traditional"),
+        ("PROGRESS", "chart.line.uptrend.xyaxis"),
+        ("SETTINGS", "gearshape.fill"),
+    ]
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            ForEach(Array(tabs.enumerated()), id: \.offset) { index, tab in
+                Button {
+                    selection = index
+                } label: {
+                    tabItem(index: index, title: tab.title, icon: tab.icon)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        // Bottom padding lifts the labels above the home-indicator zone, which the
+        // host's `.ignoresSafeArea(.container, edges: .bottom)` lets this bar's black
+        // fill (verified in the prototype harness, OS 26.x).
+        .padding(.bottom, 26)
+        .background(Apex.bg)
+        .overlay(alignment: .top) {
+            Rectangle().fill(Apex.hairline).frame(height: 1)
+        }
+    }
+
+    private func tabItem(index: Int, title: String, icon: String) -> some View {
+        let isActive = index == selection
+        let tint = isActive ? Apex.text : Apex.textFaint
+        return VStack(spacing: 6) {
+            // Top-edge indicator block — white on the active tab, clear otherwise.
+            Rectangle()
+                .fill(isActive ? Apex.text : Color.clear)
+                .frame(height: 3)
+            Image(systemName: icon)
+                .font(.system(size: 19, weight: .semibold))
+                .foregroundStyle(tint)
+                .frame(height: 22)
+            Text(title)
+                .font(.system(size: 9, weight: .bold))
+                .fontWidth(.condensed)
+                .tracking(0.8)
+                .foregroundStyle(tint)
+        }
+        .frame(maxWidth: .infinity)
+        .contentShape(Rectangle())
+    }
+}


### PR DESCRIPTION
## What

Replaces the native `UITabBar` (styled via `UITabBarAppearance` in #542) with a bespoke Brutalist **`ApexTabBar`** — pure black, hard top hairline, condensed slab labels, and a **monochrome white-block indicator** over the active tab. Lime stays strictly for actions, never navigation (the user reversed an initial lime-block choice after seeing the triple-lime collision live).

This is **slice 1** of the nav-bar + action-dock + pre-start redesign (umbrella #538). Visual-only — tab switching, per-tab state, and all session/paused behaviour are unchanged.

## Why this structure (verified in the `UIPrototypes` harness, iOS 26.x)

Two non-obvious iOS 26 findings drove the implementation:

1. **`.toolbar(.hidden, for: .tabBar)` on the TabView _container_ does NOT hide the iOS 26 floating "Liquid Glass" tab bar.** It only *looks* hidden when an opaque custom bar masks it. Applied **per-tab** (on each tab's content, including the `NavigationStack` tabs) it genuinely removes the floating bar. So `tabContent` applies it to all four tabs.
2. **The custom bar is a VStack _sibling_ below the TabView, not a `.safeAreaInset(.bottom)`.** The inset approach lets each tab's content *underlap* the bar. `.ignoresSafeArea(.container, edges: .bottom)` lets the bar's black fill the home-indicator zone; the bar's own bottom padding keeps labels above it.

Both findings were confirmed with real `TabView` renders in the prototype harness before porting.

## Changes
- **New** `ProjectApex/DesignSystem/ApexTabBar.swift` — the bespoke bar component.
- `ContentView.swift` — split `mainContent` into `tabContent` (the `TabView`, per-tab bar hidden) + `mainContent` (the VStack carrying the bar). The "Now Training" pill (#462) now stacks just above the bar in the same VStack, replacing the old bottom overlay + magic 56pt padding. Removed the now-orphaned `import UIKit` and `applyBrutalistTabBarAppearance()`.

## Verification
- `xcodebuild` integration build: **BUILD SUCCEEDED** (iPhone 17 Pro, OS 26.5).
- Prototype harness renders confirm: no native floating bar, content correctly inset above the bar, monochrome white-block active indicator, NavigationStack tabs behave the same.

## Review note
Holding for **on-device review** before the action-dock rollout (next slice). Part of #538 — does **not** close the umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)