### PR TITLE
feat(#321): offline deterministic per-set fallback — live loop survives a dead connection

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,38 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-29 — The workout no longer stops when the coach can't be reached
+
+**The problem (in plain words):**
+Every set waited on the AI coach to tell you the weight and reps. If the
+connection hiccuped (which happens — see the earlier "Coach offline" fixes), you
+got a pop-up asking you to tap "Try again," sometimes more than once, before you
+could do your next set. Mid-workout, that's exactly the wrong moment to be poking
+at a retry button. The set was effectively held hostage by the network.
+
+**What I changed:**
+When the coach can't be reached because of a connection problem (a timeout, a
+dropped request, a server hiccup), the app now just keeps you moving: it
+instantly fills in a sensible set — your last logged weight for that exercise
+(or last session's, if it's your first set) with the program's rep and rest
+targets — and shows a small "Coach offline" note. No pop-up, no waiting. The AI
+becomes a bonus when it's reachable, not a gate when it isn't. The pop-up is kept
+ONLY for the rare cases where retrying actually can't help (the app sent a broken
+request, the coach replied with gibberish, or a setup file is missing) — there
+you still get a choice, as before.
+
+**How it was checked:**
+The app builds clean and the workout-engine tests pass, including new ones: a
+connection failure now auto-fills the set (no pop-up), the failure-type
+classification is pinned (connection issues vs. broken-request), and a genuinely
+broken response still shows the pop-up. The existing "Continue with last weights"
+button and the tricky concurrency safeguards were kept intact.
+
+**Status:** iOS-only change, no server deploy needed. (#321, part of #558 /
+ADR-0030; pairs with the earlier "Coach offline" reliability fixes #555/#556.)
+
+---
+
 ## 2026-06-29 — Removed an old, unused program-builder (cleanup)
 
 **The problem (in plain words):**

--- a/ProjectApex/AICoach/AIInferenceService.swift
+++ b/ProjectApex/AICoach/AIInferenceService.swift
@@ -681,6 +681,36 @@ nonisolated enum FallbackReason: Sendable {
     case systemPromptUnavailable(String)
 }
 
+extension FallbackReason {
+    /// ADR-0030 / #321: split per-set failures into a *transient* class (the
+    /// network/service didn't return a usable answer this time) and a
+    /// *permanent* class (something structural is wrong).
+    ///
+    /// - `.transient` failures degrade silently to a deterministic, capability-
+    ///   based prescription (plan targets + last logged weight) with a "Coach
+    ///   offline" notice — the live loop is never gated on the LLM (#555/#556).
+    /// - `.permanent` failures keep ADR-0007's surface policy: the retry sheet,
+    ///   so the user gets agency (`malformedResponse`) or is directed to support
+    ///   (`encodingFailed` / `systemPromptUnavailable`) rather than silently
+    ///   training on a best-effort guess for a structurally broken call.
+    nonisolated enum Classification: Sendable, Equatable {
+        case transient
+        case permanent
+    }
+
+    // nonisolated so the WorkoutSessionManager actor (not MainActor) can read it;
+    // the project default-isolates to MainActor, and extension members don't
+    // inherit the enum's `nonisolated` automatically.
+    nonisolated var classification: Classification {
+        switch self {
+        case .timeout, .maxRetriesExceeded, .llmProviderError:
+            return .transient
+        case .encodingFailed, .malformedResponse, .systemPromptUnavailable:
+            return .permanent
+        }
+    }
+}
+
 nonisolated enum PrescriptionResult: Sendable {
     case success(SetPrescription)
     case fallback(reason: FallbackReason)

--- a/ProjectApex/Features/Workout/WorkoutSessionManager.swift
+++ b/ProjectApex/Features/Workout/WorkoutSessionManager.swift
@@ -892,46 +892,55 @@ actor WorkoutSessionManager {
         print("[WorkoutSessionManager] Session-only weight override — \(confirmedWeight)kg (GymFactStore NOT updated)")
     }
 
-    /// Called when the user taps "Continue with last weights" on InferenceRetrySheet.
-    /// Builds a prescription from the most recently logged set for this exercise in the
-    /// current session, falling back to program defaults if no prior set exists.
-    func applyManualFallbackPrescription(for exercise: PlannedExercise) {
+    /// Builds a deterministic, capability-based prescription for an exercise:
+    /// the most recently logged set for this exercise this session, else the
+    /// last-session history anchor (`historySeedWeight`), else 0.0 (genuine
+    /// bodyweight / no history). Reps inherit the last set or fall back to the
+    /// plan's `repRange.min`; rest/tempo/RIR come from the plan. Marked
+    /// `isManualFallback` with `confidence: nil` so the UI renders it distinctly
+    /// from an AI prescription. Shared by the manual "Continue with last weights"
+    /// path and the #321 automatic transient-failure fallback.
+    private func deterministicPrescription(
+        for exercise: PlannedExercise,
+        coachingCue: String,
+        reasoning: String,
+        setFraming: String
+    ) -> SetPrescription {
         let lastSet = completedSets
             .filter { $0.exerciseId == exercise.exerciseId }
             .max(by: { $0.setNumber < $1.setNumber })
-
-        // Intent carry-over: when the user opts into the manual fallback
-        // ("Continue with last weights"), inherit the prior set's intent as a
-        // *suggestion* for the picker to prefill. Stays `nil` when there's no
-        // prior set in the session — the picker then has no prefill and the
-        // user must pick explicitly per Slice 6's no-silent-default rule.
-
-        // #318 U7 / G-F1: with no in-session set, seed the weight from the
-        // last-session history (cachedLastPerformance top set) instead of
-        // 0.0 — no more "BW" shown on a loaded movement. 0.0 survives ONLY
-        // for genuine bodyweight history (all sets 0 kg) or no history at all.
+        // #318 U7 / G-F1: seed from last in-session set, else last-session
+        // history (cachedLastPerformance top set), else 0.0 — no phantom "BW"
+        // on a loaded movement; 0.0 survives only for genuine bodyweight / none.
         let seedWeight = lastSet?.weightKg
             ?? historySeedWeight(for: exercise.exerciseId)
             ?? 0.0
-
-        let prescription = SetPrescription(
+        return SetPrescription(
             weightKg:          seedWeight,
             reps:              lastSet?.repsCompleted ?? exercise.repRange.min,
             tempo:             exercise.tempo,
             rirTarget:         exercise.rirTarget,
             restSeconds:       exercise.restSeconds,
-            coachingCue:       "Using last session weights",
-            reasoning:         "Manual fallback — AI unavailable.",
+            coachingCue:       coachingCue,
+            reasoning:         reasoning,
             safetyFlags:       [],
             confidence:        nil,
             userCorrectedWeight: nil,
             isManualFallback:  true,
             intent:            lastSet?.intent,
-            // Manual-fallback path uses a generic framing — there's no AI
-            // call to produce one. Inherits intent from last set; framing
-            // mirrors that. No silent default at the AI layer; this is
-            // the explicit fallback shape.
-            setFraming:        "Using last session weights. No AI guidance."
+            setFraming:        setFraming
+        )
+    }
+
+    /// Called when the user taps "Continue with last weights" on InferenceRetrySheet.
+    /// Builds a prescription from the most recently logged set for this exercise in the
+    /// current session, falling back to program defaults if no prior set exists.
+    func applyManualFallbackPrescription(for exercise: PlannedExercise) {
+        let prescription = deterministicPrescription(
+            for: exercise,
+            coachingCue: "Using last session weights",
+            reasoning: "Manual fallback — AI unavailable.",
+            setFraming: "Using last session weights. No AI guidance."
         )
         currentPrescription = prescription
         inferenceRetryNeeded = false
@@ -1413,12 +1422,39 @@ actor WorkoutSessionManager {
             pendingRetrySetNumber = 0
 
         case .fallback(let reason):
-            // No silent fallback — store failure state and let the user choose.
-            currentFallbackReason = reason
-            inferenceRetryReason = reason
-            pendingRetryExercise = targetExercise
-            pendingRetrySetNumber = targetSetNumber
-            // currentPrescription stays nil — the retry sheet will be shown.
+            switch reason.classification {
+            case .transient:
+                // #321 / ADR-0030: a transient failure (timeout / retries
+                // exhausted / provider error) degrades silently to a
+                // deterministic prescription instead of gating the set on the
+                // retry sheet — the live loop must survive a dead connection
+                // (#555/#556). The "Coach offline" banner is driven by
+                // currentFallbackReason; the shared state-transition switch
+                // below advances preflight/resting/active off currentPrescription
+                // exactly as the success path does. No await here, so the
+                // function-top generation guard still covers staleness.
+                currentPrescription = deterministicPrescription(
+                    for: targetExercise,
+                    coachingCue: "Using your last weights",
+                    reasoning: "Coach offline — auto-applied your last weights and the program's targets.",
+                    setFraming: "Coach offline. Using last weights + program targets."
+                )
+                currentFallbackReason = reason
+                inferenceRetryNeeded = false
+                inferenceRetryReason = nil
+                pendingRetryExercise = nil
+                pendingRetrySetNumber = 0
+            case .permanent:
+                // ADR-0007 surface policy (unchanged): a structural failure
+                // (our bug / malformed LLM output / deploy misconfig) is NOT
+                // silently defaulted — store the failure and let the user choose
+                // via the retry sheet.
+                currentFallbackReason = reason
+                inferenceRetryReason = reason
+                pendingRetryExercise = targetExercise
+                pendingRetrySetNumber = targetSetNumber
+                // currentPrescription stays nil — the retry sheet will be shown.
+            }
         }
 
         // Transition .preflight → .active (first set) or

--- a/ProjectApexTests/WorkoutSessionManagerTests.swift
+++ b/ProjectApexTests/WorkoutSessionManagerTests.swift
@@ -97,8 +97,12 @@ private final class GatedRetryProvider: LLMProvider, @unchecked Sendable {
         lock.unlock()
 
         if n == 1 {
-            // startSession inference — fail fast so we land in pending-retry.
-            throw LLMProviderError.httpError(statusCode: 401, body: "Invalid API key")
+            // startSession inference — return malformed output so it classifies
+            // as a PERMANENT failure (#321) and lands in pending-retry (the
+            // transient class now auto-applies a deterministic fallback and would
+            // not arm a retry). This keeps the #369 [19] retry-generation-guard
+            // premise intact: retryInference (call #2) has something to retry.
+            return "not a valid prescription"
         }
 
         // ONLY the retry call (#2) is gated — park until the test releases it. Every
@@ -514,32 +518,70 @@ final class WorkoutSessionManagerTests: XCTestCase {
         XCTAssertEqual(logs[0].exerciseId, day.exercises[0].exerciseId)
     }
 
-    // MARK: Test 3: Fallback path (smart retry — no silent fallback)
+    // MARK: Test 3: Transient failure → deterministic fallback (#321 / ADR-0030)
 
-    func testCompleteSet_fallbackPath_setsFallbackReason() async throws {
-        // Use a failing provider so prescribe() always returns .fallback
+    func testCompleteSet_transientFailure_appliesDeterministicFallback() async throws {
+        // FailingLLMProvider throws an HTTP error → prescribe() returns
+        // .fallback(.llmProviderError), a TRANSIENT class. Per #321 the live
+        // loop must NOT gate on the LLM: a deterministic prescription is applied
+        // with a "Coach offline" notice, and NO retry sheet is shown.
         let manager = makeManager(provider: FailingLLMProvider())
         let day = makeTrainingDay(exerciseCount: 2, setsPerExercise: 2)
 
         await manager.startSession(trainingDay: day, programId: UUID())
         try await Task.sleep(nanoseconds: 300_000_000)
 
-        // After startSession with a failing provider, inference fails →
-        // state stays in .preflight (no silent fallback), retry is needed.
+        // "Coach offline" notice is armed (currentFallbackReason drives the banner).
         let fallbackReason = await manager.currentFallbackReason
-        XCTAssertNotNil(fallbackReason, "Fallback reason should be set when AI fails")
+        XCTAssertNotNil(fallbackReason, "Transient failure should set currentFallbackReason for the offline banner")
 
+        // No retry sheet — the deterministic fallback was auto-applied.
         let retryNeeded = await manager.inferenceRetryNeeded
-        XCTAssertTrue(retryNeeded, "inferenceRetryNeeded should be true when inference fails during preflight")
+        XCTAssertFalse(retryNeeded, "Transient failure must NOT surface the retry sheet (#321)")
 
-        // No silent fallback prescription — user must choose retry or pause
+        // A deterministic prescription IS present and marked as a fallback.
         let prescription = await manager.currentPrescription
-        XCTAssertNil(prescription, "No silent fallback: prescription should be nil when inference fails")
+        XCTAssertNotNil(prescription, "Transient failure must auto-apply a deterministic prescription (#321)")
+        XCTAssertEqual(prescription?.isManualFallback, true, "Deterministic fallback is flagged isManualFallback")
+        XCTAssertNil(prescription?.confidence, "Deterministic fallback carries no AI confidence")
 
-        // State should stay in .preflight (not advance to .active without a prescription)
+        // Session advances to .active (the set card appears) rather than blocking.
+        let state = await manager.sessionState
+        guard case .active = state else {
+            XCTFail("Transient fallback should advance preflight → .active, got \(state)")
+            return
+        }
+    }
+
+    func testFallbackReason_classification_transientVsPermanent() {
+        // Transient class → deterministic fallback (live loop never gated).
+        XCTAssertEqual(FallbackReason.timeout.classification, .transient)
+        XCTAssertEqual(FallbackReason.maxRetriesExceeded(lastError: "x").classification, .transient)
+        XCTAssertEqual(FallbackReason.llmProviderError("x").classification, .transient)
+        // Permanent class → retry sheet (ADR-0007 surface preserved).
+        XCTAssertEqual(FallbackReason.malformedResponse("x").classification, .permanent)
+        XCTAssertEqual(FallbackReason.encodingFailed("x").classification, .permanent)
+        XCTAssertEqual(FallbackReason.systemPromptUnavailable("x").classification, .permanent)
+    }
+
+    func testCompleteSet_permanentFailure_surfacesRetrySheet() async throws {
+        // A malformed LLM response is a PERMANENT failure → ADR-0007 surface
+        // policy is preserved: no silent prescription, the retry sheet is shown.
+        let manager = makeManager(provider: MockLLMProvider(response: "not valid prescription json"))
+        let day = makeTrainingDay(exerciseCount: 2, setsPerExercise: 2)
+
+        await manager.startSession(trainingDay: day, programId: UUID())
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let fallbackReason = await manager.currentFallbackReason
+        XCTAssertNotNil(fallbackReason, "Permanent failure should set currentFallbackReason")
+        let retryNeeded = await manager.inferenceRetryNeeded
+        XCTAssertTrue(retryNeeded, "Permanent failure must surface the retry sheet (ADR-0007 preserved)")
+        let prescription = await manager.currentPrescription
+        XCTAssertNil(prescription, "Permanent failure: no silent prescription")
         let state = await manager.sessionState
         guard case .preflight = state else {
-            XCTFail("Expected .preflight (retry needed) when AI fails, got \(state)")
+            XCTFail("Permanent failure should stay .preflight (retry needed), got \(state)")
             return
         }
     }
@@ -1953,7 +1995,11 @@ final class PrescriptionGuardrailTests: XCTestCase {
         WSMHistoryURLProtocol.setLogRowsJSON = historySetLogRowsJSON(
             exerciseId: "exercise_0", weightKg: 80.0, reps: [8, 8, 7]
         )
-        let manager = makeHistoryManager(provider: FailingLLMProvider())
+        // Permanent failure (malformed) so the retry sheet arms and the manual
+        // "Continue with last weights" path is what seeds the prescription —
+        // a transient failure would now auto-apply the deterministic fallback
+        // first (#321), which is covered separately.
+        let manager = makeHistoryManager(provider: MockLLMProvider(response: "not valid prescription json"))
         let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 2)
         await manager.startSession(trainingDay: day, programId: UUID())
         try await Task.sleep(nanoseconds: 400_000_000)
@@ -1984,7 +2030,11 @@ final class PrescriptionGuardrailTests: XCTestCase {
         WSMHistoryURLProtocol.setLogRowsJSON = historySetLogRowsJSON(
             exerciseId: "exercise_0", weightKg: 0.0, reps: [12, 10]
         )
-        let manager = makeHistoryManager(provider: FailingLLMProvider())
+        // Permanent failure (malformed) so the retry sheet arms and the manual
+        // "Continue with last weights" path is what seeds the prescription —
+        // a transient failure would now auto-apply the deterministic fallback
+        // first (#321), which is covered separately.
+        let manager = makeHistoryManager(provider: MockLLMProvider(response: "not valid prescription json"))
         let day = makeTrainingDay(exerciseCount: 1, setsPerExercise: 2)
         await manager.startSession(trainingDay: day, programId: UUID())
         try await Task.sleep(nanoseconds: 400_000_000)

--- a/docs/adr/0007-llm-retry-and-surface-policy.md
+++ b/docs/adr/0007-llm-retry-and-surface-policy.md
@@ -2,6 +2,8 @@
 
 **Status**: accepted, 2026-05-04
 
+> **Superseded in part by [ADR-0030](0030-committed-deterministic-program-generation.md) (#321, 2026-06-29) — transient class only.** For the *per-set live-loop prescription*, a **transient** failure (timeout / retries-exhausted / provider error) no longer surfaces the retry sheet; it degrades silently to a deterministic, capability-based prescription (plan targets + last logged weight) with a "Coach offline" notice, so the workout is never gated on the LLM (#555/#556). ADR-0007's retry-sheet surface policy is unchanged for the **permanent** class (malformed response / encoding failure / system-prompt-unavailable) and for all non-per-set call sites.
+
 ## Context
 
 Phase 3's mid-session resilience work (P3-MR-F01 — `TransientRetryPolicy`, P3-T07 — `InferenceRetrySheet`, P3-MR-F05 — `FallbackLogRecord`) introduced retry behaviour for LLM provider calls in response to FB-012, the Anthropic 529 outage on 22 Apr 2026. The work shipped as a hot-patch and was documented in `ARCHITECTURE.md §7.5` but never formalised as an ADR. As a result the rules were scattered: which HTTP codes count as transient lived in `TransientRetryPolicy.transientCodes`, retry orchestration lived in `AIInferenceService.prescribe`, the foreground UI surface lived in `InferenceRetrySheet`, and what happens to the work-ahead queue on permanent failure was implicit.


### PR DESCRIPTION
## What & why

Every set hard-gated on the live LLM call — a transient failure (timeout / dropped request / provider error) surfaced a **modal retry sheet mid-workout** (the #555/#556 "Coach offline" pain). Per **ADR-0030** (partially supersedes ADR-0007 for the *transient class only*), the live loop now degrades **silently** to a deterministic prescription: AI is an upgrade, not a gate.

Order-8 slice of umbrella **#558** (folded existing issue).

## Change
- **`FallbackReason.classification`** (`nonisolated`): `transient` = `timeout` / `maxRetriesExceeded` / `llmProviderError`; `permanent` = `encodingFailed` / `malformedResponse` / `systemPromptUnavailable`.
- **`handleInferenceResult` `.fallback`** branches on classification:
  - **transient** → auto-apply `deterministicPrescription` (last logged weight → last-session history anchor → 0.0; plan reps/rest/RIR; `isManualFallback`, `confidence` nil) + set `currentFallbackReason` (drives the existing "Coach offline" banner) + `inferenceRetryNeeded = false`. The shared post-switch transition advances preflight/resting/active off `currentPrescription`. **No new `await`** → the function-top generation guard still covers staleness (dissolves the reviewer's race + async-exclusions concerns).
  - **permanent** → unchanged ADR-0007 surface (retry sheet).
- Extracted **`deterministicPrescription()`** shared by the manual "Continue with last weights" path and the new auto path (manual path behaviour byte-identical).
- **No `WorkoutViewModel`/`WorkoutView` changes** — the offline banner is already wired to `currentFallbackReason`; the retry sheet is already keyed on `inferenceRetryNeeded`.

## Why `llmProviderError` is transient
A 401/500/network error mid-workout shouldn't block the user — last-weights is always a safe continuation (#321's core intent). It also makes the path testable via the fast `FailingLLMProvider`.

## Tests — `WorkoutSessionManagerTests` 33/33
- New: transient → deterministic fallback (no sheet, advances to `.active`); `classification` mapping; permanent → retry sheet preserved.
- The two history-seed tests retargeted to the **manual** path via a permanent-failure provider (the manual button still exists for permanent failures).
- `GatedRetryProvider` call #1 switched to a **permanent** failure so the **#369 [19]** retry-generation-guard regression still arms a retry.
- Full `xcodebuild build-for-testing` SUCCEEDED.

iOS-only; **no Edge Function deploy needed**. Amends the ADR-0007 header.

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)