### PR TITLE
feat(#164): cadence-scale per-muscle volumeTolerance to actual training frequency

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,40 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-29 — Volume targets now match how often you actually train
+
+**The problem (in plain words):**
+The coach has a target for how many hard sets each muscle should get. That
+target was baked in assuming everyone trains about 4 times a week. But the way
+it's measured is "sets over your last 7 workouts for that muscle" — and 7
+workouts is a different amount of time depending on how often you train. If you
+train a muscle 6×/week, 7 workouts is barely over a week, so the fixed target was
+actually ~145% of what a week should be — too high. If you train it 2×/week, 7
+workouts spans 3+ weeks, so the same target was only ~57% of a week — too low. So
+high-frequency people looked permanently "under target" and low-frequency people
+looked "done" when they weren't.
+
+**What I changed:**
+The target now scales to how often you actually train each muscle (read straight
+from the timestamps of your own sessions for that muscle). Train it more often →
+the per-window target comes down to match a sensible weekly amount; train it less
+often → it goes up. At 4×/week nothing changes. I capped the scaling to a sane
+range so someone training once a week (or twice a day) doesn't get an absurd
+number. Important detail I got right: the target is always recalculated from the
+fixed baseline, never from last time's already-scaled number — otherwise it would
+quietly drift lower and lower every workout.
+
+**How it was checked:**
+19 automated tests on the math (8 new — including one that proves it does NOT
+drift when you train at a steady pace), plus a full end-to-end test that runs in
+CI against a real database. The existing targets tests still pass (a brand-new
+user with one session sees the same baseline as before).
+
+**Heads-up for deploy:** server-side coach change — live only after
+`supabase functions deploy update-trainee-model`. (#164, part of #558 / ADR-0030.)
+
+---
+
 ## 2026-06-29 — Stop pushing muscle-builders into a powerlifter's "peak"
 
 **The problem (in plain words):**

--- a/supabase/functions/_shared/per-muscle-rules.ts
+++ b/supabase/functions/_shared/per-muscle-rules.ts
@@ -6,9 +6,9 @@
 //
 // Q1 threshold-semantic lock (2026-05-13): MEV interpretation, per-7-events
 // targets scaled at 4×/week alpha-cohort cadence. Bootstrap-only — EWMA-update
-// of tolerance is deferred to a follow-up issue. Cadence-scaling per user's
-// actual sessionsPerWeek is also deferred (alpha cohort ≈ 4×/week makes this
-// adequate).
+// of tolerance is deferred to a follow-up issue. Cadence-scaling per the
+// user's actual training frequency is implemented per #164 (see
+// `computeCadenceScalingFactor` / `cadenceScaledTolerance`).
 
 import {
   canonicalizeExerciseId,
@@ -58,9 +58,9 @@ export const MUSCLE_GROUPS: ReadonlySet<MuscleGroup> = new Set<MuscleGroup>([
 /**
  * Q1-locked per-muscle volume targets (MEV midpoints, per-7-events at
  * 4×/week cadence). volumeTolerance is bootstrapped from this table per
- * 2026-05-13 prep-prompt lock. Follow-up: EWMA-update of tolerance from
- * observed RPE/recovery signals; cadence-scaling for users away from
- * 4×/week.
+ * 2026-05-13 prep-prompt lock, then cadence-scaled per #164
+ * (`cadenceScaledTolerance`). Follow-up: EWMA-update of tolerance from
+ * observed RPE/recovery signals.
  */
 export const MUSCLE_VOLUME_TARGETS: Record<MuscleGroup, number> = {
   back: 21,
@@ -70,6 +70,47 @@ export const MUSCLE_VOLUME_TARGETS: Record<MuscleGroup, number> = {
   triceps: 12,
   legs: 18,
 };
+
+/**
+ * Cadence-scaling factor for the per-muscle volume model (#164).
+ *
+ * `MUSCLE_VOLUME_TARGETS` are locked as per-7-events targets at a **4×/week**
+ * cadence: `locked = MEV_per_week × (7 / 4)`. The 7-event window spans a
+ * different number of weeks at other cadences, so a fixed per-7-events target
+ * drifts from the intended per-week MEV semantic — a 6×/week trainee's window
+ * is only ~1.2 weeks (target effectively ~145% of MEV/week, too high), a
+ * 2×/week trainee's is ~3.5 weeks (~57% of MEV/week, too low).
+ *
+ * The cadence-correct per-7-events target is `MEV_per_week × (7 / cadence)`;
+ * dividing by the locked `MEV × 7/4` gives the factor `4 / cadence_per_week`
+ * = `4 × cadenceDays / 7`. So higher frequency → smaller factor, lower
+ * frequency → larger factor. Clamped to `[0.5, 2.0]` (≈2×–8×/week) so extreme
+ * cadences can't produce degenerate tolerances. `null` cadence (<2 events,
+ * cold-start) → `1.0` (the 4×/week alpha-cohort assumption).
+ *
+ * Exported so the volume-ceiling prior (#570) scales by the same factor.
+ */
+export function computeCadenceScalingFactor(cadenceDays: number | null): number {
+  if (cadenceDays === null || cadenceDays <= 0) return 1.0;
+  const factor = (4 * cadenceDays) / 7;
+  return Math.min(2.0, Math.max(0.5, factor));
+}
+
+/**
+ * Cadence-scaled `volumeTolerance` for a muscle (#164). Always scales the
+ * Q1-locked **baseline constant** `MUSCLE_VOLUME_TARGETS[muscleGroup]` — never
+ * a persisted (already-scaled) value, which would double-scale on every apply.
+ * Rounded to an integer so the downstream `volumeDeficit` (an `Int` on the
+ * Swift side) stays integral.
+ */
+export function cadenceScaledTolerance(
+  muscleGroup: MuscleGroup,
+  cadenceDays: number | null,
+): number {
+  return Math.round(
+    MUSCLE_VOLUME_TARGETS[muscleGroup] * computeCadenceScalingFactor(cadenceDays),
+  );
+}
 
 /**
  * Bootstrap shape of a `MuscleProfile` JSONB entry. Mirrors

--- a/supabase/functions/_shared/per-muscle-rules_test.ts
+++ b/supabase/functions/_shared/per-muscle-rules_test.ts
@@ -9,11 +9,16 @@
 // Run locally:
 //   deno test --allow-all supabase/functions/_shared/per-muscle-rules_test.ts
 
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  assertAlmostEquals,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
 import {
   aggregateMuscleSetCounts,
   aggregateStagnationStatus,
   bootstrapMuscleProfile,
+  cadenceScaledTolerance,
+  computeCadenceScalingFactor,
   computeFocusWeight,
   computeVolumeDeficit,
   proposeMuscleConfidence,
@@ -233,4 +238,64 @@ Deno.test("proposeMuscleConfidence: biceps (zero major patterns; isolation only)
     }),
     "established",
   );
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// #164: cadence-scaling of volumeTolerance. Locked targets are per-7-events at
+// 4×/week (locked = MEV × 7/4); the cadence-correct factor is 4/cadence_per_week
+// = 4 × cadenceDays / 7, clamped to [0.5, 2.0]. Higher frequency → smaller
+// factor; lower frequency → larger factor (the 7-event window spans fewer/more
+// weeks). null cadence (cold-start) → 1.0.
+// ─────────────────────────────────────────────────────────────────────────
+
+Deno.test("#164 computeCadenceScalingFactor: 4×/week (cadenceDays=1.75) → 1.0 (baseline unchanged)", () => {
+  assertEquals(computeCadenceScalingFactor(1.75), 1.0);
+});
+
+Deno.test("#164 computeCadenceScalingFactor: 6×/week (cadenceDays=7/6) → ~0.667 (scale DOWN for high frequency)", () => {
+  assertAlmostEquals(computeCadenceScalingFactor(7 / 6), 4 / 6, 1e-9);
+});
+
+Deno.test("#164 computeCadenceScalingFactor: 3×/week (cadenceDays=7/3) → ~1.333 (scale UP for low frequency)", () => {
+  assertAlmostEquals(computeCadenceScalingFactor(7 / 3), 4 / 3, 1e-9);
+});
+
+Deno.test("#164 computeCadenceScalingFactor: 2×/week (cadenceDays=3.5) → 2.0 (clamp ceiling)", () => {
+  assertEquals(computeCadenceScalingFactor(3.5), 2.0);
+});
+
+Deno.test("#164 computeCadenceScalingFactor: null cadence (cold-start, <2 events) → 1.0", () => {
+  assertEquals(computeCadenceScalingFactor(null), 1.0);
+});
+
+Deno.test("#164 computeCadenceScalingFactor: extreme cadences clamp to [0.5, 2.0]", () => {
+  // ~14×/week (cadenceDays=0.5) → raw 0.286 → clamped to 0.5 floor.
+  assertEquals(computeCadenceScalingFactor(0.5), 0.5);
+  // 1×/week (cadenceDays=7) → raw 4.0 → clamped to 2.0 ceiling.
+  assertEquals(computeCadenceScalingFactor(7), 2.0);
+  // zero/negative guarded → 1.0.
+  assertEquals(computeCadenceScalingFactor(0), 1.0);
+});
+
+Deno.test("#164 cadenceScaledTolerance: scales the locked baseline by cadence (rounded), null → baseline", () => {
+  // legs baseline = 18.
+  assertEquals(cadenceScaledTolerance("legs", 1.75), 18); // 4×/week → ×1.0
+  assertEquals(cadenceScaledTolerance("legs", 3.5), 36); // 2×/week → ×2.0
+  assertEquals(cadenceScaledTolerance("legs", 7 / 6), 12); // 6×/week → round(18×0.667)
+  assertEquals(cadenceScaledTolerance("legs", 7 / 3), 24); // 3×/week → round(18×1.333)
+  assertEquals(cadenceScaledTolerance("legs", null), 18); // cold-start → baseline
+  // back baseline = 21.
+  assertEquals(cadenceScaledTolerance("back", 3.5), 42); // ×2.0
+});
+
+Deno.test("#164 cadenceScaledTolerance: NO double-scaling — repeated calls derive from the constant baseline, never a prior result", () => {
+  // The function takes only (muscleGroup, cadenceDays) — it cannot read a
+  // persisted/already-scaled value, so re-applying at the same cadence is
+  // idempotent. This is the structural guard against tolerance drift.
+  const first = cadenceScaledTolerance("chest", 7 / 3); // 3×/week
+  const second = cadenceScaledTolerance("chest", 7 / 3);
+  const third = cadenceScaledTolerance("chest", 7 / 3);
+  assertEquals(first, second);
+  assertEquals(second, third);
+  assertEquals(first, 24); // chest 18 × 1.333 rounded
 });

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -114,6 +114,7 @@ import {
   aggregateMuscleSetCounts,
   aggregateStagnationStatus,
   bootstrapMuscleProfile,
+  cadenceScaledTolerance,
   computeFocusWeight,
   computeVolumeDeficit,
   proposeMuscleConfidence,
@@ -1248,8 +1249,21 @@ function applyPerMuscleRules(
       fieldsChanged.push(`muscles.${muscleKey}.weeklyVolumeHistory`);
     }
 
-    // (b) Recompute volumeDeficit from the (possibly updated) history.
-    const tolerance = (profile.volumeTolerance as number) ?? 0;
+    // (b) Cadence-scale volumeTolerance (#164), then recompute volumeDeficit.
+    // The Q1-locked targets assume 4×/week; the muscle's actual frequency comes
+    // from its OWN weeklyVolumeHistory timestamps (each bucket = one training
+    // event for this muscle). <2 events → null cadence → factor 1.0. Always
+    // scaled from the baseline constant inside cadenceScaledTolerance, so the
+    // value cannot drift across applies (no double-scaling).
+    const cadenceDays = sessionsCadenceDays(
+      newHistory.map((bucket) => bucket.loggedAtIso),
+    );
+    const tolerance = cadenceScaledTolerance(muscleGroup, cadenceDays);
+    if (tolerance !== profile.volumeTolerance) {
+      profile.volumeTolerance = tolerance;
+      rulesFired.add("muscle-volume-tolerance");
+      fieldsChanged.push(`muscles.${muscleKey}.volumeTolerance`);
+    }
     const newDeficit = computeVolumeDeficit(newHistory, tolerance);
     if (newDeficit !== profile.volumeDeficit) {
       profile.volumeDeficit = newDeficit;

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -24,6 +24,7 @@ import postgres from "postgres";
 import { applySession } from "./index.ts";
 import type { ApplyCompleteEvent, LateArrivalEvent } from "../_shared/observability.ts";
 import { LLMTransientError } from "../_shared/llm-retry.ts";
+import { cadenceScaledTolerance } from "../_shared/per-muscle-rules.ts";
 
 const DB_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
 
@@ -2356,6 +2357,82 @@ orchestratorTest(
     assertEquals(proj.lastRecalibratedPatterns.includes("squat"), true);
     // Patterns that did NOT outgrow their band are not in the list.
     assertEquals(proj.lastRecalibratedPatterns.includes("horizontal_push"), false);
+  },
+);
+
+orchestratorTest(
+  "#164: volumeTolerance cadence-scales from the muscle's own event timestamps; stable across re-apply (no drift)",
+  async () => {
+    const userId = await seedFreshUser();
+    // Three legs sessions spaced exactly 3.5 days apart → mean cadence 3.5
+    // days = 2×/week → scaling factor 2.0 → legs tolerance 18 × 2 = 36.
+    const dates = [
+      "2026-05-08T10:00:00Z",
+      "2026-05-11T22:00:00Z",
+      "2026-05-15T10:00:00Z",
+    ];
+    for (const loggedAt of dates) {
+      await applySession(
+        {
+          user_id: userId,
+          session_id: crypto.randomUUID(),
+          session_payload: {
+            logged_at: loggedAt,
+            set_logs: [
+              { exercise_id: "barbell_back_squat", set_number: 1, weight_kg: 130, reps_completed: 5, intent: "top" },
+            ],
+          },
+        },
+        sql,
+        { stage2Hook: noopStage2 },
+      );
+    }
+
+    let rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    let legs = (
+      (rows[0].model_json as Record<string, unknown>).muscles as Record<
+        string,
+        Record<string, unknown>
+      >
+    ).legs;
+
+    const expected = cadenceScaledTolerance("legs", 3.5); // = 36
+    assertEquals(legs.volumeTolerance, expected);
+    assertEquals(legs.volumeTolerance, 36);
+    // Proves the scaling actually fired (baseline would have been 18).
+    assertEquals(legs.volumeTolerance !== 18, true);
+
+    // A fourth apply at the same 3.5-day spacing must NOT drift the tolerance
+    // — the orchestrator scales from the locked baseline each time, never from
+    // the persisted (already-scaled) value. This is the end-to-end guard
+    // against the double-scaling bug.
+    await applySession(
+      {
+        user_id: userId,
+        session_id: crypto.randomUUID(),
+        session_payload: {
+          logged_at: "2026-05-18T22:00:00Z",
+          set_logs: [
+            { exercise_id: "barbell_back_squat", set_number: 1, weight_kg: 130, reps_completed: 5, intent: "top" },
+          ],
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    legs = (
+      (rows[0].model_json as Record<string, unknown>).muscles as Record<
+        string,
+        Record<string, unknown>
+      >
+    ).legs;
+    assertEquals(legs.volumeTolerance, 36); // unchanged — no double-scaling
   },
 );
 


### PR DESCRIPTION
## What & why

`volumeTolerance` was locked as a **per-7-events target at a 4×/week** cadence assumption. But the 7-event window spans a different number of *weeks* at other cadences, so a fixed target drifts from the intended per-week MEV semantic:
- **6×/week:** 7 events ≈ 1.2 weeks → fixed target ≈ **145% of MEV/week** (too high)
- **2×/week:** 7 events ≈ 3.5 weeks → fixed target ≈ **57% of MEV/week** (too low)

So high-frequency users read as chronically under-target and low-frequency users as "done" when they aren't.

Order-13 slice of umbrella **#558** / **ADR-0030**. Establishes the cadence factor #570 (volume ceiling) reuses.

## Change
- **`computeCadenceScalingFactor(cadenceDays)`** = `4 / cadence_per_week` (= `4 × cadenceDays / 7`), clamped to `[0.5, 2.0]` (≈2×–8×/week); `null` cadence → `1.0`. Higher frequency → smaller factor. Exported for #570.
- **`cadenceScaledTolerance(muscle, cadenceDays)`** scales the `MUSCLE_VOLUME_TARGETS` **baseline constant** — never a persisted (already-scaled) value, so tolerance **cannot double-scale** across applies. Rounded so `volumeDeficit` stays integral.
- `applyPerMuscleRules` derives each muscle's cadence from its **own `weeklyVolumeHistory` timestamps** (the muscle's actual training frequency) and recomputes tolerance + deficit per apply.

## Direction correction
The original per-pattern design draft proposed the factor as `cadence/4` (scale *up* for high frequency) — backwards. The issue's own per-week-equivalent impact table (6× = 145% too-high, 2× = 57% too-low) confirms the correct factor is `4/cadence`. Caught during grounding; unit tests pin the direction.

## Tests
- `per-muscle-rules_test.ts`: **19/19** (8 new — factor at 4×/3×/6×/2×/extremes/null, scaled-tolerance values, and a **no-double-scaling idempotence** test).
- `orchestrator_test.ts`: new end-to-end case — 3 legs sessions at 3.5-day spacing → tolerance scales 18→36, and a 4th apply at the same cadence keeps it 36 (end-to-end no-drift guard). Runs in CI against live Postgres.
- `deno check` clean.

## Grep-before-done
The two existing `volumeTolerance` assertions in `orchestrator_test.ts` (lines 1839, 2013) are single-session cold-start fixtures → null cadence → factor 1.0 → baseline. **Unchanged** by this PR (verified by inspection).

## ⚠️ Manual deploy (owner)
After merge: `supabase functions deploy update-trainee-model`. Additive/forward-only — existing rows recompute tolerance on their next apply; no migration, no Codable shape change.

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)