### PR TITLE
feat(#562): queue-native Program/SlotTemplate model + Mesocycle.flatten() adapter

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,36 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-30 — New "queue" shape for programs (groundwork, nothing visible yet)
+
+**The problem (in plain words):**
+Now that the fake calendar is gone, a program is really just an ordered list of
+workout "slots" you work through one at a time — not a 12-week grid. But the code
+still stored it as the old week-by-week grid. Before the next steps (committing a
+fixed set of exercises per slot, and building each day's session without the AI),
+the app needs a clean "queue of slots" way to look at a program.
+
+**What I changed:**
+Added a new queue-shaped program model (an ordered list of day-slots + a pointer
+to the next one you haven't done) and a converter that turns the existing stored
+program into it. Crucially, the converter works on the *already-loaded* program
+object — it doesn't re-read the saved data a new way — so there's zero chance it
+trips over a real saved program and breaks it. Everyone's existing day labels are
+carried over exactly (those are the key the app uses to match your lift history).
+Nothing in the app reads this new shape yet — it's pure groundwork.
+
+**How it was checked:**
+Six new tests prove the converter keeps every slot in the right order, carries
+every day label across, points at the right "next" slot whether the program is
+fresh / partly done / finished, and survives a full save→load→convert round-trip
+without error (the guard against stranding a live program). Full build + the
+program-model test suite pass.
+
+**Status:** iOS-only, additive, no server deploy, no data migration — saved
+programs are untouched. (#562, part of #558 / ADR-0030.)
+
+---
+
 ## 2026-06-30 — Removed the fake "12-week calendar" from the program
 
 **The problem (in plain words):**

--- a/ProjectApex/Models/Program.swift
+++ b/ProjectApex/Models/Program.swift
@@ -1,0 +1,97 @@
+// Program.swift — ADR-0030 / #562: queue-native program model + flatten adapter.
+//
+// The committed, queue-native program: a frozen ordered queue of day-slots
+// (exercise identity + rep-range frozen per slot) with a queue position; length
+// is measured in sessions, not weeks (ADR-0002 — no calendar, no dayOfWeek).
+//
+// This slice is ADDITIVE and behind nothing user-facing: it ships the model and
+// a `Mesocycle.flatten()` adapter that reads the live calendar-shaped `Mesocycle`
+// into a `Program`. Nothing on the live path reads `Program` yet (the block-commit
+// writer is #563; the deterministic instantiator is #564).
+//
+// Why an adapter over the decoded `Mesocycle` rather than a new JSON decoder: the
+// existing `Mesocycle` decoder (JSONDecoder.workoutProgram) already decodes every
+// live `mesocycle_json` row today. `flatten()` is a total, pure transformation of
+// an already-valid `Mesocycle` object — there is no new JSON-parse path, so this
+// slice cannot strand an active program on a decode error (the data-risk the issue
+// flags). The on-disk JSONB column shape is unchanged.
+
+import Foundation
+
+// MARK: - SlotTemplate
+
+/// One committed day-slot in the program's queue. Exercise identity and rep-range
+/// are frozen for the block; set-count / RIR progress deterministically later
+/// (#564), so they are not modeled here.
+nonisolated struct SlotTemplate: Identifiable, Sendable {
+    let id: UUID
+    /// Per-user join key, preserved VERBATIM from the source `TrainingDay`.
+    /// ADR-0017: `deepLiftHistory` joins `day_type == dayLabel` — this must never
+    /// be rewritten or the lift-history join silently breaks.
+    let dayLabel: String
+    /// The committed exercise pool for this slot (frozen identity per ADR-0030).
+    let exercisePool: [PlannedExercise]
+    /// Frozen rep-range for the slot — the primary (first) exercise's rep-range.
+    /// `nil` for an empty, not-yet-generated (pending) slot; #563 sets this
+    /// explicitly when it commits the pool.
+    let repRange: RepRange?
+    /// Terminal status carried from the source day — drives `queuePosition`.
+    let status: TrainingDayStatus
+
+    /// Mirrors `TrainingDay.isTerminal` (#445): `.completed` / `.skipped` both
+    /// advance the queue and count as done.
+    var isTerminal: Bool { status == .completed || status == .skipped }
+}
+
+// MARK: - Program
+
+/// The committed, queue-native program (ADR-0030). A frozen ordered queue of
+/// day-slots plus the queue head (`queuePosition`).
+nonisolated struct Program: Identifiable, Sendable {
+    let id: UUID
+    let userId: UUID
+    let createdAt: Date
+    var isActive: Bool
+    /// Ordered queue of day-slots, in source week-then-day order.
+    let split: [SlotTemplate]
+    /// Index of the queue head — the first non-terminal slot. Equals
+    /// `split.count` when every slot is terminal (program complete).
+    let queuePosition: Int
+    let periodizationModel: String
+}
+
+// MARK: - Mesocycle → Program flatten adapter
+
+extension Mesocycle {
+    /// Flatten this calendar-shaped `Mesocycle` into a queue-native `Program`
+    /// (ADR-0030 / #562). Walks `weeks` in order, concatenates `trainingDays`
+    /// into one ordered `split`, preserves each `dayLabel` verbatim (ADR-0017),
+    /// freezes each slot's rep-range from its primary exercise, and sets
+    /// `queuePosition` to the first non-terminal slot.
+    ///
+    /// Pure transformation over an already-decoded `Mesocycle` — no JSON re-parse,
+    /// so it cannot fail to decode a live row.
+    func flatten() -> Program {
+        let slots: [SlotTemplate] = weeks
+            .flatMap(\.trainingDays)
+            .map { day in
+                SlotTemplate(
+                    id: day.id,
+                    dayLabel: day.dayLabel,
+                    exercisePool: day.exercises,
+                    repRange: day.exercises.first?.repRange,
+                    status: day.status
+                )
+            }
+        let queuePosition = slots.firstIndex { !$0.isTerminal } ?? slots.count
+        return Program(
+            id: id,
+            userId: userId,
+            createdAt: createdAt,
+            isActive: isActive,
+            split: slots,
+            queuePosition: queuePosition,
+            periodizationModel: periodizationModel
+        )
+    }
+}

--- a/ProjectApexTests/WorkoutProgramTests.swift
+++ b/ProjectApexTests/WorkoutProgramTests.swift
@@ -308,4 +308,83 @@ final class WorkoutProgramTests: XCTestCase {
         XCTAssertEqual(mock.completedDayCount, 2,
                        "completedDayCount must count .completed + .skipped only (1 + 1)")
     }
+
+    // MARK: ─── #562: Mesocycle.flatten() → queue-native Program ──────────────
+
+    private func flattenDay(_ label: String, _ status: TrainingDayStatus,
+                            exercises: [PlannedExercise] = []) -> TrainingDay {
+        TrainingDay(id: UUID(), dayOfWeek: 1, dayLabel: label,
+                    exercises: exercises, sessionNotes: nil, status: status)
+    }
+
+    private func flattenWeek(_ n: Int, _ days: [TrainingDay]) -> TrainingWeek {
+        TrainingWeek(id: UUID(), weekNumber: n, phase: .accumulation, trainingDays: days)
+    }
+
+    /// flatten concatenates every training day across weeks into one ordered
+    /// `split`, preserving each `dayLabel` verbatim in week-then-day order (ADR-0017).
+    func test_flatten_preservesDayLabelsInWeekThenDayOrder() {
+        var meso = Mesocycle.mockMesocycle()
+        meso.weeks = [
+            flattenWeek(1, [flattenDay("Push_A", .pending), flattenDay("Pull_A", .pending)]),
+            flattenWeek(2, [flattenDay("Push_B", .pending), flattenDay("Pull_B", .pending)])
+        ]
+        let program = meso.flatten()
+        XCTAssertEqual(program.split.count, 4)
+        XCTAssertEqual(program.split.map(\.dayLabel),
+                       ["Push_A", "Pull_A", "Push_B", "Pull_B"],
+                       "split must preserve every dayLabel in week-then-day order")
+    }
+
+    func test_flatten_allNonTerminal_queuePositionZero() {
+        var meso = Mesocycle.mockMesocycle()
+        meso.weeks = [flattenWeek(1, [flattenDay("A", .pending), flattenDay("B", .generated)])]
+        XCTAssertEqual(meso.flatten().queuePosition, 0)
+    }
+
+    /// queuePosition is the first NON-terminal slot (.completed / .skipped are terminal).
+    func test_flatten_partiallyCompleted_queuePositionAtFirstNonTerminal() {
+        var meso = Mesocycle.mockMesocycle()
+        meso.weeks = [flattenWeek(1, [
+            flattenDay("A", .completed), flattenDay("B", .skipped),
+            flattenDay("C", .pending), flattenDay("D", .paused)
+        ])]
+        let program = meso.flatten()
+        XCTAssertEqual(program.split.count, 4)
+        XCTAssertEqual(program.queuePosition, 2,
+                       "queue head is the first non-terminal slot (.pending at index 2)")
+    }
+
+    func test_flatten_allTerminal_queuePositionAtEnd() {
+        var meso = Mesocycle.mockMesocycle()
+        meso.weeks = [flattenWeek(1, [flattenDay("A", .completed), flattenDay("B", .skipped)])]
+        let program = meso.flatten()
+        XCTAssertEqual(program.queuePosition, program.split.count,
+                       "all-terminal program: queue head is past the end")
+    }
+
+    func test_flatten_freezesRepRangeFromPrimaryExercise() {
+        // mockMesocycle's first day (Push_A) leads with a 6–10 rep-range exercise.
+        let program = Mesocycle.mockMesocycle().flatten()
+        XCTAssertEqual(program.split.first?.repRange, RepRange(min: 6, max: 10),
+                       "slot rep-range is frozen from its primary (first) exercise")
+        // An empty (pending, not-yet-generated) slot has no frozen rep-range.
+        var empty = Mesocycle.mockMesocycle()
+        empty.weeks = [flattenWeek(1, [flattenDay("Empty", .pending)])]
+        XCTAssertNil(empty.flatten().split.first?.repRange)
+    }
+
+    /// Golden decode guard: a real-shaped Mesocycle JSON decodes (existing,
+    /// unchanged decoder) and flattens without throwing or dropping a dayLabel —
+    /// a failure here would strand a live program.
+    func test_flatten_afterJSONRoundTrip_neverThrows_andPreservesDayLabels() throws {
+        let original = Mesocycle.mockMesocycle()
+        let data = try JSONEncoder.workoutProgram.encode(original)
+        let decoded = try JSONDecoder.workoutProgram.decode(Mesocycle.self, from: data)
+        let program = decoded.flatten()
+        XCTAssertFalse(program.split.isEmpty)
+        XCTAssertEqual(program.split.map(\.dayLabel),
+                       original.weeks.flatMap { $0.trainingDays.map(\.dayLabel) },
+                       "every original dayLabel preserved in order after decode→flatten")
+    }
 }


### PR DESCRIPTION
## What & why

Conceptually a program is a **frozen ordered queue of day-slots** (ADR-0002: sessions, not weeks), but it's still stored as a calendar `Mesocycle`. This ships the queue-native model + a flatten adapter that reads the live program into it. **Additive and behind nothing user-facing** — nothing reads `Program` on the live path yet (#563 writes the new shape; #564 instantiates from it).

Order-4 (spine) slice of umbrella **#558** / **ADR-0030**.

## Change
- **New `ProjectApex/Models/Program.swift`** — `Program { split: [SlotTemplate], queuePosition, … }` and `SlotTemplate { dayLabel, exercisePool, repRange?, status, isTerminal }`. Sessions-not-weeks; no `dayOfWeek`.
- **`Mesocycle.flatten() → Program`** — walks `weeks` in order, concatenates `trainingDays` into one ordered `split`, preserves each `dayLabel` **verbatim** (ADR-0017 join key), freezes each slot's rep-range from its primary exercise, sets `queuePosition` to the first non-terminal slot.

## Data-risk mitigation (the issue's headline risk)
`flatten()` is an adapter over the **already-decoded** `Mesocycle` — whose decoder already reads every live `mesocycle_json` row today — **not a new JSON `init(from:)`**. It's a total, pure transformation, so it **cannot strand an active program on a decode error**. On-disk JSONB shape unchanged; no SQL migration. I did **not** pull prod user data: representative fixtures cover the documented shape variants, and the decode path is the existing tested one.

## Tests — `WorkoutProgramTests` 24/24 (6 new)
- dayLabels preserved in week-then-day order
- `queuePosition` for all-pending / partially-completed / all-terminal
- rep-range frozen from the primary exercise (nil for empty slots)
- **decode→flatten round-trip golden guard** — never throws, never drops a `dayLabel`

(New tests appended to the existing `WorkoutProgramTests.swift`; `Program.swift` is auto-included via the app's synchronized file group — no pbxproj change.)

iOS-only; additive; **no EF deploy, no migration**.

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)