### PR TITLE
feat(#561): kill the global 12-week calendar-clock plumbing

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,40 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-30 — Removed the fake "12-week calendar" from the program
+
+**The problem (in plain words):**
+The app pretended your program ran on a fixed 12-week calendar with named blocks
+(weeks 1–4 "accumulation", 5–8 "intensification", 9–11 "peaking", week 12
+"deload") and even guessed which weekdays you'd train (Mon/Wed/Thu/Sat). None of
+that was real — the coach actually decides intensity per lift based on how that
+lift is progressing, not on a calendar. The fake calendar showed up in three
+places: the data the coach was handed, the coach's instructions, and the Program
+tab ("WEEK 3 / 12" with a phase progress bar). It was confusing scaffolding that
+the next round of work needs gone before building on top.
+
+**What I changed:**
+Stripped the calendar fiction everywhere: no more hardcoded week→phase table, no
+more invented weekday slots (days are just numbered slots now), no fake "where
+this week sits" volume ramp, and the coach's instructions no longer mention a
+global phase or 12-week framework — each lift uses its own phase, which is the
+only real clock. On the Program tab the "WEEK X / 12" hero and the
+ACCUM→INTENS→PEAK→DL bar are replaced with a plain "PROGRAM" title (I kept the
+honest "X / Y sessions, Z% complete" progress), and the date-driven
+"current week" highlight + auto-scroll are gone. The per-lift coaching engine and
+all saved programs are untouched — this only removes a display/labeling layer.
+
+**How it was checked:**
+App + tests build clean. Searched the whole codebase to confirm none of the
+removed pieces are referenced anywhere. Updated the tests that checked the old
+calendar fields (and added guards that the removed fields no longer ship). The
+program still generates and the existing day-labels are preserved.
+
+**Status:** iOS-only; no server deploy. First piece of the deeper
+program-generation rework. (#561, part of #558 / ADR-0030.)
+
+---
+
 ## 2026-06-29 — The workout no longer stops when the coach can't be reached
 
 **The problem (in plain words):**

--- a/ProjectApex/ContentView.swift
+++ b/ProjectApex/ContentView.swift
@@ -425,7 +425,7 @@ struct ContentView: View {
                             Task { @MainActor in
                                 await programViewModel?.loadProgram()
                                 selectedTab = 0
-                                programViewModel?.scrollToCurrentWeekTrigger += 1
+                                // #561: auto-scroll-to-current-week removed (calendar fiction).
                             }
                         },
                         onSkipSession: { runDayId in

--- a/ProjectApex/Features/Program/ProgramOverviewView.swift
+++ b/ProjectApex/Features/Program/ProgramOverviewView.swift
@@ -289,77 +289,46 @@ struct ProgramOverviewView: View {
     // MARK: - Loaded: 12-Week Grid
 
     private func loadedView(mesocycle: Mesocycle) -> some View {
-        let currentWeekIndex = viewModel.currentWeekIndex(in: mesocycle)
-        return ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(spacing: 12) {
-                    // NEXT UP hero — the calendar's primary action. Renders only when
-                    // there is a next incomplete day; an in-progress session turns it
-                    // into a Resume card (#507).
-                    nextUpHero(mesocycle: mesocycle)
-                        .padding(.horizontal, 16)
-                        .padding(.top, 16)
+        // #561 (Decision 4): the date-driven current-week highlight + auto-scroll
+        // were calendar fiction — removed. The program is a plain ordered list of
+        // day slots; no week is "current".
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                // NEXT UP hero — the program's primary action. Renders only when
+                // there is a next incomplete day; an in-progress session turns it
+                // into a Resume card (#507).
+                nextUpHero(mesocycle: mesocycle)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 16)
 
-                    // Phase progress bar header
-                    phaseProgressBar(mesocycle: mesocycle, currentWeekIndex: currentWeekIndex)
-                        .padding(.horizontal, 16)
-                        .padding(.top, hasNextUp(in: mesocycle) ? 0 : 16)
-                        .id("header")
+                // #561 (Decision 3): plain "PROGRAM" header (+ honest session
+                // progress) replaces the fictional WEEK X/12 + phase-arc hero.
+                programHeader(mesocycle: mesocycle)
+                    .padding(.horizontal, 16)
+                    .padding(.top, hasNextUp(in: mesocycle) ? 0 : 16)
 
-                    // Per-pattern phase tracking — collapsed by default
-                    patternProgressSection
+                // Per-pattern phase tracking — collapsed by default
+                patternProgressSection
 
-                    // Phase ranges (0-based week indices), matching phaseProgressBar above.
-                    let phaseRanges: [(phase: MesocyclePhase, range: ClosedRange<Int>)] = [
-                        (.accumulation,    0...3),
-                        (.intensification, 4...7),
-                        (.peaking,         8...10),
-                        (.deload,          11...11)
-                    ]
-
-                    // Week rows
-                    ForEach(Array(mesocycle.weeks.enumerated()), id: \.element.id) { index, week in
-                        // Compute phase-relative week position for the row label
-                        let phaseInfo = phaseRanges.first { $0.range.contains(index) }
-                        let phaseStart     = phaseInfo?.range.lowerBound ?? 0
-                        let phaseEnd       = phaseInfo?.range.upperBound ?? 0
-                        let phaseWeekNum   = index - phaseStart + 1
-                        let phaseWeekTot   = phaseEnd - phaseStart + 1
-
-                        WeekRowView(
-                            week: week,
-                            isCurrent: index == currentWeekIndex,
-                            weekIndex: index,
-                            mesocycleCreatedAt: mesocycle.createdAt,
-                            mesocycleId: mesocycle.id,
-                            viewModel: viewModel,
-                            gymProfile: gymProfile,
-                            phaseWeekNumber: phaseWeekNum,
-                            phaseWeekTotal: phaseWeekTot,
-                            liveTrainingDayId: deps.activeSessionCoordinator.liveTrainingDayId,
-                            liveSetSummary: deps.activeSessionCoordinator.liveSetSummary
-                        )
-                        .padding(.horizontal, 16)
-                        .id(week.id)
-                    }
-                }
-                .padding(.bottom, 32)
-            }
-            .onAppear {
-                scrollToCurrentWeek(proxy: proxy, mesocycle: mesocycle, currentWeekIndex: currentWeekIndex)
-            }
-            .onChange(of: viewModel.scrollToCurrentWeekTrigger) { _, _ in
-                withAnimation(.easeInOut(duration: 0.5)) {
-                    scrollToCurrentWeek(proxy: proxy, mesocycle: mesocycle, currentWeekIndex: currentWeekIndex)
+                // Week rows
+                ForEach(Array(mesocycle.weeks.enumerated()), id: \.element.id) { index, week in
+                    WeekRowView(
+                        week: week,
+                        isCurrent: false,
+                        weekIndex: index,
+                        mesocycleCreatedAt: mesocycle.createdAt,
+                        mesocycleId: mesocycle.id,
+                        viewModel: viewModel,
+                        gymProfile: gymProfile,
+                        liveTrainingDayId: deps.activeSessionCoordinator.liveTrainingDayId,
+                        liveSetSummary: deps.activeSessionCoordinator.liveSetSummary
+                    )
+                    .padding(.horizontal, 16)
+                    .id(week.id)
                 }
             }
+            .padding(.bottom, 32)
         }
-    }
-
-    private func scrollToCurrentWeek(proxy: ScrollViewProxy, mesocycle: Mesocycle, currentWeekIndex: Int) {
-        guard currentWeekIndex < mesocycle.weeks.count else { return }
-        let targetWeek = mesocycle.weeks[currentWeekIndex]
-        proxy.scrollTo(targetWeek.id, anchor: .top)
     }
 
     // MARK: - NEXT UP hero (#507)
@@ -670,88 +639,43 @@ struct ProgramOverviewView: View {
         }
     }
 
-    // MARK: - Phase Progress Bar
+    // MARK: - Program Header (#561)
 
-    private func phaseProgressBar(mesocycle: Mesocycle, currentWeekIndex: Int) -> some View {
-        let phases: [(phase: MesocyclePhase, label: String, weeks: ClosedRange<Int>)] = [
-            (.accumulation, "ACCUM", 0...3),
-            (.intensification, "INTENS", 4...7),
-            (.peaking, "PEAK", 8...10),
-            (.deload, "DL", 11...11)
-        ]
-
-        // Count completed+skipped sessions across all days for the progress label.
-        // Skipped sessions advance the programme pointer, so they count toward progress (#445).
+    /// Plain "PROGRAM" header + honest session-progress (completed/total + %).
+    /// Replaces the fictional WEEK X/12 hero and the ACCUM→INTENS→PEAK→DL phase
+    /// arc (ADR-0030 / #561 Decision 3) — there is no global calendar phase.
+    private func programHeader(mesocycle: Mesocycle) -> some View {
+        // Completed + skipped sessions count toward progress (skips advance the
+        // programme pointer, #445). This is real progress, not calendar fiction.
         let allDays = mesocycle.weeks.flatMap { $0.trainingDays }
         let completedCount = mesocycle.completedDayCount
         let totalDays = allDays.count
-        // Session-based completion fraction — updates immediately when a day is marked done.
         let sessionProgress = totalDays > 0 ? Double(completedCount) / Double(totalDays) : 0.0
 
-        return VStack(alignment: .leading, spacing: 14) {
-            // Week count (hero) + sessions/percent
-            HStack(alignment: .firstTextBaseline, spacing: 10) {
-                HStack(alignment: .firstTextBaseline, spacing: 6) {
-                    Text("WEEK")
-                        .font(.system(size: 12, weight: .bold))
+        return HStack(alignment: .firstTextBaseline) {
+            Text("PROGRAM")
+                .font(.system(size: 22, weight: .black))
+                .fontWidth(.condensed)
+                .foregroundStyle(Apex.text)
+            Spacer()
+            VStack(alignment: .trailing, spacing: 1) {
+                HStack(spacing: 4) {
+                    ApexNumeral(text: "\(completedCount)", size: 17, color: Apex.accent)
+                    Text("/ \(totalDays) SESSIONS")
+                        .font(.system(size: 11, weight: .bold))
                         .fontWidth(.condensed)
                         .foregroundStyle(Apex.textDim)
-                        .baselineOffset(2)
-                    ApexNumeral(text: "\(currentWeekIndex + 1)", size: 34)
-                    Text("/ \(mesocycle.weeks.count)")
-                        .font(.system(size: 15, weight: .bold))
-                        .fontWidth(.condensed)
-                        .foregroundStyle(Apex.textDim)
                 }
-                Spacer()
-                VStack(alignment: .trailing, spacing: 1) {
-                    HStack(spacing: 4) {
-                        ApexNumeral(text: "\(completedCount)", size: 17, color: Apex.accent)
-                        Text("/ \(totalDays) SESSIONS")
-                            .font(.system(size: 11, weight: .bold))
-                            .fontWidth(.condensed)
-                            .foregroundStyle(Apex.textDim)
-                    }
-                    Text("\(Int(sessionProgress * 100))% COMPLETE")
-                        .font(.system(size: 9, weight: .semibold))
-                        .tracking(0.5)
-                        .fontWidth(.condensed)
-                        .foregroundStyle(Apex.textFaint)
-                }
-            }
-
-            // Phase segments — active segment is the one lime accent.
-            HStack(spacing: 4) {
-                ForEach(phases, id: \.phase) { item in
-                    let isActive = item.weeks.contains(currentWeekIndex)
-                    Rectangle()
-                        .fill(isActive ? Apex.accent : Color.white.opacity(0.16))
-                        .frame(height: 5)
-                        .frame(maxWidth: .infinity)
-                }
-            }
-
-            // Phase labels
-            HStack(spacing: 0) {
-                phaseTick("ACCUM", active: phases[0].weeks.contains(currentWeekIndex))
-                phaseTick("INTENS", active: phases[1].weeks.contains(currentWeekIndex))
-                phaseTick("PEAK", active: phases[2].weeks.contains(currentWeekIndex))
-                phaseTick("DL", active: phases[3].weeks.contains(currentWeekIndex), width: 26)
+                Text("\(Int(sessionProgress * 100))% COMPLETE")
+                    .font(.system(size: 9, weight: .semibold))
+                    .tracking(0.5)
+                    .fontWidth(.condensed)
+                    .foregroundStyle(Apex.textFaint)
             }
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .apexCard()
-    }
-
-    private func phaseTick(_ t: String, active: Bool, width: CGFloat? = nil) -> some View {
-        Text(t)
-            .font(.system(size: 9, weight: .bold))
-            .tracking(0.6)
-            .fontWidth(.condensed)
-            .foregroundStyle(active ? Apex.accent : Apex.textFaint)
-            .frame(maxWidth: width == nil ? .infinity : nil, alignment: width == nil ? .leading : .trailing)
-            .frame(width: width)
     }
 }
 
@@ -766,10 +690,6 @@ private struct WeekRowView: View {
     let mesocycleId: UUID
     let viewModel: ProgramViewModel
     let gymProfile: GymProfile?
-    /// 1-based position of this week within its phase (e.g. 2 for the 2nd accumulation week).
-    let phaseWeekNumber: Int
-    /// Total weeks in this week's phase (e.g. 4 for accumulation).
-    let phaseWeekTotal: Int
     /// The training day ID that currently has a live session, nil when idle.
     var liveTrainingDayId: UUID? = nil
     /// Aggregated set progress for the live session (nil when no session active).
@@ -804,12 +724,6 @@ private struct WeekRowView: View {
                 }
 
                 Spacer()
-
-                // Phase-relative progress: "WK 2/4"
-                Text("WK \(phaseWeekNumber)/\(phaseWeekTotal)")
-                    .font(.system(size: 10, weight: .semibold))
-                    .fontWidth(.condensed)
-                    .foregroundStyle(Apex.textFaint)
             }
             .padding(.horizontal, 14)
             .padding(.top, 12)

--- a/ProjectApex/Features/Program/ProgramViewModel.swift
+++ b/ProjectApex/Features/Program/ProgramViewModel.swift
@@ -123,8 +123,6 @@ final class ProgramViewModel {
     /// Internal (not private) so test targets can inject a mesocycle directly
     /// without going through the UserDefaults fast-path in loadProgram().
     var currentMesocycle: Mesocycle?
-    /// Incremented by ContentView to tell ProgramOverviewView to scroll to the current week.
-    var scrollToCurrentWeekTrigger: Int = 0
 
     /// #439 (Q3 = refuse-and-prompt): set true when `regenerateProgram` was asked to
     /// run while a live/paused session sentinel (`PausedSessionState`) still exists.
@@ -789,8 +787,7 @@ final class ProgramViewModel {
                 daysSinceLastSession: daysSinceLastSession,
                 daysSinceLastTrainedByPattern: daysSinceByPattern,
                 skippedSessionCountLast30Days: skippedCount,
-                globalProgrammePhase: week.phase.rawValue,
-                globalProgrammeWeek: week.weekNumber,
+                // #561: no global calendar phase/week — the per-pattern engine is the sole clock.
                 requiresReturnPhaseOverride: (daysSinceLastSession ?? 0) >= 28
             )
         }()

--- a/ProjectApex/Resources/Prompts/SystemPrompt_SessionPlan.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_SessionPlan.txt
@@ -48,7 +48,7 @@ You are an elite AI strength and hypertrophy coach generating a SINGLE TRAINING 
 
 Your PRIMARY JOB is to deeply know each of the user's lifts. You have access to full lift history — every set, rep, and RPE signal across all previous sessions. Use this history to prescribe the most ambitious weight the user can achieve for the prescribed rep range with good technical form.
 
-The 12-week framework provides phase context. Your job is to apply that context intelligently to the user's ACTUAL performance data.
+Each movement pattern carries its own training phase (from the trainee model's per-pattern summary). Apply that pattern's phase parameters intelligently to the user's ACTUAL performance data — there is no global calendar week or programme-wide phase.
 
 ═══════════════════════════════════════════════════════════════
 RESPONSE FORMAT
@@ -144,19 +144,19 @@ over the user's last 7 training events. Read it carefully:
 ═══════════════════════════════════════════════════════════════
 PHASE PARAMETERS (apply unless fatigue overrides)
 ═══════════════════════════════════════════════════════════════
-ACCUMULATION (weeks 1–4):   Sets 3–5 | Reps 8–15 | RIR 3–4 | Rest 90–120s
-INTENSIFICATION (weeks 5–8): Sets 3–4 | Reps 5–10 | RIR 2–3 | Rest 120–180s
-PEAKING (weeks 9–11):        Sets 2–4 | Reps 3–8  | RIR 1–2 | Rest 150–300s
-DELOAD (week 12):            Sets 2–3 | Reps 10–15 | RIR 4–5 | Rest 60–90s
+ACCUMULATION:    Sets 3–5 | Reps 8–15 | RIR 3–4 | Rest 90–120s
+INTENSIFICATION: Sets 3–4 | Reps 5–10 | RIR 2–3 | Rest 120–180s
+PEAKING:         Sets 2–4 | Reps 3–8  | RIR 1–2 | Rest 150–300s
+DELOAD:          Sets 2–3 | Reps 10–15 | RIR 4–5 | Rest 60–90s
 
-volume_landmark in week_intent tells you where this week sits (0.0–1.0).
-Adjust total sets proportionally — higher landmark = upper end of set range.
+Apply the parameters for EACH pattern's own current_phase (from the
+per-pattern summary) — phase is per-pattern, not a calendar week.
 
 ═══════════════════════════════════════════════════════════════
 RETURN-TO-TRAINING OVERRIDE
 ═══════════════════════════════════════════════════════════════
 If temporal_context.requires_return_phase_override is true, the user has been away for
-28 or more days. IGNORE the global_programme_phase and pattern phase labels above.
+28 or more days. IGNORE the per-pattern phase labels above.
 
 Generate today's session as a return-to-training ACCUMULATION BASELINE:
 • Use Accumulation phase parameters (Sets 3–4 | Reps 10–15 | RIR 3–4 | Rest 90–120s).
@@ -274,17 +274,15 @@ trainee_model_digest.per_pattern_summary[].current_phase gives the per-movement-
 periodization phase. Values: "accumulation" | "intensification" | "peaking" | "deload".
 
 The per-pattern phase reflects how much volume tolerance THAT movement pattern has
-actually built. Use it to determine sets, reps, RIR, and rest for EACH exercise — NOT
-the global programme phase. When a pattern's current_phase is "deload", prescribe that
-pattern's deload parameters (low volume, low intensity, RIR ≥ 3) regardless of the
-global programme phase.
+actually built. It is the ONLY periodization clock — there is no global programme
+phase or calendar week. Use each pattern's own current_phase to determine sets, reps,
+RIR, and rest for EACH exercise. When a pattern's current_phase is "deload", prescribe
+that pattern's deload parameters (low volume, low intensity, RIR ≥ 3).
 
-A pattern in an EARLIER phase than the global programme phase is undertrained relative
-to the programme — apply that pattern's earlier-phase parameters (higher reps, higher
-RIR, more volume) before ramping intensity. A pattern in a LATER phase than the global
-phase is ahead — apply that pattern's advanced-phase parameters. Only note divergence
-in session_notes when a pattern is 2 or more phases behind the global phase (e.g.,
-global = peaking, pattern = accumulation). Keep the note under 20 words.
+Different patterns will sit in different phases at the same time — that is expected and
+correct; apply each pattern's own phase parameters independently. Only note in
+session_notes when a pattern is in deload while the others are training normally (so the
+user understands why that lift is lighter today). Keep the note under 20 words.
 
 TRANSITION MODE (ADR-0005):
 When per_pattern_summary[i].in_transition_mode == true, the EWMA capability window has

--- a/ProjectApex/Services/MacroPlanService.swift
+++ b/ProjectApex/Services/MacroPlanService.swift
@@ -302,33 +302,22 @@ actor MacroPlanService {
         from skeleton: MesocycleSkeleton,
         userId: UUID
     ) -> Mesocycle {
-        let phaseMap: [(MesocyclePhase, ClosedRange<Int>)] = [
-            (.accumulation,    1...4),
-            (.intensification, 5...8),
-            (.peaking,         9...11),
-            (.deload,          12...12)
-        ]
-
-        func phase(for weekNumber: Int) -> MesocyclePhase {
-            for (p, range) in phaseMap {
-                if range.contains(weekNumber) { return p }
-            }
-            return .accumulation
-        }
-
+        // ADR-0030 / #561: no calendar→phase map and no ISO-weekday slots. The
+        // global periodization arc is fiction nothing honest consumes — the
+        // per-pattern trainee-model engine is the sole clock. Every week is
+        // bootstrapped to .accumulation (vestigial until #562's queue model
+        // removes weeks entirely; Decision 1), and dayOfWeek is the slot's
+        // sequential position within the week, NOT a Mon/Wed/Thu/Sat calendar slot.
         var weeks: [TrainingWeek] = []
         for (index, intent) in skeleton.weekIntents.enumerated() {
             let weekNumber = index + 1
-            let currentPhase = phase(for: weekNumber)
 
             // Build placeholder training days from day-focus strings.
             let days: [TrainingDay] = intent.dayFocus.enumerated().map { dayIndex, focus in
-                // Assign standard ISO-weekday slots: Mon=1, Tue=2, Wed=3, Thu=4, ...
-                let dayOfWeek = standardDayOfWeek(for: dayIndex, daysPerWeek: skeleton.trainingDaysPerWeek)
                 let label = normalizeDayLabel(focus)
                 return TrainingDay(
                     id: UUID(),
-                    dayOfWeek: dayOfWeek,
+                    dayOfWeek: dayIndex + 1,   // sequential slot position, not an ISO weekday
                     dayLabel: label,
                     exercises: [],
                     sessionNotes: nil,
@@ -339,7 +328,7 @@ actor MacroPlanService {
             weeks.append(TrainingWeek(
                 id: UUID(),
                 weekNumber: weekNumber,
-                phase: currentPhase,
+                phase: .accumulation,   // #561 Decision 1: vestigial default (no calendar phase arc)
                 trainingDays: days,
                 weekLabel: intent.weekLabel
             ))
@@ -354,22 +343,6 @@ actor MacroPlanService {
             totalWeeks: 12,
             periodizationModel: skeleton.periodizationModel
         )
-    }
-
-    /// Maps a 0-based day index to an ISO-8601 weekday integer (Mon=1..Sun=7)
-    /// for common training frequencies.
-    private static func standardDayOfWeek(for dayIndex: Int, daysPerWeek: Int) -> Int {
-        // Common slots: Mon, Wed, Thu, Sat for 4-day; Mon, Wed, Fri for 3-day, etc.
-        let slots4: [Int] = [1, 3, 4, 6]   // Mon, Wed, Thu, Sat
-        let slots3: [Int] = [1, 3, 5]       // Mon, Wed, Fri
-        let slots5: [Int] = [1, 2, 3, 5, 6] // Mon-Wed, Fri, Sat
-        let slots6: [Int] = [1, 2, 3, 4, 5, 6]
-        let slots2: [Int] = [1, 4]           // Mon, Thu
-
-        let table: [Int: [Int]] = [2: slots2, 3: slots3, 4: slots4, 5: slots5, 6: slots6]
-        let slots = table[daysPerWeek] ?? slots4
-        guard dayIndex < slots.count else { return dayIndex + 1 }
-        return slots[dayIndex]
     }
 
     /// Normalize a free-text day-focus string into a clean snake_case

--- a/ProjectApex/Services/SessionPlanService.swift
+++ b/ProjectApex/Services/SessionPlanService.swift
@@ -65,11 +65,6 @@ nonisolated struct TemporalContext: Codable, Sendable {
     /// Number of sessions explicitly skipped by the user in the last 30 days.
     let skippedSessionCountLast30Days: Int
 
-    /// The programme's global phase at the time of this session (MesocyclePhase raw value).
-    /// Nil when not yet available (pre-migration or test contexts).
-    let globalProgrammePhase: String?
-    /// The programme's global week number (1-based).
-    let globalProgrammeWeek: Int?
     /// True when daysSinceLastSession >= 28 — signals a significant return-to-training gap.
     /// When true the LLM ignores the pattern phase label and generates a reduced-volume
     /// accumulation baseline session instead.
@@ -79,23 +74,18 @@ nonisolated struct TemporalContext: Codable, Sendable {
         case daysSinceLastSession             = "days_since_last_session"
         case daysSinceLastTrainedByPattern    = "days_since_last_trained_by_pattern"
         case skippedSessionCountLast30Days    = "skipped_session_count_last_30_days"
-        case globalProgrammePhase             = "global_programme_phase"
-        case globalProgrammeWeek              = "global_programme_week"
         case requiresReturnPhaseOverride      = "requires_return_phase_override"
     }
 
-    /// Custom encoder:
-    /// • `daysSinceLastSession` encodes as JSON `null` (not absent) when nil so the LLM
-    ///   can distinguish "first-ever session" from "field missing from payload".
-    /// • `globalProgrammePhase` and `globalProgrammeWeek` also encode as null when nil
-    ///   so the LLM sees them explicitly rather than treating absence as an unknown.
+    /// Custom encoder: `daysSinceLastSession` encodes as JSON `null` (not absent)
+    /// when nil so the LLM can distinguish "first-ever session" from "field
+    /// missing from payload". (#561: the global calendar phase/week fields are
+    /// gone — the per-pattern engine is the sole clock.)
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(daysSinceLastSession, forKey: .daysSinceLastSession)
         try container.encode(daysSinceLastTrainedByPattern, forKey: .daysSinceLastTrainedByPattern)
         try container.encode(skippedSessionCountLast30Days, forKey: .skippedSessionCountLast30Days)
-        try container.encode(globalProgrammePhase, forKey: .globalProgrammePhase)
-        try container.encode(globalProgrammeWeek, forKey: .globalProgrammeWeek)
         try container.encode(requiresReturnPhaseOverride, forKey: .requiresReturnPhaseOverride)
     }
 
@@ -106,8 +96,6 @@ nonisolated struct TemporalContext: Codable, Sendable {
         daysSinceLastSession          = try c.decodeIfPresent(Int.self, forKey: .daysSinceLastSession)
         daysSinceLastTrainedByPattern = try c.decode([String: Int].self, forKey: .daysSinceLastTrainedByPattern)
         skippedSessionCountLast30Days = try c.decode(Int.self, forKey: .skippedSessionCountLast30Days)
-        globalProgrammePhase          = try c.decodeIfPresent(String.self, forKey: .globalProgrammePhase)
-        globalProgrammeWeek           = try c.decodeIfPresent(Int.self, forKey: .globalProgrammeWeek)
         requiresReturnPhaseOverride   = try c.decodeIfPresent(Bool.self, forKey: .requiresReturnPhaseOverride) ?? false
     }
 
@@ -116,15 +104,11 @@ nonisolated struct TemporalContext: Codable, Sendable {
         daysSinceLastSession: Int?,
         daysSinceLastTrainedByPattern: [String: Int],
         skippedSessionCountLast30Days: Int,
-        globalProgrammePhase: String? = nil,
-        globalProgrammeWeek: Int? = nil,
         requiresReturnPhaseOverride: Bool = false
     ) {
         self.daysSinceLastSession           = daysSinceLastSession
         self.daysSinceLastTrainedByPattern  = daysSinceLastTrainedByPattern
         self.skippedSessionCountLast30Days  = skippedSessionCountLast30Days
-        self.globalProgrammePhase           = globalProgrammePhase
-        self.globalProgrammeWeek            = globalProgrammeWeek
         self.requiresReturnPhaseOverride    = requiresReturnPhaseOverride
     }
 }
@@ -391,12 +375,12 @@ actor SessionPlanService {
             WeekIntent(
                 weekLabel: label,
                 dayFocus: [skeletonDay.dayLabel],
-                volumeLandmark: weekVolumeLandmark(for: week.phase, weekNumber: week.weekNumber)
+                volumeLandmark: 0.0   // #561: calendar volume ramp removed; session volume now comes from the digest
             )
         } ?? WeekIntent(
             weekLabel: "\(week.phase.displayTitle) Week \(week.weekNumber)",
             dayFocus: [skeletonDay.dayLabel],
-            volumeLandmark: weekVolumeLandmark(for: week.phase, weekNumber: week.weekNumber)
+            volumeLandmark: 0.0   // #561: calendar volume ramp removed; session volume now comes from the digest
         )
 
         // Plateau/decline + volume-deficit signals come from the digest
@@ -711,16 +695,6 @@ actor SessionPlanService {
         if newer > older * 1.03 { return "improving" }
         if newer < older * 0.97 { return "declining" }
         return "stalling"
-    }
-
-    /// Rough volume landmark for prompt context (0.0–1.0).
-    private func weekVolumeLandmark(for phase: MesocyclePhase, weekNumber: Int) -> Double {
-        switch phase {
-        case .accumulation:    return 0.4 + Double(weekNumber - 1) * 0.075
-        case .intensification: return 0.7 + Double(weekNumber - 5) * 0.05
-        case .peaking:         return 0.85 + Double(weekNumber - 9) * 0.05
-        case .deload:          return 0.3
-        }
     }
 
     // MARK: - Private: Helpers

--- a/ProjectApexTests/SkipFeatureTests.swift
+++ b/ProjectApexTests/SkipFeatureTests.swift
@@ -11,7 +11,7 @@
 //   5. nextIncompleteDay — skips both .completed and .skipped days
 //   6. markDaySkipped — sets .skipped + non-nil skippedAt, persists via UserDefaults fast path
 //   7. Golden prompt — SystemPrompt_SessionPlan.txt contains all temporal_context field names
-//   8. TemporalContext Phase 2 fields — globalProgrammePhase/Week + patternPhases round-trip
+//   8. TemporalContext round-trip — remaining temporal fields; no global calendar phase/week (#561)
 
 import Testing
 import Foundation
@@ -390,24 +390,27 @@ struct SkipFeatureTests {
         #expect(content.contains("current_phase"),            "Missing current_phase key in pattern phase schema")
     }
 
-    // MARK: 8. TemporalContext Phase 2 fields
+    // MARK: 8. TemporalContext round-trip (#561: global calendar phase/week removed)
 
-    @Test("TemporalContext with Phase 2 fields survives JSON round-trip")
-    func temporalContextPhase2FieldsRoundTrip() throws {
+    @Test("TemporalContext survives JSON round-trip; carries no global calendar phase/week (#561)")
+    func temporalContextRoundTrip_noGlobalCalendarFields() throws {
         let ctx = TemporalContext(
             daysSinceLastSession: 4,
             daysSinceLastTrainedByPattern: ["horizontal_push": 4, "squat": 7],
             skippedSessionCountLast30Days: 0,
-            globalProgrammePhase: "intensification",
-            globalProgrammeWeek: 5
+            requiresReturnPhaseOverride: true
         )
         let data = try JSONEncoder().encode(ctx)
         let decoded = try JSONDecoder().decode(TemporalContext.self, from: data)
 
-        #expect(decoded.globalProgrammePhase == "intensification")
-        #expect(decoded.globalProgrammeWeek == 5)
+        #expect(decoded.daysSinceLastSession == 4)
         #expect(decoded.daysSinceLastTrainedByPattern["horizontal_push"] == 4)
         #expect(decoded.daysSinceLastTrainedByPattern["squat"] == 7)
+        #expect(decoded.requiresReturnPhaseOverride == true)
+        // #561: the killed global calendar phase/week keys must be gone from the wire.
+        let json = String(data: data, encoding: .utf8) ?? ""
+        #expect(!json.contains("global_programme_phase"))
+        #expect(!json.contains("global_programme_week"))
     }
 
     // MARK: 9. resetDayToPending — regenerate-session eligibility (#318 U4)

--- a/ProjectApexTests/TraineeModelDigestTests.swift
+++ b/ProjectApexTests/TraineeModelDigestTests.swift
@@ -837,19 +837,21 @@ final class TraineeModelDigestTests: XCTestCase {
                       "SessionPlan must surface ADR-0005's cadence-relative semantic (current absence > 2× typical cadence)")
     }
 
-    func test_sessionPlanPrompt_b3_teachesPatternOverGlobalDivergence_whenPatternPhaseLagsGlobalPhase() throws {
+    func test_sessionPlanPrompt_561_teachesPerPatternPhaseAsSoleClock_noGlobalPhase() throws {
         let prompt = try loadSessionPlanPrompt()
 
-        // Earlier-than-global and later-than-global divergence rules — preserved
-        // from the legacy PER-PATTERN PHASE TRACKING block, restated against the
-        // new digest contract.
-        XCTAssertTrue(prompt.contains("EARLIER phase than the global"),
-                      "SessionPlan must teach that a pattern in an EARLIER phase than global is undertrained")
-        XCTAssertTrue(prompt.contains("LATER phase than the global"),
-                      "SessionPlan must teach that a pattern in a LATER phase than global is ahead")
-        // Session-notes divergence threshold — keep noisy notes off when divergence is small.
-        XCTAssertTrue(prompt.contains("2 or more phases behind"),
-                      "SessionPlan must include the 2-phase-divergence session_notes threshold")
+        // #561 / ADR-0030: the per-pattern phase is the ONLY periodization clock —
+        // there is no global programme phase or calendar week. Patterns sit in
+        // different phases independently (the old earlier/later-than-global
+        // comparison + 2-phase divergence threshold are removed).
+        XCTAssertTrue(prompt.contains("ONLY periodization clock"),
+                      "SessionPlan must teach the per-pattern phase is the sole clock (#561)")
+        XCTAssertTrue(prompt.contains("apply each pattern's own phase parameters independently"),
+                      "SessionPlan must teach independent per-pattern phase application (#561)")
+        XCTAssertFalse(prompt.contains("EARLIER phase than the global"),
+                       "SessionPlan must NOT compare a pattern phase to a global phase (#561)")
+        XCTAssertFalse(prompt.contains("2 or more phases behind"),
+                       "SessionPlan must NOT carry the old global-divergence session-notes threshold (#561)")
     }
 
     func test_sessionPlanPrompt_b3_versionHeaderRecordsB3CumulativeChange() throws {
@@ -1566,9 +1568,7 @@ final class TraineeModelDigestTests: XCTestCase {
         let ctx = TemporalContext(
             daysSinceLastSession: 4,
             daysSinceLastTrainedByPattern: ["squat": 7],
-            skippedSessionCountLast30Days: 0,
-            globalProgrammePhase: "intensification",
-            globalProgrammeWeek: 5
+            skippedSessionCountLast30Days: 0
         )
         let data = try JSONEncoder().encode(ctx)
         let json = String(data: data, encoding: .utf8) ?? ""


### PR DESCRIPTION
## What & why

The macro layer carried a **fictional global periodization clock** nothing honest consumes — a hardcoded 12-week→phase calendar, invented ISO-weekday slots, a per-phase volume ramp, and a Program-tab "WEEK X / 12" + ACCUM→INTENS→PEAK→DL hero. The real clock is the **per-pattern trainee-model engine**. Removed the fiction from data assembly, the session prompt, and the UI so the queue model (#562) + autoregulator (#564) build on a single honest clock. Mostly subtractive; the per-pattern engine is untouched.

Order-3 (spine) slice of umbrella **#558** / **ADR-0030**.

## HITL decisions (confirmed)
1. **Week phase** → `.accumulation` for every week (vestigial until #562). 2. **Phase→parameter table** → kept the *values*, stripped only calendar annotations. 3. **Program header** → plain "PROGRAM" title (+ honest session progress). 4. **Current-week highlight/scroll** → removed (calendar fiction).

## Change
**Data assembly**
- `MacroPlanService.buildPendingMesocycle`: deleted the week→phase map + `standardDayOfWeek`; `dayOfWeek` is the slot's sequential position (not ISO weekday); week phase = `.accumulation`.
- `SessionPlanService`: removed `globalProgrammePhase`/`globalProgrammeWeek` from `TemporalContext`; deleted `weekVolumeLandmark` + both call sites (neutral `0.0`). **This slice owns the `weekVolumeLandmark` deletion.** `requiresReturnPhaseOverride` + `computeTrend` kept (computeTrend retires in #564).
- `ProgramViewModel.generateDaySession`: stops populating the global-phase fields.

**Prompt** (`SystemPrompt_SessionPlan.txt`): dropped the 12-week framing; stripped calendar annotations from PHASE PARAMETERS **keeping the phase→parameter values**; deleted the `volume_landmark` instruction; removed the per-pattern-vs-global-phase comparison (each pattern's phase is the sole clock).

**Program tab**: WEEK X/12 hero + phase bar → plain "PROGRAM" header (kept session progress); removed phase-relative week labels + the date-driven current-week highlight/auto-scroll. Kept `currentWeekIndex` (completion-based + tested — not fiction).

## Grep-before-done
No remaining `globalProgramme*` / `weekVolumeLandmark` / `standardDayOfWeek` / `scrollToCurrentWeekTrigger` hits in app or tests.

## Tests
- `TemporalContext` round-trip retargeted to the remaining fields + **guards the killed `global_programme_*` keys are gone**.
- The per-pattern-vs-global golden-prompt test rewritten to assert the **per-pattern-sole-clock** language (and that the old global-comparison text is gone).
- Full `xcodebuild` suite green (624 tests; the one calendar golden-prompt test fixed).

iOS-only; **no SQL migration, no EF deploy** — existing `mesocycle_json` rows still decode (their phase/week/total fields just stop being surfaced as an arc).

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)