### PR TITLE
fix(#559): goal-branch phase-advance — non-strength goals skip the strength peak

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,39 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-29 — Stop pushing muscle-builders into a powerlifter's "peak"
+
+**The problem (in plain words):**
+The app runs a little engine that decides, for each lift you do, what "phase" of
+training you're in — building volume, pushing intensity, peaking (going very heavy
+for a few reps), or deloading (an easy week). The catch: it cycled *everyone*
+through that same loop, including the "peaking" phase, no matter what their actual
+goal was. Peaking is a powerlifting idea — very heavy, very few reps. If your goal
+is just to build muscle, getting shoved into a heavy low-rep peak is the wrong
+training. So a muscle-building user could quietly end up doing a strength-peaking
+block they never wanted.
+
+**What I changed:**
+The engine now looks at your goal first. If your goal actually says strength (or
+"max weight", "powerlifting", "1RM"), nothing changes — you still get the full
+loop with peaking. For everyone else — muscle size, endurance, general fitness, or
+if no goal is set — the loop now skips peaking entirely and goes building → harder
+→ easy week → repeat. I deliberately made "skip the peak" the safe default: if the
+app is ever unsure, it will NOT peak you, because wrongly peaking someone is the
+bug we're fixing.
+
+**How it was checked:**
+Twenty automated tests on the engine pass (the seven new ones cover both the
+strength loop staying the same and the new "skip peaking" loop), plus the 38 tests
+on the code that feeds the engine. This is the first piece of a larger
+program-generation overhaul (decision write-up ADR-0030, now accepted).
+
+**Heads-up for deploy:** this is a server-side coach change — it goes live only
+after `supabase functions deploy update-trainee-model` is run. Until then nothing
+changes for anyone. (#559, part of #558; ADR-0030 accepted via #557.)
+
+---
+
 ## 2026-06-29 — Stop the coach from going "offline" mid-workout
 
 **The problem (in plain words):**

--- a/docs/adr/0011-per-pattern-phase-advance-plateau-aware-cyclic.md
+++ b/docs/adr/0011-per-pattern-phase-advance-plateau-aware-cyclic.md
@@ -2,6 +2,8 @@
 
 **Status**: accepted, 2026-05-07
 
+> **Amended by [ADR-0030](0030-committed-deterministic-program-generation.md) (#559, 2026-06-29):** the phase cycle is now **goal-aware**. A `strength` goal keeps the arc pinned here (`accumulation → intensification → peaking → deload`); every other goal (hypertrophy, endurance, general, absent) uses a **volume arc** that skips `peaking` (`accumulation → intensification → deload`) so non-strength users are never cycled into a strength taper. The deload-end cyclic rule §(c) and the force-deload safety valve §(b) are unchanged — only the natural progressing-advance §(a) is goal-branched. The goal arc is a computed input classified from `model_json.goal.statement`, not a persisted field.
+
 ## Context
 
 ADR-0005 specifies that phase storage moves from the legacy `PatternPhaseService` to `PatternProfile.currentPhase` + `sessionsInPhase`, and that "advance logic gains plateau-awareness." It does not pin (a) the composition rule for plateau-aware blocking, (b) what happens when an advance is blocked indefinitely, or (c) whether the deload phase remains terminal as in legacy `PatternPhaseService.swift` line 126 ("Already at deload — no further transition") or rolls forward into a new mesocycle.

--- a/supabase/functions/_shared/phase-advance.ts
+++ b/supabase/functions/_shared/phase-advance.ts
@@ -33,6 +33,17 @@ export type MesocyclePhase =
   | "peaking"
   | "deload";
 
+/**
+ * Goal arc per ADR-0030 (goal-branch amendment to ADR-0011). The per-pattern
+ * phase cycle is goal-aware: a `strength` arc keeps the peaking taper; a
+ * `volume` arc skips `peaking` entirely so hypertrophy/endurance/general users
+ * are never cycled into a powerlifting peak (low reps, RIR 1–2). This is a
+ * computed *input* — it is NOT a persisted field on the wire (the goal lives in
+ * `model_json.goal.statement`; the orchestrator classifies it once and injects
+ * the resolved arc, keeping this module pure).
+ */
+export type GoalArc = "strength" | "volume";
+
 export interface PerPatternState {
   currentPhase: MesocyclePhase;
   sessionsInPhase: number;
@@ -40,6 +51,8 @@ export interface PerPatternState {
   trend: ProgressionTrend;
   consecutiveForceDeloadsOnPattern: number;
   lastPhaseTransitionAtSessionCount: number;
+  /** Resolved goal arc (ADR-0030). Computed input, not persisted. */
+  goalArc: GoalArc;
 }
 
 export interface PhaseAdvanceOutcome {
@@ -87,20 +100,60 @@ export function sessionsRequiredFor(
 }
 
 /**
- * Phase order per ADR-0011 §(c). Cyclic: deload (index 3) → accumulation
- * (index 0). Indexed-and-modulo on advance.
+ * Goal-aware phase cycle per ADR-0011 §(c) as amended by ADR-0030.
+ *   - strength arc (unchanged): accumulation → intensification → peaking → deload → accumulation
+ *   - volume arc:               accumulation → intensification → deload → accumulation  (skips peaking)
+ *
+ * `intensification` is kept for volume — progressive overload by load is fine
+ * for hypertrophy; only the strength *taper* (peaking) is wrong. The cycle is
+ * indexed-and-modulo on advance, so deload wraps back to accumulation in both
+ * arcs.
  */
-const phaseOrder: readonly MesocyclePhase[] = [
+const STRENGTH_ARC: readonly MesocyclePhase[] = [
   "accumulation",
   "intensification",
   "peaking",
   "deload",
 ];
 
-const nextPhaseInCycle = (current: MesocyclePhase): MesocyclePhase => {
-  const idx = phaseOrder.indexOf(current);
-  return phaseOrder[(idx + 1) % phaseOrder.length];
+const VOLUME_ARC: readonly MesocyclePhase[] = [
+  "accumulation",
+  "intensification",
+  "deload",
+];
+
+const phaseOrderFor = (arc: GoalArc): readonly MesocyclePhase[] =>
+  arc === "strength" ? STRENGTH_ARC : VOLUME_ARC;
+
+const nextPhaseInCycle = (
+  current: MesocyclePhase,
+  arc: GoalArc,
+): MesocyclePhase => {
+  const order = phaseOrderFor(arc);
+  const idx = order.indexOf(current);
+  // Off-arc current phase (a volume-arc pattern sitting in `peaking` from
+  // legacy data or a strength→hypertrophy goal switch): treat `peaking` as the
+  // pre-deload slot and advance explicitly to `deload`. Do NOT lean on the
+  // modulo accident (indexOf === -1 → order[0] → accumulation), which would
+  // skip the deload the pattern is owed.
+  if (idx === -1) return "deload";
+  return order[(idx + 1) % order.length];
 };
+
+/**
+ * Classify a freeform goal statement into a goal arc (ADR-0030). Returns
+ * `"strength"` iff the statement carries an explicit strength signal;
+ * everything else — including absent / empty / whitespace-only — resolves to
+ * `"volume"`. The asymmetry is deliberate and error-safe: the bug being fixed
+ * is non-strength users getting peaked, so default-no-peak fixes the majority
+ * and never wrongly peaks a user.
+ */
+export function goalArc(statement: string | null | undefined): GoalArc {
+  if (!statement || !statement.trim()) return "volume";
+  const s = statement.toLowerCase();
+  const strengthSignals = ["strength", "max weight", "powerlift", "1rm"];
+  return strengthSignals.some((sig) => s.includes(sig)) ? "strength" : "volume";
+}
 
 /**
  * Per-pattern phase advance per ADR-0011.
@@ -186,7 +239,11 @@ export function advancePhase(
     state.trend === "progressing"
   ) {
     return {
-      newPhase: nextPhaseInCycle(state.currentPhase),
+      // ADR-0030: goal-aware next phase. Strength keeps the peaking taper;
+      // volume skips it. The deload-end cyclic branch (above) and the
+      // force-deload safety valve stay goal-agnostic — only the natural
+      // progressing-advance is goal-branched.
+      newPhase: nextPhaseInCycle(state.currentPhase, state.goalArc),
       newSessionsInPhase: 0,
       newConsecutiveForceDeloads: 0,
       newLastPhaseTransitionAtSessionCount: currentSessionCount,

--- a/supabase/functions/_shared/phase-advance_test.ts
+++ b/supabase/functions/_shared/phase-advance_test.ts
@@ -12,12 +12,17 @@
 import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
   advancePhase,
+  goalArc,
   type PerPatternState,
   sessionsRequiredFor,
 } from "./phase-advance.ts";
 
 // daysPerWeek=4 → sessionsRequiredFor('accumulation', 4) = max(3, 4 × max(1, 4/2)) = 8.
 // Tests use 8 as the canonical accumulation threshold; force-deload at 2× = 16.
+//
+// goalArc defaults to "strength" so the legacy ADR-0011 arc
+// (accumulation→intensification→peaking→deload) is the baseline these tests
+// assert. Volume-arc behaviour (ADR-0030) is pinned by explicit overrides below.
 const baseState = (overrides: Partial<PerPatternState> = {}): PerPatternState => ({
   currentPhase: "accumulation",
   sessionsInPhase: 0,
@@ -25,6 +30,7 @@ const baseState = (overrides: Partial<PerPatternState> = {}): PerPatternState =>
   trend: "progressing",
   consecutiveForceDeloadsOnPattern: 0,
   lastPhaseTransitionAtSessionCount: 0,
+  goalArc: "strength",
   ...overrides,
 });
 
@@ -123,6 +129,7 @@ Deno.test("ADR-0011 §(c): cyclic deload→accumulation at threshold fires deloa
     trend: "progressing",
     consecutiveForceDeloadsOnPattern: 0,
     lastPhaseTransitionAtSessionCount: 5,
+    goalArc: "strength", // arc-agnostic fixture (deload→accumulation cycle)
   };
   const outcome = advancePhase(state, /* sessionCount */ 8);
 
@@ -148,6 +155,7 @@ Deno.test("ADR-0011 §(c): cyclic deload→accumulation regardless of trend — 
     trend: "plateaued",
     consecutiveForceDeloadsOnPattern: 1,
     lastPhaseTransitionAtSessionCount: 5,
+    goalArc: "strength", // arc-agnostic fixture (deload→accumulation cycle)
   };
   const outcome = advancePhase(state, /* sessionCount */ 8);
 
@@ -205,6 +213,7 @@ Deno.test("ADR-0011 §Consequences migration: legacy v1 terminal-deload pattern 
     trend: "plateaued", // any trend; cyclic rule fires regardless
     consecutiveForceDeloadsOnPattern: 0, // additive default on decode
     lastPhaseTransitionAtSessionCount: 0, // legacy v1 didn't track this
+    goalArc: "strength", // arc-agnostic fixture (deload transitions)
   };
 
   // Step 1 — under threshold, ratchets normally (no-op).
@@ -248,6 +257,7 @@ Deno.test("ADR-0011 §(d): deload-end-cycle does NOT reset consecutiveForceDeloa
     trend: "progressing",
     consecutiveForceDeloadsOnPattern: 3,
     lastPhaseTransitionAtSessionCount: 10,
+    goalArc: "strength", // arc-agnostic fixture (deload-end cycle)
   };
   const outcome = advancePhase(state, /* sessionCount */ 13);
 
@@ -281,6 +291,7 @@ Deno.test("ADR-0011 §(b)+(c): force-deload-trigger condition met while in deloa
     trend: "plateaued",
     consecutiveForceDeloadsOnPattern: 2, // pre-set non-zero to verify preservation
     lastPhaseTransitionAtSessionCount: 8,
+    goalArc: "strength", // arc-agnostic fixture (§(b)+(c) composition)
   };
   const outcome = advancePhase(state, /* sessionCount */ 14);
 
@@ -350,4 +361,131 @@ Deno.test("ADR-0011: plateau blocks natural advance — sessionsInPhase keeps ac
   assertEquals(outcome.newConsecutiveForceDeloads, 0);
   assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 0); // unchanged
   assertEquals(outcome.firesDeloadEndTransitionMode, false);
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// ADR-0030: goal-aware phase cycle. Strength keeps peaking; everything else
+// uses the volume arc (skip peaking). The classifier is asymmetric-error-safe:
+// only an explicit strength signal yields "strength"; absent/empty → "volume".
+// ─────────────────────────────────────────────────────────────────────────
+
+Deno.test("ADR-0030 goalArc: explicit strength signals → strength (case-insensitive); everything else → volume", () => {
+  // Strength signals.
+  assertEquals(goalArc("Strength (max weight)"), "strength");
+  assertEquals(goalArc("build STRENGTH"), "strength"); // case-insensitive
+  assertEquals(goalArc("powerlifting meet prep"), "strength");
+  assertEquals(goalArc("improve my 1RM"), "strength");
+  assertEquals(goalArc("hit a new max weight squat"), "strength");
+
+  // Non-strength → volume.
+  assertEquals(goalArc("Hypertrophy (muscle size)"), "volume");
+  assertEquals(goalArc("Muscular endurance"), "volume");
+  assertEquals(goalArc("General fitness"), "volume");
+
+  // Absent / empty / whitespace → volume (asymmetric-error-safe default).
+  assertEquals(goalArc(""), "volume");
+  assertEquals(goalArc("   "), "volume");
+  assertEquals(goalArc(null), "volume");
+  assertEquals(goalArc(undefined), "volume");
+});
+
+Deno.test("ADR-0030 strength arc UNCHANGED: intensification + progressing + threshold → peaking, natural-advance, counter reset", () => {
+  const state = baseState({
+    currentPhase: "intensification",
+    sessionsInPhase: 8,
+    trend: "progressing",
+    consecutiveForceDeloadsOnPattern: 2,
+    goalArc: "strength",
+  });
+  const outcome = advancePhase(state, /* sessionCount */ 20);
+
+  assertEquals(outcome.fired, "natural-advance");
+  assertEquals(outcome.newPhase, "peaking");
+  assertEquals(outcome.newSessionsInPhase, 0);
+  assertEquals(outcome.newConsecutiveForceDeloads, 0); // natural-advance resets
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 20);
+  assertEquals(outcome.firesDeloadEndTransitionMode, false);
+});
+
+Deno.test("ADR-0030 volume arc SKIPS peaking: intensification + progressing + threshold → deload (not peaking), natural-advance", () => {
+  const state = baseState({
+    currentPhase: "intensification",
+    sessionsInPhase: 8,
+    trend: "progressing",
+    goalArc: "volume",
+  });
+  const outcome = advancePhase(state, /* sessionCount */ 20);
+
+  assertEquals(outcome.fired, "natural-advance");
+  assertEquals(outcome.newPhase, "deload"); // skipped peaking
+  assertEquals(outcome.newSessionsInPhase, 0);
+  assertEquals(outcome.newConsecutiveForceDeloads, 0);
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 20);
+  // Volume natural-advance into deload is NOT a deload-end cycle, so it does
+  // NOT fire the transition-mode trigger (that fires only on deload→accumulation).
+  assertEquals(outcome.firesDeloadEndTransitionMode, false);
+});
+
+Deno.test("ADR-0030 volume off-arc peaking: a peaking pattern under volume arc → deload (NOT accumulation via modulo accident)", () => {
+  // Legacy data or a strength→hypertrophy goal switch can leave a pattern
+  // sitting in `peaking` under a volume arc. On natural advance it must go to
+  // deload (the slot it is owed), not jump to accumulation.
+  const state = baseState({
+    currentPhase: "peaking",
+    sessionsInPhase: 6, // sessionsRequiredFor("peaking", 4) = 6
+    sessionsRequiredForPhase: 6,
+    trend: "progressing",
+    goalArc: "volume",
+  });
+  const outcome = advancePhase(state, /* sessionCount */ 22);
+
+  assertEquals(outcome.fired, "natural-advance");
+  assertEquals(outcome.newPhase, "deload"); // NOT accumulation
+  assertEquals(outcome.newSessionsInPhase, 0);
+  assertEquals(outcome.newLastPhaseTransitionAtSessionCount, 22);
+});
+
+Deno.test("ADR-0030 accumulation→intensification identical for BOTH arcs", () => {
+  const strength = advancePhase(
+    baseState({ currentPhase: "accumulation", sessionsInPhase: 8, goalArc: "strength" }),
+    12,
+  );
+  const volume = advancePhase(
+    baseState({ currentPhase: "accumulation", sessionsInPhase: 8, goalArc: "volume" }),
+    12,
+  );
+  assertEquals(strength.fired, "natural-advance");
+  assertEquals(strength.newPhase, "intensification");
+  assertEquals(volume.fired, "natural-advance");
+  assertEquals(volume.newPhase, "intensification");
+});
+
+Deno.test("ADR-0030 force-deload UNCHANGED for volume arc: plateaued at 2× threshold → deload, force-deload, counter += 1", () => {
+  const state = baseState({
+    sessionsInPhase: 16, // 2× threshold
+    trend: "plateaued",
+    consecutiveForceDeloadsOnPattern: 0,
+    goalArc: "volume",
+  });
+  const outcome = advancePhase(state, /* sessionCount */ 20);
+
+  assertEquals(outcome.fired, "force-deload");
+  assertEquals(outcome.newPhase, "deload");
+  assertEquals(outcome.newConsecutiveForceDeloads, 1);
+  assertEquals(outcome.firesDeloadEndTransitionMode, false);
+});
+
+Deno.test("ADR-0030 deload-end cyclic UNCHANGED for volume arc: deload at threshold → accumulation, deload-end-cycle, transition-mode fires", () => {
+  const state = baseState({
+    currentPhase: "deload",
+    sessionsInPhase: 3,
+    sessionsRequiredForPhase: 3,
+    trend: "progressing",
+    goalArc: "volume",
+  });
+  const outcome = advancePhase(state, /* sessionCount */ 25);
+
+  assertEquals(outcome.fired, "deload-end-cycle");
+  assertEquals(outcome.newPhase, "accumulation");
+  assertEquals(outcome.firesDeloadEndTransitionMode, true);
 });

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -65,9 +65,11 @@ import {
 } from "../_shared/observability.ts";
 import {
   advancePhase,
-  sessionsRequiredFor,
+  goalArc,
+  type GoalArc,
   type MesocyclePhase,
   type PerPatternState,
+  sessionsRequiredFor,
 } from "../_shared/phase-advance.ts";
 import { computeTransitionModeUntil } from "../_shared/transition-mode-expiry.ts";
 import {
@@ -880,6 +882,12 @@ export function applyPerPatternRules(
   newSessionCount: number,
   exercises: Record<string, Record<string, unknown>>,
   setLogs: Array<Record<string, unknown>>,
+  // ADR-0030: resolved goal arc, classified once by the orchestrator from
+  // model_json.goal.statement. Drives the goal-aware natural-advance branch in
+  // advancePhase. The rule module stays pure — no goal-object parsing here.
+  // Defaults to "volume" (fail-safe): a caller that forgets to inject the arc
+  // never wrongly peaks a user — the asymmetric-error bias locked in #559.
+  resolvedGoalArc: GoalArc = "volume",
 ): {
   patterns: Record<string, Record<string, unknown>>;
   rulesFired: Set<string>;
@@ -987,6 +995,9 @@ export function applyPerPatternRules(
         (profile.consecutiveForceDeloadsOnPattern as number) ?? 0,
       lastPhaseTransitionAtSessionCount:
         (profile.lastPhaseTransitionAtSessionCount as number) ?? 0,
+      // ADR-0030: goal arc injected by the orchestrator (same arc for every
+      // pattern in this apply — it is a user-level goal classification).
+      goalArc: resolvedGoalArc,
     };
 
     const advanced = advancePhase(advanceState, newSessionCount);
@@ -1899,6 +1910,17 @@ export async function applySession(
         );
       }
 
+      // ADR-0030: classify the goal arc once, here, from the freeform goal
+      // statement, and inject the resolved arc into the per-pattern phase
+      // advance. Hoisted above applyPerPatternRules (the per-muscle path below
+      // reuses goalIn). Absent/empty goal → volume arc (never peaks).
+      const goalIn = modelJson.goal as Record<string, unknown> | undefined;
+      const resolvedGoalArc = goalArc(
+        typeof goalIn?.statement === "string"
+          ? (goalIn.statement as string)
+          : null,
+      );
+
       const ruled = applyPerPatternRules(
         sessionCountBackfilled.patterns,
         trainedSets.patterns,
@@ -1906,6 +1928,7 @@ export async function applySession(
         newSessionCount,
         exerciseRuled.exercises,
         setLogsArr,
+        resolvedGoalArc,
       );
       newModelJson = { ...newModelJson, patterns: ruled.patterns };
       rulesFired.push(...ruled.rulesFired);
@@ -1918,7 +1941,7 @@ export async function applySession(
       // primary_muscle strings at the boundary.
       const musclesIn =
         (modelJson.muscles as Record<string, Record<string, unknown>> | undefined) ?? {};
-      const goalIn = modelJson.goal as Record<string, unknown> | undefined;
+      // goalIn is declared above (hoisted for the ADR-0030 goal-arc classification).
       const muscleRuled = applyPerMuscleRules(
         musclesIn,
         setLogsArr,


### PR DESCRIPTION
## What & why

`advancePhase` cycled **every** pattern through `accumulation → intensification → peaking → deload` regardless of goal, so a hypertrophy / endurance / general user got cycled into a **strength peaking taper** (low reps, RIR 1–2). Verified goal-blind bug; highest value-per-effort fix in the program-gen redesign.

First slice of umbrella **#558** / **ADR-0030** (accepted via #557).

## Change

- **`goalArc(statement)`** classifier (pure, exported): explicit strength signal (`strength`, `max weight`, `powerlift`, `1rm`, case-insensitive) → `strength`; absent / empty / whitespace / everything else → `volume`. Asymmetric-error-safe: the bug is non-strength users getting peaked, so **default-no-peak**.
- Phase cycle parametrized by arc: strength `[accumulation, intensification, peaking, deload]` (unchanged); volume `[accumulation, intensification, deload]` (skips peaking).
- **Off-arc peaking** (legacy data / strength→hypertrophy switch) advances explicitly to `deload`, not via the `indexOf === -1` modulo accident.
- Only the **natural progressing-advance** is goal-branched; the deload-end cyclic rule and force-deload safety valve stay goal-agnostic.
- Orchestrator classifies the arc once from `model_json.goal.statement` and injects it into `applyPerPatternRules` (param defaults to `"volume"` fail-safe); `goalIn` read hoisted above the per-pattern call.
- No wire-shape change — `goalArc` is a computed input, not a persisted field.

## Tests
- `phase-advance_test.ts`: **20/20** (13 existing + 7 new — classifier table, strength-arc-unchanged, volume-skips-peaking, off-arc-peaking→deload, both-arc identical accumulation→intensification, force-deload & deload-end unchanged under volume).
- `index_test.ts`: **38/38** (all 8 direct `applyPerPatternRules` callers).
- `deno check` on `index.ts` + `phase-advance.ts`: clean.
- `orchestrator_test.ts` / `smoke_test.ts` failures observed locally are the live-DB integration tests (need Postgres + net), unrelated to this change.

## Grep-before-done
`phaseOrder` / `nextPhaseInCycle` exist only in `phase-advance.ts`. `global-phase-advance.ts` does not cycle through peaking — no second site needs the branch.

## ⚠️ Manual deploy (owner)
After merge: `supabase functions deploy update-trainee-model`. Until deployed, prod behaviour is unchanged. Forward-only (ADR-0006): no backfill — a pattern sitting in `peaking` under a non-strength goal advances to `deload` on its next natural advance.

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)