### PR TITLE
feat(#570): soft two-sided volume ceiling + over-volume surplus signal

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,35 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-29 — The coach can now notice when a muscle is getting *too much*
+
+**The problem (in plain words):**
+The coach tracked a *floor* for each muscle — "you're below the amount of work
+that grows this muscle, do more." But it had no *ceiling*. So it could never
+notice the opposite problem: hammering one muscle past the point where more sets
+actually help (and just dig a recovery hole). There was simply no signal for
+"this is too much volume."
+
+**What I changed:**
+Added a sensible upper limit per muscle (a research-style "you probably shouldn't
+exceed this" number, scaled to your training frequency the same way the floor is)
+and an "over-volume" reading: how far past that limit your recent sets are, zero
+if you're under it. It's **advisory only** — it does NOT cap or cut your sets;
+it just gives the coach an honest signal so its advice can reflect reality. The
+new numbers also show up in the summary the coach reasons over. Older saved
+profiles that don't have these fields yet just read as zero — nothing breaks.
+
+**How it was checked:**
+23 server-side tests pass (4 new for the ceiling + over-volume math), an
+end-to-end database test proves the signal shows up after a heavy session, and
+the iOS app builds clean with two new tests proving old saved data still loads
+and the new fields survive a save/load round-trip.
+
+**Heads-up for deploy:** server-side coach change — live only after
+`supabase functions deploy update-trainee-model`. (#570, part of #558 / ADR-0030.)
+
+---
+
 ## 2026-06-29 — Volume targets now match how often you actually train
 
 **The problem (in plain words):**

--- a/ProjectApex/Models/TraineeModelDigest.swift
+++ b/ProjectApex/Models/TraineeModelDigest.swift
@@ -379,6 +379,9 @@ struct MuscleSummary: Codable, Sendable, Hashable {
     var muscleGroup: MuscleGroup
     var volumeTolerance: Double
     var volumeDeficit: Int
+    /// #570: over-volume ceiling + surplus signal, surfaced to coaching prompts.
+    var volumeCeiling: Double
+    var volumeSurplus: Int
     var focusWeight: Double
     var stagnationStatus: ProgressionTrend
     var confidence: AxisConfidence
@@ -387,6 +390,8 @@ struct MuscleSummary: Codable, Sendable, Hashable {
         self.muscleGroup       = profile.muscleGroup
         self.volumeTolerance   = profile.volumeTolerance
         self.volumeDeficit     = profile.volumeDeficit
+        self.volumeCeiling     = profile.volumeCeiling
+        self.volumeSurplus     = profile.volumeSurplus
         self.focusWeight       = profile.focusWeight
         self.stagnationStatus  = profile.stagnationStatus
         self.confidence        = profile.confidence
@@ -396,6 +401,8 @@ struct MuscleSummary: Codable, Sendable, Hashable {
         case muscleGroup       = "muscle_group"
         case volumeTolerance   = "volume_tolerance"
         case volumeDeficit     = "volume_deficit"
+        case volumeCeiling     = "volume_ceiling"
+        case volumeSurplus     = "volume_surplus"
         case focusWeight       = "focus_weight"
         case stagnationStatus  = "stagnation_status"
         case confidence

--- a/ProjectApex/Models/TraineeModelProfiles.swift
+++ b/ProjectApex/Models/TraineeModelProfiles.swift
@@ -78,6 +78,11 @@ struct MuscleProfile: Codable, Sendable, Hashable {
     var volumeTolerance: Double
     var observedSweetSpot: Int?
     var volumeDeficit: Int
+    /// #570: MRV/MAV-midpoint ceiling prior (cadence-scaled, per-7-events).
+    /// Advisory only — pairs with `volumeSurplus` to surface over-volume.
+    var volumeCeiling: Double
+    /// #570: over-volume signal = max(0, recent sets − ceiling); 0 at/under.
+    var volumeSurplus: Int
     var focusWeight: Double
     var stagnationStatus: ProgressionTrend
     var confidence: AxisConfidence
@@ -87,6 +92,8 @@ struct MuscleProfile: Codable, Sendable, Hashable {
         volumeTolerance: Double = 0,
         observedSweetSpot: Int? = nil,
         volumeDeficit: Int = 0,
+        volumeCeiling: Double = 0,
+        volumeSurplus: Int = 0,
         focusWeight: Double = 0,
         stagnationStatus: ProgressionTrend = .progressing,
         confidence: AxisConfidence = .bootstrapping
@@ -95,9 +102,28 @@ struct MuscleProfile: Codable, Sendable, Hashable {
         self.volumeTolerance = volumeTolerance
         self.observedSweetSpot = observedSweetSpot
         self.volumeDeficit = volumeDeficit
+        self.volumeCeiling = volumeCeiling
+        self.volumeSurplus = volumeSurplus
         self.focusWeight = focusWeight
         self.stagnationStatus = stagnationStatus
         self.confidence = confidence
+    }
+
+    // Custom decoder so `volumeCeiling` / `volumeSurplus` (#570, additive)
+    // default cleanly on legacy `model_json` rows written before this field
+    // existed — mirrors the RecoveryProfile / PatternProfile additive-decode
+    // idiom. The synthesized encoder still writes all fields.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.muscleGroup = try c.decode(MuscleGroup.self, forKey: .muscleGroup)
+        self.volumeTolerance = try c.decode(Double.self, forKey: .volumeTolerance)
+        self.observedSweetSpot = try c.decodeIfPresent(Int.self, forKey: .observedSweetSpot)
+        self.volumeDeficit = try c.decode(Int.self, forKey: .volumeDeficit)
+        self.volumeCeiling = try c.decodeIfPresent(Double.self, forKey: .volumeCeiling) ?? 0
+        self.volumeSurplus = try c.decodeIfPresent(Int.self, forKey: .volumeSurplus) ?? 0
+        self.focusWeight = try c.decode(Double.self, forKey: .focusWeight)
+        self.stagnationStatus = try c.decode(ProgressionTrend.self, forKey: .stagnationStatus)
+        self.confidence = try c.decode(AxisConfidence.self, forKey: .confidence)
     }
 }
 

--- a/ProjectApexTests/TraineeModelProfilesTests.swift
+++ b/ProjectApexTests/TraineeModelProfilesTests.swift
@@ -98,6 +98,50 @@ struct MuscleProfileTests {
         let data = try JSONEncoder().encode(original)
         #expect(try JSONDecoder().decode(MuscleProfile.self, from: data) == original)
     }
+
+    @Test("Round-trip preserves volumeCeiling/volumeSurplus (#570)")
+    func roundTripCeilingSurplus() throws {
+        let original = MuscleProfile(
+            muscleGroup: .chest,
+            volumeTolerance: 18,
+            volumeDeficit: 2,
+            volumeCeiling: 24,
+            volumeSurplus: 6,
+            confidence: .calibrating
+        )
+        let data = try JSONEncoder().encode(original)
+        #expect(try JSONDecoder().decode(MuscleProfile.self, from: data) == original)
+    }
+
+    @Test("Legacy decode (#570): rows missing volumeCeiling/volumeSurplus default to 0")
+    func legacyDecodeDefaultsCeilingSurplus() throws {
+        // Simulate a pre-#570 model_json row (the ~10 live rows): encode a
+        // modern profile, strip the two new keys, then decode. The additive
+        // decoder must default both to 0 without throwing.
+        let modern = MuscleProfile(
+            muscleGroup: .back,
+            volumeTolerance: 28,
+            volumeDeficit: 3,
+            volumeCeiling: 28,
+            volumeSurplus: 5,
+            confidence: .established
+        )
+        var dict = try JSONSerialization.jsonObject(
+            with: JSONEncoder().encode(modern)
+        ) as! [String: Any]
+        dict.removeValue(forKey: "volumeCeiling")
+        dict.removeValue(forKey: "volumeSurplus")
+        let legacyData = try JSONSerialization.data(withJSONObject: dict)
+
+        let decoded = try JSONDecoder().decode(MuscleProfile.self, from: legacyData)
+        #expect(decoded.volumeCeiling == 0)
+        #expect(decoded.volumeSurplus == 0)
+        // Pre-existing fields are still decoded normally.
+        #expect(decoded.muscleGroup == .back)
+        #expect(decoded.volumeTolerance == 28)
+        #expect(decoded.volumeDeficit == 3)
+        #expect(decoded.confidence == .established)
+    }
 }
 
 @Suite("PatternProfile.recentSessionDays")

--- a/supabase/functions/_shared/per-muscle-rules.ts
+++ b/supabase/functions/_shared/per-muscle-rules.ts
@@ -72,6 +72,24 @@ export const MUSCLE_VOLUME_TARGETS: Record<MuscleGroup, number> = {
 };
 
 /**
+ * Q1-companion per-muscle volume CEILINGS (#570). MRV/MAV-midpoint priors in the
+ * same per-7-events @4×/week units as MUSCLE_VOLUME_TARGETS, so they cadence-scale
+ * by the same factor (`cadenceScaledCeiling`). These are *fixed priors* (≈1.3×
+ * the MEV midpoints), NOT learned values, and are **advisory only** — nothing
+ * hard-caps prescribed sets from them. They exist so the model can surface an
+ * over-volume signal (`volumeSurplus`) distinct from the per-pattern fatigue
+ * axis. Subject to tuning once alpha data accrues.
+ */
+export const MUSCLE_VOLUME_CEILING: Record<MuscleGroup, number> = {
+  back: 28,
+  chest: 24,
+  shoulders: 24,
+  biceps: 20,
+  triceps: 16,
+  legs: 24,
+};
+
+/**
  * Cadence-scaling factor for the per-muscle volume model (#164).
  *
  * `MUSCLE_VOLUME_TARGETS` are locked as per-7-events targets at a **4×/week**
@@ -113,6 +131,21 @@ export function cadenceScaledTolerance(
 }
 
 /**
+ * Cadence-scaled `volumeCeiling` for a muscle (#570). Mirrors
+ * `cadenceScaledTolerance` — scales the fixed `MUSCLE_VOLUME_CEILING` prior by
+ * the same cadence factor so the over-volume signal stays in per-week terms.
+ * Scales from the baseline constant (no double-scaling); rounded to an integer.
+ */
+export function cadenceScaledCeiling(
+  muscleGroup: MuscleGroup,
+  cadenceDays: number | null,
+): number {
+  return Math.round(
+    MUSCLE_VOLUME_CEILING[muscleGroup] * computeCadenceScalingFactor(cadenceDays),
+  );
+}
+
+/**
  * Bootstrap shape of a `MuscleProfile` JSONB entry. Mirrors
  * `ProjectApex/Models/TraineeModelProfiles.swift::MuscleProfile`. Keys are
  * camelCase to match the Swift decoder's default CodingKeys (no rename).
@@ -125,6 +158,10 @@ export interface BootstrapMuscleProfile {
   volumeTolerance: number;
   observedSweetSpot: number | null;
   volumeDeficit: number;
+  /** #570: MRV/MAV-midpoint ceiling prior (per-7-events @4×/week; cadence-scaled on apply). */
+  volumeCeiling: number;
+  /** #570: over-volume signal = max(0, sum − ceiling); 0 on cold-start. */
+  volumeSurplus: number;
   focusWeight: number;
   stagnationStatus: "progressing" | "plateaued" | "declining";
   confidence: "bootstrapping" | "calibrating" | "established";
@@ -151,6 +188,10 @@ export function bootstrapMuscleProfile(
     volumeTolerance: MUSCLE_VOLUME_TARGETS[muscleGroup],
     observedSweetSpot: null,
     volumeDeficit: 0,
+    // #570: baseline ceiling prior; the orchestrator recomputes it cadence-
+    // scaled on each apply (cold-start cadence = null → factor 1.0 → baseline).
+    volumeCeiling: MUSCLE_VOLUME_CEILING[muscleGroup],
+    volumeSurplus: 0,
     focusWeight: 0,
     stagnationStatus: "progressing",
     confidence: "bootstrapping",
@@ -226,6 +267,23 @@ export function computeVolumeDeficit(
   const recent = history.slice(-MUSCLE_VOLUME_WINDOW);
   const sum = recent.reduce((acc, bucket) => acc + bucket.sets, 0);
   return Math.max(0, volumeTolerance - sum);
+}
+
+/**
+ * `volumeSurplus = max(0, Σ sets in last MUSCLE_VOLUME_WINDOW buckets −
+ * volumeCeiling)` (#570). The upper-bound companion to `computeVolumeDeficit`:
+ * a positive surplus means the user is training this muscle *past* its
+ * productive ceiling (a real over-volume / overreaching signal, distinct from
+ * the per-pattern fatigue axis). 0 at/under the ceiling; 0 on cold-start
+ * (empty history). Advisory only — no code path hard-caps prescribed sets.
+ */
+export function computeVolumeSurplus(
+  history: WeeklyVolumeBucket[],
+  volumeCeiling: number,
+): number {
+  const recent = history.slice(-MUSCLE_VOLUME_WINDOW);
+  const sum = recent.reduce((acc, bucket) => acc + bucket.sets, 0);
+  return Math.max(0, sum - volumeCeiling);
 }
 
 /**

--- a/supabase/functions/_shared/per-muscle-rules_test.ts
+++ b/supabase/functions/_shared/per-muscle-rules_test.ts
@@ -17,11 +17,15 @@ import {
   aggregateMuscleSetCounts,
   aggregateStagnationStatus,
   bootstrapMuscleProfile,
+  cadenceScaledCeiling,
   cadenceScaledTolerance,
   computeCadenceScalingFactor,
   computeFocusWeight,
   computeVolumeDeficit,
+  computeVolumeSurplus,
+  MUSCLE_VOLUME_CEILING,
   proposeMuscleConfidence,
+  type MuscleGroup,
 } from "./per-muscle-rules.ts";
 
 Deno.test("bootstrapMuscleProfile: legs returns ADR-0005 defaults + Q1-locked MEV threshold", () => {
@@ -298,4 +302,65 @@ Deno.test("#164 cadenceScaledTolerance: NO double-scaling — repeated calls der
   assertEquals(first, second);
   assertEquals(second, third);
   assertEquals(first, 24); // chest 18 × 1.333 rounded
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// #570: soft two-sided volume ceiling. MUSCLE_VOLUME_CEILING is an MRV/MAV
+// prior in the same per-7-events @4×/week units, cadence-scaled by the SAME
+// factor as tolerance. volumeSurplus = max(0, sum − ceiling), advisory only.
+// ─────────────────────────────────────────────────────────────────────────
+
+Deno.test("#570 bootstrapMuscleProfile: includes baseline volumeCeiling + 0 volumeSurplus for all six muscles", () => {
+  const expectedCeilings: Record<MuscleGroup, number> = {
+    back: 28,
+    chest: 24,
+    shoulders: 24,
+    biceps: 20,
+    triceps: 16,
+    legs: 24,
+  };
+  for (const muscle of Object.keys(expectedCeilings) as MuscleGroup[]) {
+    const profile = bootstrapMuscleProfile(muscle);
+    assertEquals(profile.volumeCeiling, expectedCeilings[muscle]);
+    assertEquals(profile.volumeCeiling, MUSCLE_VOLUME_CEILING[muscle]);
+    assertEquals(profile.volumeSurplus, 0);
+  }
+});
+
+Deno.test("#570 computeVolumeSurplus: max(0, sum − ceiling) over last-7 buckets", () => {
+  const bucket = (sets: number) => ({ loggedAtIso: "2026-05-01T00:00:00Z", sets });
+  // Under ceiling → 0.
+  assertEquals(computeVolumeSurplus([bucket(10)], 24), 0);
+  // At ceiling exactly → 0.
+  assertEquals(computeVolumeSurplus([bucket(12), bucket(12)], 24), 0);
+  // Over ceiling → positive surplus.
+  assertEquals(computeVolumeSurplus([bucket(15), bucket(15)], 24), 6); // 30 − 24
+  // Cold-start (empty history) → 0.
+  assertEquals(computeVolumeSurplus([], 24), 0);
+  // Only the last 7 buckets contribute (8th-oldest dropped).
+  const eight = [9, 1, 1, 1, 1, 1, 1, 1].map(bucket); // first (9) is outside last-7
+  assertEquals(computeVolumeSurplus(eight, 5), 2); // last-7 sum = 7 → 7 − 5
+});
+
+Deno.test("#570 computeVolumeSurplus + computeVolumeDeficit are independent (both directions)", () => {
+  const bucket = (sets: number) => ({ loggedAtIso: "2026-05-01T00:00:00Z", sets });
+  // 15 sets, tolerance 18, ceiling 24 → deficit 3, surplus 0.
+  assertEquals(computeVolumeDeficit([bucket(15)], 18), 3);
+  assertEquals(computeVolumeSurplus([bucket(15)], 24), 0);
+  // 25 sets, tolerance 18, ceiling 24 → deficit 0, surplus 1.
+  assertEquals(computeVolumeDeficit([bucket(25)], 18), 0);
+  assertEquals(computeVolumeSurplus([bucket(25)], 24), 1);
+});
+
+Deno.test("#570 cadenceScaledCeiling: scales the ceiling baseline by the shared cadence factor; null → baseline", () => {
+  // legs ceiling baseline = 24.
+  assertEquals(cadenceScaledCeiling("legs", 1.75), 24); // 4×/week → ×1.0
+  assertEquals(cadenceScaledCeiling("legs", 3.5), 48); // 2×/week → ×2.0
+  assertEquals(cadenceScaledCeiling("legs", 7 / 6), 16); // 6×/week → round(24×0.667)
+  assertEquals(cadenceScaledCeiling("legs", null), 24); // cold-start → baseline
+  // Uses the same factor as tolerance: factor = scaledCeiling/baseline.
+  assertEquals(
+    cadenceScaledCeiling("legs", 3.5) / MUSCLE_VOLUME_CEILING["legs"],
+    computeCadenceScalingFactor(3.5),
+  );
 });

--- a/supabase/functions/update-trainee-model/index.ts
+++ b/supabase/functions/update-trainee-model/index.ts
@@ -114,9 +114,11 @@ import {
   aggregateMuscleSetCounts,
   aggregateStagnationStatus,
   bootstrapMuscleProfile,
+  cadenceScaledCeiling,
   cadenceScaledTolerance,
   computeFocusWeight,
   computeVolumeDeficit,
+  computeVolumeSurplus,
   proposeMuscleConfidence,
   MUSCLE_GROUPS,
   MUSCLE_VOLUME_WINDOW,
@@ -1269,6 +1271,23 @@ function applyPerMuscleRules(
       profile.volumeDeficit = newDeficit;
       rulesFired.add("muscle-volume-deficit");
       fieldsChanged.push(`muscles.${muscleKey}.volumeDeficit`);
+    }
+
+    // (b') Cadence-scaled volume CEILING + over-volume surplus (#570). Same
+    // cadence factor as tolerance; the ceiling is an MRV/MAV-midpoint prior,
+    // ADVISORY ONLY (nothing hard-caps prescribed sets). volumeSurplus =
+    // max(0, Σ sets in last-7 − ceiling), 0 at/under ceiling and on cold-start.
+    const ceiling = cadenceScaledCeiling(muscleGroup, cadenceDays);
+    if (ceiling !== profile.volumeCeiling) {
+      profile.volumeCeiling = ceiling;
+      rulesFired.add("muscle-volume-ceiling");
+      fieldsChanged.push(`muscles.${muscleKey}.volumeCeiling`);
+    }
+    const newSurplus = computeVolumeSurplus(newHistory, ceiling);
+    if (newSurplus !== profile.volumeSurplus) {
+      profile.volumeSurplus = newSurplus;
+      rulesFired.add("muscle-volume-surplus");
+      fieldsChanged.push(`muscles.${muscleKey}.volumeSurplus`);
     }
 
     // (c) Recompute stagnationStatus per ADR-0009's worst-across-patterns

--- a/supabase/functions/update-trainee-model/orchestrator_test.ts
+++ b/supabase/functions/update-trainee-model/orchestrator_test.ts
@@ -24,7 +24,10 @@ import postgres from "postgres";
 import { applySession } from "./index.ts";
 import type { ApplyCompleteEvent, LateArrivalEvent } from "../_shared/observability.ts";
 import { LLMTransientError } from "../_shared/llm-retry.ts";
-import { cadenceScaledTolerance } from "../_shared/per-muscle-rules.ts";
+import {
+  cadenceScaledCeiling,
+  cadenceScaledTolerance,
+} from "../_shared/per-muscle-rules.ts";
 
 const DB_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
 
@@ -2433,6 +2436,53 @@ orchestratorTest(
       >
     ).legs;
     assertEquals(legs.volumeTolerance, 36); // unchanged — no double-scaling
+  },
+);
+
+orchestratorTest(
+  "#570: over-volume surplus surfaces end-to-end + volumeCeiling is set on the muscle profile",
+  async () => {
+    const userId = await seedFreshUser();
+    // One session with 30 contributing legs sets — above the legs ceiling.
+    // Single event → null cadence → factor 1.0 → ceiling = baseline 24.
+    await applySession(
+      {
+        user_id: userId,
+        session_id: crypto.randomUUID(),
+        session_payload: {
+          logged_at: "2026-05-10T10:00:00Z",
+          set_logs: Array.from({ length: 30 }, (_, i) => ({
+            exercise_id: "barbell_back_squat",
+            set_number: i + 1,
+            weight_kg: 130,
+            reps_completed: 5,
+            intent: "top",
+          })),
+        },
+      },
+      sql,
+      { stage2Hook: noopStage2 },
+    );
+
+    const rows = await sql`
+      SELECT model_json FROM public.trainee_models WHERE user_id = ${userId}
+    `;
+    const legs = (
+      (rows[0].model_json as Record<string, unknown>).muscles as Record<
+        string,
+        Record<string, unknown>
+      >
+    ).legs;
+
+    const expectedCeiling = cadenceScaledCeiling("legs", null); // 24
+    assertEquals(legs.volumeCeiling, expectedCeiling);
+    assertEquals(legs.volumeCeiling, 24);
+    // 30 sets − 24 ceiling = 6 surplus (advisory over-volume signal).
+    assertEquals(legs.volumeSurplus, 6);
+    // Deficit is 0 in the same apply — the two signals are independent.
+    assertEquals(legs.volumeDeficit, 0);
+    // Tolerance is the cold-start baseline.
+    assertEquals(legs.volumeTolerance, cadenceScaledTolerance("legs", null)); // 18
   },
 );
 


### PR DESCRIPTION
## What & why

`computeVolumeDeficit` only modeled a **MEV floor** (`max(0, tolerance − sum)`), so the per-muscle model could never signal **over-volume** — training a muscle past its productive ceiling (a real overreaching signal, distinct from the per-pattern fatigue axis). This adds the upper bound.

Order-14 slice of umbrella **#558** / **ADR-0030**. Reuses #164's cadence factor.

## Change

**Edge Function (`per-muscle-rules.ts`)**
- `MUSCLE_VOLUME_CEILING` — fixed MRV/MAV-midpoint priors (≈1.3× the MEV targets), same per-7-events @4×/week units.
- `cadenceScaledCeiling(muscle, cadenceDays)` — scales the ceiling by the **same** `computeCadenceScalingFactor` introduced in #164.
- `computeVolumeSurplus(history, ceiling)` = `max(0, Σ last-7 sets − ceiling)`; 0 at/under ceiling, 0 cold-start.
- `bootstrapMuscleProfile` + `applyPerMuscleRules` block (b') recompute ceiling + surplus each apply.
- **Advisory only** — no code path hard-caps prescribed sets from the ceiling.

**Swift (additive, backward-compatible)**
- `MuscleProfile` gains `volumeCeiling: Double` + `volumeSurplus: Int`, with a custom `init(from:)` using `decodeIfPresent ?? 0` (mirrors the established `RecoveryProfile`/`PatternProfile` additive-decode idiom) so the **~10 live `model_json` rows decode cleanly**. The `ProgressView` mocks use the defaulted memberwise init → unchanged.
- `MuscleSummary` projects both fields into the coaching digest.

## Tests
- `per-muscle-rules_test.ts`: **23/23** (4 new — ceiling table/bootstrap, surplus math incl. last-7 windowing & cold-start, deficit/surplus independence, cadence-scaled ceiling sharing the #164 factor).
- `orchestrator_test.ts`: new end-to-end case — a heavy legs session surfaces `volumeSurplus = 6` with `volumeCeiling = 24` (CI/live-DB).
- Swift: `MuscleProfile` round-trip preserves the new fields **and** a legacy row missing them decodes to `0` (the ~10-live-row guarantee). Full `xcodebuild build-for-testing` **SUCCEEDED**; targeted `MuscleProfileTests` pass.
- `deno check` clean.

## Grep-before-done
Cross-validation parity fixture has `"muscles": {}` (empty → unaffected). Orchestrator key-set assertions check muscle *groups*, not field sets. The two existing `volumeTolerance` assertions are cold-start → unaffected.

## ⚠️ Manual deploy (owner)
After merge: `supabase functions deploy update-trainee-model`. Additive/forward-only — no SQL migration, no Codable break.

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)