### PR TITLE
fix(coach): stop mid-workout "Coach is offline" retries (QUIC stall + neutered auto-retry)

### DIFF
--- a/ProjectApex/AICoach/AIInferenceService.swift
+++ b/ProjectApex/AICoach/AIInferenceService.swift
@@ -6,7 +6,7 @@
 //
 // Key design decisions:
 //   • Swift actor for safe concurrent LLM calls (no data races on callCount, etc.)
-//   • 8-second per-call timeout enforced via Task.detached + withTaskCancellationHandler
+//   • 30-second per-call timeout enforced via Task.detached + withTaskCancellationHandler
 //   • Decode / validation failures are PERMANENT (ADR-0007 §1): they return
 //     `.fallback` immediately and surface the retry sheet — no same-prompt retry.
 //     Only transient HTTP errors are retried, inside `TransientRetryPolicy`.
@@ -865,7 +865,7 @@ actor AIInferenceService {
     /// Produces a `SetPrescription` for the given `WorkoutContext`.
     /// Decode / validation failures are permanent (ADR-0007 §1): this returns
     /// `.fallback` immediately without retrying. Only transient HTTP errors are
-    /// retried, inside the 8-second timeout via `TransientRetryPolicy`.
+    /// retried, inside the 30-second timeout via `TransientRetryPolicy`.
     func prescribe(context: WorkoutContext) async -> PrescriptionResult {
 
         // 1. Encode context to JSON (user payload for the LLM)
@@ -900,13 +900,13 @@ actor AIInferenceService {
         // re-ran. Sometimes worked for malformed JSON; ADR-0007 §1 nevertheless
         // classes malformed responses as permanent because the same prompt is
         // unlikely to yield a different shape, and a fail-fast surface gives
-        // the user agency rather than burning the 8-second budget on a
+        // the user agency rather than burning the 30-second budget on a
         // probably-doomed retry. See spinoff issue for the broader audit.
-        // 2. Call LLM with 8-second timeout (transient HTTP retries happen
+        // 2. Call LLM with 30-second timeout (transient HTTP retries happen
         //    inside the timeout per ADR-0007 §2).
         let rawResponse: String
         do {
-            rawResponse = try await withTimeout(seconds: 8.0) {
+            rawResponse = try await withTimeout(seconds: 30.0) {
                 try await TransientRetryPolicy.execute {
                     try await self.provider.complete(
                         systemPrompt: systemPrompt,
@@ -917,7 +917,7 @@ actor AIInferenceService {
         } catch is TimeoutError {
             FallbackLogRecord(
                 callSite: FallbackLogRecord.prescribeCallSite,
-                reason: "timeout (8s)",
+                reason: "timeout (30s)",
                 sessionId: context.sessionMetadata.sessionId
             ).emit()
             return .fallback(reason: .timeout)
@@ -1039,7 +1039,7 @@ actor AIInferenceService {
         }
 
         do {
-            let rawResponse = try await withTimeout(seconds: 8.0) {
+            let rawResponse = try await withTimeout(seconds: 30.0) {
                 try await TransientRetryPolicy.execute {
                     try await self.provider.complete(
                         systemPrompt: systemPrompt,
@@ -1106,7 +1106,7 @@ actor AIInferenceService {
         } catch is TimeoutError {
             FallbackLogRecord(
                 callSite: FallbackLogRecord.prescribeAdaptationCallSite,
-                reason: "timeout (8s)"
+                reason: "timeout (30s)"
             ).emit()
             return .fallback(reason: .timeout)
         } catch {

--- a/ProjectApex/App/AppDependencies.swift
+++ b/ProjectApex/App/AppDependencies.swift
@@ -211,10 +211,13 @@ final class AppDependencies {
         // 6b. GymStreakService — training consistency for AI intensity modulation (P4-E1)
         self.gymStreakService = GymStreakService(supabase: supabaseClient)
 
-        // 7. AI Inference — needs Anthropic key (sonnet model, 8-second timeout)
+        // 7. AI Inference — needs Anthropic key (sonnet model). Gets a dedicated
+        // QUIC-safe URLSession (see makeInferenceURLSession): per-attempt 8s budget
+        // with auto-retry under a 30s overall ceiling, so a stalled mid-workout
+        // coach call recovers on its own instead of forcing the user to tap retry.
         self.anthropicKey = anthropicKey
         let inferenceService = AIInferenceService(
-            provider: AnthropicProvider(apiKey: anthropicKey)
+            provider: AnthropicProvider(apiKey: anthropicKey, urlSession: Self.makeInferenceURLSession())
         )
         self.aiInferenceService = inferenceService
 
@@ -332,13 +335,31 @@ final class AppDependencies {
         self.activeSessionCoordinator = ActiveSessionCoordinator(manager: manager)
     }
 
+    // MARK: - Inference transport
+
+    /// Dedicated URLSession for the set-inference coach (mid-workout `prescribe`
+    /// and `prescribeAdaptation` calls). Mirrors the GoTrue auth fix above:
+    /// `.ephemeral` carries no cached Alt-Svc, so it negotiates HTTP/2 over TCP
+    /// rather than inheriting the stale "try QUIC first" preference that stalls
+    /// coach calls on some networks across launches; `waitsForConnectivity` rides
+    /// out a brief connectivity drop. The 8s per-request timeout is the per-attempt
+    /// budget — a stuck connection fails fast so `AIInferenceService`'s retry loop
+    /// opens a fresh one (bounded by the 30s overall ceiling in `prescribe`).
+    private static func makeInferenceURLSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.waitsForConnectivity = true
+        config.timeoutIntervalForRequest = 8
+        config.timeoutIntervalForResource = 660
+        return URLSession(configuration: config)
+    }
+
     // MARK: - Re-initialisation
 
     /// Replaces AI services with fresh instances using the current Anthropic key.
     /// Call this if the API key changes (e.g. after re-login via Developer Settings).
     func reinitialiseAIInference() {
         aiInferenceService = AIInferenceService(
-            provider: AnthropicProvider(apiKey: anthropicKey)
+            provider: AnthropicProvider(apiKey: anthropicKey, urlSession: Self.makeInferenceURLSession())
         )
         programGenerationService = ProgramGenerationService(
             provider: AnthropicProvider.forProgramGeneration(apiKey: anthropicKey)


### PR DESCRIPTION
## Problem

Mid-workout, the coach frequently showed **"Coach is offline"** and the user had to tap **Try again** several times before a set prescription came through. Two root causes, both confirmed in code:

1. **Stuck connection (QUIC stall).** The set-inference coach used `URLSessionConfiguration.default`, which inherits the device's persisted Alt-Svc "try HTTP/3/QUIC first" preference. On some Wi-Fi/cell networks the QUIC handshake stalls and the request just hangs — the **same bug that hit auth** (#392/#394). Auth was fixed with a dedicated ephemeral HTTP/2 session; the coach never got that treatment.
2. **Auto-retry that couldn't fire.** The retry loop (`TransientRetryPolicy`, 4 attempts, 1s→2s→4s backoff) ran *inside* an **8s overall ceiling** (`AIInferenceService.withTimeout(8.0)`). The backoff waits alone exceed 8s, so a stalled first attempt consumed the whole budget and no automatic retry ever ran. The burden fell on the user to tap — and each manual tap opened a *fresh* connection, which is why "retry a few times" eventually worked.

## Fix

- **Dedicated QUIC-safe `URLSession` for the set-inference coach** — `.ephemeral` (drops the stale Alt-Svc preference, negotiates HTTP/2 over TCP) + `waitsForConnectivity` (rides out brief drops) + an **8s per-attempt** timeout so a stuck connection fails fast. Applied at **both** construction sites (`init` and `reinitialiseAIInference`, so a dev re-login can't silently revert it). Mirrors the existing GoTrue auth fix.
- **Overall ceiling 8s → 30s** on **both** mid-workout coach paths — `prescribe` (next set / exercise transition) and `prescribeAdaptation` (weight corrections). The retry loop now gets ~3–4 fresh-connection attempts on its own before surfacing the offline sheet.

**Net effect:** a stuck call fails fast per attempt, the app silently reopens the connection and retries, and it almost always lands **without the user tapping**. Worst case is a ~30s silent wait, then the offline sheet (which already falls back to program defaults, so the workout is never blocked). User chose the "max reliability, ~30s" trade-off.

## Scope / cross-cutting note

Per the grep-and-report rule, these share the same `URLSessionConfiguration.default` QUIC vulnerability but were **deliberately left untouched** (out of scope for this fix):

- `SessionPlanService` (Start Workout) — `AppDependencies.swift:269/350`
- `ExerciseSwapService` (mid-session swap) — `AppDependencies.swift:277`
- `AnthropicProvider.forProgramGeneration` (program / macro plan generation)
- `OpenAIProvider` (Whisper/speech — different host)

Recommendation: give Start Workout (and likely the swap path) the same dedicated QUIC-safe session in a follow-up, since those are also user-facing and would stall the same way. Happy to do that next if you want it.

## Verification

- `xcodebuild ... build` → **BUILD SUCCEEDED** (iPhone 17 Pro sim).
- No behavioural change to the shared `TransientRetryPolicy`, the offline-sheet UX, or the no-silent-fallback stance — only the coach's transport config and its overall timeout budget changed.
- The unrelated working-tree `project.pbxproj` change present at branch time was **not** included in this PR.

## Residual caveat

`.ephemeral` clears the bad QUIC preference *per app launch*; a long-lived session can slowly re-learn Alt-Svc within a single run. This is strictly better than today and matches what fixed auth. If it proves insufficient in practice, the next lever is forcing HTTP/2 per request. Worth watching `FallbackLogRecord` (`reason: "timeout (30s)"`) to confirm the drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
