### PR TITLE
feat(#563): block-commit LLM call — committed exercise pool + frozen rep-range per slot

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,42 @@ Started 2026-06-07.
 
 ---
 
+## 2026-06-30 — The coach now commits your exercises once per block (groundwork)
+
+**The problem (in plain words):**
+Until now the AI picked your exercises from scratch *every single session*, and it
+only ever saw one day at a time — so it couldn't balance the whole week, and your
+"Push day" might have different lifts each time, making it hard to actually track
+whether you're getting stronger on a given lift. The right model: pick a solid set
+of exercises for each day ONCE when a training block starts, looking at the whole
+week together, and freeze them so you can chase progress on the same lifts.
+
+**What I changed:**
+Rebuilt the program-builder into a single "block commit" call. In one pass it now
+sees every training day at once and, for each day, picks a fixed, ordered list of
+exercises (compounds first) with a frozen rep-range per exercise. It avoids
+anything your equipment can't do (a safety filter drops stragglers) and can take
+your injuries into account as a hard "don't program this" rule. It only chooses
+*which* movements and *what rep-range* — how many sets and how hard stays with the
+deterministic engine (that part lands next). Per your call: same lifts each time
+within a block, separate rep-ranges for compounds vs. isolations, and when a new
+block starts it keeps the core lifts and rotates a couple of accessories.
+
+**Important:** this is groundwork — the committed exercises are now produced and
+stored, but the workout screen doesn't *use* them yet (the next change wires that
+in). So nothing visible changes for you today; existing programs are untouched.
+
+**How it was checked:**
+14 tests pass — including new ones proving the committed exercises flow through
+with frozen rep-ranges and repeat across the block, the equipment filter drops a
+lift you can't do, and your limitations ride along in the request. Full build green.
+
+**Status:** iOS-only, groundwork, no server deploy. Injuries are carried *when
+provided* — wiring the injury source into the live path is a small follow-up (that
+data isn't persisted yet). (#563, part of #558 / ADR-0030.)
+
+---
+
 ## 2026-06-30 — New "queue" shape for programs (groundwork, nothing visible yet)
 
 **The problem (in plain words):**

--- a/ProjectApex/Models/WorkoutProgram.swift
+++ b/ProjectApex/Models/WorkoutProgram.swift
@@ -288,8 +288,21 @@ nonisolated struct WeekIntent: Codable, Sendable {
     }
 }
 
+/// #563: a committed day-slot — the frozen exercise pool for one distinct slot,
+/// chosen once at block commit and repeated across the block's weeks.
+nonisolated struct CommittedSlot: Codable, Sendable {
+    let dayLabel: String
+    let exercises: [PlannedExercise]
+
+    enum CodingKeys: String, CodingKey {
+        case dayLabel  = "day_label"
+        case exercises
+    }
+}
+
 /// A 12-week macro skeleton produced by MacroPlanService.
-/// Contains phase names, weekly intent, and day-focus strings — no exercises or weights.
+/// Carries weekly intent + day-focus labels, and (#563) the committed per-slot
+/// exercise pools (frozen identity + rep-range) the block-commit call returns.
 nonisolated struct MesocycleSkeleton: Codable, Sendable {
     let id: UUID
     let userId: UUID
@@ -299,6 +312,9 @@ nonisolated struct MesocycleSkeleton: Codable, Sendable {
     let periodizationModel: String
     /// Ordered list of 12 week intents (index 0 = week 1).
     let weekIntents: [WeekIntent]
+    /// #563: committed exercise pools, one per distinct day-slot (keyed by dayLabel).
+    /// Empty for legacy callers that only built the skeleton structure.
+    var committedSlots: [CommittedSlot] = []
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -308,6 +324,7 @@ nonisolated struct MesocycleSkeleton: Codable, Sendable {
         case trainingDaysPerWeek = "training_days_per_week"
         case periodizationModel  = "periodization_model"
         case weekIntents         = "week_intents"
+        case committedSlots      = "committed_slots"
     }
 }
 

--- a/ProjectApex/Resources/Prompts/SystemPrompt_MacroPlan.txt
+++ b/ProjectApex/Resources/Prompts/SystemPrompt_MacroPlan.txt
@@ -1,137 +1,82 @@
-You are an elite periodisation architect. Your task is to generate a 12-week MACRO SKELETON for a strength and hypertrophy programme.
+You are a strength & hypertrophy coach committing a training BLOCK. In ONE pass you choose the exercises for every training day at once (so you can balance the whole week), and you FREEZE that choice for the block.
 
-The skeleton defines the STRUCTURAL FRAMEWORK ONLY — phase organisation, weekly intent labels, and day-focus muscle groups for each training day. It does NOT contain individual exercises, sets, reps, or weights. Those are generated session-by-session by a separate AI immediately before each workout.
+You decide WHICH exercises each day contains and the REP-RANGE for each. You do NOT decide sets, RIR, weight, or any week-to-week progression — a deterministic engine owns those and reads your committed choices. Pick the movements; the engine decides how hard.
 
 ═══════════════════════════════════════════════════════════════
-⚠️  CRITICAL CONSTRAINT — READ FIRST
+⚠️  HARD CONSTRAINTS — READ FIRST
 ═══════════════════════════════════════════════════════════════
-The user's training frequency is provided in constraints.training_days_per_week.
-
-**The day_focus array in EVERY week MUST contain EXACTLY constraints.training_days_per_week entries.**
-
-Do NOT default to 4 days. Do NOT assume any standard split template.
-Derive the day structure from first principles based on the user's frequency,
-experience level, and goals. Count the day_focus entries before finalising
-your response — they must equal constraints.training_days_per_week. Hard constraint.
+• constraints.training_days_per_week tells you how many DISTINCT day-slots to return. The split array MUST contain EXACTLY that many slots. Do NOT default to 4. Count before finalising.
+• Use ONLY exercise_id values from the CANONICAL EXERCISE LIBRARY below. Never invent an exercise_id. The library is already filtered to the user's available equipment — everything listed is usable.
+• injuries / limitations are a HARD EXCLUSION. If a limitation contraindicates a movement (e.g. a knee issue → avoid deep-knee-flexion loading; a shoulder issue → avoid heavy overhead pressing), do NOT include that exercise. Choose a safe alternative that trains the same muscles.
 
 ═══════════════════════════════════════════════════════════════
 RESPONSE FORMAT
 ═══════════════════════════════════════════════════════════════
-Return ONLY a single JSON object — no prose, no markdown fences, no explanation outside the JSON.
-
-Top-level structure:
+Return ONLY a single JSON object — no prose, no markdown fences.
 
 {
-  "macro_plan": {
-    "periodization_model": "<e.g. linear_periodization>",
+  "program": {
+    "periodization_model": "<e.g. undulating>",
     "training_days_per_week": <integer>,
-    "weeks": [
+    "split": [
       {
-        "week_number": <1–12>,
-        "phase": "<accumulation | intensification | peaking | deload>",
-        "week_label": "<concise intent label, e.g. 'High Volume Accumulation'>",
-        "day_focus": ["<Day 1 focus>", "<Day 2 focus>", ...],
-        "volume_landmark": <float 0.0–1.0>
-      },
-      ... (12 entries total)
+        "day_label": "<slot label, e.g. 'Push_A'>",
+        "exercises": [
+          {
+            "exercise_id": "<canonical id from the library>",
+            "name": "<human-readable name>",
+            "primary_muscle": "<primary muscle group>",
+            "equipment_required": "<equipment key from the library>",
+            "rep_min": <int>,
+            "rep_max": <int>
+          }
+        ]
+      }
+      // ... exactly training_days_per_week slots
     ]
   }
 }
 
 ═══════════════════════════════════════════════════════════════
-PHASE STRUCTURE
+HOW TO CHOOSE EACH SLOT'S EXERCISES
 ═══════════════════════════════════════════════════════════════
-Weeks 1–4:   Accumulation    — build volume progressively
-Weeks 5–8:   Intensification — raise intensity, reduce volume slightly
-Weeks 9–11:  Peaking         — high intensity, low volume
-Week 12:     Deload          — active recovery, ~50% volume
+• 3–6 exercises per slot. Lead with the heaviest / most CNS-demanding COMPOUND for that day's focus, then supporting compounds, then isolations. Order matters — list them in the order they should be performed.
+• Cover the movement patterns the day's focus implies (e.g. a "Push" day needs a horizontal press, a vertical/overhead press, and a chest or triceps isolation).
+• REP-RANGE per exercise, matched to the movement: heavy compounds 5–8, secondary compounds 6–10, isolations 12–15 (use judgement; these are guides). Freeze a single {rep_min, rep_max} per exercise.
+• Size the slot to roughly hit each major muscle's weekly volume need across the split. Working-set guidance per muscle per week (MEV → productive ceiling): back ~12–22, chest/shoulders/legs ~10–20, biceps ~8–16, triceps ~6–14. Across the WHOLE split each major muscle group should be trained at least ~2×/week. You are choosing exercises (and therefore which muscles get hit, and how many slots touch each) — the deterministic engine sets the actual set counts.
 
 ═══════════════════════════════════════════════════════════════
-VOLUME LANDMARKS (volume_landmark field)
+SIBLING-AWARENESS (you see the whole week)
 ═══════════════════════════════════════════════════════════════
-• No two consecutive weeks may have the same volume_landmark value.
-• Values must trend: lower → higher within Accumulation (0.40 → 0.65),
-  moderate in Intensification (0.60 → 0.75), peak in Peaking (0.75 → 0.90),
-  then drop sharply to 0.30 in Deload.
-• Use increments of 0.05 minimum between consecutive weeks.
+• Balance the week: don't over-concentrate one muscle in a single slot if another slot can share it; aim for the ~2×/week frequency target per major muscle.
+• Avoid stacking two maximally-fatiguing compounds for the SAME muscle on consecutive slots when the split allows separating them.
+• Keep total exercises per slot realistic for one session.
 
 ═══════════════════════════════════════════════════════════════
-DAY FOCUS (day_focus array)
+BLOCK REFRESH (history.current_split present = re-committing a new block)
 ═══════════════════════════════════════════════════════════════
-• day_focus is an ORDERED array with exactly training_days_per_week entries.
-• Each entry is a concise muscle-group focus label, e.g.:
-    "Upper Push", "Lower", "Upper Pull", "Full Body"
-    "Push", "Pull", "Legs", "Upper"
-    "Chest/Shoulders/Triceps", "Back/Biceps", "Legs/Glutes", "Arms/Core"
-• DO NOT use named splits like "Push A" or "PPL" — derive the structure
-  from first principles based on the user's goal, training age, and recovery.
-• Reason about optimal frequency per muscle group given the user's training_days_per_week
-  and recovery capacity. For example:
-    – 3 days: Full Body × 3, or Push/Pull/Legs
-    – 4 days: Upper/Lower × 2, or Push/Pull/Legs/Upper
-    – 5 days: Push/Pull/Legs/Upper/Lower, or similar
-    – 6 days: Push/Pull/Legs × 2
-• All 12 weeks MUST use the SAME day_focus order (consistent structure).
-  The session AI adapts exercise selection within each focus, not the structure.
+When history.current_split is present, the user already trained a block on those exact exercises. KEEP the core lifts (the lead compound(s) per slot) for progressive-overload continuity, and ROTATE 1–2 ACCESSORIES per slot to a fresh choice for novel stimulus. Do not re-shuffle everything — continuity on the main lifts is the point.
 
 ═══════════════════════════════════════════════════════════════
 DAY-LABEL CONTINUITY (history.recent_day_labels)
 ═══════════════════════════════════════════════════════════════
-When history.recent_day_labels is present, the user ALREADY has training history
-under an established day-label convention. Per-exercise progression is looked up
-by day label, so a fresh convention would silently detach all of that history.
-You MUST preserve the user's convention:
-
-• REUSE the exact strings in history.recent_day_labels as your day_focus values —
-  same spelling — for ALL 12 weeks. Arrange them into a sensible weekly order.
-• These historical labels TAKE PRECEDENCE over the "derive from first principles /
-  do not use named splits" rule above. If the user's convention is a named split
-  like "Push_A"/"Pull_A"/"Legs_A", reuse it verbatim.
-• Still honor the hard training_days_per_week count. Use exactly
-  training_days_per_week labels. If the user has FEWER distinct historical labels
-  than training_days_per_week, extend the convention in the SAME naming style
-  (e.g. add "Push_B"/"Pull_B"). If MORE, pick the training_days_per_week that best
-  cover the user's split.
-• When history.recent_day_labels is ABSENT, derive day_focus from first principles
-  exactly as described in the DAY FOCUS section above.
-
-This keeps one consistent label convention across the whole mesocycle and across
-regenerations, so the user's lift history stays attached to each day.
+Per-exercise progression is looked up by day_label, so the label convention must stay stable across regenerations.
+• When history.recent_day_labels is present, REUSE those exact strings as your day_label values (same spelling). If there are fewer labels than training_days_per_week, extend in the same style (e.g. add "Push_B"); if more, pick the best-covering training_days_per_week.
+• When absent, derive sensible slot labels from first principles (e.g. "Push_A", "Pull_A", "Legs_A", "Upper_A") based on frequency, experience, and goal — do not assume a fixed template.
 
 ═══════════════════════════════════════════════════════════════
-WEEK LABELS
+USER & GOAL GUIDANCE
 ═══════════════════════════════════════════════════════════════
-week_label must be concise (≤8 words) and descriptive, e.g.:
-  "Foundation Volume Block"
-  "High Volume Accumulation"
-  "Intensity Build — Load Focus"
-  "Peak Week — Max Effort"
-  "Active Recovery Deload"
-
-═══════════════════════════════════════════════════════════════
-USER PROFILE GUIDANCE
-═══════════════════════════════════════════════════════════════
-• beginner: if frequency permits, prefer simpler splits (Upper/Lower or Full Body).
-• intermediate: Push/Pull/Legs/Upper or Upper/Lower × 2 if frequency allows.
-• advanced: higher frequency per muscle group when frequency is 4+.
-• Always use the user's actual training_days_per_week — these are style hints only.
-• goals "hypertrophy": higher volume, moderate intensity, more variety across weeks.
-• goals "strength": lower volume, heavier loads, more compound-focused days.
-• goals "fat_loss": higher rep ranges, shorter rest, metabolic conditioning days.
-
-═══════════════════════════════════════════════════════════════
-EQUIPMENT AWARENESS
-═══════════════════════════════════════════════════════════════
-available_equipment is a list of { "key", "name" } objects (key = canonical
-equipment string, name = human-readable label). It informs which muscle groups
-can be effectively trained.
-If cable machines are absent, avoid cable-dominant focus days (still train the muscles).
-If no barbell is present, acknowledge this affects strength peaking.
+• goal "hypertrophy": more isolation variety, moderate rep-ranges (8–15 on most accessories).
+• goal "strength": more compound focus, lower rep-ranges (3–6) on the main lifts.
+• beginner: simpler splits, fewer exercises per slot, compound-dominant.
+• advanced: can handle more exercises and higher per-muscle frequency.
+These are style hints — always honour the user's actual training_days_per_week and equipment.
 
 ═══════════════════════════════════════════════════════════════
 JSON VALIDITY RULES
 ═══════════════════════════════════════════════════════════════
-• Return exactly 12 week objects in weeks[].
-• phase distribution: accumulation weeks 1–4, intensification 5–8, peaking 9–11, deload 12.
-• training_days_per_week must match the length of every day_focus array.
+• split length == training_days_per_week.
+• Every exercise_id appears in the canonical library.
+• rep_min ≤ rep_max, both positive integers.
 • No prose, no markdown, no trailing commas, no comments.

--- a/ProjectApex/Services/MacroPlanService.swift
+++ b/ProjectApex/Services/MacroPlanService.swift
@@ -52,12 +52,28 @@ nonisolated struct MacroPlanRequest: Codable, Sendable {
     /// it instead of inventing a fresh one (#172). Optional → the key is omitted
     /// (encodeIfPresent) for a user with no training history (first program).
     let history: MacroPlanHistory?
+    /// #563: active injuries / limitations — a HARD exclusion for exercise
+    /// selection. Omitted from the payload when empty.
+    let limitations: [String]?
 
     enum CodingKeys: String, CodingKey {
         case userProfile  = "user_profile"
         case gymProfile   = "gym_profile"
         case constraints
         case history
+        case limitations
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(userProfile, forKey: .userProfile)
+        try c.encode(gymProfile, forKey: .gymProfile)
+        try c.encode(constraints, forKey: .constraints)
+        try c.encodeIfPresent(history, forKey: .history)
+        // Omit the key entirely when there are no limitations.
+        if let limitations, !limitations.isEmpty {
+            try c.encode(limitations, forKey: .limitations)
+        }
     }
 }
 
@@ -115,42 +131,54 @@ nonisolated struct MacroPlanConstraints: Codable, Sendable {
     static let `default` = MacroPlanConstraints(trainingDaysPerWeek: 4, totalWeeks: 12)
 }
 
-// MARK: - Response DTOs
+// MARK: - Response DTOs (#563: block-commit committed split)
 
-/// One week in the skeleton response from the LLM.
-nonisolated struct SkeletonWeek: Codable, Sendable {
-    let weekNumber: Int
-    let phase: MesocyclePhase
-    let weekLabel: String
-    let dayFocus: [String]
-    let volumeLandmark: Double
+/// One committed exercise in a slot, as returned by the block-commit LLM call.
+/// Identity + frozen rep-range only — sets/RIR/weight are deterministic (#564).
+nonisolated struct CommittedExerciseDTO: Codable, Sendable {
+    let exerciseId: String
+    let name: String
+    let primaryMuscle: String?
+    let equipmentRequired: String?
+    let repMin: Int
+    let repMax: Int
 
     enum CodingKeys: String, CodingKey {
-        case weekNumber     = "week_number"
-        case phase
-        case weekLabel      = "week_label"
-        case dayFocus       = "day_focus"
-        case volumeLandmark = "volume_landmark"
+        case exerciseId        = "exercise_id"
+        case name
+        case primaryMuscle     = "primary_muscle"
+        case equipmentRequired = "equipment_required"
+        case repMin            = "rep_min"
+        case repMax            = "rep_max"
     }
 }
 
-nonisolated struct MacroPlanSkeletonWrapper: Codable, Sendable {
-    let macroPlan: MacroPlanSkeletonPayload
+/// One committed day-slot: a frozen ordered exercise list for the block.
+nonisolated struct CommittedSlotDTO: Codable, Sendable {
+    let dayLabel: String
+    let exercises: [CommittedExerciseDTO]
 
     enum CodingKeys: String, CodingKey {
-        case macroPlan = "macro_plan"
+        case dayLabel  = "day_label"
+        case exercises
     }
 }
 
-nonisolated struct MacroPlanSkeletonPayload: Codable, Sendable {
+nonisolated struct MacroPlanProgramWrapper: Codable, Sendable {
+    let program: MacroPlanProgramPayload
+}
+
+nonisolated struct MacroPlanProgramPayload: Codable, Sendable {
     let periodizationModel: String
     let trainingDaysPerWeek: Int
-    let weeks: [SkeletonWeek]
+    /// One entry per DISTINCT day-slot (phases gone; the split is identical
+    /// across weeks, so the LLM commits each slot once — #561/#562).
+    let split: [CommittedSlotDTO]
 
     enum CodingKeys: String, CodingKey {
         case periodizationModel  = "periodization_model"
         case trainingDaysPerWeek = "training_days_per_week"
-        case weeks
+        case split
     }
 }
 
@@ -182,12 +210,17 @@ actor MacroPlanService {
         ageYears: Int? = nil,
         trainingAge: String? = nil,
         trainingDaysPerWeek: Int = 4,
-        historicalDayLabels: [String] = []
+        historicalDayLabels: [String] = [],
+        limitations: [String] = []
     ) async throws -> MesocycleSkeleton {
         isGenerating = true
         defer { isGenerating = false }
 
+        // #563: the block-commit call selects exercises, so the prompt must carry
+        // the equipment-filtered canonical exercise library (the candidate set).
+        let ownedKeys = Set(gymProfile.equipmentRefs.map { $0.key })
         let systemPrompt = try Self.loadSystemPrompt()
+            + ExerciseLibrary.promptReferenceBlock(ownedEquipmentKeys: ownedKeys)
 
         #if DEBUG
         print("[MacroPlanService] Generating macro skeleton — training_days_per_week: \(trainingDaysPerWeek), historical_day_labels: \(historicalDayLabels)")
@@ -211,7 +244,8 @@ actor MacroPlanService {
             // (#172); omit the block entirely for a user with no history.
             history: historicalDayLabels.isEmpty
                 ? nil
-                : MacroPlanHistory(recentDayLabels: historicalDayLabels)
+                : MacroPlanHistory(recentDayLabels: historicalDayLabels),
+            limitations: limitations
         )
 
         let encoder = JSONEncoder()
@@ -222,20 +256,20 @@ actor MacroPlanService {
             throw MacroPlanError.encodingFailed("Failed to encode MacroPlanRequest.")
         }
 
-        let payload = try await callAndDecodeSkeleton(
+        let payload = try await callAndDecodeProgram(
             systemPrompt: systemPrompt,
             userPayload: requestJSON
         )
 
-        return buildSkeleton(from: payload, userId: userId)
+        return buildSkeleton(from: payload, userId: userId, ownedKeys: ownedKeys)
     }
 
     // MARK: - Private: LLM call
 
-    private func callAndDecodeSkeleton(
+    private func callAndDecodeProgram(
         systemPrompt: String,
         userPayload: String
-    ) async throws -> MacroPlanSkeletonPayload {
+    ) async throws -> MacroPlanProgramPayload {
         let rawResponse: String
         do {
             rawResponse = try await provider.complete(
@@ -254,30 +288,64 @@ actor MacroPlanService {
         }
 
         do {
-            let wrapper = try JSONDecoder().decode(MacroPlanSkeletonWrapper.self, from: data)
-            return wrapper.macroPlan
+            let wrapper = try JSONDecoder().decode(MacroPlanProgramWrapper.self, from: data)
+            return wrapper.program
         } catch let err {
             #if DEBUG
             print("[MacroPlanService] Decode failure. Raw response:\n\(rawResponse)")
             #endif
             throw MacroPlanError.decodingFailed(
-                "Skeleton decode failed: \(err.localizedDescription). Raw: \(String(extracted.prefix(400)))"
+                "Block-commit decode failed: \(err.localizedDescription). Raw: \(String(extracted.prefix(400)))"
             )
         }
     }
 
-    // MARK: - Private: Build MesocycleSkeleton
+    // MARK: - Private: Build MesocycleSkeleton (#563: committed split)
 
+    /// Map the block-commit response into a MesocycleSkeleton: 12 weeks of the
+    /// same slot structure (no calendar phase arc — #561) plus the committed
+    /// per-slot exercise pools (frozen identity + rep-range). The equipment
+    /// safety rail drops any exercise whose required equipment isn't owned (the
+    /// candidate library was pre-filtered, but this is the belt-and-braces rail).
     private func buildSkeleton(
-        from payload: MacroPlanSkeletonPayload,
-        userId: UUID
+        from payload: MacroPlanProgramPayload,
+        userId: UUID,
+        ownedKeys: Set<String>
     ) -> MesocycleSkeleton {
-        let weekIntents = payload.weeks.map { sw in
-            WeekIntent(
-                weekLabel: sw.weekLabel,
-                dayFocus: sw.dayFocus,
-                volumeLandmark: sw.volumeLandmark
-            )
+        let committedSlots: [CommittedSlot] = payload.split.map { slotDTO in
+            let exercises: [PlannedExercise] = slotDTO.exercises.compactMap { dto in
+                let equipment = EquipmentType(typeKey: dto.equipmentRequired ?? "")
+                let ex = PlannedExercise(
+                    id: UUID(),
+                    exerciseId: dto.exerciseId,
+                    name: dto.name,
+                    primaryMuscle: ExerciseLibrary.primaryMuscle(for: dto.exerciseId)?.rawValue
+                        ?? (dto.primaryMuscle ?? "unknown"),
+                    synergists: [],
+                    equipmentRequired: equipment,
+                    sets: 3,                                  // #564 (autoregulator) overrides
+                    repRange: RepRange(min: dto.repMin, max: dto.repMax),  // FROZEN per slot
+                    tempo: "",
+                    restSeconds: 120,                         // #564 overrides
+                    rirTarget: 2,                             // #564 overrides
+                    coachingCues: []
+                )
+                // Equipment safety rail: bodyweight always passes; otherwise the
+                // required equipment must be owned (mirrors SessionPlanService).
+                let bodyweight = (ExerciseLibrary.lookup(ex.exerciseId)?.bodyweightOnly ?? false)
+                    || equipment.isNaturallyBodyweightOnly
+                return (bodyweight || ownedKeys.contains(equipment.typeKey)) ? ex : nil
+            }
+            return CommittedSlot(dayLabel: Self.normalizeDayLabel(slotDTO.dayLabel), exercises: exercises)
+        }
+
+        // weekIntents carry the RAW slot labels (buildPendingMesocycle normalizes
+        // them, and that normalized label matches each CommittedSlot.dayLabel for
+        // the committed-exercise lookup). Keeping them raw preserves the day-focus
+        // strings the rest of the pipeline + tests expect.
+        let rawDayLabels = payload.split.map(\.dayLabel)
+        let weekIntents = (1...12).map { _ in
+            WeekIntent(weekLabel: "", dayFocus: rawDayLabels, volumeLandmark: 0.0)
         }
 
         return MesocycleSkeleton(
@@ -287,7 +355,8 @@ actor MacroPlanService {
             isActive: true,
             trainingDaysPerWeek: payload.trainingDaysPerWeek,
             periodizationModel: payload.periodizationModel,
-            weekIntents: weekIntents
+            weekIntents: weekIntents,
+            committedSlots: committedSlots
         )
     }
 
@@ -312,14 +381,19 @@ actor MacroPlanService {
         for (index, intent) in skeleton.weekIntents.enumerated() {
             let weekNumber = index + 1
 
-            // Build placeholder training days from day-focus strings.
+            // Build training days from day-focus labels, filling each with its
+            // committed exercise pool (#563) matched by dayLabel. Status stays
+            // .pending — the committed pool is the frozen identity; the
+            // deterministic instantiator (#564) reads it at session start. Empty
+            // committedSlots (legacy/skeleton-only callers) → empty days as before.
             let days: [TrainingDay] = intent.dayFocus.enumerated().map { dayIndex, focus in
                 let label = normalizeDayLabel(focus)
+                let committed = skeleton.committedSlots.first { $0.dayLabel == label }?.exercises ?? []
                 return TrainingDay(
                     id: UUID(),
                     dayOfWeek: dayIndex + 1,   // sequential slot position, not an ISO weekday
                     dayLabel: label,
-                    exercises: [],
+                    exercises: committed,
                     sessionNotes: nil,
                     status: .pending
                 )

--- a/ProjectApexTests/MacroPlanServiceDayCountTests.swift
+++ b/ProjectApexTests/MacroPlanServiceDayCountTests.swift
@@ -30,10 +30,23 @@ private final class CapturingMockProvider: LLMProvider, @unchecked Sendable {
     }
 }
 
+/// Returns a fixed response (for asserting on the committed-split decode + rail).
+private final class StaticMockProvider: LLMProvider, @unchecked Sendable {
+    private(set) var lastUserPayload: String = ""
+    private let response: String
+    init(response: String) { self.response = response }
+    func complete(systemPrompt: String, userPayload: String) async throws -> String {
+        lastUserPayload = userPayload
+        return response
+    }
+}
+
 // MARK: - JSON factory
 
-/// Builds a minimal valid macro_plan skeleton with exactly `daysPerWeek`
-/// entries in every day_focus array and sensible structural labels.
+/// Builds a minimal valid block-commit response (#563) with exactly `daysPerWeek`
+/// committed slots, each with a couple of owned-equipment exercises + frozen
+/// rep-ranges. The day-count threading tests only assert on the captured REQUEST,
+/// so the response just needs to decode into the program.split shape.
 private func makeMockSkeletonJSON(daysPerWeek: Int) -> String {
     let dayLabels: [Int: [String]] = [
         3: ["Full Body A", "Full Body B", "Full Body C"],
@@ -42,36 +55,26 @@ private func makeMockSkeletonJSON(daysPerWeek: Int) -> String {
         6: ["Push A", "Pull A", "Legs A", "Push B", "Pull B", "Legs B"]
     ]
     let labels = dayLabels[daysPerWeek] ?? Array(repeating: "Training Day", count: daysPerWeek)
-    let dayFocusJSON = labels.map { "\"\($0)\"" }.joined(separator: ", ")
 
-    var weeks: [String] = []
-    let phaseMap: [(phase: String, range: ClosedRange<Int>)] = [
-        ("accumulation",    1...4),
-        ("intensification", 5...8),
-        ("peaking",         9...11),
-        ("deload",          12...12)
-    ]
-    for weekNum in 1...12 {
-        let phase = phaseMap.first { $0.range.contains(weekNum) }?.phase ?? "accumulation"
-        let landmark = 0.40 + Double(weekNum - 1) * 0.05
-        weeks.append("""
+    let slots = labels.map { label in
+        """
           {
-            "week_number": \(weekNum),
-            "phase": "\(phase)",
-            "week_label": "Week \(weekNum) Block",
-            "day_focus": [\(dayFocusJSON)],
-            "volume_landmark": \(String(format: "%.2f", min(landmark, 0.95)))
+            "day_label": "\(label)",
+            "exercises": [
+              { "exercise_id": "barbell_bench_press", "name": "Barbell Bench Press", "primary_muscle": "chest", "equipment_required": "barbell", "rep_min": 5, "rep_max": 8 },
+              { "exercise_id": "barbell_back_squat", "name": "Barbell Back Squat", "primary_muscle": "quads", "equipment_required": "barbell", "rep_min": 6, "rep_max": 10 }
+            ]
           }
-        """)
+        """
     }
 
     return """
     {
-      "macro_plan": {
-        "periodization_model": "linear_periodization",
+      "program": {
+        "periodization_model": "undulating",
         "training_days_per_week": \(daysPerWeek),
-        "weeks": [
-    \(weeks.joined(separator: ",\n"))
+        "split": [
+    \(slots.joined(separator: ",\n"))
         ]
       }
     }
@@ -408,5 +411,65 @@ struct MacroPlanServiceHistoricalLabelsTests {
         let root = try parseMacroPlanPayload(provider.lastUserPayload)
         #expect(root["history"] == nil,
                 "history must be omitted (not null) when the user has no established labels")
+    }
+}
+
+// MARK: - #563 block-commit
+
+@Suite("MacroPlanService — block-commit (#563)")
+struct MacroPlanBlockCommitTests {
+
+    @Test("#563: the user's limitations are sent in the block-commit request payload")
+    func blockCommit_sendsLimitations() async throws {
+        let provider = CapturingMockProvider(daysPerWeek: 4)
+        let service = MacroPlanService(provider: provider)
+        _ = try await service.generateSkeleton(
+            userId: UUID(),
+            gymProfile: makeGymProfile(),
+            trainingDaysPerWeek: 4,
+            limitations: ["left knee pain"]
+        )
+        #expect(provider.lastUserPayload.contains("left knee pain"),
+                "request must carry limitations for hard-exclusion")
+        #expect(provider.lastUserPayload.contains("limitations"))
+    }
+
+    @Test("#563: committed exercises flow into the mesocycle with frozen per-exercise rep-ranges, repeated across the block")
+    func blockCommit_committedExercisesIntoMesocycle() async throws {
+        let provider = CapturingMockProvider(daysPerWeek: 4)
+        let service = MacroPlanService(provider: provider)
+        let userId = UUID()
+        let skeleton = try await service.generateSkeleton(
+            userId: userId, gymProfile: makeGymProfile(), trainingDaysPerWeek: 4
+        )
+        #expect(skeleton.committedSlots.count == 4, "one committed slot per distinct day")
+
+        let meso = MacroPlanService.buildPendingMesocycle(from: skeleton, userId: userId)
+        let firstDay = meso.weeks[0].trainingDays[0]
+        #expect(!firstDay.exercises.isEmpty, "committed exercises fill the day")
+        #expect(firstDay.exercises.first?.repRange == RepRange(min: 5, max: 8),
+                "rep-range is frozen per exercise from the block-commit")
+        // Frozen identity: the same committed exercises repeat across the block's weeks.
+        #expect(meso.weeks[0].trainingDays[0].exercises.map(\.exerciseId)
+            == meso.weeks[5].trainingDays[0].exercises.map(\.exerciseId))
+    }
+
+    @Test("#563: equipment safety rail drops a committed exercise the user can't equip")
+    func blockCommit_equipmentRailDropsUnowned() async throws {
+        // Commit a barbell lift (owned) + a cable lift (the test gym has no cable).
+        let json = """
+        { "program": { "periodization_model": "undulating", "training_days_per_week": 1,
+          "split": [ { "day_label": "Full_Body", "exercises": [
+            { "exercise_id": "barbell_bench_press", "name": "Bench", "primary_muscle": "chest", "equipment_required": "barbell", "rep_min": 5, "rep_max": 8 },
+            { "exercise_id": "cable_tricep_pushdown", "name": "Pushdown", "primary_muscle": "triceps", "equipment_required": "cable_machine", "rep_min": 12, "rep_max": 15 }
+          ] } ] } }
+        """
+        let service = MacroPlanService(provider: StaticMockProvider(response: json))
+        let skeleton = try await service.generateSkeleton(
+            userId: UUID(), gymProfile: makeGymProfile(), trainingDaysPerWeek: 1
+        )
+        let ids = skeleton.committedSlots.first?.exercises.map(\.exerciseId) ?? []
+        #expect(ids.contains("barbell_bench_press"), "owned-equipment exercise kept")
+        #expect(!ids.contains("cable_tricep_pushdown"), "unowned cable exercise dropped by the rail")
     }
 }


### PR DESCRIPTION
## What & why

Demotes the LLM to job (1) of **ADR-0030**: ONE sibling-aware call per block that **freezes the exercise pool + per-exercise rep-range** for each day-slot, replacing per-session from-scratch generation that was blind to its sibling days (so weekly balance + progressive-overload tracking were impossible).

Order-5 (spine) slice of umbrella **#558**. **Coaching-prompt direction reviewed + approved by you** before building.

## Approved direction (your calls)
- **Fixed exercises per slot** (same lifts each Push_A, frozen for the block → clean overload tracking)
- **Per-exercise rep-ranges** (compounds 5–8, isolations 12–15)
- **Block refresh = keep core, rotate 1–2 accessories**

## Change
**Prompt (`SystemPrompt_MacroPlan.txt`, rewritten):** returns `program.split` — one committed slot per distinct day, each an ordered (compound-first) exercise list with a frozen `{rep_min, rep_max}` per exercise. Sibling-aware (~2×/week per-muscle frequency), equipment-filtered candidate library appended, injuries a **hard exclusion**, slot size guided by static per-muscle MEV→ceiling. LLM picks *what movements + rep-ranges*; the engine (#564) owns sets/RIR/weight.

**Swift:**
- New committed-split response DTOs replace the skeleton DTOs. Key realization: phases gone + the split is identical across weeks (#561), so the LLM commits each **distinct slot once**.
- `MesocycleSkeleton.committedSlots`; `buildSkeleton` maps the split into 12 weeks of the same slots + the committed pools, applying the **equipment safety rail** (bodyweight ‖ owned); `buildPendingMesocycle` fills each day's exercises from its `CommittedSlot`. Rep-range/identity frozen; sets/RIR are placeholders #564 overrides.
- `generateSkeleton` appends the equipment-filtered `ExerciseLibrary` reference + threads a `limitations` param into the request.

## ⚠️ Safe-inert
**Session-start is unchanged** — committed pools sit in the mesocycle but are still re-rolled per session until #564 consumes them. **No live behaviour change yet** (verifiable by the request-shape/decode tests; #564 flips consumption + is the device-test gate).

## Tests — 14 pass
- Day-count threading suite (11; mock updated to `program.split`)
- New block-commit suite (3): limitations carried in the request; committed exercises flow through with frozen rep-ranges + repeat across the block; equipment rail drops an unowned lift.
- Full `build-for-testing` green; grep-before-done clean (no app/test refs to removed DTOs or the old `macro_plan` shape).

## Follow-up
Wire the injury **source** into the live callers — injuries aren't persisted yet (pre-existing gap); the request already carries `limitations` when provided.

iOS-only; no SQL migration, no EF deploy.

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)