### PR TITLE
chore: reflection-notes follow-ups — build/render/ship scripts + CLAUDE.md guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ xcuserdata/
 build/
 DerivedData/
 
+# Local derivedDataPath + logs used by scripts/apex-build.sh & apex-render.sh,
+# and their screenshot output dir. Rebuildable caches — never commit.
+.build/
+.build-proto/
+renders/
+
 # Bundled alpha API key (#329). The real key lives in APIKeys.local.xcconfig,
 # which is NEVER committed. The committed APIKeys.xcconfig holds only the
 # placeholder default and optionally includes the local file; APIKeys.xcconfig.example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,20 @@
 3. **Slice completion tracking:** When I confirm a tracer-bullet slice is complete and working, close the corresponding GitHub issue with a completion comment summarising what shipped, any pre-deploy reminders, and links to spinoff issues. (The Slice 1 closure pattern in #2 is the precedent — issue closure happens via a merged PR's Closes #N keyword per Process commitment rule 1, not before.) `BACKLOG.md` is the long-form work log: append phase/slice entries to it when a phase or major slice closes, and mark the things-to-do in §2D when the dispatch surfaces new follow-ups. Sweep cadence applies (re-read on phase boundary, prune what reality has moved past). The pre-2026-06-01 prohibition on touching `BACKLOG.md` is retired — reality moved past it.
 4. **Wait for Commands:** After completing a coding task or closing the slice issue, simply tell me it is done and wait for my next instruction. Do not proceed on your own.
 
+## Autonomy modes
+
+The default above (rules 1 & 4) is **non-autonomous**. In practice it gets suspended by hand almost every campaign, so name the modes instead of renegotiating each time.
+
+- **Autopilot** — when I say "autopilot", "autocomplete it", "autopilot this campaign", or set a `/goal`, that unlocks, for the stated task/campaign: proceeding through its slices and follow-ups without a per-step check-in; making ordinary implementation decisions and continuing; and committing → PR → `--admin` squash-merge on green (merge autonomy is already granted — memory `feedback_merge_autonomy`). You do **not** need to stop and ask "what next?" between slices of the agreed scope.
+- **Still gated even under autopilot — ask first:** scope changes beyond the stated goal; destructive or irreversible ops (deleting data, force-pushing `main`, prod DB migrations, rotating/altering secrets, publishing anything to an external service); and anything a memory file or issue marks OWNER-only.
+- **Orchestration is announced, not silent.** Before spawning a multi-agent fan-out (worktree agents, a Workflow), state the shape and rough cost first; once I say go, run it without further asking. (Rejected once for auto-spawning a team without announcing — c8f89cf3.)
+- Autopilot ends when the task/campaign is done, or when I say "stop autopilot".
+
+## Asking the user
+
+- **Taste is open-ended, not multiple-choice.** For aesthetic / subjective / design-feel decisions, ask in plain text and let me answer free-form — don't force it through `AskUserQuestion`'s options (I kept breaking out of that UI to type real answers — ee75633c). Reserve `AskUserQuestion` for genuine either/or forks (the kind grill-me uses well).
+- **Investigate before asking.** On an investigation/debugging task, look first and only ask when actually blocked — don't open with a question you could answer by reading the code.
+
 ## Doc map — where each kind of information lives
 
 Each doc has one job. When you need an answer, go to the doc whose job covers it; when you change reality, update only that doc.
@@ -31,7 +45,29 @@ When the fix is to a *pattern* rather than a single call site (test-harness bugs
 
 Practical form: after writing the fix, grep for the pattern that motivated it (e.g. `request.httpBody` for URLProtocol mocks, `static var.*Handler` for shared mock state, `weightKg >=` for validation predicates) and confirm every hit either uses the fix or has a documented reason to differ. Report the grep result alongside the fix, not after the user notices the second site.
 
+## Shell & harness gotchas
+
+Small, identical mistakes that burned turns in nearly every session. Internalize these; the fix is one habit each.
+
+- **Read before Edit.** The Edit tool refuses a file you haven't Read this session ("File has not been read yet"). If a build/screenshot hook or another process may have rewritten the file since you read it, Read it again before editing ("File has been modified since read" — hit 8× on one file).
+- **Quote globs — this shell is zsh, not bash.** Unquoted `--include=*.swift` / `*.swift` → "no matches found" (zsh globs before the command sees it). Quote it (`'*.swift'`) or just use `rg`. Same family: no `declare -a`, avoid `$(( ))` arithmetic on UUID-looking strings, watch for `bad substitution`.
+- **No foreground `sleep`.** The harness blocks it. Run long-running commands as a **background Bash job** and poll the log, or use Monitor / an `until`-loop.
+- **`timeout`, `sed -i`, `rg`, `curl` may be missing** in a fresh sandbox PATH (macOS has no GNU `timeout`; BSD `sed -i` needs `-i ''`). Check the command exists before relying on it.
+- **Workflow scripts are plain JavaScript** — no TypeScript type annotations/interfaces/generics (rejected 4× in one session). Also no `Date.now()`/`Math.random()`.
+- **Prefer the checked-in build scripts** (`scripts/apex-*.sh`, see below) over hand-typing `xcodebuild`/`simctl`/`gh` — that recipe is where the destination/UDID/stale-`.app` mistakes come from.
+
 ## Agent skills
+
+### Build / render / test / ship
+
+Use the checked-in `scripts/apex-*.sh` helpers instead of re-deriving the xcodebuild/simctl/`gh` recipe by hand (the single biggest recurring cost):
+- `scripts/apex-build.sh [build|test] [--only-testing X]` — pins scheme/UDID/derivedDataPath, copies `APIKeys.xcconfig`, disk-preflight; runs in the background, prints `LOG:` first.
+- `scripts/apex-render.sh <app|PROTO_SCREEN> [--out DIR]` — build → install freshest `.app` → launch → screenshot → `sips -Z 1400`.
+- `scripts/ship-pr.sh [<branch>|<worktree>]` — push → PR → wait on checks (ignoring the flaky `iOS Build & Test`) → `--admin` squash-merge → prune worktree.
+- `scripts/deploy-efs.sh [names|--all]` — deploy the Edge Functions changed vs `origin/main`.
+- `scripts/apex-status.sh` — "what's left?" rollup (open PRs+checks, issues, BACKLOG §2D).
+
+Full recipe, env overrides, and the hard-won constants: **`docs/agents/build-and-render.md`**.
 
 ### Issue tracker
 

--- a/docs/agents/build-and-render.md
+++ b/docs/agents/build-and-render.md
@@ -1,0 +1,93 @@
+# Build / render / test / ship — the canonical recipe
+
+One place for the xcodebuild/simctl/PR recipe that used to be re-derived from
+scratch almost every session. The `scripts/` helpers below encode it so you
+don't. Prefer them over hand-typed `xcodebuild`/`simctl`/`gh` incantations.
+
+All scripts live in `scripts/` and are checked in. They work from the main
+checkout **and** from a `.claude/worktrees/*` worktree (they resolve their own
+root from `$0`), so an agent in a worktree runs the same command.
+
+## `scripts/apex-build.sh [build|test] [--only-testing X ...]`
+
+Builds or tests the app. What it pins so you never re-derive it:
+
+- **scheme** `ProjectApex`, **config** Debug, `CODE_SIGNING_ALLOWED=NO`.
+- **one concrete simulator UDID** — newest installed iOS runtime, an
+  already-booted `iPhone 17 Pro` preferred. Used for `-destination id=<udid>`.
+  This kills the recurring *build-OS vs booted-sim mismatch* and the stale
+  hardcoded-UDID problem.
+- `-derivedDataPath <root>/.build` — never pollutes the global DerivedData cache.
+- copies the git-ignored `APIKeys.xcconfig` into a fresh worktree if missing.
+- **free-disk preflight**: warns under 8 GB; purges the *global* Xcode
+  DerivedData cache (a pure rebuildable cache) under a 4 GB floor. ENOSPC once
+  caused real data loss mid-orchestration; this is the guard.
+
+Runs `xcodebuild` in the foreground, teeing to a timestamped log under
+`.build/logs/`. The **first line printed is `LOG: <path>`**. Run the script
+itself as a **background Bash job** and tail/Monitor that log — never foreground
+a long build with `-quiet`, it can be killed.
+
+```bash
+scripts/apex-build.sh build
+scripts/apex-build.sh test --only-testing ProjectApexTests/WorkoutSessionManagerTests
+```
+
+Env: `APEX_SIM_NAME` (default `iPhone 17 Pro`), `APEX_MAIN_REPO`.
+
+## `scripts/apex-render.sh <app|PROTO_SCREEN> [--out DIR]`
+
+Build → install the **freshest `.app` by mtime** (not `head -1`, which grabbed a
+stale DerivedData dir and cost days of re-render loops) → launch → screenshot →
+`sips -Z 1400`. Screenshots land in `--out` (default `./renders`).
+
+- `app` renders the real `ProjectApex` app (bundle id read from the built
+  `.app`, so no hardcoding).
+- any other key renders `UIPrototypes/ApexUIProto` with
+  `SIMCTL_CHILD_PROTO_SCREEN=<key>` — the redesign-harness convention. Errors
+  cleanly if the prototype project isn't present.
+
+```bash
+scripts/apex-render.sh app
+scripts/apex-render.sh navbarlive --out UIPrototypes/renders
+```
+
+## `scripts/ship-pr.sh [<branch>|<worktree-path>] [--title T --body B]`
+
+push → create PR (standard Claude Code trailer) → wait on required checks
+**ignoring the known flaky `iOS Build & Test` check** → `gh pr merge --squash
+--admin --delete-branch` → prune the worktree if one was passed.
+
+Merge autonomy is durably granted (memory `feedback_merge_autonomy`), so this
+admin-merges on green without asking. It **aborts** if a *non-ignored* check
+fails. Override the flake pattern with `APEX_FLAKY_CHECK` (regex).
+
+```bash
+scripts/ship-pr.sh                                   # current branch
+scripts/ship-pr.sh .claude/worktrees/slice-3-foo     # a worktree, pruned after merge
+```
+
+## `scripts/deploy-efs.sh [names… | --all]`
+
+Deploys the Supabase Edge Functions **changed vs `origin/main`** (or the ones you
+name, or `--all`). Edge Functions deploy manually and often; this removes the
+"OWNER must deploy X" hand-step. Needs the Supabase CLI logged in + project
+linked; secrets stay in Supabase-managed env vars, never on disk. See
+`docs/agents/edge-functions.md`.
+
+## `scripts/apex-status.sh`
+
+One "what's left?" rollup: open PRs + their check state, open issues (umbrellas
+first), the BACKLOG §2D things-to-do, recent commits. Read-only; the model
+reading the dump does the synthesis.
+
+## Hard-won constants (don't re-learn these)
+
+- Build **`OS=26.5`** locally (CI pins 26.2, which isn't installed here;
+  `xcodebuild` exits 70 on a missing runtime). The scripts sidestep this by
+  targeting a real device UDID instead of an `OS=` string.
+- Fresh worktrees lack the git-ignored **`APIKeys.xcconfig`** → the scripts copy
+  it from `APEX_MAIN_REPO`.
+- Do **not** run `xcodebuild` inside a Workflow subagent (3-min stall-detector
+  kills it). Use the Agent tool + background Bash builds, or these scripts.
+- `.build/` (local derivedDataPath) is git-ignored.

--- a/scripts/apex-build.sh
+++ b/scripts/apex-build.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# apex-build.sh — one canonical way to build/test ProjectApex on the simulator.
+#
+# Usage:
+#   scripts/apex-build.sh build                         # build the app
+#   scripts/apex-build.sh test                          # run the full test suite
+#   scripts/apex-build.sh test --only-testing ProjectApexTests/FooTests
+#   scripts/apex-build.sh test --only-testing ProjectApexTests/FooTests/testBar
+#
+# Env overrides: APEX_SIM_NAME (default "iPhone 17 Pro"), APEX_MAIN_REPO.
+#
+# What it pins for you (so it never gets re-derived by hand — reflection item 1):
+#   • scheme = ProjectApex
+#   • one concrete simulator UDID (newest runtime, booted iPhone 17 Pro preferred)
+#     used for BOTH -destination and any later install/launch → no OS mismatch
+#   • -derivedDataPath <root>/.build  → never touches the global DerivedData cache
+#   • copies APIKeys.xcconfig into fresh worktrees
+#   • free-disk preflight (+ purges the global cache when critically low)
+#
+# Runs xcodebuild in the foreground, teeing to a timestamped log whose path is
+# printed on the FIRST line. Run this script itself as a background Bash job when
+# you want async, then tail/Monitor the printed log (never foreground a long
+# build with -quiet — it can be killed).
+
+set -euo pipefail
+source "$(cd "$(dirname "$0")/lib" && pwd)/apex-sim.sh"
+
+action="${1:-build}"; shift || true
+case "$action" in
+  build|test) ;;
+  *) apex_die "usage: apex-build.sh [build|test] [--only-testing X ...]" ;;
+esac
+
+only_testing_args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --only-testing) only_testing_args+=("-only-testing:$2"); shift 2 ;;
+    *) apex_die "unknown arg: $1" ;;
+  esac
+done
+
+ROOT="$(apex_root)"
+apex_disk_preflight
+apex_ensure_apikeys "$ROOT"
+UDID="$(apex_resolve_udid)"
+apex_log "simulator UDID: $UDID"
+
+LOG_DIR="$ROOT/.build/logs"
+mkdir -p "$LOG_DIR"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+LOG="$LOG_DIR/${action}-${STAMP}.log"
+# First line of output = the log path, so a background run surfaces it immediately.
+echo "LOG: $LOG"
+
+set -x
+xcodebuild "$action" \
+  -project "$ROOT/ProjectApex.xcodeproj" \
+  -scheme ProjectApex \
+  -configuration Debug \
+  -destination "platform=iOS Simulator,id=$UDID" \
+  -derivedDataPath "$ROOT/.build" \
+  CODE_SIGNING_ALLOWED=NO \
+  "${only_testing_args[@]+"${only_testing_args[@]}"}" 2>&1 | tee "$LOG"

--- a/scripts/apex-render.sh
+++ b/scripts/apex-render.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# apex-render.sh — build, install, launch, and screenshot on the simulator.
+#
+# Usage:
+#   scripts/apex-render.sh app [--out DIR]         # the real ProjectApex app
+#   scripts/apex-render.sh <PROTO_SCREEN> [--out DIR]   # a UIPrototypes screen
+#
+# "app"  → builds ProjectApex, installs the FRESHEST .app (by mtime), launches
+#          RTG.ProjectApex, screenshots, downscales with `sips -Z 1400`.
+# a key  → builds UIPrototypes/ApexUIProto, launches with
+#          SIMCTL_CHILD_PROTO_SCREEN=<key> (the redesign harness convention).
+#
+# Fixes the re-typed render boilerplate and the `head -1` stale-.app bug
+# (reflection-notes.md item 1). Screenshots land in --out (default: ./renders).
+
+set -euo pipefail
+source "$(cd "$(dirname "$0")/lib" && pwd)/apex-sim.sh"
+
+target="${1:-}"; [[ -n "$target" ]] || apex_die "usage: apex-render.sh <app|PROTO_SCREEN> [--out DIR]"
+shift
+OUT="./renders"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out) OUT="$2"; shift 2 ;;
+    *) apex_die "unknown arg: $1" ;;
+  esac
+done
+
+ROOT="$(apex_root)"
+mkdir -p "$OUT"
+apex_disk_preflight
+UDID="$(apex_resolve_udid)"
+apex_boot "$UDID"
+
+build_bg() {  # build in background, poll the log for BUILD SUCCEEDED/FAILED
+  local desc="$1"; shift
+  local log; log="$ROOT/.build/logs/render-${desc}-$(date +%H%M%S).log"
+  mkdir -p "$(dirname "$log")"
+  apex_log "building $desc → $log"
+  ( "$@" >"$log" 2>&1 ) &
+  local pid=$!
+  while kill -0 "$pid" 2>/dev/null; do sleep 5; done
+  wait "$pid" || { tail -30 "$log" >&2; apex_die "$desc build failed (see $log)"; }
+  apex_log "$desc build OK"
+}
+
+if [[ "$target" == "app" ]]; then
+  apex_ensure_apikeys "$ROOT"
+  build_bg app xcodebuild build \
+    -project "$ROOT/ProjectApex.xcodeproj" -scheme ProjectApex -configuration Debug \
+    -destination "platform=iOS Simulator,id=$UDID" -derivedDataPath "$ROOT/.build" \
+    CODE_SIGNING_ALLOWED=NO
+  APP="$(apex_freshest_app "$ROOT/.build/Build/Products" ProjectApex.app)"
+  [[ -n "$APP" ]] || apex_die "no ProjectApex.app under $ROOT/.build"
+  SHOT="$OUT/app-$(date +%Y%m%d-%H%M%S).png"
+  LAUNCH_ENV=()
+else
+  PROTO="$ROOT/UIPrototypes/ApexUIProto.xcodeproj"
+  [[ -d "$PROTO" ]] || apex_die "UIPrototypes/ApexUIProto.xcodeproj not found (redesign harness absent)."
+  build_bg "proto" xcodebuild build \
+    -project "$PROTO" -scheme ApexUIProto -configuration Debug \
+    -destination "platform=iOS Simulator,id=$UDID" -derivedDataPath "$ROOT/.build-proto" \
+    CODE_SIGNING_ALLOWED=NO
+  APP="$(apex_freshest_app "$ROOT/.build-proto/Build/Products" ApexUIProto.app)"
+  [[ -n "$APP" ]] || apex_die "no ApexUIProto.app under $ROOT/.build-proto"
+  SHOT="$OUT/${target}-$(date +%Y%m%d-%H%M%S).png"
+  LAUNCH_ENV=(SIMCTL_CHILD_PROTO_SCREEN="$target")
+fi
+
+BUNDLE="$(apex_bundle_id "$APP")"
+[[ -n "$BUNDLE" ]] || apex_die "could not read bundle id from $APP"
+apex_log "installing $APP ($BUNDLE)"
+xcrun simctl install "$UDID" "$APP"
+xcrun simctl terminate "$UDID" "$BUNDLE" >/dev/null 2>&1 || true
+env "${LAUNCH_ENV[@]+"${LAUNCH_ENV[@]}"}" xcrun simctl launch "$UDID" "$BUNDLE" >/dev/null
+sleep 3   # let the first frame render (cold start can capture blank otherwise)
+xcrun simctl io "$UDID" screenshot "$SHOT"
+sips -Z 1400 "$SHOT" >/dev/null
+apex_log "screenshot: $SHOT"
+echo "$SHOT"

--- a/scripts/apex-status.sh
+++ b/scripts/apex-status.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# apex-status.sh — one "what's left?" rollup.
+#
+# Gathers the raw facts that the recurring "what else is left to finish?" question
+# is always answered from by hand (reflection item 10): open issues, open PRs +
+# their check state, umbrella issues, and the BACKLOG things-to-do section. Prints
+# a compact dump; the model reading it does the synthesis.
+#
+# Usage: scripts/apex-status.sh
+
+set -euo pipefail
+cd "$(cd "$(dirname "$0")/.." && pwd)"
+REPO=thearnavmenon/ProjectApex
+
+echo "=================== OPEN PRs ==================="
+gh pr list --repo "$REPO" --state open \
+  --json number,title,headRefName,isDraft,statusCheckRollup \
+  -q '.[] | "#\(.number) \(if .isDraft then "[draft] " else "" end)\(.title)  <\(.headRefName)>  checks:" +
+        ( [ .statusCheckRollup[]? | (.conclusion // .state // .status // "?") ]
+          | (if length==0 then "none" else (group_by(.) | map("\(.[0])×\(length)") | join(",")) end) )' \
+  2>/dev/null || echo "(gh pr list failed)"
+
+echo
+echo "=================== OPEN ISSUES (umbrellas first) ==================="
+gh issue list --repo "$REPO" --state open --limit 100 \
+  --json number,title,labels \
+  -q 'sort_by( ([.labels[].name] | index("umbrella") // 999) )
+      | .[] | "#\(.number) \(.title)  [\( [.labels[].name] | join(",") )]"' \
+  2>/dev/null || echo "(gh issue list failed)"
+
+echo
+echo "=================== BACKLOG — things-to-do (§2D) ==================="
+if [[ -f BACKLOG.md ]]; then
+  awk '/##.*2D|§2D|Things to do|things-to-do|To-?do/{f=1} f{print} /^## /{if(f&&!/2D|To-?do|Things/) exit}' BACKLOG.md \
+    | head -60
+else
+  echo "(no BACKLOG.md)"
+fi
+
+echo
+echo "=================== recent commits ==================="
+git log --oneline -8

--- a/scripts/deploy-efs.sh
+++ b/scripts/deploy-efs.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# deploy-efs.sh — deploy the Supabase Edge Functions touched on this branch.
+#
+# Usage:
+#   scripts/deploy-efs.sh                     # auto: functions changed vs origin/main
+#   scripts/deploy-efs.sh update-trainee-model update-trainee-goal   # explicit
+#   scripts/deploy-efs.sh --all               # every function under supabase/functions
+#
+# Edge Functions deploy manually and often, and "OWNER must deploy X" reminders
+# litter the memory files (reflection item 7). This makes the common case one
+# command. It does NOT store secrets — production secrets live in Supabase-managed
+# env vars (docs/agents/edge-functions.md). Requires the Supabase CLI to be logged
+# in (`supabase login`) and the project linked (`supabase link`); the access token
+# should come from your keychain/secret store, never pasted into a chat.
+
+set -euo pipefail
+cd "$(cd "$(dirname "$0")/.." && pwd)"
+
+command -v supabase >/dev/null 2>&1 || { echo "supabase CLI not found" >&2; exit 1; }
+
+fns=()
+if [[ "${1:-}" == "--all" ]]; then
+  for d in supabase/functions/*/; do
+    b="$(basename "$d")"; [[ "$b" == _* ]] && continue   # skip _shared etc.
+    fns+=("$b")
+  done
+elif [[ $# -gt 0 ]]; then
+  fns=("$@")
+else
+  # Auto-detect: function dirs with changes vs origin/main.
+  git fetch -q origin main 2>/dev/null || true
+  base="$(git merge-base origin/main HEAD 2>/dev/null || echo origin/main)"
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    name="$(sed -E 's#^supabase/functions/([^/]+)/.*#\1#' <<<"$f")"
+    [[ "$name" == _* ]] && continue
+    fns+=("$name")
+  done < <(git diff --name-only "$base"...HEAD -- 'supabase/functions/*' | sort -u)
+  # de-dupe
+  if [[ ${#fns[@]} -gt 0 ]]; then
+    IFS=$'\n' read -r -d '' -a fns < <(printf '%s\n' "${fns[@]}" | sort -u && printf '\0')
+  fi
+fi
+
+if [[ ${#fns[@]} -eq 0 ]]; then
+  echo "No changed Edge Functions vs origin/main. Nothing to deploy."
+  exit 0
+fi
+
+echo "Will deploy: ${fns[*]}"
+for fn in "${fns[@]}"; do
+  echo "── supabase functions deploy $fn ──"
+  supabase functions deploy "$fn"
+done
+echo "Deployed: ${fns[*]}"

--- a/scripts/lib/apex-sim.sh
+++ b/scripts/lib/apex-sim.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Shared helpers for the apex-* build/render scripts.
+# Source this; don't execute it. All functions echo to stderr for progress and
+# to stdout only for their return value, so callers can capture cleanly.
+#
+# Why this exists: the xcodebuild/simctl recipe was re-derived by hand in almost
+# every session (see reflection-notes.md item 1). The three recurring failures
+# this file removes for good:
+#   1. Simulator UDID re-derived / hardcoded then gone stale.
+#   2. Build-OS vs booted-sim mismatch (build for 26.5, sim is 26.3).
+#   3. Wrong .app installed because `head -1` grabbed a stale DerivedData dir.
+# We fix all three by resolving ONE concrete device UDID (newest runtime,
+# preferring an already-booted iPhone 17 Pro) and using `-destination id=<udid>`
+# for the build AND `simctl <udid>` for install/launch — so build and run always
+# target the same simulator, and by picking the freshest .app by mtime.
+
+set -euo pipefail
+
+# The canonical main checkout. Fresh worktrees copy APIKeys.xcconfig from here.
+APEX_MAIN_REPO="${APEX_MAIN_REPO:-/Users/arnav/Desktop/ProjectApex}"
+
+# Device family we standardize on. Override with APEX_SIM_NAME if needed.
+APEX_SIM_NAME="${APEX_SIM_NAME:-iPhone 17 Pro}"
+
+apex_log() { printf '\033[2m[apex]\033[0m %s\n' "$*" >&2; }
+apex_die() { printf '\033[31m[apex] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Root of the repo/worktree this script lives in (scripts/lib/.. -> scripts/.. ).
+apex_root() {
+  local here
+  here="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  printf '%s\n' "$here"
+}
+
+# Copy the git-ignored APIKeys.xcconfig into a fresh worktree if it is missing,
+# so the build does not break. No-op in the main checkout.
+apex_ensure_apikeys() {
+  local root="$1"
+  if [[ ! -f "$root/APIKeys.xcconfig" ]]; then
+    if [[ -f "$APEX_MAIN_REPO/APIKeys.xcconfig" ]]; then
+      cp "$APEX_MAIN_REPO/APIKeys.xcconfig" "$root/APIKeys.xcconfig"
+      apex_log "copied APIKeys.xcconfig into $root"
+    else
+      apex_log "WARNING: no APIKeys.xcconfig found (build may fail)"
+    fi
+  fi
+}
+
+# Free-disk preflight. DerivedData ballooning to ENOSPC caused real data loss
+# (reflection-notes.md item 1). We pin -derivedDataPath to the repo's .build, so
+# the risk is the global Xcode DerivedData cache — safe to purge, Xcode rebuilds
+# it. Warn under 8 GB free; auto-purge the *global* cache under a 4 GB floor.
+apex_disk_preflight() {
+  local free_gb
+  free_gb="$(df -g / | awk 'NR==2 {print $4}')"
+  apex_log "free disk: ${free_gb} GB"
+  if (( free_gb < 8 )); then
+    apex_log "WARNING: low disk (${free_gb} GB free)."
+    local global="$HOME/Library/Developer/Xcode/DerivedData"
+    if (( free_gb < 4 )) && [[ -d "$global" ]]; then
+      apex_log "purging global Xcode DerivedData cache to reclaim space: $global"
+      rm -rf "${global:?}/"* 2>/dev/null || true
+      apex_log "purged. (Local -derivedDataPath builds are unaffected.)"
+    fi
+  fi
+}
+
+# Resolve one concrete simulator UDID: newest iOS runtime, our device family,
+# preferring an already-booted one. Echoes the UDID on stdout.
+apex_resolve_udid() {
+  local name="${1:-$APEX_SIM_NAME}"
+  local udid
+  udid="$(xcrun simctl list devices available -j | jq -r --arg name "$name" '
+    [ .devices | to_entries[]
+      | select(.key | test("iOS"))
+      | ( .key | capture("iOS-(?<a>[0-9]+)-(?<b>[0-9]+)(-(?<c>[0-9]+))?") ) as $v
+      | .value[]
+      | select(.name == $name)
+      | { udid: .udid,
+          booted: (if .state == "Booted" then 1 else 0 end),
+          ver: [ ($v.a|tonumber), ($v.b|tonumber), (($v.c // "0")|tonumber) ] } ]
+    | sort_by([ .booted, .ver ]) | last | .udid // empty')"
+  # Fall back to any "iPhone 17*" if the exact family name is missing.
+  if [[ -z "$udid" && "$name" == "$APEX_SIM_NAME" ]]; then
+    udid="$(xcrun simctl list devices available -j | jq -r '
+      [ .devices | to_entries[]
+        | select(.key | test("iOS"))
+        | ( .key | capture("iOS-(?<a>[0-9]+)-(?<b>[0-9]+)(-(?<c>[0-9]+))?") ) as $v
+        | .value[]
+        | select(.name | test("^iPhone 1[567]"))
+        | { udid: .udid,
+            booted: (if .state == "Booted" then 1 else 0 end),
+            ver: [ ($v.a|tonumber), ($v.b|tonumber), (($v.c // "0")|tonumber) ] } ]
+      | sort_by([ .booted, .ver ]) | last | .udid // empty')"
+  fi
+  [[ -n "$udid" ]] || apex_die "no available iPhone simulator found (need '$name')."
+  printf '%s\n' "$udid"
+}
+
+# Boot the given UDID and wait for it to be ready (no-op if already booted).
+apex_boot() {
+  local udid="$1"
+  apex_log "booting simulator $udid (waits for ready)…"
+  xcrun simctl bootstatus "$udid" -b >/dev/null 2>&1 || xcrun simctl boot "$udid" 2>/dev/null || true
+}
+
+# Freshest .app by MODIFICATION TIME (not `head -1`, which grabbed stale dirs and
+# cost 6 days of re-render loops in one session). Args: <search-root> <AppName.app>
+apex_freshest_app() {
+  local search_root="$1" app_name="$2" newest="" app
+  while IFS= read -r app; do
+    [[ -z "$app" ]] && continue
+    if [[ -z "$newest" || "$(stat -f '%m' "$app")" -gt "$(stat -f '%m' "$newest")" ]]; then
+      newest="$app"
+    fi
+  done < <(find "$search_root" -maxdepth 4 -name "$app_name" -type d 2>/dev/null)
+  printf '%s\n' "$newest"
+}
+
+# Bundle id read straight from a built .app (avoids hardcoding / drift).
+apex_bundle_id() {
+  /usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$1/Info.plist" 2>/dev/null
+}

--- a/scripts/ship-pr.sh
+++ b/scripts/ship-pr.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# ship-pr.sh — push → PR → wait on required checks (ignoring the known flake) →
+#              squash-admin-merge → delete branch → prune worktree.
+#
+# Usage:
+#   scripts/ship-pr.sh                       # current branch, in the cwd repo
+#   scripts/ship-pr.sh <branch>              # a branch in the main checkout
+#   scripts/ship-pr.sh /path/to/worktree     # a worktree (uses git -C, prunes it after)
+#   scripts/ship-pr.sh --title "..." --body "..."   # override PR title/body
+#
+# The mechanical PR dance re-hand-rolled every campaign (reflection item 3).
+# Merge autonomy is durably granted (memory: feedback_merge_autonomy), so this
+# admin-merges on green without asking. It IGNORES the flaky iOS build check —
+# override the pattern with APEX_FLAKY_CHECK (regex).
+#
+# The known flake: the "iOS Build & Test" GitHub check is intermittently red for
+# infra reasons; the rule "don't block on it" was re-pasted 30+ times. It lives
+# here now instead of in prompts.
+
+set -euo pipefail
+
+FLAKY="${APEX_FLAKY_CHECK:-(iOS )?Build & Test|iOS-Build-Test|build-and-test}"
+POLL_SECS="${APEX_POLL_SECS:-30}"
+MAX_WAIT_SECS="${APEX_MAX_WAIT_SECS:-1800}"
+
+TITLE=""; BODY=""; ARG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title) TITLE="$2"; shift 2 ;;
+    --body)  BODY="$2";  shift 2 ;;
+    -*) echo "unknown flag: $1" >&2; exit 2 ;;
+    *) ARG="$1"; shift ;;
+  esac
+done
+
+# Resolve the repo dir + branch from the positional arg.
+WORKTREE=""
+if [[ -n "$ARG" && -d "$ARG" ]]; then
+  REPO_DIR="$(cd "$ARG" && pwd)"; WORKTREE="$REPO_DIR"
+  BRANCH="$(git -C "$REPO_DIR" branch --show-current)"
+elif [[ -n "$ARG" ]]; then
+  REPO_DIR="$(pwd)"; BRANCH="$ARG"
+else
+  REPO_DIR="$(pwd)"; BRANCH="$(git -C "$REPO_DIR" branch --show-current)"
+fi
+g() { git -C "$REPO_DIR" "$@"; }
+[[ -n "$BRANCH" && "$BRANCH" != "main" ]] || { echo "refusing to ship '$BRANCH' — use a feature branch" >&2; exit 1; }
+echo "[ship] repo=$REPO_DIR branch=$BRANCH"
+
+echo "[ship] pushing…"
+g push -u origin "$BRANCH"
+
+# Create the PR if none exists yet (standard Claude Code trailer on the body).
+if ! gh pr view "$BRANCH" --repo thearnavmenon/ProjectApex >/dev/null 2>&1; then
+  TRAILER=$'\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)'
+  if [[ -n "$TITLE" ]]; then
+    gh pr create --repo thearnavmenon/ProjectApex --head "$BRANCH" \
+      --title "$TITLE" --body "${BODY}${TRAILER}"
+  else
+    gh pr create --repo thearnavmenon/ProjectApex --head "$BRANCH" --fill
+    gh pr edit "$BRANCH" --repo thearnavmenon/ProjectApex \
+      --body "$(gh pr view "$BRANCH" --repo thearnavmenon/ProjectApex --json body -q .body)${TRAILER}" >/dev/null || true
+  fi
+fi
+PR_URL="$(gh pr view "$BRANCH" --repo thearnavmenon/ProjectApex --json url -q .url)"
+echo "[ship] PR: $PR_URL"
+
+# Poll checks, ignoring the flake. A check is "settled OK" when COMPLETED with a
+# non-failing conclusion. We proceed once every non-ignored check is settled OK;
+# we abort if a non-ignored check actually fails.
+echo "[ship] waiting on required checks (ignoring: $FLAKY)…"
+waited=0
+while true; do
+  ROLLUP="$(gh pr view "$BRANCH" --repo thearnavmenon/ProjectApex --json statusCheckRollup -q '.statusCheckRollup')"
+  pending="$(jq -r --arg flaky "$FLAKY" '
+    [ .[] | select((.name // .context) | test($flaky) | not)
+          | select((.status // "COMPLETED") != "COMPLETED") ] | length' <<<"$ROLLUP")"
+  failed="$(jq -r --arg flaky "$FLAKY" '
+    [ .[] | select((.name // .context) | test($flaky) | not)
+          | select((.conclusion // .state // "") | test("FAILURE|CANCELLED|TIMED_OUT|ERROR|STARTUP_FAILURE")) ]
+    | (map(.name // .context) | join(", "))' <<<"$ROLLUP")"
+  if [[ -n "$failed" && "$failed" != "" ]]; then
+    echo "[ship] ABORT — required check failed: $failed" >&2
+    echo "[ship] fix and re-run; not merging." >&2
+    exit 1
+  fi
+  if [[ "$pending" == "0" ]]; then
+    echo "[ship] all required checks green (flake ignored)."
+    break
+  fi
+  (( waited >= MAX_WAIT_SECS )) && { echo "[ship] timed out after ${MAX_WAIT_SECS}s waiting on checks" >&2; exit 1; }
+  echo "[ship]   $pending check(s) still running… (${waited}s)"
+  sleep "$POLL_SECS"; waited=$((waited + POLL_SECS))
+done
+
+echo "[ship] merging (squash, admin, delete-branch)…"
+gh pr merge "$BRANCH" --repo thearnavmenon/ProjectApex --squash --admin --delete-branch
+
+# Prune the worktree if we were given one.
+if [[ -n "$WORKTREE" ]]; then
+  echo "[ship] pruning worktree $WORKTREE"
+  git -C "${APEX_MAIN_REPO:-$WORKTREE}" worktree remove "$WORKTREE" --force 2>/dev/null \
+    || git worktree remove "$WORKTREE" --force 2>/dev/null || true
+fi
+echo "[ship] done: $PR_URL"


### PR DESCRIPTION
Implements the in-repo actionable items from `reflection-notes.md`:

- **item 1/3/7/10** — `scripts/apex-build.sh`, `apex-render.sh`, `ship-pr.sh`, `deploy-efs.sh`, `apex-status.sh` (+ `lib/apex-sim.sh`) encode the xcodebuild/simctl/gh recipe that was re-derived by hand almost every session. Verified `apex-build.sh build` → BUILD SUCCEEDED on iPhone 17 Pro / iOS 26.5. This PR is being merged **by `ship-pr.sh` itself** (dogfood).
- **item 4** — "Shell & harness gotchas" cheat-sheet in CLAUDE.md.
- **item 5** — "Autonomy modes" (autopilot keyword) — wording is provisional, easy to adjust.
- **item 8** — "Asking the user" (taste = open-ended; investigate before asking).
- `docs/agents/build-and-render.md` documents the scripts; `.build/` gitignored.

Out-of-repo items (diary hook, lighting-venture CLAUDE.md, permission pruning, Supabase token rotation) are handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)